### PR TITLE
Improve `LocalisableString` formatting and interpolation API

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -32,8 +32,8 @@ namespace osu.Framework.Benchmarks
             romanisableString2 = new RomanisableString("c", "d");
             translatableString1 = new TranslatableString("e", "f");
             translatableString2 = new TranslatableString("g", "h");
-            formattableString1 = new LocalisableFormattableString("i", new object[] { "j" });
-            formattableString2 = new LocalisableFormattableString("k", new object[] { "l" });
+            formattableString1 = new LocalisableFormattableString("({0})", new object[] { "j" });
+            formattableString2 = new LocalisableFormattableString("[{0}]", new object[] { "l" });
         }
 
         [Benchmark]

--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -32,8 +32,8 @@ namespace osu.Framework.Benchmarks
             romanisableString2 = new RomanisableString("c", "d");
             translatableString1 = new TranslatableString("e", "f");
             translatableString2 = new TranslatableString("g", "h");
-            formattableString1 = new LocalisableFormattableString(1.23, "N0");
-            formattableString2 = new LocalisableFormattableString(4.56, "N1");
+            formattableString1 = new LocalisableFormattableString("i", new object[] { "j" });
+            formattableString2 = new LocalisableFormattableString("k", new object[] { "l" });
         }
 
         [Benchmark]

--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -32,8 +32,8 @@ namespace osu.Framework.Benchmarks
             romanisableString2 = new RomanisableString("c", "d");
             translatableString1 = new TranslatableString("e", "f");
             translatableString2 = new TranslatableString("g", "h");
-            formattableString1 = new LocalisableFormattableString("({0})", new object[] { "j" });
-            formattableString2 = new LocalisableFormattableString("[{0}]", new object[] { "l" });
+            formattableString1 = LocalisableString.Format("({0})", "j");
+            formattableString2 = LocalisableString.Format("[{0}]", "l");
         }
 
         [Benchmark]

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Localisation;
@@ -13,9 +12,6 @@ namespace osu.Framework.Tests.Localisation
     {
         private string makeStringA => makeString('a');
         private string makeStringB => makeString('b');
-
-        private IFormattable makeFormattableA => new DateTime(1);
-        private IFormattable makeFormattableB => new DateTime(2);
 
         [Test]
         public void TestTranslatableStringEqualsTranslatableString()
@@ -42,11 +38,11 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableFormattableEqualsLocalisableFormattable()
         {
-            var str1 = new LocalisableFormattableString(makeFormattableA, makeStringB);
-            var str2 = new LocalisableFormattableString(makeFormattableB, makeStringA);
+            var str1 = new LocalisableFormattableString(makeStringA, new object[] { makeStringB });
+            var str2 = new LocalisableFormattableString(makeStringB, new object[] { makeStringA });
 
             testEquals(true, str1, str1);
-            testEquals(true, str1, new LocalisableFormattableString(makeFormattableA, makeStringB));
+            testEquals(true, str1, new LocalisableFormattableString(makeStringA, new object[] { makeStringB }));
             testEquals(false, str1, str2);
         }
 
@@ -84,10 +80,10 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableStringEqualsLocalisableFormattable()
         {
-            LocalisableString localisable = new LocalisableFormattableString(makeFormattableA, makeStringB);
+            LocalisableString localisable = new LocalisableFormattableString(makeStringA, new object[] { makeStringB });
 
-            testEquals(true, localisable, new LocalisableFormattableString(makeFormattableA, makeStringB));
-            testEquals(false, localisable, new LocalisableFormattableString(makeFormattableB, makeStringA));
+            testEquals(true, localisable, new LocalisableFormattableString(makeStringA, new object[] { makeStringB }));
+            testEquals(false, localisable, new LocalisableFormattableString(makeStringB, new object[] { makeStringA }));
         }
 
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -38,11 +38,11 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableFormattableEqualsLocalisableFormattable()
         {
-            var str1 = new LocalisableFormattableString(makeStringA, new object[] { makeStringB });
-            var str2 = new LocalisableFormattableString(makeStringB, new object[] { makeStringA });
+            var str1 = LocalisableString.Format(makeStringA, makeStringB);
+            var str2 = LocalisableString.Format(makeStringB, makeStringA);
 
             testEquals(true, str1, str1);
-            testEquals(true, str1, new LocalisableFormattableString(makeStringA, new object[] { makeStringB }));
+            testEquals(true, str1, LocalisableString.Format(makeStringA, makeStringB));
             testEquals(false, str1, str2);
         }
 
@@ -80,10 +80,10 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableStringEqualsLocalisableFormattable()
         {
-            LocalisableString localisable = new LocalisableFormattableString(makeStringA, new object[] { makeStringB });
+            LocalisableString localisable = LocalisableString.Format(makeStringA, makeStringB);
 
-            testEquals(true, localisable, new LocalisableFormattableString(makeStringA, new object[] { makeStringB }));
-            testEquals(false, localisable, new LocalisableFormattableString(makeStringB, new object[] { makeStringA }));
+            testEquals(true, localisable, LocalisableString.Format(makeStringA, makeStringB));
+            testEquals(false, localisable, LocalisableString.Format(makeStringB, makeStringA));
         }
 
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -143,8 +143,9 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestFormattedAndLocalisedUsingInterpolate()
         {
+            var formattable = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
             var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
-            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, 0.1234.ToLocalisableString("0.00%"));
+            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, formattable);
 
             manager.AddLanguage("ja", new FakeStorage("ja"));
             config.SetValue(FrameworkSetting.Locale, "ja");
@@ -157,8 +158,9 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestFormattedAndLocalisedUsingFormat()
         {
+            var formattable = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
             var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
-            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, 0.1234.ToLocalisableString("0.00%"));
+            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, formattable);
 
             manager.AddLanguage("ja", new FakeStorage("ja"));
             config.SetValue(FrameworkSetting.Locale, "ja");
@@ -312,7 +314,8 @@ namespace osu.Framework.Tests.Localisation
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
-            var text = manager.GetLocalisedBindableString(new TranslatableString(key, key, 0.1234.ToLocalisableString("0.00%")));
+            var arg = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
+            var text = manager.GetLocalisedBindableString(new TranslatableString(key, key, arg));
 
             Assert.AreEqual("number 12.34% EN", text.Value);
 

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -364,7 +364,7 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
             var text = manager.GetLocalisedBindableString(new TranslatableString(key, key,
-                LocalisableString.Interpolate($"{12.34:0.00%}"),
+                LocalisableString.Interpolate($"{12.34:0.00}"),
                 new TranslatableString(nested_key, nested_key, LocalisableString.Interpolate($"{0.9876:0.00%}")),
                 new TranslatableString(nested_key, nested_key, new RomanisableString("unicode", "romanised"))));
 
@@ -391,8 +391,8 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
             var text = manager.GetLocalisedBindableString(LocalisableString.Format("{0} / {1} / {2}",
-                12.34.ToLocalisableString("0.00"),
-                new TranslatableString(nested_key, nested_key, 0.9876.ToLocalisableString("0.00%")),
+                LocalisableString.Interpolate($"{12.34:0.00}"),
+                new TranslatableString(nested_key, nested_key, LocalisableString.Interpolate($"{0.9876:0.00%}")),
                 new TranslatableString(nested_key, nested_key, new RomanisableString("unicode", "romanised"))));
 
             Assert.AreEqual("12.34 / number 98.76% EN / number unicode EN", text.Value);

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -141,6 +141,34 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestFormattedAndLocalisedUsingInterpolate()
+        {
+            var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
+            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, 0.1234.ToLocalisableString("0.00%"));
+
+            manager.AddLanguage("ja", new FakeStorage("ja"));
+            config.SetValue(FrameworkSetting.Locale, "ja");
+
+            var formattedText = manager.GetLocalisedBindableString(LocalisableString.Interpolate($"{translatable1} -> {translatable2}"));
+
+            Assert.AreEqual("localised JA -> 12.34% localised JA", formattedText.Value);
+        }
+
+        [Test]
+        public void TestFormattedAndLocalisedUsingFormat()
+        {
+            var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
+            var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, 0.1234.ToLocalisableString("0.00%"));
+
+            manager.AddLanguage("ja", new FakeStorage("ja"));
+            config.SetValue(FrameworkSetting.Locale, "ja");
+
+            var formattedText = manager.GetLocalisedBindableString(LocalisableString.Format("{0} -> {1}", translatable1, translatable2));
+
+            Assert.AreEqual("localised JA -> 12.34% localised JA", formattedText.Value);
+        }
+
+        [Test]
         public void TestNumberCultureAware()
         {
             const double value = 1.23;
@@ -284,7 +312,7 @@ namespace osu.Framework.Tests.Localisation
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
-            var text = manager.GetLocalisedBindableString(new TranslatableString(key, key, new LocalisableFormattableString(0.1234, "0.00%")));
+            var text = manager.GetLocalisedBindableString(new TranslatableString(key, key, 0.1234.ToLocalisableString("0.00%")));
 
             Assert.AreEqual("number 12.34% EN", text.Value);
 
@@ -333,8 +361,8 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
             var text = manager.GetLocalisedBindableString(new TranslatableString(key, key,
-                new LocalisableFormattableString(12.34, "0.00"),
-                new TranslatableString(nested_key, nested_key, new LocalisableFormattableString(0.9876, "0.00%")),
+                12.34.ToLocalisableString("0.00"),
+                new TranslatableString(nested_key, nested_key, 0.9876.ToLocalisableString("0.00%")),
                 new TranslatableString(nested_key, nested_key, new RomanisableString("unicode", "romanised"))));
 
             Assert.AreEqual("number 12.34 with number 98.76% EN and number unicode EN EN", text.Value);
@@ -353,15 +381,15 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
-        public void TestTranslatableComplexStringUsesFallbackFormatWithTranslatedParts()
+        public void TestFormatComplexStringUsesFallbackFormatWithTranslatedParts()
         {
             const string nested_key = FakeStorage.LOCALISABLE_NUMBER_FORMAT_STRING_EN;
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
-            var text = manager.GetLocalisedBindableString(new TranslatableString("_", "{0} / {1} / {2}",
-                new LocalisableFormattableString(12.34, "0.00"),
-                new TranslatableString(nested_key, nested_key, new LocalisableFormattableString(0.9876, "0.00%")),
+            var text = manager.GetLocalisedBindableString(LocalisableString.Format("{0} / {1} / {2}",
+                12.34.ToLocalisableString("0.00"),
+                new TranslatableString(nested_key, nested_key, 0.9876.ToLocalisableString("0.00%")),
                 new TranslatableString(nested_key, nested_key, new RomanisableString("unicode", "romanised"))));
 
             Assert.AreEqual("12.34 / number 98.76% EN / number unicode EN", text.Value);

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -364,8 +364,8 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
             var text = manager.GetLocalisedBindableString(new TranslatableString(key, key,
-                12.34.ToLocalisableString("0.00"),
-                new TranslatableString(nested_key, nested_key, 0.9876.ToLocalisableString("0.00%")),
+                LocalisableString.Interpolate($"{12.34:0.00%}"),
+                new TranslatableString(nested_key, nested_key, LocalisableString.Interpolate($"{0.9876:0.00%}")),
                 new TranslatableString(nested_key, nested_key, new RomanisableString("unicode", "romanised"))));
 
             Assert.AreEqual("number 12.34 with number 98.76% EN and number unicode EN EN", text.Value);

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestFormattedAndLocalisedUsingInterpolate()
         {
-            var formattable = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
+            var formattable = LocalisableString.Format("{0:0.00%}", 0.1234);
             var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
             var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, formattable);
 
@@ -158,7 +158,7 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestFormattedAndLocalisedUsingFormat()
         {
-            var formattable = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
+            var formattable = LocalisableString.Format("{0:0.00%}", 0.1234);
             var translatable1 = new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN);
             var translatable2 = new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, formattable);
 
@@ -314,7 +314,7 @@ namespace osu.Framework.Tests.Localisation
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
 
-            var arg = new LocalisableFormattableString("{0:0.00%}", new object[] { 0.1234 });
+            var arg = LocalisableString.Format("{0:0.00%}", 0.1234);
             var text = manager.GetLocalisedBindableString(new TranslatableString(key, key, arg));
 
             Assert.AreEqual("number 12.34% EN", text.Value);

--- a/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
+++ b/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
@@ -15,8 +15,7 @@ namespace osu.Framework.Extensions.LocalisationExtensions
         /// </summary>
         /// <param name="value">The value to format.</param>
         /// <param name="format">The format string.</param>
-        public static LocalisableFormattableString ToLocalisableString(this IFormattable value, string? format = null)
-            => new LocalisableFormattableString($"{{0:{format}}}", new object?[] { value });
+        public static LocalisableString ToLocalisableString(this IFormattable value, string? format = null) => LocalisableString.Format($"{{0:{format}}}", value);
 
         /// <summary>
         /// Returns a <see cref="CaseTransformableString"/> with the specified underlying localisable string uppercased.

--- a/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
+++ b/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Extensions.LocalisationExtensions
         /// <param name="value">The value to format.</param>
         /// <param name="format">The format string.</param>
         public static LocalisableFormattableString ToLocalisableString(this IFormattable value, string? format = null)
-            => new LocalisableFormattableString(value, format);
+            => new LocalisableFormattableString($"{{0:{format}}}", new object?[] { value });
 
         /// <summary>
         /// Returns a <see cref="CaseTransformableString"/> with the specified underlying localisable string uppercased.

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -4,52 +4,95 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Localisation
 {
     /// <summary>
-    /// A string which formats an <see cref="IFormattable"/>s using the current locale.
+    /// A localisable string with formatting support.
     /// </summary>
     public class LocalisableFormattableString : IEquatable<LocalisableFormattableString>, ILocalisableStringData
     {
-        public readonly IFormattable Value;
-        public readonly string? Format;
+        public readonly string Format;
+        public readonly object?[] Args;
 
         /// <summary>
         /// Creates a <see cref="LocalisableFormattableString"/> with an <see cref="IFormattable"/> value and a format string.
         /// </summary>
-        /// <param name="value">The <see cref="IFormattable"/> value.</param>
-        /// <param name="format">The format string.</param>
-        public LocalisableFormattableString(IFormattable value, string? format)
+        /// <param name="interpolation">The interpolated string containing format and arguments.</param>
+        public LocalisableFormattableString(FormattableString interpolation)
+            : this(interpolation.Format, interpolation.GetArguments())
         {
-            Value = value;
-            Format = format;
         }
 
-        public string GetLocalised(LocalisationParameters parameters)
+        /// <summary>
+        /// Creates a <see cref="LocalisableFormattableString"/> with an <see cref="IFormattable"/> value and a format string.
+        /// </summary>
+        /// <remarks>
+        /// Note that the <paramref name="args"/> parameter is intentionally not marked with <c>params</c> to avoid taking priority over the <see cref="LocalisableFormattableString(FormattableString)"/> constructor.
+        /// For more information, see https://github.com/dotnet/roslyn/issues/46.
+        /// </remarks>
+        /// <param name="format">The format string.</param>
+        /// <param name="args">The objects to format.</param>
+        public LocalisableFormattableString(string format, object?[] args)
+        {
+            Format = format;
+            Args = args;
+        }
+
+        public string GetLocalised(LocalisationParameters parameters) => FormatString(Format, Args, parameters);
+
+        protected virtual string FormatString(string format, object?[] args, LocalisationParameters parameters)
         {
             if (parameters.Store == null)
                 return ToString();
 
-            return Value.ToString(Format, parameters.Store.EffectiveCulture);
+            try
+            {
+                return string.Format(parameters.Store.EffectiveCulture, format, args.Select(argument =>
+                {
+                    if (argument is LocalisableString localisableString)
+                        argument = localisableString.Data;
+
+                    if (argument is ILocalisableStringData localisableData)
+                        return localisableData.GetLocalised(parameters);
+
+                    return argument;
+                }).ToArray());
+            }
+            catch (FormatException e)
+            {
+                // The formatting has failed
+                Logger.Log($"Localised format failed. Culture: {parameters.Store.EffectiveCulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
+                    LoggingTarget.Runtime, LogLevel.Verbose);
+            }
+
+            return ToString();
         }
 
-        public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, Format, Args);
 
         public bool Equals(LocalisableFormattableString? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return EqualityComparer<object>.Default.Equals(Value, other.Value) &&
-                   Format == other.Format;
+            return Format == other.Format
+                   && Args.SequenceEqual(other.Args);
         }
 
-        public bool Equals(ILocalisableStringData? other) => other is LocalisableFormattableString formattable && Equals(formattable);
+        public virtual bool Equals(ILocalisableStringData? other) => other is LocalisableFormattableString formattable && Equals(formattable);
         public override bool Equals(object? obj) => obj is LocalisableFormattableString formattable && Equals(formattable);
 
-        public override int GetHashCode() => HashCode.Combine(Value, Format);
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(Format);
+            foreach (object? arg in Args)
+                hashCode.Add(arg);
+            return hashCode.ToHashCode();
+        }
     }
 }

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Localisation
         /// Creates a <see cref="LocalisableFormattableString"/> with an <see cref="IFormattable"/> value and a format string.
         /// </summary>
         /// <param name="interpolation">The interpolated string containing format and arguments.</param>
-        public LocalisableFormattableString(FormattableString interpolation)
+        protected internal LocalisableFormattableString(FormattableString interpolation)
             : this(interpolation.Format, interpolation.GetArguments())
         {
         }
@@ -36,7 +36,7 @@ namespace osu.Framework.Localisation
         /// </remarks>
         /// <param name="format">The format string.</param>
         /// <param name="args">The objects to format.</param>
-        public LocalisableFormattableString(string format, object?[] args)
+        protected internal LocalisableFormattableString(string format, object?[] args)
         {
             Format = format;
             Args = args;

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -33,6 +33,13 @@ namespace osu.Framework.Localisation
             Data = data;
         }
 
+        /// <summary>
+        /// Replaces one or more format items in a specified string with a localised string representation of a corresponding object in <paramref name="args"/>.
+        /// </summary>
+        /// <param name="format">The format string.</param>
+        /// <param name="args">The objects to format.</param>
+        public static LocalisableString Format(string format, params object?[] args) => new LocalisableFormattableString(format, args);
+
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;
 
@@ -40,13 +47,13 @@ namespace osu.Framework.Localisation
         public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
         public override int GetHashCode() => LocalisableStringEqualityComparer.Default.GetHashCode(this);
 
+        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
+        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
+
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
         public static implicit operator LocalisableString(LocalisableFormattableString formattable) => new LocalisableString(formattable);
         public static implicit operator LocalisableString(CaseTransformableString transformable) => new LocalisableString(transformable);
-
-        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
-        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
     }
 }

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -53,13 +53,13 @@ namespace osu.Framework.Localisation
         public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
         public override int GetHashCode() => LocalisableStringEqualityComparer.Default.GetHashCode(this);
 
-        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
-        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
-
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
         public static implicit operator LocalisableString(LocalisableFormattableString formattable) => new LocalisableString(formattable);
         public static implicit operator LocalisableString(CaseTransformableString transformable) => new LocalisableString(transformable);
+
+        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
+        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
     }
 }

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -40,6 +40,12 @@ namespace osu.Framework.Localisation
         /// <param name="args">The objects to format.</param>
         public static LocalisableString Format(string format, params object?[] args) => new LocalisableFormattableString(format, args);
 
+        /// <summary>
+        /// Creates a <see cref="LocalisableString"/> representation of the specified interpolated string.
+        /// </summary>
+        /// <param name="interpolation">The interpolated string containing format and arguments.</param>
+        public static LocalisableString Interpolate(FormattableString interpolation) => new LocalisableFormattableString(interpolation);
+
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;
 

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -41,8 +41,8 @@ namespace osu.Framework.Localisation
             Key = key;
         }
 
-        protected override string FormatString(string format, object?[] args, LocalisationParameters parameters)
-            => base.FormatString(parameters.Store?.Get(Key) ?? format, args, parameters);
+        protected override string FormatString(string fallback, object?[] args, LocalisationParameters parameters)
+            => base.FormatString(parameters.Store?.Get(Key) ?? fallback, args, parameters);
 
         public bool Equals(TranslatableString? other)
         {

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -4,20 +4,15 @@
 #nullable enable
 
 using System;
-using System.Globalization;
-using System.Linq;
-using osu.Framework.Logging;
 
 namespace osu.Framework.Localisation
 {
     /// <summary>
-    /// A string that can be translated with optional formattable arguments.
+    /// A string which can be translated using a key lookup.
     /// </summary>
-    public class TranslatableString : IEquatable<TranslatableString>, ILocalisableStringData
+    public class TranslatableString : LocalisableFormattableString, IEquatable<TranslatableString>
     {
         public readonly string Key;
-        public readonly string Fallback;
-        public readonly object?[] Args;
 
         /// <summary>
         /// Creates a <see cref="TranslatableString"/> using texts.
@@ -26,10 +21,9 @@ namespace osu.Framework.Localisation
         /// <param name="fallback">The fallback string to use when no translation can be found.</param>
         /// <param name="args">Optional formattable arguments.</param>
         public TranslatableString(string key, string fallback, params object?[] args)
+            : base(fallback, args)
         {
             Key = key;
-            Fallback = fallback;
-            Args = args;
         }
 
         /// <summary>
@@ -42,65 +36,25 @@ namespace osu.Framework.Localisation
         /// <param name="key">The key for <see cref="LocalisationManager"/> to look up with.</param>
         /// <param name="interpolation">The interpolated string containing fallback and formattable arguments.</param>
         public TranslatableString(string key, FormattableString interpolation)
+            : base(interpolation)
         {
             Key = key;
-            Fallback = interpolation.Format;
-            Args = interpolation.GetArguments();
         }
 
-        public string GetLocalised(LocalisationParameters parameters)
-        {
-            if (parameters.Store == null)
-                return ToString();
-
-            string localisedFormat = parameters.Store.Get(Key) ?? Fallback;
-
-            try
-            {
-                return string.Format(parameters.Store.EffectiveCulture, localisedFormat, Args.Select(argument =>
-                {
-                    if (argument is LocalisableString localisableString)
-                        argument = localisableString.Data;
-
-                    if (argument is ILocalisableStringData localisableData)
-                        return localisableData.GetLocalised(parameters);
-
-                    return argument;
-                }).ToArray());
-            }
-            catch (FormatException e)
-            {
-                // The formatting has failed
-                Logger.Log($"Localised format failed. Key: {Key}, culture: {parameters.Store.EffectiveCulture}, fallback format string: \"{Fallback}\", localised format string: \"{localisedFormat}\". Exception: {e}",
-                    LoggingTarget.Runtime, LogLevel.Verbose);
-            }
-
-            return ToString();
-        }
-
-        public override string ToString() => string.Format(CultureInfo.InvariantCulture, Fallback, Args);
+        protected override string FormatString(string format, object?[] args, LocalisationParameters parameters)
+            => base.FormatString(parameters.Store?.Get(Key) ?? format, args, parameters);
 
         public bool Equals(TranslatableString? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Key == other.Key
-                   && Fallback == other.Fallback
-                   && Args.SequenceEqual(other.Args);
+            return base.Equals(other) && Key == other.Key;
         }
 
-        public bool Equals(ILocalisableStringData? other) => other is TranslatableString translatable && Equals(translatable);
+        public override bool Equals(ILocalisableStringData? other) => other is TranslatableString translatable && Equals(translatable);
         public override bool Equals(object? obj) => obj is TranslatableString translatable && Equals(translatable);
 
-        public override int GetHashCode()
-        {
-            var hashCode = new HashCode();
-            hashCode.Add(Key);
-            hashCode.Add(Fallback);
-            foreach (object? arg in Args)
-                hashCode.Add(arg);
-            return hashCode.ToHashCode();
-        }
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Key);
     }
 }


### PR DESCRIPTION
- May resolve https://github.com/ppy/osu/issues/17953

Upon discussion in [discord](https://discord.com/channels/188630481301012481/589331078574112768/966564266343817266), it turns out the current way to format `LocalisableString`s or create interpolation is via `TranslatableString` with a random key (e.g. `_`), which feels counter-intuitive.

I've cleaned things up by moving the format and interpolation logic from `TranslatableString` to `LocalisableFormattableString`, and sharing it to `TranslatableString` via inheritance (rationale is that `TranslatableString` shouldn't really bother with the formatting logic, and `LocalisableFormattableString` currently exists but has been incomplete). 

Allowing for formatting and interpolation support via `LocalisableFormattableString` instead:
```diff
                 public override LocalisableString TooltipText =>
                     Current.Value == 0
-                        ? new TranslatableString("_", @"{0} ms", base.TooltipText)
-                        : new TranslatableString("_", @"{0} ms {1}", base.TooltipText, getEarlyLateText(Current.Value));
+                        ? new LocalisableFormattableString($@"{base.TooltipText} ms")
+                        : new LocalisableFormattableString($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
```

In addition, I've added a `LocalisableString.Format` method (analogue to `string.Format`), [as proposed](https://discord.com/channels/188630481301012481/589331078574112768/966572503604539423), which can be used to avoid specifying the full constructor name, or if format is preferred:
```diff
                 public override LocalisableString TooltipText =>
                     Current.Value == 0
-                        ? new LocalisableFormattableString($@"{base.TooltipText} ms")
-                        : new LocalisableFormattableString($@"{base.TooltipText} ms getEarlyLateText(Current.Value));
+                        ? LocalisableString.Format(@"{0} ms", base.TooltipText)
+                        : LocalisableString.Format(@"{0} ms {1}", base.TooltipText, getEarlyLateText(Current.Value));
```

I've also thought about making it full-blown with an implicit conversion in `LocalisableString` from an interpolation string (internally `FormattableString`) to a `LocalisableFormattableString`. But turns out that doesn't work well due to the pre-existing `string` implicit conversion, which takes priority over the `FormattableString` one, [as mentioned](https://discord.com/channels/188630481301012481/589331078574112768/966573544194596894).

This has been brought up before in [stack overflow](https://stackoverflow.com/questions/35770713/overloaded-string-methods-with-string-interpolation), and has been discussed long ago across VB and C# (https://github.com/dotnet/roslyn/issues/46), but it has since been decided for `string`s to remain at taking priority over `FormattableString`s.

The only improvement I can think of to benefit from the interpolation and avoid explicitly constructing the implementation class with its full name is by adding a `LocalisableString.Interpolate` that does the job:
```diff
                 public override LocalisableString TooltipText =>
                     Current.Value == 0
-                        ? new LocalisableFormattableString($@"{base.TooltipText} ms")
-                        : new LocalisableFormattableString($@"{base.TooltipText} ms getEarlyLateText(Current.Value));
+                        ? LocalisableString.Interpolate($@"{base.TooltipText} ms")
+                        : LocalisableString.Interpolate($@"{base.TooltipText} ms {getEarlyLateText(Current.Value)}");
```

I'm pretty happy with the state this is now in, but further suggestions and ideas are welcomed.