### PR TITLE
Mark local methods as `static` where possible to appease Rider

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -359,7 +359,7 @@ namespace osu.Framework
 
             return false;
 
-            Vector2 getCascadeLocation(int index)
+            static Vector2 getCascadeLocation(int index)
                 => new Vector2(100 + index * (TitleBar.HEIGHT + 10));
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -429,7 +429,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 positionLayout.Validate();
 
-                Anchor switchAxisAnchors(Anchor originalValue, Anchor toDisable, Anchor toEnable) => (originalValue & ~toDisable) | toEnable;
+                static Anchor switchAxisAnchors(Anchor originalValue, Anchor toDisable, Anchor toEnable) => (originalValue & ~toDisable) | toEnable;
             }
         }
 


### PR DESCRIPTION
For some reason these didn't get caught up by CI in #5121, I guess `IDExxxx` inspections in general don't get caught unless using `dotnet format`..?

<img width="740" alt="CleanShot 2022-04-26 at 10 03 17@2x" src="https://user-images.githubusercontent.com/22781491/165241490-4e7e91ce-fc62-468e-8f1d-d861a706f749.png">

(inspection is `IDE0062`)