### PR TITLE
Fix `GetLocalisableDescription` not handling `Type` inputs properly

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
@@ -26,9 +26,15 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
-        public void TestClassLocalisableDescription()
+        public void TestClassInstanceLocalisableDescription()
         {
             Assert.That(new ClassA().GetLocalisableDescription().ToString(), Is.EqualTo("Localised A"));
+        }
+
+        [Test]
+        public void TestClassTypeLocalisableDescription()
+        {
+            Assert.That(typeof(ClassA).GetLocalisableDescription().ToString(), Is.EqualTo("Localised A"));
         }
 
         [Test]

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Extensions
             if (value is Enum)
                 type = value.GetType().GetField(value.ToString());
             else
-                type = value.GetType();
+                type = value as Type ?? value.GetType();
 
             var attribute = type.GetCustomAttribute<LocalisableDescriptionAttribute>();
             if (attribute == null)
@@ -223,10 +223,10 @@ namespace osu.Framework.Extensions
         /// </list>
         /// </summary>
         public static string GetDescription(this object value)
-            => value.GetType()
-                    .GetField(value.ToString())?
-                    .GetCustomAttribute<DescriptionAttribute>()?.Description
-               ?? value.ToString();
+        {
+            Type type = value as Type ?? value.GetType();
+            return type.GetField(value.ToString())?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
+        }
 
         private static string toLowercaseHex(this byte[] bytes)
         {


### PR DESCRIPTION
As reported in [discord](https://discord.com/channels/188630481301012481/589331078574112768/968412471448707092), `GetLocalisableDescription` does not handle the case where the generic type is `Type`, since `Type.GetType() != Type`.