### PR TITLE
Improve extensibility of `LocalisationParameters`

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -69,6 +69,12 @@ namespace osu.Framework
 
         protected override Container<Drawable> Content => content;
 
+        /// <summary>
+        /// Creates a new <see cref="LocalisationManager"/>.
+        /// </summary>
+        /// <param name="frameworkConfig">The framework config manager.</param>
+        protected virtual LocalisationManager CreateLocalisationManager(FrameworkConfigManager frameworkConfig) => new LocalisationManager(frameworkConfig);
+
         protected internal virtual UserInputManager CreateUserInputManager() => new UserInputManager();
 
         /// <summary>
@@ -177,7 +183,7 @@ namespace osu.Framework
 
             dependencies.Cache(Fonts);
 
-            Localisation = new LocalisationManager(config);
+            Localisation = CreateLocalisationManager(config);
             dependencies.Cache(Localisation);
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Localisation
             configLocale.BindValueChanged(updateLocale);
 
             config.BindWith(FrameworkSetting.ShowUnicode, configPreferUnicode);
-            configPreferUnicode.BindValueChanged(updateUnicodePreference, true);
+            configPreferUnicode.BindValueChanged(_ => UpdateLocalisationParameters(), true);
         }
 
         public void AddLanguage(string language, ILocalisationStore storage)
@@ -65,38 +65,36 @@ namespace osu.Framework.Localisation
         /// <returns>The <see cref="ILocalisedBindableString"/>.</returns>
         public ILocalisedBindableString GetLocalisedBindableString(LocalisableString original) => new LocalisedBindableString(original, this);
 
+        private LocaleMapping? currentLocale;
+
         private void updateLocale(ValueChangedEvent<string> locale)
         {
             if (locales.Count == 0)
                 return;
 
-            var validLocale = locales.Find(l => l.Name == locale.NewValue);
+            currentLocale = locales.Find(l => l.Name == locale.NewValue);
 
-            if (validLocale == null)
+            if (currentLocale == null)
             {
                 var culture = string.IsNullOrEmpty(locale.NewValue) ? CultureInfo.CurrentCulture : new CultureInfo(locale.NewValue);
 
                 for (var c = culture; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
                 {
-                    validLocale = locales.Find(l => l.Name == c.Name);
-                    if (validLocale != null)
+                    currentLocale = locales.Find(l => l.Name == c.Name);
+                    if (currentLocale != null)
                         break;
                 }
 
-                validLocale ??= locales[0];
+                currentLocale ??= locales[0];
             }
 
-            ChangeSettings(CreateNewLocalisationParameters(validLocale.Storage, currentParameters.Value.PreferOriginalScript));
+            UpdateLocalisationParameters();
         }
 
-        private void updateUnicodePreference(ValueChangedEvent<bool> preferUnicode)
-            => ChangeSettings(CreateNewLocalisationParameters(currentParameters.Value.Store, preferUnicode.NewValue));
-
         /// <summary>
-        /// Changes the localisation parameters.
+        /// Retrieves the latest localisation parameters using <see cref="CreateLocalisationParameters"/> and updates the current one with.
         /// </summary>
-        /// <param name="parameters">The new localisation parameters.</param>
-        protected void ChangeSettings(LocalisationParameters parameters) => currentParameters.Value = parameters;
+        protected void UpdateLocalisationParameters() => currentParameters.Value = CreateLocalisationParameters();
 
         /// <summary>
         /// Creates new <see cref="LocalisationParameters"/>.
@@ -104,11 +102,8 @@ namespace osu.Framework.Localisation
         /// <remarks>
         /// Can be overridden to provide custom parameters for <see cref="ILocalisableStringData"/> implementations.
         /// </remarks>
-        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.</param>
-        /// <param name="preferOriginalScript">Whether to prefer the "original" script of <see cref="RomanisableString"/>s.</param>
         /// <returns>The resultant <see cref="LocalisationParameters"/>.</returns>
-        protected virtual LocalisationParameters CreateNewLocalisationParameters(ILocalisationStore? store, bool preferOriginalScript)
-            => new LocalisationParameters(store, preferOriginalScript);
+        protected virtual LocalisationParameters CreateLocalisationParameters() => new LocalisationParameters(currentLocale?.Storage, configPreferUnicode.Value);
 
         private class LocaleMapping
         {

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -21,6 +21,15 @@ namespace osu.Framework.Localisation
         public readonly bool PreferOriginalScript;
 
         /// <summary>
+        /// Creates a new instance of <see cref="LocalisationParameters"/> based off another <see cref="LocalisationParameters"/>.
+        /// </summary>
+        /// <param name="parameters">The <see cref="LocalisationParameters"/> to copy values from.</param>
+        protected LocalisationParameters(LocalisationParameters parameters)
+            : this(parameters.Store, parameters.PreferOriginalScript)
+        {
+        }
+
+        /// <summary>
         /// Creates a new instance of <see cref="LocalisationParameters"/>.
         /// </summary>
         /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.</param>


### PR DESCRIPTION
After writing up a [wiki page regarding localisation](https://github.com/ppy/osu-framework/wiki/Localisation), it turns out `LocalisationParameters` isn't actually extensible given the way it's currently created and updated in `LocalisationManager`, along with the fact that there's no `CreateLocalisationManager` to create the custom subclass with.

The end goal would be to extend `LocalisationParameters` from a consumer project with simplicity in mind:
```csharp
    protected override LocalisationManager CreateLocalisationManager(FrameworkConfigManager frameworkConfig) 
        => new CustomLocalisationManager(frameworkConfig, localConfig);

    public class CustomLocalisationManager : LocalisationManager
    {
        private readonly IBindable<int> custom = new BindableInt();

        public CustomLocalisationManager(FrameworkConfigManager frameworkConfig, CustomConfigManager config)
            : base(frameworkConfig)
        {
            config.BindWith(CustomSetting.Custom, custom);
            custom.BindValueChanged(_ => UpdateLocalisationParameters(), true);
        }

        protected override LocalisationParameters CreateLocalisationParameters() => new CustomLocalisationParameters(base.CreateLocalisationParameters(), custom.Value);

        private class CustomLocalisationParameters : LocalisationParameters
        {
            public readonly int Custom;

            public CustomLocalisationParameters(LocalisationParameters parameters, int custom)
                : base(parameters.Store, parameters.PreferOriginalScript)
            {
                Custom = custom;
            }
        }
    }