### PR TITLE
Fix iOS text key shortcuts no longer working

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -24,23 +24,11 @@ namespace osu.Framework.iOS
     {
         private readonly IOSGameView gameView;
 
-        private IOSTextFieldKeyboardHandler textFieldKeyboardHandler;
-        private IOSHardwareKeyboardHandler hardwareKeyboardHandler;
+        public IOSTextFieldKeyboardHandler TextFieldHandler { get; private set; }
 
         public IOSGameHost(IOSGameView gameView)
         {
             this.gameView = gameView;
-        }
-
-        /// <summary>
-        /// Toggles the active state of the keyboard handlers.
-        /// When toggled on, the <see cref="IOSTextFieldKeyboardHandler"/> will be active to handle input from the <see cref="IOSGameView.HiddenTextField"/>.
-        /// When toggled off, the <see cref="IOSHardwareKeyboardHandler"/> will be active to handle input from hardware keyboard directly.
-        /// </summary>
-        public void ToggleTextFieldKeyboardHandler(bool active)
-        {
-            textFieldKeyboardHandler.KeyboardActive = active;
-            hardwareKeyboardHandler.KeyboardActive = !active;
         }
 
         protected override void SetupForRun()
@@ -74,8 +62,8 @@ namespace osu.Framework.iOS
             new InputHandler[]
             {
                 new IOSTouchHandler(gameView),
-                textFieldKeyboardHandler = new IOSTextFieldKeyboardHandler(gameView),
-                hardwareKeyboardHandler = new IOSHardwareKeyboardHandler(),
+                TextFieldHandler = new IOSTextFieldKeyboardHandler(gameView),
+                new IOSHardwareKeyboardHandler(),
                 new IOSMouseHandler(gameView),
                 new MidiHandler()
             };

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -105,7 +105,6 @@ namespace osu.Framework.iOS
         {
             public event Action<NSRange, string> HandleShouldChangeCharacters;
             public event Action HandleShouldReturn;
-            public event Action<UIKeyCommand> HandleKeyCommand;
 
             /// <summary>
             /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
@@ -119,19 +118,16 @@ namespace osu.Framework.iOS
 
             private int responderSemaphore;
 
-            private readonly IEnumerable<Selector> softwareBlockedActions = new[]
+            /// <summary>
+            /// The list of actions which can't be supported with this text field.
+            /// </summary>
+            /// <remarks>
+            /// Paste is supported since it doesn't rely on the text entered in this field, only raising an <see cref="UITextField.ShouldChangeCharacters"/> event containing the pasted text.
+            /// </remarks>
+            private readonly IEnumerable<Selector> blockedActions = new[]
             {
                 new Selector("cut:"),
                 new Selector("copy:"),
-                new Selector("select:"),
-                new Selector("selectAll:"),
-            };
-
-            private readonly IEnumerable<Selector> rawBlockedActions = new[]
-            {
-                new Selector("cut:"),
-                new Selector("copy:"),
-                new Selector("paste:"),
                 new Selector("select:"),
                 new Selector("selectAll:"),
             };
@@ -139,18 +135,6 @@ namespace osu.Framework.iOS
             public override UITextSmartDashesType SmartDashesType => UITextSmartDashesType.No;
             public override UITextSmartInsertDeleteType SmartInsertDeleteType => UITextSmartInsertDeleteType.No;
             public override UITextSmartQuotesType SmartQuotesType => UITextSmartQuotesType.No;
-
-            private bool softwareKeyboard = true;
-
-            internal bool SoftwareKeyboard
-            {
-                get => softwareKeyboard;
-                set
-                {
-                    softwareKeyboard = value;
-                    resetText();
-                }
-            }
 
             public HiddenTextField()
             {
@@ -176,39 +160,14 @@ namespace osu.Framework.iOS
                 };
             }
 
-            public override UIKeyCommand[] KeyCommands => new[]
-            {
-                UIKeyCommand.Create(UIKeyCommand.LeftArrow, 0, new Selector("keyPressed:")),
-                UIKeyCommand.Create(UIKeyCommand.RightArrow, 0, new Selector("keyPressed:")),
-                UIKeyCommand.Create(UIKeyCommand.UpArrow, 0, new Selector("keyPressed:")),
-                UIKeyCommand.Create(UIKeyCommand.DownArrow, 0, new Selector("keyPressed:"))
-            };
-
-            public override bool CanPerform(Selector action, NSObject withSender)
-            {
-                if ((!softwareKeyboard && rawBlockedActions.Contains(action)) || (softwareKeyboard && softwareBlockedActions.Contains(action)))
-                    return false;
-
-                return base.CanPerform(action, withSender);
-            }
-
-            [Export("keyPressed:")]
-            private void keyPressed(UIKeyCommand cmd) => HandleKeyCommand?.Invoke(cmd);
+            public override bool CanPerform(Selector action, NSObject withSender) => !blockedActions.Contains(action) && base.CanPerform(action, withSender);
 
             private void resetText()
             {
-                if (SoftwareKeyboard)
-                {
-                    // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                    Text = placeholder_text;
-                    var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
-                    SelectedTextRange = GetTextRange(newPosition, newPosition);
-                }
-                else
-                {
-                    Text = "";
-                    SelectedTextRange = GetTextRange(BeginningOfDocument, BeginningOfDocument);
-                }
+                // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
+                Text = placeholder_text;
+                var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
+                SelectedTextRange = GetTextRange(newPosition, newPosition);
             }
 
             public void UpdateFirstResponder(bool become)

--- a/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
@@ -16,10 +16,10 @@ namespace osu.Framework.iOS.Input
 
         public override bool Initialize(GameHost host)
         {
-            if (!(UIApplication.SharedApplication is GameUIApplication game) || !(host is IOSGameHost iosHost))
-                return false;
+            var iosApp = (GameUIApplication)UIApplication.SharedApplication;
+            var iosHost = (IOSGameHost)host;
 
-            game.KeyEvent += (keyCode, isDown) =>
+            iosApp.KeyEvent += (keyCode, isDown) =>
             {
                 if (!IsActive)
                     return;

--- a/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
@@ -12,8 +12,7 @@ namespace osu.Framework.iOS.Input
 {
     public class IOSHardwareKeyboardHandler : InputHandler
     {
-        internal bool KeyboardActive = true;
-        public override bool IsActive => KeyboardActive;
+        public override bool IsActive => true;
 
         public override bool Initialize(GameHost host)
         {

--- a/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSHardwareKeyboardHandler.cs
@@ -16,13 +16,19 @@ namespace osu.Framework.iOS.Input
 
         public override bool Initialize(GameHost host)
         {
-            if (!(UIApplication.SharedApplication is GameUIApplication game))
+            if (!(UIApplication.SharedApplication is GameUIApplication game) || !(host is IOSGameHost iosHost))
                 return false;
 
             game.KeyEvent += (keyCode, isDown) =>
             {
-                if (IsActive && keyMap.ContainsKey(keyCode))
-                    PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));
+                if (!IsActive)
+                    return;
+
+                var key = keyMap.GetValueOrDefault(keyCode);
+                if (key == Key.Unknown || iosHost.TextFieldHandler.Handled(key))
+                    return;
+
+                PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));
             };
 
             return true;

--- a/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
@@ -23,6 +23,11 @@ namespace osu.Framework.iOS.Input
             view.KeyboardTextField.HandleKeyCommand += handleKeyCommand;
         }
 
+        /// <summary>
+        /// Whether the specified key has been handled by this handler.
+        /// </summary>
+        public bool Handled(Key key) => PendingInputs.OfType<KeyboardKeyInput>().Any(i => i.Entries.Any(e => e.Button == key));
+
         private void handleShouldChangeCharacters(NSRange range, string text)
         {
             if (!IsActive)

--- a/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using Foundation;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osuTK.Input;
-using UIKit;
 
 namespace osu.Framework.iOS.Input
 {
@@ -20,7 +20,6 @@ namespace osu.Framework.iOS.Input
             this.view = view;
             view.KeyboardTextField.HandleShouldChangeCharacters += handleShouldChangeCharacters;
             view.KeyboardTextField.HandleShouldReturn += handleShouldReturn;
-            view.KeyboardTextField.HandleKeyCommand += handleKeyCommand;
         }
 
         /// <summary>
@@ -77,47 +76,6 @@ namespace osu.Framework.iOS.Input
 
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, true));
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, false));
-        }
-
-        private void handleKeyCommand(UIKeyCommand cmd)
-        {
-            if (!IsActive)
-                return;
-
-            Key? key;
-            bool upper = false;
-
-            // UIKeyCommand constants are not actually constants, so we can't use a switch
-            if (cmd.Input == UIKeyCommand.LeftArrow)
-                key = Key.Left;
-            else if (cmd.Input == UIKeyCommand.RightArrow)
-                key = Key.Right;
-            else if (cmd.Input == UIKeyCommand.UpArrow)
-                key = Key.Up;
-            else if (cmd.Input == UIKeyCommand.DownArrow)
-                key = Key.Down;
-            else
-                key = keyForString(cmd.Input, out upper);
-
-            if (!key.HasValue) return;
-
-            bool shiftHeld = (cmd.ModifierFlags & UIKeyModifierFlags.Shift) > 0 || upper;
-            bool superHeld = (cmd.ModifierFlags & UIKeyModifierFlags.Command) > 0;
-            bool ctrlHeld = (cmd.ModifierFlags & UIKeyModifierFlags.Control) > 0;
-            bool optionHeld = (cmd.ModifierFlags & UIKeyModifierFlags.Alternate) > 0;
-
-            if (shiftHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LShift, true));
-            if (superHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LWin, true));
-            if (ctrlHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LControl, true));
-            if (optionHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LAlt, true));
-
-            PendingInputs.Enqueue(new KeyboardKeyInput(key.Value, true));
-            PendingInputs.Enqueue(new KeyboardKeyInput(key.Value, false));
-
-            if (optionHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LAlt, false));
-            if (ctrlHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LControl, false));
-            if (superHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LWin, false));
-            if (shiftHeld) PendingInputs.Enqueue(new KeyboardKeyInput(Key.LShift, false));
         }
 
         private Key? keyForString(string str, out bool upper)
@@ -260,7 +218,6 @@ namespace osu.Framework.iOS.Input
         {
             view.KeyboardTextField.HandleShouldChangeCharacters -= handleShouldChangeCharacters;
             view.KeyboardTextField.HandleShouldReturn -= handleShouldReturn;
-            view.KeyboardTextField.HandleKeyCommand -= handleKeyCommand;
             base.Dispose(disposing);
         }
 

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.iOS.Input
         {
             view.KeyboardTextField.HandleShouldChangeCharacters += handleShouldChangeCharacters;
             view.KeyboardTextField.UpdateFirstResponder(true);
-            host.ToggleTextFieldKeyboardHandler(true);
+            host.TextFieldHandler.KeyboardActive = true;
         }
 
         protected override void EnsureTextInputActivated(bool allowIme)
@@ -43,7 +43,7 @@ namespace osu.Framework.iOS.Input
         {
             view.KeyboardTextField.HandleShouldChangeCharacters -= handleShouldChangeCharacters;
             view.KeyboardTextField.UpdateFirstResponder(false);
-            host.ToggleTextFieldKeyboardHandler(false);
+            host.TextFieldHandler.KeyboardActive = false;
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -247,7 +247,11 @@ namespace osu.Framework.Graphics.UserInterface
 
                 case PlatformAction.Paste:
                     if (textInputBlocking)
-                        // the text has been pasted into the hidden textbox, so we don't need any direct clipboard interaction here.
+                        // TextInputSource received text while this action got activated.
+                        // This is an indicator that text has already been pasted at an OS level
+                        // and has been received here through the TextInputSource flow.
+                        //
+                        // This is currently only happening on iOS since it relies on a hidden UITextField for software keyboard.
                         return true;
 
                     InsertString(clipboard?.GetText());


### PR DESCRIPTION
- Closes #5143 

Gladly this didn't require reverting #5106. Done by keeping the `IOSHardwareKeyboardHandler` active all the time, and avoid duplicating input if handled by `IOSTextFieldKeyboardHandler`.

This can be best reviewed commit-by-commit, to explain how this was approached and what it has changed.

I have tested this on an iOS simulator and confirmed text shortcuts work now, but as I was testing this, for some reason some keys get stuck in a pressed state, and I have no clue how to tell if it's due to the game running poorly due to OpenGL or otherwise.

@peppy please check that this is working alright for you, and that pasting works properly from both hardware keyboard and software keyboard, and that no keys actually get stuck in pressed state (if that occurs, pressing left/right or triggering any framework platform action will no longer work).

If for some reason something doesn't work then it's probably best to revert #5106 for now and call it a day.