### PR TITLE
Use same key bindings on macOS and iOS

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -16,6 +16,7 @@ using osu.Framework.iOS.Graphics.Textures;
 using osu.Framework.iOS.Graphics.Video;
 using osu.Framework.iOS.Input;
 using osu.Framework.Platform;
+using osu.Framework.Platform.MacOS;
 using UIKit;
 
 namespace osu.Framework.iOS
@@ -104,37 +105,6 @@ namespace osu.Framework.iOS
         public override VideoDecoder CreateVideoDecoder(Stream stream)
             => new IOSVideoDecoder(stream);
 
-        public override IEnumerable<KeyBinding> PlatformKeyBindings => new[]
-        {
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.X), PlatformAction.Cut),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.C), PlatformAction.Copy),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.V), PlatformAction.Paste),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.A), PlatformAction.SelectAll),
-            new KeyBinding(InputKey.Left, PlatformAction.MoveBackwardChar),
-            new KeyBinding(InputKey.Right, PlatformAction.MoveForwardChar),
-            new KeyBinding(InputKey.BackSpace, PlatformAction.DeleteBackwardChar),
-            new KeyBinding(InputKey.Delete, PlatformAction.DeleteForwardChar),
-            new KeyBinding(new KeyCombination(InputKey.Shift, InputKey.Left), PlatformAction.SelectBackwardChar),
-            new KeyBinding(new KeyCombination(InputKey.Shift, InputKey.Right), PlatformAction.SelectForwardChar),
-            new KeyBinding(new KeyCombination(InputKey.Shift, InputKey.BackSpace), PlatformAction.DeleteBackwardChar),
-            new KeyBinding(new KeyCombination(InputKey.Shift, InputKey.Delete), PlatformAction.DeleteForwardChar),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Left), PlatformAction.MoveBackwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Right), PlatformAction.MoveForwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.BackSpace), PlatformAction.DeleteBackwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Delete), PlatformAction.DeleteForwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Shift, InputKey.Left), PlatformAction.SelectBackwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Shift, InputKey.Right), PlatformAction.SelectForwardWord),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Left), PlatformAction.MoveBackwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Right), PlatformAction.MoveForwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.BackSpace), PlatformAction.DeleteBackwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Delete), PlatformAction.DeleteForwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Shift, InputKey.Left), PlatformAction.SelectBackwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Shift, InputKey.Right), PlatformAction.SelectForwardLine),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Super, InputKey.Left), PlatformAction.DocumentPrevious),
-            new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Super, InputKey.Right), PlatformAction.DocumentNext),
-            new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Tab), PlatformAction.DocumentNext),
-            new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Tab), PlatformAction.DocumentPrevious),
-            new KeyBinding(new KeyCombination(InputKey.Delete), PlatformAction.Delete),
-        };
+        public override IEnumerable<KeyBinding> PlatformKeyBindings => MacOSGameHost.KeyBindings;
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -64,7 +64,12 @@ namespace osu.Framework.Platform.MacOS
             return handlers;
         }
 
-        public override IEnumerable<KeyBinding> PlatformKeyBindings => new[]
+        public override IEnumerable<KeyBinding> PlatformKeyBindings => KeyBindings;
+
+        /// <summary>
+        /// <see cref="PlatformKeyBindings"/> for macOS and iOS.
+        /// </summary>
+        internal static IEnumerable<KeyBinding> KeyBindings => new[]
         {
             new KeyBinding(new KeyCombination(InputKey.Super, InputKey.X), PlatformAction.Cut),
             new KeyBinding(new KeyCombination(InputKey.Super, InputKey.C), PlatformAction.Copy),

--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -14,6 +14,7 @@ using osu.Framework.Testing;
 
 [assembly: InternalsVisibleTo("osu.Framework.Android")]
 [assembly: InternalsVisibleTo("osu.Framework.Benchmarks")]
+[assembly: InternalsVisibleTo("osu.Framework.iOS")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.Dynamic")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.iOS")]


### PR DESCRIPTION
So that iOS key bindings don't have to be updated separately. Currently, `IOSGameHost` is missing some key bindings from `MacOSGameHost`, while all the existing ones match:

```diff
diff --git a/osu.Framework.iOS/IOSGameHost.cs b/osu.Framework.iOS/IOSGameHost.cs
index ffed393d1..267cff408 100644
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -132,9 +132,24 @@ public override VideoDecoder CreateVideoDecoder(Stream stream)
             new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Shift, InputKey.Right), PlatformAction.SelectForwardLine),
             new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Super, InputKey.Left), PlatformAction.DocumentPrevious),
             new KeyBinding(new KeyCombination(InputKey.Alt, InputKey.Super, InputKey.Right), PlatformAction.DocumentNext),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.W), PlatformAction.DocumentClose),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.N), PlatformAction.DocumentNew),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.T), PlatformAction.TabNew),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Shift, InputKey.T), PlatformAction.TabRestore),
             new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Tab), PlatformAction.DocumentNext),
             new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Tab), PlatformAction.DocumentPrevious),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.S), PlatformAction.Save),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Up), PlatformAction.MoveToListStart),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Down), PlatformAction.MoveToListEnd),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Z), PlatformAction.Undo),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Shift, InputKey.Z), PlatformAction.Redo),
             new KeyBinding(new KeyCombination(InputKey.Delete), PlatformAction.Delete),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Plus), PlatformAction.ZoomIn),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.KeypadPlus), PlatformAction.ZoomIn),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Minus), PlatformAction.ZoomOut),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.KeypadMinus), PlatformAction.ZoomOut),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Number0), PlatformAction.ZoomDefault),
+            new KeyBinding(new KeyCombination(InputKey.Super, InputKey.Keypad0), PlatformAction.ZoomDefault),
         };
     }
 }
 ```