### PR TITLE
Fix iOS bundle identifiers not having correct prefix

### DIFF
--- a/SampleGame.iOS/Info.plist
+++ b/SampleGame.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>SampleGame.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.SampleGame-iOS</string>
+	<string>sh.ppy.sample-game</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>

--- a/osu.Framework.Tests.iOS/Info.plist
+++ b/osu.Framework.Tests.iOS/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleName</key>
 	<string>osu.Framework.Tests.iOS</string>
 	<key>CFBundleIdentifier</key>
-	<string>ppy.osu-Framework-Tests-iOS</string>
+	<string>sh.ppy.osu-framework-visual-tests</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
Having these match `sh.ppy.*` allows for using a single wildcard provisioning certificate.