### PR TITLE
Improve iOS text input deactivation to not require long delay

### DIFF
--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Threading.Tasks;
 using CoreAnimation;
 using Foundation;
 using ObjCRuntime;
@@ -144,8 +143,6 @@ namespace osu.Framework.iOS
             /// </summary>
             public const int CURSOR_POSITION = 3;
 
-            private int responderSemaphore;
-
             /// <summary>
             /// The list of actions which can't be supported with this text field.
             /// </summary>
@@ -196,24 +193,6 @@ namespace osu.Framework.iOS
                 Text = placeholder_text;
                 var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
                 SelectedTextRange = GetTextRange(newPosition, newPosition);
-            }
-
-            public void UpdateFirstResponder(bool become)
-            {
-                if (become)
-                {
-                    responderSemaphore = Math.Max(responderSemaphore + 1, 1);
-                    InvokeOnMainThread(() => BecomeFirstResponder());
-                }
-                else
-                {
-                    responderSemaphore = Math.Max(responderSemaphore - 1, 0);
-                    Task.Delay(200).ContinueWith(task =>
-                    {
-                        if (responderSemaphore <= 0)
-                            InvokeOnMainThread(() => ResignFirstResponder());
-                    });
-                }
             }
         }
     }


### PR DESCRIPTION
Something I found which is outdated by now given the refactors of `TextInputSource`, and which bugged me with its delay on hide (almost feels like the game is slow enough to hide the keyboard). Also resolves the TODO item at the same time.

Before:

https://user-images.githubusercontent.com/22781491/166139753-88cde4d4-786d-4875-9cd2-fd88ff7e7cce.mov

After:

https://user-images.githubusercontent.com/22781491/166139751-2803a330-4200-4660-ac61-44fe7250f9dd.mov

Relying on the `InputThread` scheduler may feel a bit weird, but it is about the only managed way for letting something wait one frame before it is invoked, and able to be cancelled by other operations beforehand.