### PR TITLE
Use ubuntu:16.04 for linux FFmpeg builds

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -107,11 +107,16 @@ jobs:
   build-linux:
     name: Build Linux (x64)
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:16.04
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git curl gcc make nasm
+
       - name: Checkout
         uses: actions/checkout@v2
-
-      - uses: ilammy/setup-nasm@v1
 
       - name: Build
         run: osu.Framework.NativeLibs/scripts/ffmpeg/linux/fetch_and_build.sh

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -111,10 +111,10 @@ namespace osu.Framework.Graphics.Video
             {
                 // FFmpeg.AutoGen doesn't load libraries as RTLD_GLOBAL, so we must load them ourselves to fix inter-library dependencies
                 // otherwise they would fallback to the system-installed libraries that can differ in version installed.
-                Library.Load("libavcodec.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
-                Library.Load("libavfilter.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
-                Library.Load("libavformat.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
                 Library.Load("libavutil.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
+                Library.Load("libavcodec.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
+                Library.Load("libavformat.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
+                Library.Load("libavfilter.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
                 Library.Load("libswscale.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
             }
         }


### PR DESCRIPTION
Aimed at increasing compatibility with older systems: https://github.com/ppy/osu-framework/issues/4349#issuecomment-1114013393

Supports Ubuntu 16.04 and Ubuntu 18.04 (both of which are LTS). Note that o-f won't actually run on 16.04 because our libSDL2 doesn't support it.

Sample workflow run: https://github.com/smoogipoo/osu-framework/actions/runs/2252698181

Tested on:
- Ubuntu 18.04
- My much more up to date Arch Linux with glibc 2.35.