### PR TITLE
Replace `NET6_0` with `NET6_0_OR_GREATER` instead

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -795,7 +795,7 @@ namespace osu.Framework.Graphics.Video
         protected virtual FFmpegFuncs CreateFuncs()
         {
             // other frameworks should handle native libraries themselves
-#if NET6_0
+#if NET6_0_OR_GREATER
             AGffmpeg.GetOrLoadLibrary = name =>
             {
                 int version = AGffmpeg.LibraryVersionMap[name];

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 using System.Net.Sockets;
 #endif
 using System;
@@ -149,7 +149,7 @@ namespace osu.Framework.IO.Network
         private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
 
         private static readonly HttpClient client = new HttpClient(
-#if NET6_0
+#if NET6_0_OR_GREATER
             new SocketsHttpHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
@@ -326,7 +326,7 @@ namespace osu.Framework.IO.Network
                                 formData.Add(byteContent, p.Key, p.Key);
                             }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
                             postContent = await formData.ReadAsStreamAsync(linkedToken.Token).ConfigureAwait(false);
 #else
                             postContent = await formData.ReadAsStreamAsync().ConfigureAwait(false);
@@ -434,7 +434,7 @@ namespace osu.Framework.IO.Network
 
         private async Task beginResponse(CancellationToken cancellationToken)
         {
-#if NET6_0
+#if NET6_0_OR_GREATER
             using (var responseStream = await response.Content
                                                       .ReadAsStreamAsync(cancellationToken)
                                                       .ConfigureAwait(false))
@@ -770,7 +770,7 @@ namespace osu.Framework.IO.Network
 
         #region IPv4 fallback implementation
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Whether IPv6 should be preferred. Value may change based on runtime failures.
         /// </summary>

--- a/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
+++ b/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 using System.Linq;
 using JetBrains.Annotations;
 using OpenTabletDriver;

--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Platform
             new InputHandler[]
             {
                 new KeyboardHandler(),
-#if NET6_0
+#if NET6_0_OR_GREATER
                 // tablet should get priority over mouse to correctly handle cases where tablet drivers report as mice as well.
                 new Input.Handlers.Tablet.OpenTabletDriverHandler(),
 #endif

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Platform.Windows
             // on windows this is guaranteed to exist (and be usable) so don't fallback to the base/default.
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
         public override bool CapsLockEnabled => Console.CapsLock;

--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -20,6 +20,6 @@ using osu.Framework.Testing;
 [assembly: InternalsVisibleTo("osu.Framework.Tests.iOS")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.Android")]
 
-#if NET6_0
+#if NET6_0_OR_GREATER
 [assembly: MetadataUpdateHandler(typeof(HotReloadCallbackReceiver))]
 #endif

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -181,7 +181,7 @@ namespace osu.Framework.Statistics
         {
             try
             {
-#if NET6_0
+#if NET6_0_OR_GREATER
                 using (var target = DataTarget.CreateSnapshotAndAttach(Environment.ProcessId))
 #else
                 using (var target = DataTarget.CreateSnapshotAndAttach(Process.GetCurrentProcess().Id))

--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Statistics
         // ReSharper disable once UnusedParameter.Local
         private static unsafe Type getTypeFromHandle(IntPtr handle)
         {
-#if NET6_0
+#if NET6_0_OR_GREATER
             // This is super unsafe code which is dependent upon internal CLR structures.
             TypedReferenceAccess tr = new TypedReferenceAccess { Type = handle };
             return __reftype(*(TypedReference*)&tr);
@@ -139,7 +139,7 @@ namespace osu.Framework.Statistics
 #endif
         }
 
-#if NET6_0
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Matches the internal layout of <see cref="TypedReference"/>.
         /// See: https://source.dot.net/#System.Private.CoreLib/src/System/TypedReference.cs


### PR DESCRIPTION
This has became an issue on Xamarin projects when using Rider, as it assumes `NET6_0` is defined in `AssemblyInfo.cs` for some reason, while works correctly with `NET6_0_OR_GREATER`.

https://user-images.githubusercontent.com/22781491/166141013-a84e2c83-14b5-48c6-95be-92e44ad6e9c7.mp4

Best to migrate to `NET6_0_OR_GREATER` anyways since it's the correct way of checking.

Note that regardless of this change, ReSharper on `AssemblyInfo.cs` in the desktop project will for some reason think neither `NET6_0` nor `NET6_0_OR_GREATER` is defined (only `NETSTANDARD2_1`). Probably a ReSharper bug.