### PR TITLE
Move caching specifications of markdown interfaces to be attached to the interfaces

### DIFF
--- a/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextComponent.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextComponent.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers.Markdown
 {
+    [Cached(typeof(IMarkdownTextComponent))]
     public interface IMarkdownTextComponent
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextComponent.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextComponent.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         /// Creates a <see cref="SpriteText"/> to display text within this <see cref="IMarkdownTextFlowComponent"/>.
         /// </summary>
         /// <remarks>
-        /// The <see cref="SpriteText"/> defined by the <see cref="MarkdownContainer"/> is used by default,
+        /// The <see cref="SpriteText"/> defined by the <see cref="IMarkdownTextComponent"/> resolved from dependencies is used by default,
         /// but may be overridden via this method to provide additional styling local to this <see cref="IMarkdownTextFlowComponent"/>.
         /// </remarks>
         /// <returns>The <see cref="SpriteText"/>.</returns>

--- a/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextFlowComponent.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextFlowComponent.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         /// Creates a <see cref="MarkdownTextFlowContainer"/> to display text within this <see cref="IMarkdownTextFlowComponent"/>.
         /// </summary>
         /// <remarks>
-        /// The <see cref="MarkdownTextFlowContainer"/> defined by the <see cref="MarkdownContainer"/> is used by default,
+        /// The <see cref="MarkdownTextFlowContainer"/> defined by the <see cref="IMarkdownTextFlowComponent"/> resolved from dependencies is used by default,
         /// but may be overridden via this method to provide additional styling local to this <see cref="IMarkdownTextFlowComponent"/>.
         /// </remarks>
         /// <returns>The <see cref="MarkdownTextFlowContainer"/>.</returns>

--- a/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextFlowComponent.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/IMarkdownTextFlowComponent.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+
 namespace osu.Framework.Graphics.Containers.Markdown
 {
+    [Cached(Type = typeof(IMarkdownTextFlowComponent))]
     public interface IMarkdownTextFlowComponent
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// <summary>
     /// Visualises a markdown text document.
     /// </summary>
-    [Cached(Type = typeof(IMarkdownTextComponent))]
-    [Cached(Type = typeof(IMarkdownTextFlowComponent))]
     public class MarkdownContainer : CompositeDrawable, IMarkdownTextComponent, IMarkdownTextFlowComponent
     {
         private const int root_level = 0;


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/pull/18049, it can be easy to forget adding the caching of these interfaces. I believe all usages of the interfaces intend to also cache (as that is the main purpose of the interface existing).

Rendering still seems to work okay.

Closes https://github.com/ppy/osu/issues/18039.