### PR TITLE
Adjust `GameExitTest` to attempt to understand CI failures

### DIFF
--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -35,6 +35,8 @@ namespace osu.Framework.Tests.Platform
             gameCreated.Wait(timeout);
             Assert.IsTrue(game.BecameAlive.Wait(timeout));
 
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
+
             // block game from exiting.
             game.BlockExit.Value = true;
             // `RequestExit()` should return true.
@@ -43,8 +45,8 @@ namespace osu.Framework.Tests.Platform
             Assert.That(game.LastExitResult, Is.True);
 
             // exit should be blocked.
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
             Assert.That(task.IsCompleted, Is.False);
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
 
             // unblock game from exiting.
             game.BlockExit.Value = false;

--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Tests.Platform
             gameCreated.Wait(timeout);
             Assert.IsTrue(game.BecameAlive.Wait(timeout));
 
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
+            Assert.That(host.ExecutionState, Is.EqualTo(ExecutionState.Running));
 
             // block game from exiting.
             game.BlockExit.Value = true;
@@ -46,7 +46,7 @@ namespace osu.Framework.Tests.Platform
 
             // exit should be blocked.
             Assert.That(task.IsCompleted, Is.False);
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
+            Assert.That(host.ExecutionState, Is.EqualTo(ExecutionState.Running));
 
             // unblock game from exiting.
             game.BlockExit.Value = false;
@@ -57,7 +57,7 @@ namespace osu.Framework.Tests.Platform
 
             // finally, the game should exit.
             task.Wait(timeout);
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Stopped));
+            Assert.That(host.ExecutionState, Is.EqualTo(ExecutionState.Stopped));
         }
 
         private class ManualExitHeadlessGameHost : TestRunHeadlessGameHost


### PR DESCRIPTION
I've gone through the testing procedure and code and cannot understand nor replicate how this can happen. Might be able to understand better with these modifications?

Reference:

https://github.com/ppy/osu-framework/runs/6254153200?check_suite_focus=true
https://github.com/ppy/osu-framework/runs/6240530753?check_suite_focus=true
https://github.com/ppy/osu-framework/runs/6227330132?check_suite_focus=true

Interested if anyone else can see an issue with the testing methodology.