### PR TITLE
Fix intermittent test failures in `GameExitTest` due to race condition

### DIFF
--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 
@@ -62,7 +63,12 @@ namespace osu.Framework.Tests.Platform
 
         private class ManualExitHeadlessGameHost : TestRunHeadlessGameHost
         {
-            public bool RequestExit() => OnExitRequested();
+            public bool RequestExit()
+            {
+                var exitRequestTask = new TaskCompletionSource<bool>();
+                InputThread.Scheduler.Add(() => exitRequestTask.SetResult(OnExitRequested()));
+                return exitRequestTask.Task.GetResultSafely();
+            }
         }
 
         private class TestTestGame : TestGame

--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -65,6 +65,10 @@ namespace osu.Framework.Tests.Platform
         {
             public bool RequestExit()
             {
+                // The exit request has to come from the thread that is also running the game host
+                // to avoid corrupting the host's internal state.
+                // Therefore, use a task completion source as an intermediary that can be used
+                // to request the exit on the correct thread and wait for the result of the exit operation.
                 var exitRequestTask = new TaskCompletionSource<bool>();
                 InputThread.Scheduler.Add(() => exitRequestTask.SetResult(OnExitRequested()));
                 return exitRequestTask.Task.GetResultSafely();


### PR DESCRIPTION
As has been seen in multiple CI builds:
 - https://github.com/ppy/osu-framework/runs/6254153200?check_suite_focus=true
 - https://github.com/ppy/osu-framework/runs/6254441826?check_suite_focus=true

`GameExitTest` has been failing intermittently when ran in single-thread mode. 

The reason is that, as the host is running in the background using a .NET long running task, the test requests exiting by directly calling it from the test's main thread.

When waiting for result from the `Exiting` event, on single-thread mode, `GameHost` would loop on the threads from the thread the exit was requested from:
https://github.com/ppy/osu-framework/blob/3b8c1a36e7ed73803c042f645c9eee34e0700386/osu.Framework/Platform/GameHost.cs#L407-L414

In a normal scenario, this can only be the one and only thread `GameHost` has. But in this case, this is the test's main thread instead. Therefore race conditions occur between the background thread the host is running on and the test's main thread from the `OnExitRequested` call which is looping on `RunMainLoop`.

Simply solved by scheduling the exit request to the input thread of the background host, to avoid such race conditions. It might make sense to add an assertion at the point of calling `RunMainLoop`, but I'm not 100% sure how correct it would be to use `InputThread.IsCurrent` if this method is running the main loop again (not that I tried it).

Have gave this a [few spins on CI](https://github.com/frenzibyte/osu-framework/actions/runs/2257382825) and don't see any sign of failures.