### PR TITLE
Refactor `SearchContainer` filtering operation and fix potential flaws

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
@@ -117,7 +118,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(count);
         }
 
-        [TestCase]
+        [Test]
         public void TestRefilterAfterNewChild()
         {
             setTerm("multi");
@@ -126,6 +127,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(1);
             AddStep("Add new unfiltered item", () => search.Add(new SearchableText { Text = "multi visible" }));
             checkCount(2);
+        }
+
+        [Test]
+        public void TestFilterRespectsHiddenChild()
+        {
+            AddStep("Add new hidden filtered item", () => search.Add(new HeaderContainer("Subsection 3")
+            {
+                AutoSizeAxes = Axes.Both,
+                Child = new Container
+                {
+                    Alpha = 0f,
+                    AutoSizeAxes = Axes.Both,
+                    Child = new SearchableText { Text = "Hidden text" },
+                },
+            }));
+            setTerm("Hidden text");
+
+            checkCount(0);
+            AddAssert("No subsection displayed", () => search.ChildrenOfType<HeaderContainer>().All(h => !h.IsPresent));
         }
 
         private void checkCount(int count)

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -132,10 +132,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestFilterRespectsHiddenChild()
         {
-            AddStep("Add new hidden filtered item", () => search.Add(new HeaderContainer("Subsection 3")
+            HeaderContainer header = null;
+            Container hiddenTextContainer = null;
+
+            AddStep("Add new hidden filtered item", () => search.Add(header = new HeaderContainer("Subsection 3")
             {
                 AutoSizeAxes = Axes.Both,
-                Child = new Container
+                Child = hiddenTextContainer = new Container
                 {
                     Alpha = 0f,
                     AutoSizeAxes = Axes.Both,
@@ -146,6 +149,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             checkCount(0);
             AddAssert("No subsection displayed", () => search.ChildrenOfType<HeaderContainer>().All(h => !h.IsPresent));
+
+            AddStep("Show hidden text", () => hiddenTextContainer.Alpha = 1f);
+
+            checkCount(1);
+            AddAssert("Subsection displayed", () => search.ChildrenOfType<HeaderContainer>().Single(h => h.IsPresent) == header);
         }
 
         private void checkCount(int count)

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -133,16 +133,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
         public void TestFilterRespectsHiddenChild()
         {
             HeaderContainer header = null;
-            Container hiddenTextContainer = null;
+            HideableSearchText hiddenText = null;
 
             AddStep("Add new hidden filtered item", () => search.Add(header = new HeaderContainer("Subsection 3")
             {
                 AutoSizeAxes = Axes.Both,
-                Child = hiddenTextContainer = new Container
+                Child = hiddenText = new HideableSearchText
                 {
-                    Alpha = 0f,
-                    AutoSizeAxes = Axes.Both,
-                    Child = new SearchableText { Text = "Hidden text" },
+                    State = { Value = Visibility.Hidden },
+                    Text = { Text = "Hidden Text" },
                 },
             }));
             setTerm("Hidden text");
@@ -150,7 +149,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(0);
             AddAssert("No subsection displayed", () => search.ChildrenOfType<HeaderContainer>().All(h => !h.IsPresent));
 
-            AddStep("Show hidden text", () => hiddenTextContainer.Alpha = 1f);
+            AddStep("Show hidden text", () => hiddenText.State.Value = Visibility.Visible);
 
             checkCount(1);
             AddAssert("Subsection displayed", () => search.ChildrenOfType<HeaderContainer>().Single(h => h.IsPresent) == header);
@@ -269,6 +268,20 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 set { }
             }
+        }
+
+        private class HideableSearchText : VisibilityContainer
+        {
+            public SearchableText Text { get; private set; }
+
+            public HideableSearchText()
+            {
+                AutoSizeAxes = Axes.Both;
+                Child = Text = new SearchableText();
+            }
+
+            protected override void PopIn() => Alpha = 1;
+            protected override void PopOut() => Alpha = 0;
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Search term: " + term, () => textBox.Text = term);
         }
 
-        private class HeaderContainer : Container, IHasFilterableChildren
+        private class HeaderContainer : Container, IFilterable
         {
             public IEnumerable<string> FilterTerms => header.FilterTerms;
 
@@ -163,8 +163,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 set { }
             }
-
-            public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
 
             protected override Container<Drawable> Content => flowContainer;
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -216,7 +216,7 @@ namespace osu.Framework.Graphics.Containers
 
             if (!childLayout.IsValid)
             {
-                layout.Invalidate();
+                InvalidateLayout();
                 childLayout.Validate();
             }
 

--- a/osu.Framework/Graphics/Containers/IFilterable.cs
+++ b/osu.Framework/Graphics/Containers/IFilterable.cs
@@ -3,15 +3,18 @@
 
 namespace osu.Framework.Graphics.Containers
 {
+    /// <summary>
+    /// Represents a component which can be filtered out on non-matching search terms.
+    /// </summary>
+    /// <remarks>
+    /// Hiding <see cref="IFilterable"/>s for purposes other than filtering require being wrapped in a
+    /// <see cref="VisibilityContainer"/> with its visibility state set to <see cref="Visibility.Hidden"/>.
+    /// </remarks>
     public interface IFilterable : IHasFilterTerms
     {
         /// <summary>
         /// Whether the current object is matching (ie. visible) given the current filter criteria of a parent.
         /// </summary>
-        /// <remarks>
-        /// It is recommended to not let this property update the <see cref="Drawable.Alpha"/> state of this filterable, as to not conflict with hiding it via other means.
-        /// But instead, override <see cref="Drawable.IsPresent"/> to respect the filter state, and invalidate <see cref="Invalidation.Presence"/> accordingly.
-        /// </remarks>
         bool MatchingFilter { set; }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/IFilterable.cs
+++ b/osu.Framework/Graphics/Containers/IFilterable.cs
@@ -6,10 +6,6 @@ namespace osu.Framework.Graphics.Containers
     /// <summary>
     /// Represents a component which can be filtered out on non-matching search terms.
     /// </summary>
-    /// <remarks>
-    /// Hiding <see cref="IFilterable"/>s for purposes other than filtering require being wrapped in a
-    /// <see cref="VisibilityContainer"/> with its visibility state set to <see cref="Visibility.Hidden"/>.
-    /// </remarks>
     public interface IFilterable : IHasFilterTerms
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/IFilterable.cs
+++ b/osu.Framework/Graphics/Containers/IFilterable.cs
@@ -8,6 +8,10 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Whether the current object is matching (ie. visible) given the current filter criteria of a parent.
         /// </summary>
+        /// <remarks>
+        /// It is recommended to not let this property update the <see cref="Drawable.Alpha"/> state of this filterable, as to not conflict with hiding it via other means.
+        /// But instead, override <see cref="Drawable.IsPresent"/> to respect the filter state, and invalidate <see cref="Invalidation.Presence"/> accordingly.
+        /// </remarks>
         bool MatchingFilter { set; }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/IHasFilterableChildren.cs
+++ b/osu.Framework/Graphics/Containers/IHasFilterableChildren.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 
 namespace osu.Framework.Graphics.Containers
 {
+    [Obsolete("IFilterable children are now looked up automatically. Replace this with IFilterable.")] // can be removed 20221103
     public interface IHasFilterableChildren : IFilterable
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -21,9 +21,9 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     /// <remarks>
     /// <list type="bullet">
-    /// <item>Children which are searchable should be marked with the <see cref="IFilterable"/> interface. They do not need to be direct children.</item>
-    /// <item>Containers above <see cref="IFilterable"/>s which should be hidden only when all children are filtered away should also be marked with the <see cref="IFilterable"/> interface.</item>
-    /// <item>Containers which have the potential to hide children via external means should be <see cref="VisibilityContainer"/>s, in order to correctly exclude hidden child <see cref="IFilterable"/>s from search.</item>
+    /// <item>Children which are searchable should be marked with the <see cref="IFilterable"/> interface. They do not need to be direct children to work (filtering will traverse the full drawable subtree).</item>
+    /// <item>Marking a container (ie. a "group" or "section" that contains nested <see cref="IFilterable"/>s) as <see cref="IFilterable"/> will automatically keep it non-filtered as long as at least one nested item is not filtered away.</item>
+    /// <item>Any <see cref="IFilterable"/>s which are contained in a <see cref="VisibilityContainer"/> that is hidden will be excluded from filtering. This can be used to exclude certain items from consideration (ie. items which are hidden from display), allowing group/sections to be correctly filtered away.</item>
     /// </list>
     /// </remarks>
     public class SearchContainer<T> : FillFlowContainer<T> where T : Drawable

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Graphics.Containers
         {
             bool matching = match(drawable, searchTerms, nonContiguousMatching, out var nonMatchingTerms);
 
-            if (drawable.IsPresent && drawable is IContainerEnumerable<Drawable> container)
+            if (drawable is IContainerEnumerable<Drawable> container && (container as VisibilityContainer)?.State.Value != Visibility.Hidden)
             {
                 foreach (var child in container.Children)
                     matching |= matchSubTree(child, nonMatchingTerms, searchActive, nonContiguousMatching);
@@ -133,9 +133,6 @@ namespace osu.Framework.Graphics.Containers
                 // reset filter to ensure presence is not influenced by previous filter state when checking.
                 filterable.MatchingFilter = true;
             }
-
-            if (!drawable.IsPresent)
-                return false;
 
             return nonMatchingTerms.Count == 0;
         }

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using osu.Framework.Caching;
+using osu.Framework.Layout;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -69,12 +69,11 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private readonly Cached filterValid = new Cached();
+        private readonly LayoutValue filterValid = new LayoutValue(Invalidation.DrawSize | Invalidation.Presence, InvalidationSource.Child);
 
-        protected override void InvalidateLayout()
+        public SearchContainer()
         {
-            base.InvalidateLayout();
-            filterValid.Invalidate();
+            AddLayout(filterValid);
         }
 
         protected override void Update()

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Caching;
 
 namespace osu.Framework.Graphics.Containers
 {
+    /// <inheritdoc />
     public class SearchContainer : SearchContainer<Drawable>
     {
     }
@@ -18,7 +19,13 @@ namespace osu.Framework.Graphics.Containers
     /// Re-filtering will only be performed when the <see cref="SearchTerm"/> changes, or
     /// new items are added as direct children of this container.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <remarks>
+    /// <list type="bullet">
+    /// <item>Children which are searchable should be marked with the <see cref="IFilterable"/> interface. They do not need to be direct children.</item>
+    /// <item>Containers above <see cref="IFilterable"/>s which should be hidden only when all children are filtered away should also be marked with the <see cref="IFilterable"/> interface.</item>
+    /// <item>Containers which have the potential to hide children via external means should be <see cref="VisibilityContainer"/>s, in order to correctly exclude hidden child <see cref="IFilterable"/>s from search.</item>
+    /// </list>
+    /// </remarks>
     public class SearchContainer<T> : FillFlowContainer<T> where T : Drawable
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Graphics.Containers
         {
             bool matching = match(drawable, searchTerms, nonContiguousMatching, out var nonMatchingTerms);
 
-            if (drawable is IContainerEnumerable<Drawable> container)
+            if (drawable.IsPresent && drawable is IContainerEnumerable<Drawable> container)
             {
                 foreach (var child in container.Children)
                     matching |= matchSubTree(child, nonMatchingTerms, searchActive, nonContiguousMatching);
@@ -127,7 +127,15 @@ namespace osu.Framework.Graphics.Containers
             nonMatchingTerms = searchTerms;
 
             if (drawable is IFilterable filterable)
+            {
                 nonMatchingTerms = nonMatchingTerms.Where(term => !checkTerms(filterable.FilterTerms, term, nonContiguousMatching)).ToArray();
+
+                // reset filter to ensure presence is not influenced by previous filter state when checking.
+                filterable.MatchingFilter = true;
+            }
+
+            if (!drawable.IsPresent)
+                return false;
 
             return nonMatchingTerms.Count == 0;
         }

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -63,13 +63,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        protected internal override void AddInternal(Drawable drawable)
+        private readonly Cached filterValid = new Cached();
+
+        protected override void InvalidateLayout()
         {
-            base.AddInternal(drawable);
+            base.InvalidateLayout();
             filterValid.Invalidate();
         }
-
-        private readonly Cached filterValid = new Cached();
 
         protected override void Update()
         {

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -16,8 +16,7 @@ namespace osu.Framework.Graphics.Containers
 
     /// <summary>
     /// A container which filters children based on a search term.
-    /// Re-filtering will only be performed when the <see cref="SearchTerm"/> changes, or
-    /// new items are added as direct children of this container.
+    /// Re-filtering will only be performed when the <see cref="SearchTerm"/> changes, or the layout of the container is invalidated.
     /// </summary>
     /// <remarks>
     /// <list type="bullet">

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using osu.Framework.Layout;
+using osu.Framework.Caching;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -69,11 +69,12 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private readonly LayoutValue filterValid = new LayoutValue(Invalidation.DrawSize | Invalidation.Presence, InvalidationSource.Child);
+        private readonly Cached filterValid = new Cached();
 
-        public SearchContainer()
+        protected override void InvalidateLayout()
         {
-            AddLayout(filterValid);
+            base.InvalidateLayout();
+            filterValid.Invalidate();
         }
 
         protected override void Update()

--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -10,7 +10,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 
 namespace osu.Framework.Testing.Drawables
 {
-    internal class TestGroupButton : VisibilityContainer, IHasFilterableChildren
+    internal class TestGroupButton : VisibilityContainer, IFilterable
     {
         public IEnumerable<string> FilterTerms => headerButton?.FilterTerms ?? Enumerable.Empty<string>();
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -231,8 +231,10 @@ namespace osu.Framework.Testing
 
             searchTextBox.OnCommit += delegate
             {
-                var firstTest = leftFlowContainer.Where(b => b.IsPresent).SelectMany(b => b.FilterableChildren).OfType<TestSubButton>()
+                var firstTest = leftFlowContainer.ChildrenOfType<TestSubButton>()
+                                                 .Where(b => b.IsPresent)
                                                  .FirstOrDefault(b => b.MatchingFilter)?.TestType;
+
                 if (firstTest != null)
                     LoadTest(firstTest);
             };


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18003

I've initially intended to look at just adding guards against non-present drawables, but the current logic for filtering out drawables was quite convoluted that I looked at first refactoring it with flexibility in mind, then adding the necessary guards to solve the issues pointed out in ppy/osu#18003.