### PR TITLE
Add Ctrl+Y as an alternative "redo" platform binding

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePlatformActionContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePlatformActionContainer.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Input
+{
+    public class TestScenePlatformActionContainer : FrameworkTestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Add(new TestPlatformActionHandler
+            {
+                RelativeSizeAxes = Axes.Both
+            });
+        }
+
+        private class TestPlatformActionHandler : CompositeDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChild = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding(20),
+                    Spacing = new Vector2(10),
+                    ChildrenEnumerable = Enum.GetValues(typeof(PlatformAction))
+                                             .Cast<PlatformAction>()
+                                             .Select(action => new PlatformBindingBox(action))
+                };
+            }
+        }
+
+        private class PlatformBindingBox : CompositeDrawable, IKeyBindingHandler<PlatformAction>
+        {
+            private readonly PlatformAction platformAction;
+
+            private Box background;
+
+            public PlatformBindingBox(PlatformAction platformAction)
+            {
+                this.platformAction = platformAction;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AutoSizeAxes = Axes.Both;
+                InternalChildren = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = FrameworkColour.GreenDarker
+                    },
+                    new SpriteText
+                    {
+                        Text = platformAction.ToString(),
+                        Margin = new MarginPadding(10)
+                    }
+                };
+            }
+
+            public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+            {
+                if (e.Action != platformAction)
+                    return false;
+
+                background.FlashColour(FrameworkColour.YellowGreen, 250, Easing.OutQuint);
+                return true;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)
+            {
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1176,6 +1176,7 @@ namespace osu.Framework.Platform
             new KeyBinding(InputKey.Home, PlatformAction.MoveToListStart),
             new KeyBinding(InputKey.End, PlatformAction.MoveToListEnd),
             new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Z), PlatformAction.Undo),
+            new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Y), PlatformAction.Redo),
             new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Z), PlatformAction.Redo),
             new KeyBinding(InputKey.Delete, PlatformAction.Delete),
             new KeyBinding(new KeyCombination(InputKey.Control, InputKey.Plus), PlatformAction.ZoomIn),


### PR DESCRIPTION
Closes #5157

I believe this shouldn't apply to macOS, because that has [an entirely disparate set of platform keybindings](https://github.com/ppy/osu-framework/blob/80cffac85458e307d02bfa804d7da4d47405095f/osu.Framework/Platform/MacOS/MacOSGameHost.cs#L67-L118), but would appreciate testing to make sure.

Diff includes simple manual test scene for testing convenience (press any platform binding and the boxes will flash):

![image](https://user-images.githubusercontent.com/20418176/166881891-9d0290e8-76c9-4e84-8806-36628eaa8604.png)
