### PR TITLE
Clarify usage of `[Cached]` when placed on classes/interfaces in xmldoc

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -110,6 +110,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
+            Assert.IsNull(dependencies.Get<object>());
             Assert.IsNotNull(dependencies.Get<ProvidedType1>());
         }
 
@@ -274,6 +275,29 @@ namespace osu.Framework.Tests.Dependencies
 
             Assert.IsNotNull(dependencies.Get<IProviderInterface3>());
             Assert.IsNotNull(dependencies.Get<IProviderInterface2>());
+        }
+
+        [Test]
+        public void TestInheritancePreservesCachingViaBaseType()
+        {
+            var provider = new Provider26();
+
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.AreEqual(provider, dependencies.Get<Provider1>());
+            Assert.IsNull(dependencies.Get<Provider26>());
+        }
+
+        [Test]
+        public void TestImplementationOfDerivedInterfacePreservesCaching()
+        {
+            var provider = new Provider27();
+
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.AreEqual(provider, dependencies.Get<IProviderInterface2>());
+            Assert.IsNull(dependencies.Get<IProviderInterface4>());
+            Assert.IsNull(dependencies.Get<Provider27>());
         }
 
         private interface IProvidedInterface1
@@ -459,6 +483,14 @@ namespace osu.Framework.Tests.Dependencies
         {
         }
 
+        private class Provider26 : Provider1
+        {
+        }
+
+        private class Provider27 : IProviderInterface4
+        {
+        }
+
         [Cached]
         private interface IProviderInterface3 : IProviderInterface2
         {
@@ -466,6 +498,10 @@ namespace osu.Framework.Tests.Dependencies
 
         [Cached]
         private interface IProviderInterface2
+        {
+        }
+
+        private interface IProviderInterface4 : IProviderInterface2
         {
         }
     }

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -13,9 +13,39 @@ using osu.Framework.Graphics;
 namespace osu.Framework.Allocation
 {
     /// <summary>
-    /// An attribute that may be attached to a class definitions, fields, or properties of a <see cref="Drawable"/> to indicate that the value should be cached as a dependency.
+    /// An attribute that may be attached to a class, interface, field, or property definitions of a <see cref="Drawable"/>
+    /// to indicate that the value should be cached as a dependency.
     /// Cached values may be resolved through <see cref="BackgroundDependencyLoaderAttribute"/> or <see cref="ResolvedAttribute"/>.
     /// </summary>
+    /// <remarks>
+    /// The behaviour of this attribute differs in meaning depending on the type of member it is placed on.
+    /// <list type="bullet">
+    /// <item>
+    /// <para>
+    /// In the case of fields and properties, the dependency will be cached for the children of the drawable that contains the field or property.
+    /// </para>
+    /// <para>
+    /// Unless specified differently by <see cref="Type"/>, the dependency will be cached using the field/property value's concrete (most-derived) type.
+    /// See the examples section of the <see cref="Type"/> property documentation for further information.
+    /// </para>
+    /// </item>
+    /// <item>
+    /// <para>
+    /// Instances of classes annotated with <see cref="CachedAttribute"/> will cache themselves for their own children.
+    /// Unless specified differently by <see cref="Type"/>, the dependency will be cached using the type <em>at the point where the <see cref="CachedAttribute"/> was declared</em>.
+    /// </para>
+    /// <para>
+    /// Note that while the <see cref="CachedAttribute"/> itself is not inherited, derived class instances will still cache themselves using the base class.
+    /// See the examples section of the <see cref="Type"/> property documentation for further information.
+    /// </para>
+    /// </item>
+    /// <item>
+    /// If a class implements an interface annotated with <see cref="CachedAttribute"/>, then instances of that class will cache themselves for their own children using the interface type.
+    /// As with classes, the <see cref="CachedAttribute"/> is not inherited between interfaces either,
+    /// but an instance of a class will cache itself to children using all cacheable interface types that it implements.
+    /// </item>
+    /// </list>
+    /// </remarks>
     [MeansImplicitUse]
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
     public class CachedAttribute : Attribute
@@ -23,14 +53,40 @@ namespace osu.Framework.Allocation
         internal const BindingFlags ACTIVATOR_FLAGS = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
         /// <summary>
-        /// The type to cache the value as. If null, the value will be cached as the value's most derived type.
+        /// The type to cache the value as. If null, the type depends on the type of member that the attribute is placed on:
+        /// <list type="bullet">
+        /// <item>In the case of fields and properties, the attribute will use the concrete/most-derived type of the field/property's value.</item>
+        /// <item>In the case of classes and interfaces, the attribute will use the class/interface type on which the <see cref="CachedAttribute"/> was <em>directly placed</em>.</item>
+        /// </list>
         /// </summary>
         /// <example>
-        /// For example, if this value is null on the following field definition:
+        /// <para>
+        /// In the case of fields and properties, if this value is <see langword="null"/> on the following field definition:
+        /// <code>
+        /// [Cached]
+        /// private BaseType obj = new DerivedType();
+        /// </code>
+        /// then the cached type will be <c>DerivedType</c>.
+        /// </para>
+        /// <para>
+        /// In the case of classes, given the following structure:
+        /// <code>
+        /// [Cached]
+        /// public class A { }
         ///
-        /// private BaseType obj = new DerivedType()
-        ///
-        /// Then the cached type will be "DerivedType".
+        /// public class B : A { }
+        /// </code>
+        /// the following things will happen:
+        /// <list type="bullet">
+        /// <item>Instances of <c>A</c> will cache themselves to children using type <c>A</c>.</item>
+        /// <item>Instances of <c>B</c> will cache themselves to children using type <c>A</c>.</item>
+        /// <item>
+        /// Instances of <c>B</c> will <em>not</em> cache themselves to children using type <c>B</c>.
+        /// To achieve that effect, the <see cref="CachedAttribute"/> has to be repeated on class <c>B</c>.
+        /// </item>
+        /// </list>
+        /// <see cref="CachedAttribute"/> placed in interface inheritance hierarchies follows analogous rules to the ones described above for classes.
+        /// </para>
         /// </example>
         public Type Type;
 


### PR DESCRIPTION
This has been a point of confusion twice (?) this week now, with the latest instance being [here](https://github.com/ppy/osu/pull/18101#discussion_r865650509). So this expands xmldoc to the point where this *hopefully* isn't an issue anymore.

Test coverage for the inheritance edge cases described in the new xmldoc attached within.