### PR TITLE
Fix default maximum size being invalid on Windows

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = sdlWindow.MinSize - new Size(1, 1)));
             AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = new Size(-1, -1)));
-            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(int.MaxValue, int.MaxValue));
+            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(int.MaxValue / 2, int.MaxValue / 2));
         }
 
         private void setWindowSize(Size size) => config.SetValue(FrameworkSetting.WindowedSize, size);

--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = sdlWindow.MinSize - new Size(1, 1)));
             AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = new Size(-1, -1)));
-            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(int.MaxValue / 2, int.MaxValue / 2));
+            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(int.MaxValue, int.MaxValue));
         }
 
         private void setWindowSize(Size size) => config.SetValue(FrameworkSetting.WindowedSize, size);

--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = sdlWindow.MinSize - new Size(1, 1)));
             AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = new Size(-1, -1)));
-            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(int.MaxValue, int.MaxValue));
+            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(65536, 65536));
         }
 
         private void setWindowSize(Size size) => config.SetValue(FrameworkSetting.WindowedSize, size);

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Configuration
         {
             SetDefault(FrameworkSetting.ShowLogOverlay, false);
 
-            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
+            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480), new Size(65536, 65536));
             SetDefault(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
             SetDefault(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             SetDefault(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Configuration
         {
             SetDefault(FrameworkSetting.ShowLogOverlay, false);
 
-            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
+            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480), new Size(int.MaxValue / 2, int.MaxValue / 2));
             SetDefault(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
             SetDefault(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             SetDefault(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Configuration
         {
             SetDefault(FrameworkSetting.ShowLogOverlay, false);
 
-            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480), new Size(int.MaxValue / 2, int.MaxValue / 2));
+            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
             SetDefault(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
             SetDefault(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             SetDefault(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -189,18 +189,12 @@ namespace osu.Framework.Platform
         /// <summary>
         /// The minimum size of the window.
         /// </summary>
-        /// <remarks>
-        /// To remove this constraint, set an empty <see cref="Size"/>: <c>Size.Empty</c>.
-        /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown when setting a negative size, or a size greater than <see cref="MaxSize"/>.</exception>
         Size MinSize { get; set; }
 
         /// <summary>
         /// The maximum size of the window.
         /// </summary>
-        /// <remarks>
-        /// To remove this constraint, set a <see cref="Size"/> of maximum integer value: <c>new Size(int.MaxValue, int.MaxValue)</c>.
-        /// </remarks>
         /// <exception cref="InvalidOperationException">Thrown when setting a negative or zero size, or a size less than <see cref="MinSize"/>.</exception>
         Size MaxSize { get; set; }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -477,7 +477,10 @@ namespace osu.Framework.Platform
                 if (max.Width < sizeWindowed.MinValue.Width || max.Height < sizeWindowed.MinValue.Height)
                     throw new InvalidOperationException($"Expected a size greater than min window size ({sizeWindowed.MinValue}), got {max}");
 
-                ScheduleCommand(() => SDL.SDL_SetWindowMaximumSize(SDLWindowHandle, max.Width, max.Height));
+                // Windows treats very large values as zero.
+                const int max_size = int.MaxValue / 2;
+
+                ScheduleCommand(() => SDL.SDL_SetWindowMaximumSize(SDLWindowHandle, Math.Min(max.Width, max_size), Math.Min(max.Height, max_size)));
             };
 
             sizeWindowed.TriggerChange();

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -477,10 +477,7 @@ namespace osu.Framework.Platform
                 if (max.Width < sizeWindowed.MinValue.Width || max.Height < sizeWindowed.MinValue.Height)
                     throw new InvalidOperationException($"Expected a size greater than min window size ({sizeWindowed.MinValue}), got {max}");
 
-                // Windows treats very large values as zero.
-                const int max_size = int.MaxValue / 2;
-
-                ScheduleCommand(() => SDL.SDL_SetWindowMaximumSize(SDLWindowHandle, Math.Min(max.Width, max_size), Math.Min(max.Height, max_size)));
+                ScheduleCommand(() => SDL.SDL_SetWindowMaximumSize(SDLWindowHandle, max.Width, max.Height));
             };
 
             sizeWindowed.TriggerChange();


### PR DESCRIPTION
Not sure why, but Windows treats `int.MaxValue` as zero here.
This would result in the window being forced to resize to minimum size (640x480) when trying to move or resize it.