### PR TITLE
Fix `PlatfomAction` test not highlighting actions that map to the same key combination

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePlatformActionContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePlatformActionContainer.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Tests.Visual.Input
                     return false;
 
                 background.FlashColour(FrameworkColour.YellowGreen, 250, Easing.OutQuint);
-                return true;
+                return e.Action == PlatformAction.Exit;
             }
 
             public void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)


### PR DESCRIPTION
Eg. `Delete` and `DeleteForwardChar` are both mapped to the `Del` key, and only one would highlight previously.

`Exit` is still handled to allow testing without closing the window.