### PR TITLE
Enable `SDL_HINT_MOUSE_AUTO_CAPTURE` when not using relative mode

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -93,11 +93,11 @@ namespace osu.Framework.Input.Handlers.Mouse
             cursorState = desktopWindow.CursorStateBindable.GetBoundCopy();
             cursorState.BindValueChanged(_ => updateRelativeMode());
 
-            UseRelativeMode.BindValueChanged(_ =>
+            UseRelativeMode.BindValueChanged(e =>
             {
-                if (window != null)
-                    updateRelativeMode();
-            });
+                window.MouseAutoCapture = !e.NewValue;
+                updateRelativeMode();
+            }, true);
 
             Enabled.BindValueChanged(enabled =>
             {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -138,6 +138,11 @@ namespace osu.Framework.Platform
             }
         }
 
+        internal bool MouseAutoCapture
+        {
+            set => ScheduleCommand(() => SDL.SDL_SetHint("SDL_MOUSE_AUTO_CAPTURE", value ? "1" : "0"));
+        }
+
         private Size size = new Size(default_width, default_height);
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -138,6 +138,17 @@ namespace osu.Framework.Platform
             }
         }
 
+        /// <summary>
+        /// Controls whether the mouse is automatically captured when buttons are pressed and the cursor is outside the window.
+        /// Only works with <see cref="RelativeMouseMode"/> disabled.
+        /// </summary>
+        /// <remarks>
+        /// If the cursor leaves the window while it's captured, <see cref="SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE"/> is not sent until the button(s) are released.
+        /// And if the cursor leaves and enters the window while captured, <see cref="SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER"/> is not sent either.
+        /// We disable relative mode when the cursor exits window bounds (not on the event), but we only enable it again on <see cref="SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER"/>.
+        /// The above culminate in <see cref="RelativeMouseMode"/> staying off when the cursor leaves and enters the window bounds when any buttons are pressed.
+        /// This is an invalid state, as the cursor is inside the window, and <see cref="RelativeMouseMode"/> is off.
+        /// </remarks>
         internal bool MouseAutoCapture
         {
             set => ScheduleCommand(() => SDL.SDL_SetHint("SDL_MOUSE_AUTO_CAPTURE", value ? "1" : "0"));

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -151,7 +151,7 @@ namespace osu.Framework.Platform
         /// </remarks>
         internal bool MouseAutoCapture
         {
-            set => ScheduleCommand(() => SDL.SDL_SetHint("SDL_MOUSE_AUTO_CAPTURE", value ? "1" : "0"));
+            set => ScheduleCommand(() => SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_AUTO_CAPTURE, value ? "1" : "0"));
         }
 
         private Size size = new Size(default_width, default_height);


### PR DESCRIPTION
Depends on:
- [x] SDL bump (for https://github.com/libsdl-org/SDL/commit/5ff42438e36e98c9d72ac70f5f5ce4599b96d3d2)

Partially resolves #4055. Now the issue only happens when relative mode is enabled.

To get mouse capture for relative mode, we'd probably want to do it locally in `MouseHandler` by keeping track of pressed buttons.