### PR TITLE
[#5164] Add driver workarounds support

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -45,6 +45,8 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.IgnoredInputHandlers, string.Empty);
             SetDefault(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
 #pragma warning restore 618
+
+            SetDefault(FrameworkSetting.PlatformWorkaroundMode, PlatformWorkaroundMode.Auto);
         }
 
         public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
@@ -104,5 +106,7 @@ namespace osu.Framework.Configuration
 
         [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         MapAbsoluteInputToWindow,
+
+        PlatformWorkaroundMode
     }
 }

--- a/osu.Framework/Platform/GraphicsBackendMetadata.cs
+++ b/osu.Framework/Platform/GraphicsBackendMetadata.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Contains information to identify a specific graphics backend vendor and renderer
+    /// </summary>
+    public readonly struct GraphicsBackendMetadata
+    {
+        /// <summary>
+        /// Product or software used to render the display
+        /// </summary>
+        public readonly string RendererName;
+
+        /// <summary>
+        /// Vendor of the renderer product or software
+        /// </summary>
+        public readonly string Vendor;
+
+        /// <summary>
+        /// OpenGL version string, including vendor-specific version info
+        /// </summary>
+        public readonly string VersionString;
+
+
+        public GraphicsBackendMetadata(string rendererName, string vendor, string versionString)
+        {
+            this.RendererName = rendererName;
+            this.Vendor = vendor;
+            this.VersionString = versionString;
+        }
+    }
+}

--- a/osu.Framework/Platform/IGraphicsBackend.cs
+++ b/osu.Framework/Platform/IGraphicsBackend.cs
@@ -14,6 +14,11 @@ namespace osu.Framework.Platform
         bool VerticalSync { get; set; }
 
         /// <summary>
+        /// Returns information about the renderer, if available.
+        /// </summary>
+        GraphicsBackendMetadata? RendererMetadata { get; }
+
+        /// <summary>
         /// Initialises the graphics backend, given the current window backend.
         /// It is assumed that the window backend has been initialised.
         /// </summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -86,6 +86,11 @@ namespace osu.Framework.Platform
         bool VerticalSync { get; set; }
 
         /// <summary>
+        /// Returns information about the window's renderer, if available.
+        /// </summary>
+        GraphicsBackendMetadata? RendererMetadata { get; }
+
+        /// <summary>
         /// Returns the default <see cref="WindowMode"/> for the implementation.
         /// </summary>
         WindowMode DefaultWindowMode { get; }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -9,7 +9,6 @@ using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Mouse;
-using osuTK.Graphics.OpenGL;
 
 namespace osu.Framework.Platform.MacOS
 {
@@ -41,15 +40,6 @@ namespace osu.Framework.Platform.MacOS
         public override Clipboard GetClipboard() => new MacOSClipboard();
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new MacOSReadableKeyCombinationProvider();
-
-        protected override void Swap()
-        {
-            base.Swap();
-
-            // It has been reported that this helps performance on macOS (https://github.com/ppy/osu/issues/7447)
-            if (!Window.VerticalSync)
-                GL.Finish();
-        }
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers()
         {

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -30,6 +30,8 @@ namespace osu.Framework.Platform
         [NotNull]
         public abstract IGraphicsContext Context { get; }
 
+        public GraphicsBackendMetadata? RendererMetadata { get; protected set; }
+
         /// <summary>
         /// Return value decides whether we should intercept and cancel this exit (if possible).
         /// </summary>
@@ -130,6 +132,13 @@ namespace osu.Framework.Platform
             UpdateFrame += (o, e) => UpdateFrameScheduler.Update();
 
             MakeCurrent();
+
+            this.RendererMetadata =
+                new GraphicsBackendMetadata(
+                     rendererName: GL.GetString(StringName.Renderer),
+                           vendor: GL.GetString(StringName.Vendor),
+                    versionString: GL.GetString(StringName.Version)
+                );
 
             string version = GL.GetString(StringName.Version);
             string versionNumberSubstring = getVersionNumberSubstring(version);

--- a/osu.Framework/Platform/PassthroughGraphicsBackend.cs
+++ b/osu.Framework/Platform/PassthroughGraphicsBackend.cs
@@ -27,6 +27,9 @@ namespace osu.Framework.Platform
 
         internal bool IsEmbedded { get; private set; }
 
+        public GraphicsBackendMetadata? RendererMetadata { get; protected set; }
+
+
         public abstract bool VerticalSync { get; set; }
 
         protected abstract IntPtr CreateContext();
@@ -42,6 +45,14 @@ namespace osu.Framework.Platform
             MakeCurrent(Context);
 
             loadTKBindings();
+
+
+            this.RendererMetadata =
+                new GraphicsBackendMetadata(
+                     rendererName: GL.GetString(StringName.Renderer),
+                           vendor: GL.GetString(StringName.Vendor),
+                    versionString: GL.GetString(StringName.Version)
+                );
 
             string version = GL.GetString(StringName.Version);
             string versionNumberSubstring = getVersionNumberSubstring(version);

--- a/osu.Framework/Platform/PlatformWorkaroundDetector.cs
+++ b/osu.Framework/Platform/PlatformWorkaroundDetector.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Framework.Platform
+{
+    public static class PlatformWorkaroundDetector
+    {
+        public static PlatformWorkaroundMode DetectWorkaround(GraphicsBackendMetadata backendMetadata)
+            => DetectWorkaround(backendMetadata, RuntimeInfo.OS);
+
+        public static PlatformWorkaroundMode DetectWorkaround(GraphicsBackendMetadata backendMetadata, RuntimeInfo.Platform platform)
+        {
+            //HACK: Force macOS to use glFinish for the time being, until it is further investigated (https://github.com/ppy/osu/issues/7447)
+            if (platform == RuntimeInfo.Platform.macOS)
+                return PlatformWorkaroundMode.ForceFinish;
+
+
+            if (backendMetadata.Vendor == "Intel")
+            {
+                if (backendMetadata.RendererName.Contains("UHD Graphics 620") ||
+                    backendMetadata.RendererName.Contains("UHD Graphics 630"))
+                {
+                    // UHD 620/630 needs custom workarounds for Windows
+                    //  due to the bug causing excess overload until
+                    //  dwm or the driver ends up crashing.
+                    if (platform == RuntimeInfo.Platform.Windows)
+                        return PlatformWorkaroundMode.WorkaroundIntelUHD630_Windows;
+
+                    // On macOS there is simply just a scheduling bug,
+                    //  which can be kept in sync by just a mere glFinish.
+                    if (platform == RuntimeInfo.Platform.macOS)
+                        return PlatformWorkaroundMode.ForceFinish;
+                }
+            }
+
+            return PlatformWorkaroundMode.Default;
+        }
+    }
+
+    public enum PlatformWorkaroundMode
+    {
+        /// <summary>
+        /// Default is to glFinish on VSync, but don't otherwise.
+        /// </summary>
+        [Description("No workaround")]
+        Default,
+
+        /// <summary>
+        /// Acts just like <see cref="Default"/>, but should indicate
+        ///  forced workaround detection.
+        /// </summary>
+        [Description("Automatic workaround detection")]
+        Auto,
+
+        /// <summary>
+        /// Always call glFinish after SwapBuffers.
+        /// </summary>
+        [Description("Force drawing")]
+        ForceFinish,
+
+        /// <summary>
+        /// Never call glFinish after SwapBuffers.
+        /// </summary>
+        [Description("No synchronization")]
+        ForceNoFinish,
+
+        /// <summary>
+        /// Use InvalidateRect + glFinish twice to
+        ///  synchronize the UHD 620/630 driver
+        /// </summary>
+        [Description("Intel UHD 620/630 stutter workaround (Windows)")]
+        WorkaroundIntelUHD630_Windows
+    }
+}

--- a/osu.Framework/Platform/PlatformWorkaroundDetector.cs
+++ b/osu.Framework/Platform/PlatformWorkaroundDetector.cs
@@ -32,6 +32,10 @@ namespace osu.Framework.Platform
                     //  which can be kept in sync by just a mere glFinish.
                     if (platform == RuntimeInfo.Platform.macOS)
                         return PlatformWorkaroundMode.ForceFinish;
+                    
+                    // UHD 630 is not broken on Linux due to the Mesa driver being mature
+                    //  due to being open-source, and supported by the community.
+                    // Perhaps a check should be here for Linux to see if it's not running on Mesa drivers?
                 }
             }
 
@@ -57,13 +61,13 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Always call glFinish after SwapBuffers.
         /// </summary>
-        [Description("Force drawing")]
+        [Description("Force drawing synchronization")]
         ForceFinish,
 
         /// <summary>
         /// Never call glFinish after SwapBuffers.
         /// </summary>
-        [Description("No synchronization")]
+        [Description("Disable drawing synchronization")]
         ForceNoFinish,
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Platform
 
         private readonly IGraphicsBackend graphicsBackend;
 
+        public GraphicsBackendMetadata? RendererMetadata => graphicsBackend.RendererMetadata;
+
         private bool focused;
 
         /// <summary>

--- a/osu.Framework/Platform/Windows/Native/Window.cs
+++ b/osu.Framework/Platform/Windows/Native/Window.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Windows.Native
+{
+    internal static class Window
+    {
+        [DllImport("user32.dll")]
+        internal static extern uint InvalidateRect(IntPtr hwnd, IntPtr lpRect, bool bErase);
+    }
+}


### PR DESCRIPTION
I tried my best to put things at logical places, but to me it still feels like a bit of a hack, especially where the driver metadata is propagated through out to be reachable by GameHost.

I'm not good at naming things, so things like GraphicsBackendMetadata and PlatformWorkaroundMode might have to be renamed as well.


Tested on Windows, macOS, and Linux (Solus), and it seems to work as intended. Tested with a different GPU as well on Windows, and it's also fine there.