### PR TITLE
Support matching by both base and localised text in `SearchContainer`

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -1,9 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Localisation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -17,6 +24,37 @@ namespace osu.Framework.Tests.Visual.UserInterface
     {
         private SearchContainer search;
         private BasicTextBox textBox;
+
+        [Resolved]
+        private FrameworkConfigManager configManager { get; set; }
+
+        [Cached]
+        private LocalisationManager manager;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            manager.AddLanguage("en", new TestLocalisationStore("en", new Dictionary<string, string>
+            {
+                [goodbye] = "Goodbye",
+            }));
+            manager.AddLanguage("es", new TestLocalisationStore("es", new Dictionary<string, string>
+            {
+                [goodbye] = "Adiós",
+            }));
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var dependencies = new DependencyContainer(parent);
+
+            configManager = parent.Get<FrameworkConfigManager>();
+            dependencies.Cache(manager = new LocalisationManager(configManager));
+
+            return dependencies;
+        }
+
+        private const string goodbye = "goodbye";
 
         [SetUp]
         public void SetUp() => Schedule(() =>
@@ -68,6 +106,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                                     {
                                         new SearchableText { Text = "?!()[]{}" },
                                         new SearchableText { Text = "@€$" },
+                                        new SearchableText { Text = new LocalisableString(new TranslatableString(goodbye, "Goodbye")) },
                                     },
                                 },
                             },
@@ -85,7 +124,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [TestCase("èê", 1)]
         [TestCase("321", 0)]
         [TestCase("mul pi", 1)]
-        [TestCase("header", 8)]
+        [TestCase("header", 9)]
         public void TestFiltering(string term, int count)
         {
             setTerm(term);
@@ -95,7 +134,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [TestCase("tst", 2)]
         [TestCase("ssn 1", 6)]
         [TestCase("sns 1", 0)]
-        [TestCase("hdr", 8)]
+        [TestCase("hdr", 9)]
         [TestCase("tt", 2)]
         [TestCase("ttt", 0)]
         public void TestEagerFilteringEnabled(string term, int count)
@@ -127,6 +166,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(1);
             AddStep("Add new unfiltered item", () => search.Add(new SearchableText { Text = "multi visible" }));
             checkCount(2);
+        }
+
+        [TestCase]
+        public void TestFilterLocalisedStrings()
+        {
+            AddStep("Change locale to en", () => configManager.SetValue(FrameworkSetting.Locale, "en"));
+            setTerm("Goodbye");
+            checkCount(1);
+            AddStep("Change locale to es", () => configManager.SetValue(FrameworkSetting.Locale, "es"));
+            setTerm("Adiós");
+            checkCount(1);
+            setTerm("Goodbye");
+            checkCount(1);
         }
 
         private void checkCount(int count)
@@ -243,6 +295,32 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public bool FilteringActive
             {
                 set { }
+            }
+        }
+
+        private class TestLocalisationStore : ILocalisationStore
+        {
+            public CultureInfo EffectiveCulture { get; }
+
+            private readonly IDictionary<string, string> translations;
+
+            public TestLocalisationStore(string locale, IDictionary<string, string> translations)
+            {
+                EffectiveCulture = new CultureInfo(locale);
+
+                this.translations = translations;
+            }
+
+            public string Get(string key) => translations.TryGetValue(key, out string value) ? value : null;
+
+            public Task<string> GetAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(Get(key));
+
+            public Stream GetStream(string name) => throw new NotSupportedException();
+
+            public IEnumerable<string> GetAvailableResources() => Array.Empty<string>();
+
+            public void Dispose()
+            {
             }
         }
     }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Localisation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -146,7 +147,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class HeaderContainer : Container, IHasFilterableChildren
         {
-            public IEnumerable<string> FilterTerms => header.FilterTerms;
+            public IEnumerable<LocalisableString> FilterTerms => header.FilterTerms;
 
             public bool MatchingFilter
             {
@@ -188,7 +189,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class FilterableFlowContainer : FillFlowContainer, IFilterable
         {
-            public IEnumerable<string> FilterTerms => Children.OfType<IHasFilterTerms>().SelectMany(d => d.FilterTerms);
+            public IEnumerable<LocalisableString> FilterTerms => Children.OfType<IHasFilterTerms>().SelectMany(d => d.FilterTerms);
 
             public bool MatchingFilter
             {

--- a/osu.Framework/Graphics/Containers/IHasFilterTerms.cs
+++ b/osu.Framework/Graphics/Containers/IHasFilterTerms.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Localisation;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -14,6 +15,6 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// An enumerator of relevant terms which match the current object in a filtered scenario.
         /// </summary>
-        IEnumerable<string> FilterTerms { get; }
+        IEnumerable<LocalisableString> FilterTerms { get; }
     }
 }

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -97,8 +97,8 @@ namespace osu.Framework.Graphics.Containers
 
         private bool match(IFilterable filterable, IEnumerable<string> searchTerms, bool searchActive, bool nonContiguousMatching)
         {
-            IEnumerable<string> filterTerms = filterable.FilterTerms.SelectMany(localizedStr =>
-                new[] { localizedStr.ToString(), localisation?.GetLocalisedString(localizedStr) });
+            IEnumerable<string> filterTerms = filterable.FilterTerms.SelectMany(localisedStr =>
+                new[] { localisedStr.ToString(), localisation.GetLocalisedString(localisedStr) });
 
             //Words matched by parent is not needed to match children
             string[] childTerms = searchTerms.Where(term =>

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         [Resolved]
-        private static LocalisationManager localisation { get; set; }
+        private LocalisationManager localisation { get; set; }
 
         protected internal override void AddInternal(Drawable drawable)
         {
@@ -95,10 +95,10 @@ namespace osu.Framework.Graphics.Containers
             Children.OfType<IFilterable>().ForEach(child => match(child, terms, terms.Length > 0, allowNonContiguousMatching));
         }
 
-        private static bool match(IFilterable filterable, IEnumerable<string> searchTerms, bool searchActive, bool nonContiguousMatching)
+        private bool match(IFilterable filterable, IEnumerable<string> searchTerms, bool searchActive, bool nonContiguousMatching)
         {
             IEnumerable<string> filterTerms = filterable.FilterTerms.SelectMany(localizedStr =>
-                new string[] {localizedStr.ToString(), localisation.GetLocalisedString(localizedStr)}).ToArray();
+                new[] { localizedStr.ToString(), localisation?.GetLocalisedString(localizedStr) });
 
             //Words matched by parent is not needed to match children
             string[] childTerms = searchTerms.Where(term =>

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Caching;
+using osu.Framework.Localisation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 
 namespace osu.Framework.Graphics.Containers
@@ -64,6 +66,9 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        [Resolved]
+        private static LocalisationManager localisation { get; set; }
+
         protected internal override void AddInternal(Drawable drawable)
         {
             base.AddInternal(drawable);
@@ -92,9 +97,12 @@ namespace osu.Framework.Graphics.Containers
 
         private static bool match(IFilterable filterable, IEnumerable<string> searchTerms, bool searchActive, bool nonContiguousMatching)
         {
+            IEnumerable<string> filterTerms = filterable.FilterTerms.SelectMany(localizedStr =>
+                new string[] {localizedStr.ToString(), localisation.GetLocalisedString(localizedStr)}).ToArray();
+
             //Words matched by parent is not needed to match children
             string[] childTerms = searchTerms.Where(term =>
-                !filterable.FilterTerms.Any(filterTerm =>
+                !filterTerms.Any(filterTerm =>
                     checkTerm(filterTerm, term, nonContiguousMatching))).ToArray();
 
             bool matching = childTerms.Length == 0;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -636,6 +636,6 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        public IEnumerable<LocalisableString> FilterTerms => new LocalisableString(displayedText).Yield();
+        public IEnumerable<LocalisableString> FilterTerms => Text.Yield();
     }
 }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -636,6 +636,6 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        public IEnumerable<string> FilterTerms => displayedText.Yield();
+        public IEnumerable<LocalisableString> FilterTerms => new LocalisableString(displayedText).Yield();
     }
 }

--- a/osu.Framework/Testing/Drawables/TestButtonBase.cs
+++ b/osu.Framework/Testing/Drawables/TestButtonBase.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using osuTK.Graphics;
 using Container = osu.Framework.Graphics.Containers.Container;
 
@@ -15,7 +16,7 @@ namespace osu.Framework.Testing.Drawables
 {
     internal abstract class TestButtonBase : ClickableContainer, IFilterable
     {
-        public IEnumerable<string> FilterTerms => text.Children.OfType<IHasFilterTerms>().SelectMany(c => c.FilterTerms);
+        public IEnumerable<LocalisableString> FilterTerms => text.Children.OfType<IHasFilterTerms>().SelectMany(c => c.FilterTerms);
 
         private bool matchingFilter = true;
 

--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -12,7 +13,7 @@ namespace osu.Framework.Testing.Drawables
 {
     internal class TestGroupButton : VisibilityContainer, IHasFilterableChildren
     {
-        public IEnumerable<string> FilterTerms => headerButton?.FilterTerms ?? Enumerable.Empty<string>();
+        public IEnumerable<LocalisableString> FilterTerms => headerButton?.FilterTerms ?? Enumerable.Empty<LocalisableString>();
 
         public bool MatchingFilter
         {


### PR DESCRIPTION
- Needed for https://github.com/ppy/osu/pull/18270, from feedback.
- [x] Fix the tests

Note this change will require each class which inherits `IHasFilterTerms` (about 20 in osu!lazer) to have their definition of `FilterItems` be a `IEnumerable<LocalizedString>`

Now SearchContainer should match based on base text **and** localised text.