### PR TITLE
Fix horizontal scrolling being inverted on non-Apple platforms

### DIFF
--- a/osu.Framework.Android/Input/AndroidMouseHandler.cs
+++ b/osu.Framework.Android/Input/AndroidMouseHandler.cs
@@ -209,7 +209,9 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private Vector2 getEventScroll(MotionEvent e) => new Vector2(e.GetAxisValue(Axis.Hscroll), e.GetAxisValue(Axis.Vscroll));
+        private Vector2 getEventScroll(MotionEvent e) =>
+            // Android reports horizontal scroll opposite of what framework expects.
+            new Vector2(-e.GetAxisValue(Axis.Hscroll), e.GetAxisValue(Axis.Vscroll));
 
         private void handleMouseMoveEvent(MotionEvent evt)
         {

--- a/osu.Framework/Input/Events/ScrollEvent.cs
+++ b/osu.Framework/Input/Events/ScrollEvent.cs
@@ -15,6 +15,9 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// The relative change in scroll associated with this event.
         /// </summary>
+        /// <remarks>
+        /// Delta is positive when mouse wheel scrolled to the up or left, in non-"natural" scroll mode (ie. the classic way).
+        /// </remarks>
         public readonly Vector2 ScrollDelta;
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -959,7 +959,7 @@ namespace osu.Framework.Platform
         }
 
         private void handleMouseWheelEvent(SDL.SDL_MouseWheelEvent evtWheel) =>
-            // SDL reports horizontal scroll opposite of what framework expects.
+            // SDL reports horizontal scroll opposite of what framework expects (in non-"natural" mode, scrolling to the right gives negative deltas while we expect positive).
             TriggerMouseWheel(new Vector2(-evtWheel.x, evtWheel.y), false);
 
         private void handleMouseButtonEvent(SDL.SDL_MouseButtonEvent evtButton)
@@ -1540,6 +1540,9 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked when the user scrolls the mouse wheel over the window.
         /// </summary>
+        /// <remarks>
+        /// Delta is positive when mouse wheel scrolled to the up or left, in non-"natural" scroll mode (ie. the classic way).
+        /// </remarks>
         public event Action<Vector2, bool> MouseWheel;
 
         protected void TriggerMouseWheel(Vector2 delta, bool precise) => MouseWheel?.Invoke(delta, precise);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -959,7 +959,8 @@ namespace osu.Framework.Platform
         }
 
         private void handleMouseWheelEvent(SDL.SDL_MouseWheelEvent evtWheel) =>
-            TriggerMouseWheel(new Vector2(evtWheel.x, evtWheel.y), false);
+            // SDL reports horizontal scroll opposite of what framework expects.
+            TriggerMouseWheel(new Vector2(-evtWheel.x, evtWheel.y), false);
 
         private void handleMouseButtonEvent(SDL.SDL_MouseButtonEvent evtButton)
         {

--- a/osu.Framework/Testing/Input/TestCursorContainer.cs
+++ b/osu.Framework/Testing/Input/TestCursorContainer.cs
@@ -146,8 +146,7 @@ namespace osu.Framework.Testing.Input
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            var delta = new Vector2(e.ScrollDelta.X, -e.ScrollDelta.Y);
-            circle.MoveTo(circle.Position + delta * 10).MoveTo(Vector2.Zero, 500, Easing.OutQuint);
+            circle.MoveTo(circle.Position - e.ScrollDelta * 10).MoveTo(Vector2.Zero, 500, Easing.OutQuint);
             return base.OnScroll(e);
         }
 


### PR DESCRIPTION
- Closes: #5167

Tested on:
- [x] Windows
- [x] Android
- [x] Linux (wayland/X11?)
- iPadOS/iOS (just to confirm it's the same as macOS)

Breaking changes
---

`ScrollEvent.ScrollDelta.X` (horizontal scrolling) is now consistent across platforms. Previously, Windows, Linux and Android were inverted. As a reminder:

> Delta is positive when mouse wheel scrolled to the up or left, in non-"natural" scroll mode (ie. the classic way).