### PR TITLE
Fix Android project failing to build on CI

### DIFF
--- a/osu.Framework.Android/global.json
+++ b/osu.Framework.Android/global.json
@@ -3,9 +3,5 @@
     "allowPrerelease": false,
     "rollForward": "minor",
     "version": "3.1.100"
-  },
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "3.0.22",
-    "Microsoft.Build.Traversal": "3.0.2"
   }
 }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup Label="Project">
     <TargetFramework>monoandroid10.0</TargetFramework>
     <OutputType>Library</OutputType>

--- a/osu.Framework.iOS/global.json
+++ b/osu.Framework.iOS/global.json
@@ -3,9 +3,5 @@
     "allowPrerelease": false,
     "rollForward": "minor",
     "version": "3.1.100"
-  },
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "3.0.22",
-    "Microsoft.Build.Traversal": "3.0.2"
   }
 }

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.22">
   <PropertyGroup Label="Project">
     <TargetFramework>xamarinios10</TargetFramework>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
An interim fix until https://github.com/ppy/osu-framework/pull/5080 is merged, intended to fix the recent Android build failures such as https://github.com/ppy/osu-framework/runs/6464582633?check_suite_focus=true

I've changed the iOS project to match.

Haven't tested @peppy 's local build/deploy pipelines.