### PR TITLE
Fix back-to-front X delta parsing in `KeyCombination.FromScrollDelta`

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -281,9 +281,9 @@ namespace osu.Framework.Tests.Visual.Input
                 scrollMouseWheel(0, -1);
                 check(TestAction.WheelDown, allPressAndReleased);
 
-                scrollMouseWheel(-1, 0);
-                check(TestAction.WheelLeft, allPressAndReleased);
                 scrollMouseWheel(1, 0);
+                check(TestAction.WheelLeft, allPressAndReleased);
+                scrollMouseWheel(-1, 0);
                 check(TestAction.WheelRight, allPressAndReleased);
 
                 toggleKey(Key.ControlLeft);

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -623,10 +623,10 @@ namespace osu.Framework.Input.Bindings
                 yield return InputKey.MouseWheelDown;
 
             if (scrollDelta.X > 0)
-                yield return InputKey.MouseWheelRight;
+                yield return InputKey.MouseWheelLeft;
 
             if (scrollDelta.X < 0)
-                yield return InputKey.MouseWheelLeft;
+                yield return InputKey.MouseWheelRight;
         }
 
         public static InputKey FromMidiKey(MidiKey key) => (InputKey)((int)InputKey.MidiA0 + key - MidiKey.A0);


### PR DESCRIPTION
This used to be "correct" on non-Apple platforms prior to #5179, but it has since been decided that left = +X and right = -X.