### PR TITLE
Add support for horizontal scrolling via Shift key 

### DIFF
--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -32,6 +32,9 @@ namespace osu.Framework.Input.StateChanges
 
             if (Delta != Vector2.Zero)
             {
+                if (!IsPrecise && Delta.X == 0 && state.Keyboard.ShiftPressed)
+                    Delta = new Vector2(Delta.Y, 0);
+
                 var lastScroll = mouse.Scroll;
                 mouse.Scroll += Delta;
                 mouse.LastSource = this;


### PR DESCRIPTION
- Closes #5183

Brings other platforms in line with macOS, where horizontal scrolling is applied at OS level.
Doesn't apply to [precision touchpads](https://discord.com/channels/188630481301012481/589331078574112768/976734156576915516), as 2D scrolling is always supported there natively.

Shift+scroll is used in the osu! editor for faster scrolling, but this change doesn't affect that as the components are [added together](https://github.com/ppy/osu/blob/ab5c736da1a8d3ab99f85a4621bc97a254834dc2/osu.Game/Screens/Edit/Editor.cs#L530).