### PR TITLE
Move `CreateFileSafely` implement to non-virtual to avoid potential misuse

### DIFF
--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -42,13 +42,6 @@ namespace osu.Framework.Platform
 
         public override void Move(string from, string to) => File.Move(GetFullPath(from), GetFullPath(to));
 
-        public override Stream CreateFileSafely(string path)
-        {
-            string temporaryPath = Path.Combine(Path.GetDirectoryName(path), $"_{Path.GetFileName(path)}_{Guid.NewGuid()}");
-
-            return new SafeWriteStream(temporaryPath, path, this);
-        }
-
         public override IEnumerable<string> GetDirectories(string path) => getRelativePaths(Directory.GetDirectories(GetFullPath(path)));
 
         public override IEnumerable<string> GetFiles(string path, string pattern = "*") => getRelativePaths(Directory.GetFiles(GetFullPath(path), pattern));
@@ -113,39 +106,6 @@ namespace osu.Framework.Platform
             string fullPath = GetFullPath(path, true);
 
             return (Storage)Activator.CreateInstance(GetType(), fullPath, host);
-        }
-
-        /// <summary>
-        /// Uses a temporary file to ensure a file is written to completion before existing at its specified location.
-        /// </summary>
-        private class SafeWriteStream : FlushingStream
-        {
-            private readonly string temporaryPath;
-            private readonly string finalPath;
-            private readonly Storage storage;
-
-            public SafeWriteStream(string temporaryPath, string finalPath, Storage storage)
-                : base(storage.GetFullPath(temporaryPath, true), FileMode.Create, FileAccess.Write)
-            {
-                this.temporaryPath = temporaryPath;
-                this.finalPath = finalPath;
-                this.storage = storage;
-            }
-
-            private bool isDisposed;
-
-            protected override void Dispose(bool disposing)
-            {
-                base.Dispose(disposing);
-
-                if (!isDisposed)
-                {
-                    storage.Delete(finalPath);
-                    storage.Move(temporaryPath, finalPath);
-
-                    isDisposed = true;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Abstract methods in storage are only required where they are used to change actual file or path access. Because `CreateFileSafely` is performing all actions via calls to the `Storage` API, it does not need an `abstract` implementation.

---

For the full ratification of this change:

While integrating these changes in osu! side, I found unexpected test failures due to the fact that the `NativeStorage` implementation of this function is passing itself as a storage.

In osu!, we have the concept of a `WrappedStorage`, where all calls for path lookups are supposed to be re-routed. Due to the structure of how this was implemented, it was actually impossible to get correct behaviour, unless changing `WrappedStorage` to implement `NativeStorage` (and use the existing implementation of `CreateFileSafely`, which would then pass through the `WrappedStorage` correctly).

I've tested this change to work as expected osu! side.