### PR TITLE
Disable more unnecessary FFmpeg external libs

### DIFF
--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -16,13 +16,16 @@ FFMPEG_FLAGS=(
 )
 
 function build_ffmpeg() {
-    echo "-> Downloading source..."
-
-    curl https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.gz | tar zxf -
-    cd ffmpeg-$FFMPEG_VERSION
+    if [ ! -d "ffmpeg-$FFMPEG_VERSION" ]; then
+        echo "-> Downloading source..."
+        curl https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.gz | tar zxf -
+    else
+        echo "-> ffmpeg-$FFMPEG_VERSION already exists, not re-downloading."
+    fi
 
     echo "-> Configuring..."
 
+    cd ffmpeg-$FFMPEG_VERSION
     ./configure "${FFMPEG_FLAGS[@]}"
 
     CORES=0

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -12,6 +12,18 @@ FFMPEG_FLAGS=(
     --disable-avdevice
     --disable-swresample
     --disable-librtmp
+    --disable-alsa
+    --disable-iconv
+    --disable-libxcb
+    --disable-libxcb-shm
+    --disable-libxcb-xfixes
+    --disable-libxcb-shape
+    --disable-sdl2
+    --disable-zlib
+    --disable-bzlib
+    --disable-lzma
+    --disable-xlib
+    --disable-schannel
     --enable-shared
 )
 


### PR DESCRIPTION
Hoping to pre-empt any future issues like https://github.com/ppy/osu/issues/18379 from arising.

As per https://github.com/ppy/osu-framework/runs/6209510854?check_suite_focus=true (see the `Build` step):
- The Windows build does not link to lzma/bz2/sdl/etc because those libs are unavailable in the first place.
  - This PR disables lzma/bz2/sdl for Linux/macOS to match, as well as ALSA/X11 linking.
- The Windows build links to `schannel`, which is for TLS/SSL support, but we don't support networking in FFmpeg.
  - This PR disables `schannel`.

I've tested the Linux build on the o!f visual test + https://osu.ppy.sh/beatmapsets/6687#osu/29955, haven't tested the Windows/macOS build.