### PR TITLE
Log SDL errors (and forward SDL logs to framework logs)

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1019,5 +1019,68 @@ namespace osu.Framework.Platform.SDL2
             SDL.SDL_PixelFormatEnumToMasks(mode.format, out int bpp, out _, out _, out _, out _);
             return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, displayIndex);
         }
+
+        public static string ReadableName(this SDL.SDL_LogCategory category)
+        {
+            switch (category)
+            {
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_APPLICATION:
+                    return "application";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_ERROR:
+                    return "error";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_ASSERT:
+                    return "assert";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_SYSTEM:
+                    return "system";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_AUDIO:
+                    return "audio";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_VIDEO:
+                    return "video";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_RENDER:
+                    return "render";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_INPUT:
+                    return "input";
+
+                case SDL.SDL_LogCategory.SDL_LOG_CATEGORY_TEST:
+                    return "test";
+
+                default:
+                    return "unknown";
+            }
+        }
+
+        public static string ReadableName(this SDL.SDL_LogPriority priority)
+        {
+            switch (priority)
+            {
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_VERBOSE:
+                    return "verbose";
+
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG:
+                    return "debug";
+
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_INFO:
+                    return "info";
+
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_WARN:
+                    return "warn";
+
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_ERROR:
+                    return "error";
+
+                case SDL.SDL_LogPriority.SDL_LOG_PRIORITY_CRITICAL:
+                    return "critical";
+
+                default:
+                    return "unknown";
+            }
+        }
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -440,7 +440,10 @@ namespace osu.Framework.Platform
 
         public SDL2DesktopWindow()
         {
-            SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_GAMECONTROLLER);
+            if (SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_GAMECONTROLLER) < 0)
+            {
+                throw new InvalidOperationException($"Failed to initialise SDL: {SDL.SDL_GetError()}");
+            }
 
             SDL.SDL_LogSetPriority((int)SDL.SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL.SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL.SDL_LogSetOutputFunction(logOutputDelegate = (_, categoryInt, priority, messagePtr) =>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -435,8 +435,13 @@ namespace osu.Framework.Platform
         private readonly BindableDouble windowPositionY = new BindableDouble();
         private readonly Bindable<DisplayIndex> windowDisplayIndexBindable = new Bindable<DisplayIndex>();
 
+        // references must be kept to avoid GC, see https://stackoverflow.com/a/6193914
+
         [UsedImplicitly]
         private SDL.SDL_LogOutputFunction logOutputDelegate;
+
+        [UsedImplicitly]
+        private SDL.SDL_EventFilter eventFilterDelegate;
 
         public SDL2DesktopWindow()
         {
@@ -532,10 +537,6 @@ namespace osu.Framework.Platform
 
             WindowMode.TriggerChange();
         }
-
-        // reference must be kept to avoid GC, see https://stackoverflow.com/a/6193914
-        [UsedImplicitly]
-        private SDL.SDL_EventFilter eventFilterDelegate;
 
         /// <summary>
         /// Starts the window's run loop.


### PR DESCRIPTION
Helps for debugging issues such as:
- https://github.com/ppy/osu/issues/18273#issuecomment-1126901064
- https://github.com/ppy/osu-framework/issues/5190

I originally intended to check return values for all native SDL calls, but this resulted in really ugly (and unnecessary) code.
This PR is an intermediate step to better handling of SDL errors, allowing us to see where potential problems may arise, and where special handling may be needed.

Setting the log handler before `SDL_Init` is probably wrong, so that has separate handling.
Since setting `SDL_LogSetOutputFunction` will take full control over SDL logging, all log messages need to be handled. Can't only handle the errors, as that will drop logs from eg. `SDL_HINT_EVENT_LOGGING`, which are useful for debugging.

The log priority for errors needs to be changed so [`SDL_SetError` logs them](https://github.com/libsdl-org/SDL/blob/120c76c84bbce4c1bfed4e9eb74e10678bd83120/src/SDL_error.c#L44-L47).

No SDL errors so far on windows (played a bit of osu!).

Diff for testing - generating SDL errors and log entries:

```diff
diff --git a/osu.Framework/Platform/SDL2DesktopWindow.cs b/osu.Framework/Platform/SDL2DesktopWindow.cs
index 98fbbf702..a6b3c3241 100644
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -506,6 +506,7 @@ public virtual void Create()
             SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_IME_SHOW_UI, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, "0");
+            SDL.SDL_SetHint(SDL.SDL_HINT_EVENT_LOGGING, "2");
 
             // we want text input to only be active when SDL2DesktopWindowTextInput is active.
             // SDL activates it by default on some platforms: https://github.com/libsdl-org/SDL/blob/release-2.0.16/src/video/SDL_video.c#L573-L582
@@ -1050,6 +1051,8 @@ private void handleKeyboardEvent(SDL.SDL_KeyboardEvent evtKey)
             switch (evtKey.type)
             {
                 case SDL.SDL_EventType.SDL_KEYDOWN:
+                    if (evtKey.keysym.sym == SDL.SDL_Keycode.SDLK_1)
+                        SDL.SDL_GetCurrentDisplayMode(-1, out _);
                     KeyDown?.Invoke(key);
                     break;
 
 ```