### PR TITLE
Detect exclusive fullscreen on Windows

### DIFF
--- a/osu.Framework/Platform/Windows/FullscreenCapability.cs
+++ b/osu.Framework/Platform/Windows/FullscreenCapability.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Windows
+{
+    public enum FullscreenCapability
+    {
+        /// <summary>
+        /// Fullscreen capability is unknown.
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// Unable to enter exclusive fullscreen.
+        /// </summary>
+        Incapable,
+
+        /// <summary>
+        /// Able to enter exclusive fullscreen.
+        /// </summary>
+        Capable
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -344,6 +344,6 @@ namespace osu.Framework.Platform.Windows
             QUNS_PRESENTATION_MODE = 4,
             QUNS_ACCEPTS_NOTIFICATIONS = 5,
             QUNS_QUIET_TIME = 6
-        };
+        }
     }
 }

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Platform.Windows
                         ? Windows.FullscreenCapability.Capable
                         : Windows.FullscreenCapability.Incapable;
 
-                    Logger.Log($"Exclusive fullscreen capability: {fullscreenCapability.Value}");
+                    Logger.Log($"Exclusive fullscreen capability: {fullscreenCapability.Value} ({notificationState})");
                 }
                 catch (Exception ex)
                 {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Platform.Windows
             fullscreenCapabilityDetectionCancellationSource?.Dispose();
             fullscreenCapabilityDetectionCancellationSource = null;
 
-            if (state != WindowState.Fullscreen || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
+            if (state != WindowState.Fullscreen || !IsActive.Value || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
                 return;
 
             var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -4,8 +4,12 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using osu.Framework.Bindables;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Logging;
 using osu.Framework.Platform.SDL2;
 using osu.Framework.Platform.Windows.Native;
 using osuTK;
@@ -23,6 +27,9 @@ namespace osu.Framework.Platform.Windows
         private const int large_icon_size = 256;
         private const int small_icon_size = 16;
 
+        public IBindable<FullscreenCapability> FullscreenCapability => fullscreenCapability;
+        private readonly Bindable<FullscreenCapability> fullscreenCapability = new Bindable<FullscreenCapability>();
+
         private Icon smallIcon;
         private Icon largeIcon;
 
@@ -39,6 +46,46 @@ namespace osu.Framework.Platform.Windows
             {
                 // API doesn't exist on Windows 7 so it needs to be allowed to fail silently.
             }
+
+            IsActive.BindValueChanged(_ => detectFullscreenCapability(WindowState));
+            WindowStateChanged += detectFullscreenCapability;
+            detectFullscreenCapability(WindowState);
+        }
+
+        private CancellationTokenSource fullscreenCapabilityDetectionCancellationSource;
+
+        private void detectFullscreenCapability(WindowState state)
+        {
+            fullscreenCapabilityDetectionCancellationSource?.Cancel();
+            fullscreenCapabilityDetectionCancellationSource?.Dispose();
+            fullscreenCapabilityDetectionCancellationSource = null;
+
+            if (state != WindowState.Fullscreen || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
+                return;
+
+            var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();
+
+            Task.Delay(5000, cancellationSource.Token).ContinueWith(_ => ScheduleEvent(() =>
+            {
+                if (cancellationSource.IsCancellationRequested || WindowState != WindowState.Fullscreen || !IsActive.Value)
+                    return;
+
+                try
+                {
+                    SHQueryUserNotificationState(out var notificationState);
+
+                    fullscreenCapability.Value = notificationState == QueryUserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN
+                        ? Windows.FullscreenCapability.Capable
+                        : Windows.FullscreenCapability.Incapable;
+
+                    Logger.Log($"Exclusive fullscreen capability: {fullscreenCapability.Value}");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to detect fullscreen capabilities.");
+                    fullscreenCapability.Value = Windows.FullscreenCapability.Capable;
+                }
+            }), cancellationSource.Token);
         }
 
         public override void Create()
@@ -269,5 +316,18 @@ namespace osu.Framework.Platform.Windows
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("shell32.dll")]
+        private static extern int SHQueryUserNotificationState(out QueryUserNotificationState state);
+
+        private enum QueryUserNotificationState
+        {
+            QUNS_NOT_PRESENT = 1,
+            QUNS_BUSY = 2,
+            QUNS_RUNNING_D3D_FULL_SCREEN = 3,
+            QUNS_PRESENTATION_MODE = 4,
+            QUNS_ACCEPTS_NOTIFICATIONS = 5,
+            QUNS_QUIET_TIME = 6
+        };
     }
 }


### PR DESCRIPTION
Using the API [`SHQueryUserNotificationState`](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shqueryusernotificationstate).

The state enters `QUNS_RUNNING_D3D_FULL_SCREEN` even for OpenGL applications. Otherwise, like on my Optimus-enabled laptop, the state enters `QUNS_BUSY`.

You can't seem to be able to query this value right away - it takes some time after the mode change. I've set a 5s timer before the value is queried.

Testing:
- [x] Desktop + Radeon Linux
  - Message does not show.
- [x] Desktop + Windows (Radeon 5700XT)
  - Detects capable.
- [x] Desktop + Windows (GTX 1650)
  - Detects capable.
- [x] Optimus laptop + Windows (Intel HD Graphics 530 + GTX 960M) dGPU:
  - Detects incapable.
- [x] Laptop + Windows (Ryzen 7 5700U w/ Radeon Graphics, iGPU only)
  - Detects capable.

Not sure about these ones:

- Optimus laptop + Windows (Intel HD Graphics 530 + GTX 960M) iGPU:
  - Detects incapable.
- Laptop + Windows (Intel HD Graphics 4400, iGPU only)
  - Detects incapable.
- Desktop + Windows (Intel HD Graphics 2500, iGPU only)
  - Detects incapable.
- Parallels / VMWare
  - Detects incapable.