### PR TITLE
Reduce verbosity of midi initialisation failure

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Input.Handlers.Midi
 
                 // stop attempting to refresh devices until next startup.
                 inGoodState = false;
-                scheduledRefreshDevices.Cancel();
+                scheduledRefreshDevices?.Cancel();
                 return false;
             }
         }

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -20,8 +20,9 @@ namespace osu.Framework.Input.Handlers.Midi
     public class MidiHandler : InputHandler
     {
         public override string Description => "MIDI";
-        public override bool IsActive => active;
-        private bool active = true;
+        public override bool IsActive => inGoodState;
+
+        private bool inGoodState = true;
 
         private ScheduledDelegate scheduledRefreshDevices;
 
@@ -42,6 +43,7 @@ namespace osu.Framework.Input.Handlers.Midi
             {
                 if (e.NewValue)
                 {
+                    inGoodState = true;
                     host.InputThread.Scheduler.Add(scheduledRefreshDevices = new ScheduledDelegate(() => refreshDevices(), 0, 500));
                 }
                 else
@@ -101,11 +103,15 @@ namespace osu.Framework.Input.Handlers.Midi
             }
             catch (Exception e)
             {
-                Logger.Error(e, RuntimeInfo.OS == RuntimeInfo.Platform.Linux
-                    ? "Couldn't list input devices. Is libasound2-dev installed?"
-                    : "Couldn't list input devices. There may be another application already using MIDI.");
+                string message = RuntimeInfo.OS == RuntimeInfo.Platform.Linux
+                    ? "Is libasound2-dev installed?"
+                    : "There may be another application already using MIDI.";
 
-                active = false;
+                Logger.Log($"MIDI devices could not be enumerated. {message} ({e.Message})");
+
+                // stop attempting to refresh devices until next startup.
+                inGoodState = false;
+                scheduledRefreshDevices.Cancel();
                 return false;
             }
         }


### PR DESCRIPTION
Also fix initialisation loop continuing to execute every 500ms even after an error.

As noticed at https://sentry.ppy.sh/organizations/ppy/issues/836/events/ce98f382a4cb4aa990c22c90def42c27.