### PR TITLE
Add IsNull()/IsNotNull() helper extensions

### DIFF
--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
-
 #nullable enable
+
+using System.Diagnostics;
 
 namespace osu.Framework.Extensions.ObjectExtensions
 {
@@ -27,5 +27,15 @@ namespace osu.Framework.Extensions.ObjectExtensions
             Debug.Assert(obj != null);
             return obj;
         }
+
+        /// <summary>
+        /// If the given object is null.
+        /// </summary>
+        public static bool IsNull<T>(this T obj) => ReferenceEquals(obj, null);
+
+        /// <summary>
+        /// <c>true</c> if the given object is not null, <c>false</c> otherwise.
+        /// </summary>
+        public static bool IsNotNull<T>(this T obj) => !ReferenceEquals(obj, null);
     }
 }

--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace osu.Framework.Extensions.ObjectExtensions
 {
@@ -31,11 +32,11 @@ namespace osu.Framework.Extensions.ObjectExtensions
         /// <summary>
         /// If the given object is null.
         /// </summary>
-        public static bool IsNull<T>(this T obj) => ReferenceEquals(obj, null);
+        public static bool IsNull<T>([NotNullWhen(false)] this T obj) => ReferenceEquals(obj, null);
 
         /// <summary>
         /// <c>true</c> if the given object is not null, <c>false</c> otherwise.
         /// </summary>
-        public static bool IsNotNull<T>(this T obj) => !ReferenceEquals(obj, null);
+        public static bool IsNotNull<T>([NotNullWhen(true)] this T obj) => !ReferenceEquals(obj, null);
     }
 }


### PR DESCRIPTION
The following is a typical usage of binding to events of DI'd members:
```csharp
#nullable enable

public class MyDrawable : Drawable
{
    [Resolved]
    private SomeObject SomeDependency { get; set; } = null!;

    protected override void LoadComplete()
    {
        base.LoadComplete();
        SomeDependency.SomeEvent += someMethod;
    }

    private void someMethod()
    {
    }

    protected override void Dispose(bool disposing)
    {
        base.Dispose(disposing);

        if (SomeDependency != null) // WARNING: Expression is always true according to NRT rules.
            SomeDependency.SomeEvent -= someMethod;
    }
}
```
I propose the `IsNull()`/`IsNotNull()` extension methods in order to bypass the warning inside `Dispose()` and increase our coverage of NRT. The resultant code becomes:
```csharp
protected override void Dispose(bool disposing)
{
    base.Dispose(disposing);

    if (SomeDependency.IsNotNull())
        SomeDependency.SomeEvent -= someMethod;
}
```