### PR TITLE
Avoid GC overhead during game load by only doing a full blocking collect at the end of a test run

### DIFF
--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -421,6 +421,10 @@ namespace osu.Framework.Testing
             checkForErrors();
             runner.RunTestBlocking(this);
             checkForErrors();
+
+            // Force any unobserved exceptions to fire against the current test run.
+            // Without this they could be delayed until a future test scene is running, making tracking down the cause difficult.
+            collectAndFireUnobserved();
         }
 
         [OneTimeTearDown]
@@ -454,10 +458,6 @@ namespace osu.Framework.Testing
 
             if (runTask.Exception != null)
                 throw runTask.Exception;
-
-            // Force any unobserved exceptions to fire against the current test run.
-            // Without this they could be delayed until a future test scene is running, making tracking down the cause difficult.
-            collectAndFireUnobserved();
         }
 
         private static void collectAndFireUnobserved()


### PR DESCRIPTION
Previously this would be occurring many times during game load, causing crippling test performance in scenarios where the game takes considerable time to load.