### PR TITLE
Implicitly confine the cursor when it can't leave to another display

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -184,12 +184,14 @@ namespace osu.Framework.Tests.Visual.Input
             AddSliderStep("Cursor sensitivity", 0.5, 5, 1, setCursorSensitivityConfig);
             setCursorSensitivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
-            AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
+            AddStep("Set confine to Never", () => setConfineMouseModeConfig(ConfineMouseMode.Never));
+            AddStep("Set confine to Fullscreen", () => setConfineMouseModeConfig(ConfineMouseMode.Fullscreen));
+            AddStep("Set confine to Always", () => setConfineMouseModeConfig(ConfineMouseMode.Always));
             AddToggleStep("Toggle cursor visibility", setCursorVisibility);
             AddToggleStep("Toggle cursor confine rect", setCursorConfineRect);
 
             setRelativeMode(false);
-            setConfineMouseModeConfig(false);
+            setConfineMouseModeConfig(ConfineMouseMode.Never);
             setCursorConfineRect(false);
 
             AddStep("Reset handlers", () => host.ResetInputHandlers());
@@ -231,9 +233,9 @@ namespace osu.Framework.Tests.Visual.Input
                 host.Window.CursorState |= CursorState.Hidden;
         }
 
-        private void setConfineMouseModeConfig(bool enabled)
+        private void setConfineMouseModeConfig(ConfineMouseMode mode)
         {
-            config.SetValue(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+            config.SetValue(FrameworkSetting.ConfineMouseMode, mode);
         }
 
         private void setCursorConfineRect(bool enabled)

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Immutable;
+using System.Drawing;
+using System.Linq;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.EnumExtensions;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Input;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Input
 {
@@ -36,11 +40,27 @@ namespace osu.Framework.Input
                     var mouse = mousePositionChange.State.Mouse;
 
                     // confine cursor
-                    if (Host.Window != null && Host.Window.CursorState.HasFlagFast(CursorState.Confined))
+                    if (Host.Window != null)
                     {
+                        RectangleF? cursorConfineRect = null;
                         var clientSize = Host.Window.ClientSize;
-                        var cursorConfineRect = Host.Window.CursorConfineRect ?? new RectangleF(0, 0, clientSize.Width, clientSize.Height);
-                        mouse.Position = Vector2.Clamp(mouse.Position, cursorConfineRect.Location, cursorConfineRect.Location + cursorConfineRect.Size - Vector2.One);
+                        var windowRect = new RectangleF(0, 0, clientSize.Width, clientSize.Height);
+
+                        if (Host.Window.CursorState.HasFlagFast(CursorState.Confined))
+                        {
+                            cursorConfineRect = Host.Window.CursorConfineRect ?? windowRect;
+                        }
+                        else if (mouseOutsideAllDisplays(mouse.Position))
+                        {
+                            // Implicitly confine the cursor to prevent a feedback loop of MouseHandler warping the cursor to an invalid position
+                            // and the OS immediately warping it back inside a display.
+
+                            // Window.CursorConfineRect is not used here as that should only be used when confining is explicitly enabled.
+                            cursorConfineRect = windowRect;
+                        }
+
+                        if (cursorConfineRect.HasValue)
+                            mouse.Position = Vector2.Clamp(mouse.Position, cursorConfineRect.Value.Location, cursorConfineRect.Value.Location + cursorConfineRect.Value.Size - Vector2.One);
                     }
 
                     break;
@@ -59,6 +79,27 @@ namespace osu.Framework.Input
             }
 
             base.HandleInputStateChange(inputStateChange);
+        }
+
+        private bool mouseOutsideAllDisplays(Vector2 mousePosition)
+        {
+            Point windowLocation;
+
+            switch (Host.Window.WindowMode.Value)
+            {
+                case WindowMode.Windowed:
+                    windowLocation = Host.Window is SDL2DesktopWindow sdlWindow ? sdlWindow.Position : Point.Empty;
+                    break;
+
+                default:
+                    windowLocation = Host.Window.CurrentDisplayBindable.Value.Bounds.Location;
+                    break;
+            }
+
+            int x = (int)MathF.Floor(windowLocation.X + mousePosition.X);
+            int y = (int)MathF.Floor(windowLocation.Y + mousePosition.Y);
+
+            return !Host.Window.Displays.Any(d => d.Bounds.Contains(x, y));
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18159

Previously, moving the mouse outside the window in fullscreen would warp it and give back control to the OS. The OS would then warp the cursor back into the game window. In this short period, the cursor would jitter between being inside and outside the window.

The solution provided is not perfect, the cursor can still jitter if `Sensitivity < 1`:
Eg. on a 1920x1080 display, it can go down to 1079.9999999999, but will warp to 1079 flat. Importantly, it'll never leave the window.

This can probably be fixed by checking if there are adjacent displays, and then warping if `> 1079` instead of `>= 1080`, but it's not really that important. (Always checking for `> 1079` would leave the cursor in an invalid position when it's in-between two displays—potentially preventing it from escaping the window.)