### PR TITLE
Simplify exiting flow

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -115,7 +115,7 @@ namespace osu.Framework
         public virtual void SetHost(GameHost host)
         {
             Host = host;
-            host.Exiting += OnExiting;
+            host.ExitRequested += RequestExit;
             host.Activated += () => isActive.Value = true;
             host.Deactivated += () => isActive.Value = false;
         }
@@ -381,7 +381,7 @@ namespace osu.Framework
             switch (e.Action)
             {
                 case PlatformAction.Exit:
-                    Host.Window?.RequestClose();
+                    RequestExit();
                     return true;
             }
 
@@ -392,6 +392,18 @@ namespace osu.Framework
         {
         }
 
+        /// <summary>
+        /// Requests the game to exit. This exit can be blocked by <see cref="OnExiting"/>.
+        /// </summary>
+        public void RequestExit()
+        {
+            if (!OnExiting())
+                Exit();
+        }
+
+        /// <summary>
+        /// Force-closes the game, ignoring <see cref="OnExiting"/> return value.
+        /// </summary>
         public void Exit()
         {
             if (Host == null)
@@ -401,8 +413,9 @@ namespace osu.Framework
         }
 
         /// <summary>
-        /// Fired when the game host signals that an exit has been requested.
+        /// Fired when an exit has been requested.
         /// </summary>
+        /// <remarks>Usually fired because <see cref="PlatformAction.Exit"/> or the window close (X) button was pressed.</remarks>
         /// <returns>Return <c>true</c> to block the exit process.</returns>
         protected virtual bool OnExiting() => false;
 

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -33,10 +33,10 @@ namespace osu.Framework.Platform
         void Create();
 
         /// <summary>
-        /// Return value decides whether we should intercept and cancel this exit (if possible).
+        /// Invoked when the window close (X) button or another platform-native exit action has been pressed.
         /// </summary>
         [CanBeNull]
-        event Func<bool> ExitRequested;
+        event Action ExitRequested;
 
         /// <summary>
         /// Invoked when the <see cref="IWindow"/> has closed.
@@ -151,6 +151,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Attempts to close the window.
         /// </summary>
+        [Obsolete("Use Game.RequestExit() instead.")]
         void RequestClose();
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -149,12 +149,6 @@ namespace osu.Framework.Platform
         void Close();
 
         /// <summary>
-        /// Attempts to close the window.
-        /// </summary>
-        [Obsolete("Use Game.RequestExit() instead.")]
-        void RequestClose();
-
-        /// <summary>
         /// Start the window's run loop.
         /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
         /// </summary>

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -120,6 +120,8 @@ namespace osu.Framework.Platform
 
             Closing += (sender, e) =>
             {
+                // always block a graceful exit as it's treated as a regular window event.
+                // the host will force-close the window if the game decides not to block the exit.
                 ExitRequested?.Invoke();
                 e.Cancel = true;
             };

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -31,10 +31,9 @@ namespace osu.Framework.Platform
         public abstract IGraphicsContext Context { get; }
 
         /// <summary>
-        /// Return value decides whether we should intercept and cancel this exit (if possible).
+        /// Invoked when the window close (X) button or another platform-native exit action has been pressed.
         /// </summary>
-        [CanBeNull]
-        public event Func<bool> ExitRequested;
+        public event Action ExitRequested;
 
         /// <summary>
         /// Invoked when the <see cref="OsuTKWindow"/> has closed.
@@ -119,7 +118,11 @@ namespace osu.Framework.Platform
                 Resized?.Invoke();
             };
 
-            Closing += (sender, e) => e.Cancel = ExitRequested?.Invoke() ?? false;
+            Closing += (sender, e) =>
+            {
+                ExitRequested?.Invoke();
+                e.Cancel = true;
+            };
             Closed += (sender, e) => Exited?.Invoke();
 
             MouseEnter += (sender, args) => cursorInWindow.Value = true;
@@ -428,10 +431,10 @@ namespace osu.Framework.Platform
 
         public void Close() => OsuTKGameWindow.Close();
 
+        [Obsolete("Use Game.RequestExit() instead.")]
         public void RequestClose()
         {
-            if (ExitRequested?.Invoke() != true)
-                Close();
+            ExitRequested?.Invoke();
         }
 
         public void ProcessEvents() => OsuTKGameWindow.ProcessEvents();

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -433,12 +433,6 @@ namespace osu.Framework.Platform
 
         public void Close() => OsuTKGameWindow.Close();
 
-        [Obsolete("Use Game.RequestExit() instead.")]
-        public void RequestClose()
-        {
-            ExitRequested?.Invoke();
-        }
-
         public void ProcessEvents() => OsuTKGameWindow.ProcessEvents();
         public Point PointToClient(Point point) => OsuTKGameWindow.PointToClient(point);
         public Point PointToScreen(Point point) => OsuTKGameWindow.PointToScreen(point);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -604,10 +604,10 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Attempts to close the window.
         /// </summary>
+        [Obsolete("Use Game.RequestExit() instead.")]
         public void RequestClose() => ScheduleEvent(() =>
         {
-            if (ExitRequested?.Invoke() != true)
-                Close();
+            ExitRequested?.Invoke();
         });
 
         public void SwapBuffers()
@@ -831,7 +831,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void handleQuitEvent(SDL.SDL_QuitEvent evtQuit) => RequestClose();
+        private void handleQuitEvent(SDL.SDL_QuitEvent evtQuit) => ExitRequested?.Invoke();
 
         private void handleDropEvent(SDL.SDL_DropEvent evtDrop)
         {
@@ -1529,9 +1529,9 @@ namespace osu.Framework.Platform
         public event Action<WindowState> WindowStateChanged;
 
         /// <summary>
-        /// Invoked when the user attempts to close the window. Return value of true will cancel exit.
+        /// Invoked when the window close (X) button or another platform-native exit action has been pressed.
         /// </summary>
-        public event Func<bool> ExitRequested;
+        public event Action ExitRequested;
 
         /// <summary>
         /// Invoked when the window is about to close.

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -601,15 +601,6 @@ namespace osu.Framework.Platform
         /// </summary>
         public void Close() => ScheduleCommand(() => Exists = false);
 
-        /// <summary>
-        /// Attempts to close the window.
-        /// </summary>
-        [Obsolete("Use Game.RequestExit() instead.")]
-        public void RequestClose() => ScheduleEvent(() =>
-        {
-            ExitRequested?.Invoke();
-        });
-
         public void SwapBuffers()
         {
             graphicsBackend.SwapBuffers();


### PR DESCRIPTION
- Resolves #5194 
- Closes #5193 
- Fixes [OSU-C](https://sentry.ppy.sh/organizations/ppy/issues/13/?project=2)

The 'exit requested' event is now processed like any other window event, leaving it to the `Game` to handle it and exit the host.

Since `Game.OnExitRequested()` is called the same as before, this PR has no breaking changes.