### PR TITLE
Fix test performance overhead due to held references of previous `GameHost`s

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -481,7 +481,6 @@ namespace osu.Framework.Threading
                 Debug.Assert(state.Value == GameThreadState.Running);
                 Debug.Assert(exitState == GameThreadState.Exited || exitState == GameThreadState.Paused);
 
-                SynchronizationContext.SetSynchronizationContext(null);
                 synchronizationContext.Dispose();
 
                 Thread = null;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -481,7 +481,7 @@ namespace osu.Framework.Threading
                 Debug.Assert(state.Value == GameThreadState.Running);
                 Debug.Assert(exitState == GameThreadState.Exited || exitState == GameThreadState.Paused);
 
-                synchronizationContext.Dispose();
+                synchronizationContext.DisassociateGameThread();
 
                 Thread = null;
                 OnSuspended();

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -481,6 +481,9 @@ namespace osu.Framework.Threading
                 Debug.Assert(state.Value == GameThreadState.Running);
                 Debug.Assert(exitState == GameThreadState.Exited || exitState == GameThreadState.Paused);
 
+                SynchronizationContext.SetSynchronizationContext(null);
+                synchronizationContext.Dispose();
+
                 Thread = null;
                 OnSuspended();
 

--- a/osu.Framework/Threading/GameThreadSynchronizationContext.cs
+++ b/osu.Framework/Threading/GameThreadSynchronizationContext.cs
@@ -3,7 +3,6 @@
 
 #nullable enable
 
-using System;
 using System.Threading;
 
 namespace osu.Framework.Threading
@@ -19,7 +18,7 @@ namespace osu.Framework.Threading
     /// - Order of execution is guaranteed (in our case, it is guaranteed over <see cref="Send"/> and <see cref="Post"/> calls alike).
     /// - To enforce the above, calling <see cref="Send"/> will flush any pending work until the newly queued item has been completed.
     /// </remarks>
-    internal class GameThreadSynchronizationContext : SynchronizationContext, IDisposable
+    internal class GameThreadSynchronizationContext : SynchronizationContext
     {
         /// <summary>
         /// The total tasks this synchronization context has run.
@@ -61,7 +60,11 @@ namespace osu.Framework.Threading
         /// </summary>
         public void RunWork() => scheduler?.Update();
 
-        public void Dispose()
+        /// <summary>
+        /// Disassociate any references to the <see cref="GameThread"/> provided at construction time.
+        /// This ensures external components cannot hold a reference to potentially expensive game instances.
+        /// </summary>
+        public void DisassociateGameThread()
         {
             scheduler = null;
         }


### PR DESCRIPTION
During test runs, realm could potentially hold a `SynchronizationContext` open beyond known `GameHost` lifetime. By extension, a previous game instance could be referenced via a long reference path.

I foresee this change may be hard to swallow in the current location (I'm not sure how correct it is to stop executing events that reached the `SynchronizationContext` when the `scheduler` goes away). Open to any other suggestions of where we should be resolving this. Potentially calling `UnregisterThread` on host shutdown? Using a `WeakReference` to the `GameThread`?

Note that I'm also looking into multiple other similar issues, including why realm is holding the reference in the first place (is probably our fault). If this direction or the others proposed above are not seen as correct, the follow-up PRs may inherently solve the same issue.

![Parallels Desktop 2022-05-30 at 04 16 29](https://user-images.githubusercontent.com/191335/170916131-d1df306a-7e67-4777-9cee-011145917944.png)
![Parallels Desktop 2022-05-30 at 04 16 45](https://user-images.githubusercontent.com/191335/170916147-0cb1814c-0db3-4967-be1e-48a7e34cf20e.png)
![Parallels Desktop 2022-05-30 at 04 17 32](https://user-images.githubusercontent.com/191335/170916232-d7ae708e-7737-4bfb-b615-c13574b68621.png)

This reduces test runs of the osu! test suite considerably:

`master`:

![](https://camo.githubusercontent.com/d6ad11c167109f014ac33cd48ec47a55a17461921948437dc5b6dfe5e8e3bbec/68747470733a2f2f63646e2e646973636f72646170702e636f6d2f6174746163686d656e74732f3635323732323137353739303534363934352f3938303336303631343931303233343633342f756e6b6e6f776e2e706e67)

this PR:

![](https://user-images.githubusercontent.com/191335/170889259-0a7ab5ad-153b-4914-a40c-493fa33d73a3.png)
