### PR TITLE
Statically cache font parsing results to reduce unit test overhead

### DIFF
--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -41,6 +42,13 @@ namespace osu.Framework.IO.Stores
         private readonly TaskCompletionSource<BitmapFont> completionSource = new TaskCompletionSource<BitmapFont>();
 
         /// <summary>
+        /// This is a rare usage of a static framework-wide cache.
+        /// In normal execution font instances are held locally by font stores and this will add no overhead or improvement.
+        /// It exists specifically to avoid overheads of parsing fonts repeatedly in unit tests.
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, BitmapFont> font_cache = new ConcurrentDictionary<string, BitmapFont>();
+
+        /// <summary>
         /// Create a new glyph store.
         /// </summary>
         /// <param name="store">The store to provide font resources.</param>
@@ -66,8 +74,20 @@ namespace osu.Framework.IO.Stores
             try
             {
                 BitmapFont font;
+
                 using (var s = Store.GetStream($@"{AssetName}"))
-                    font = BitmapFont.FromStream(s, FormatHint.Binary, false);
+                {
+                    string hash = s.ComputeMD5Hash();
+
+                    if (font_cache.TryGetValue(hash, out font))
+                    {
+                        Logger.Log($"Cached font load for {AssetName}");
+                    }
+                    else
+                    {
+                        font_cache.TryAdd(hash, font = BitmapFont.FromStream(s, FormatHint.Binary, false));
+                    }
+                }
 
                 completionSource.SetResult(font);
             }


### PR DESCRIPTION
This doesn't improve test performance in local testing as much as I hoped for, but it does reduce alloc traffic and may convert to better savings on CI runs. Note that the benefit is not seen in o!f test runs due to far less fonts being loaded in the first place.

If this isn't seen as a quick merge for one reason or another I'm okay with closing instead.


![Parallels Desktop 2022-05-30 at 04 35 59](https://user-images.githubusercontent.com/191335/170918339-b55814e9-d5a1-433c-b350-bd4e2c4122c0.png)

![Parallels Desktop 2022-05-30 at 04 34 49](https://user-images.githubusercontent.com/191335/170917903-8d791f97-05d3-486f-8f7c-f6455ff22a0e.png)

