### PR TITLE
Use pooled memory for texture uploads to avoid an extra memory allocation

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
@@ -89,9 +89,7 @@ namespace osu.Framework.Graphics.Textures
             {
                 using (var buffer = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<byte>((int)stream.Length))
                 {
-                    int read = stream.Read(buffer.Memory.Span);
-
-                    Debug.Assert(read == stream.Length);
+                    stream.ReadToFill(buffer.Memory.Span);
 
                     using (var stbiImage = Stbi.LoadFromMemory(buffer.Memory.Span, 4))
                         return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -86,12 +86,9 @@ namespace osu.Framework.Graphics.Textures
 
             try
             {
-                using (var m = new MemoryStream())
-                {
-                    stream.CopyTo(m);
-                    using (var stbiImage = Stbi.LoadFromMemory(m, 4))
-                        return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
-                }
+                using (var buffer = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<byte>((int)stream.Length))
+                using (var stbiImage = Stbi.LoadFromMemory(buffer.Memory.Span, 4))
+                    return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
             }
             catch (Exception e)
             {

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using osu.Framework.Extensions.ImageExtensions;
@@ -87,8 +88,14 @@ namespace osu.Framework.Graphics.Textures
             try
             {
                 using (var buffer = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<byte>((int)stream.Length))
-                using (var stbiImage = Stbi.LoadFromMemory(buffer.Memory.Span, 4))
-                    return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
+                {
+                    int read = stream.Read(buffer.Memory.Span);
+
+                    Debug.Assert(read == stream.Length);
+
+                    using (var stbiImage = Stbi.LoadFromMemory(buffer.Memory.Span, 4))
+                        return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Running osu! navigation test namespace sees a reduction of around 6%

![Parallels Desktop 2022-05-30 at 06 25 07](https://user-images.githubusercontent.com/191335/170930015-a1fbfbbb-d290-417e-a469-d3e02dc34e33.png)

![Parallels Desktop 2022-05-30 at 06 28 11](https://user-images.githubusercontent.com/191335/170930330-abbf5004-ccf9-4a97-af59-a3ba3c9c9244.png)

(Left is this PR)