### PR TITLE
Synchronously exit `ThreadRunner` threads

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -341,9 +341,22 @@ namespace osu.Framework.Threading
             }
             else
             {
-                while (state.Value != targetState)
-                    Thread.Sleep(1);
+                switch (targetState)
+                {
+                    case GameThreadState.Exited:
+                    case GameThreadState.Paused:
+                        Thread.Join();
+                        break;
+
+                    default:
+                        while (state.Value != targetState)
+                            Thread.Sleep(1);
+
+                        break;
+                }
             }
+
+            Debug.Assert(state.Value == targetState);
         }
 
         /// <summary>

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -341,19 +341,8 @@ namespace osu.Framework.Threading
             }
             else
             {
-                switch (targetState)
-                {
-                    case GameThreadState.Exited:
-                    case GameThreadState.Paused:
-                        Thread.Join();
-                        break;
-
-                    default:
-                        while (state.Value != targetState)
-                            Thread.Sleep(1);
-
-                        break;
-                }
+                while (state.Value != targetState)
+                    Thread.Sleep(1);
             }
 
             Debug.Assert(state.Value == targetState);


### PR DESCRIPTION
- Closes #5216
- Fixes [OSU-G6](https://sentry.ppy.sh/organizations/ppy/issues/547/?referrer=github_integration)

I've omitted the timeout as it will break the synchronicity of the exiting process. If the timeout is something that is wanted, it can be added back, but `throw`ing instead of just logging (and should probably apply to the `while` loops as well).