### PR TITLE
Avoid unnecessary copy operations between `Waveform` and its draw node

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -297,6 +297,12 @@ namespace osu.Framework.Graphics.Audio
                 texture = Source.texture;
                 drawSize = Source.DrawSize;
 
+                baseColour = Source.baseColour;
+
+                lowColour = Source.lowColour ?? baseColour;
+                midColour = Source.midColour ?? baseColour;
+                highColour = Source.highColour ?? baseColour;
+
                 if (Source.resampledVersion != version)
                 {
                     points.Clear();
@@ -305,14 +311,10 @@ namespace osu.Framework.Graphics.Audio
                         points.AddRange(Source.resampledPoints);
 
                     channels = Source.resampledChannels;
+
                     highMax = Source.resampledMaxHighIntensity;
                     midMax = Source.resampledMaxMidIntensity;
                     lowMax = Source.resampledMaxLowIntensity;
-
-                    baseColour = Source.baseColour;
-                    lowColour = Source.lowColour ?? baseColour;
-                    midColour = Source.midColour ?? baseColour;
-                    highColour = Source.highColour ?? baseColour;
 
                     version = Source.resampledVersion;
                 }


### PR DESCRIPTION
As seen osu!-side during profiling spiky behaviour on waveforms changing position (but not actually being resampled).

https://user-images.githubusercontent.com/191335/171110238-2da561de-7a0d-47e2-aeac-1ec0efaf1811.mp4

![JetBrains Rider 2022-05-31 at 06 30 15](https://user-images.githubusercontent.com/191335/171110255-15cfcf0d-2e6a-4a35-a6cf-ee0249cd6da4.png)

![JetBrains Rider 2022-05-31 at 06 30 02](https://user-images.githubusercontent.com/191335/171110265-4f6e3937-0e3b-44c5-8ea3-01b0f11e78f1.png)

