### PR TITLE
Fix convex polygon clipper edge cases

### DIFF
--- a/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
@@ -56,9 +56,6 @@ namespace osu.Framework.Tests.Polygons
         {
             Task[] tasks = new Task[parallelism];
 
-            uint countValid = 0;
-            uint countInvalid = 0;
-
             for (int i = 0; i < tasks.Length; i++)
             {
                 tasks[i] = Task.Factory.StartNew(() =>
@@ -82,10 +79,7 @@ namespace osu.Framework.Tests.Polygons
 
                         try
                         {
-                            if (clip(poly1, poly2).Length > 0)
-                                Interlocked.Increment(ref countValid);
-                            else
-                                Interlocked.Increment(ref countInvalid);
+                            clip(poly1, poly2);
                         }
                         catch (Exception ex)
                         {
@@ -95,10 +89,7 @@ namespace osu.Framework.Tests.Polygons
 
                         try
                         {
-                            if (clip(poly2, poly1).Length > 0)
-                                Interlocked.Increment(ref countValid);
-                            else
-                                Interlocked.Increment(ref countInvalid);
+                            clip(poly2, poly1);
                         }
                         catch (Exception ex)
                         {

--- a/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;

--- a/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace osu.Framework.Tests.Polygons
+{
+    [TestFixture]
+    [Ignore("This test will never complete if working correctly. Test manually if required.")]
+    public class ConvexPolygonClipperFuzzingTest
+    {
+        private const int parallelism = 4;
+
+        private static readonly float[] possible_values =
+        {
+            float.NegativeInfinity,
+            float.MinValue,
+            float.MinValue / 2,
+            -10.0f,
+            -2.0f,
+            -1.0f,
+            -0.5f,
+            -0.1f,
+            0.0f,
+            float.Epsilon,
+            0.1f,
+            0.5f,
+            1.0f,
+            2.0f,
+            10.0f,
+            float.MaxValue / 2,
+            float.MaxValue,
+            float.PositiveInfinity,
+            float.NaN,
+        };
+
+        private static readonly int[] possible_sizes =
+        {
+            3,
+            4,
+            5,
+            8,
+            16
+        };
+
+        [Test]
+        public void RunTest()
+        {
+            Task[] tasks = new Task[parallelism];
+
+            uint countValid = 0;
+            uint countInvalid = 0;
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Factory.StartNew(() =>
+                {
+                    while (true)
+                    {
+                        int count1 = getRand(possible_sizes);
+                        int count2 = getRand(possible_sizes);
+
+                        HashSet<Vector2> vertices1 = new HashSet<Vector2>();
+                        HashSet<Vector2> vertices2 = new HashSet<Vector2>();
+
+                        while (vertices1.Count < count1)
+                            vertices1.Add(new Vector2(getRand(possible_values), getRand(possible_values)));
+
+                        while (vertices2.Count < count2)
+                            vertices2.Add(new Vector2(getRand(possible_values), getRand(possible_values)));
+
+                        SimpleConvexPolygon poly1 = new SimpleConvexPolygon(vertices1.ToArray());
+                        SimpleConvexPolygon poly2 = new SimpleConvexPolygon(vertices2.ToArray());
+
+                        try
+                        {
+                            if (clip(poly1, poly2).Length > 0)
+                                Interlocked.Increment(ref countValid);
+                            else
+                                Interlocked.Increment(ref countInvalid);
+                        }
+                        catch (Exception ex)
+                        {
+                            Assert.Fail($"Failed.\nPoly1: {poly1}\nPoly2: {poly2}\n\nException: {ex}");
+                            return;
+                        }
+
+                        try
+                        {
+                            if (clip(poly2, poly1).Length > 0)
+                                Interlocked.Increment(ref countValid);
+                            else
+                                Interlocked.Increment(ref countInvalid);
+                        }
+                        catch (Exception ex)
+                        {
+                            Assert.Fail($"Failed.\nPoly1: {poly2}\nPoly2: {poly1}\n\nException: {ex}");
+                            return;
+                        }
+                    }
+                }, TaskCreationOptions.LongRunning);
+            }
+
+            Task.WaitAny(tasks);
+        }
+
+        private static Vector2[] clip(SimpleConvexPolygon poly1, SimpleConvexPolygon poly2)
+        {
+            var clipper = new ConvexPolygonClipper<SimpleConvexPolygon, SimpleConvexPolygon>(ref poly1, ref poly2);
+
+            Span<Vector2> buffer = stackalloc Vector2[clipper.GetClipBufferSize()];
+
+            return clipper.Clip(buffer).ToArray();
+        }
+
+        private static T getRand<T>(T[] arr) => arr[RNG.Next(0, arr.Length)];
+    }
+}

--- a/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
@@ -241,6 +241,64 @@ namespace osu.Framework.Tests.Polygons
                 false);
         }
 
+        private static object[] fuzzedEdgeCases => new object[]
+        {
+            new object[]
+            {
+                new[] { new Vector2(0, 0.5f), new Vector2(100, 1), new Vector2(2, 2), new Vector2(1, 2) },
+                new[] { new Vector2(0, 0.5f), new Vector2(100, 0), new Vector2(0.5f, 100) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(0, 1), new Vector2(100, 0), new Vector2(100, 2), new Vector2(2, 2) },
+                new[] { new Vector2(1, 100), new Vector2(2, 0.5f), new Vector2(100, 2) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(0, 1), new Vector2(2, 0.5f), new Vector2(100, 0), new Vector2(1, 2) },
+                new[] { new Vector2(1, 0.5f), new Vector2(100, 0), new Vector2(1, 100) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(0, 1), new Vector2(0, 0), new Vector2(2, 1), new Vector2(1, 2) },
+                new[] { new Vector2(0.5f, 2), new Vector2(100, 0.5f), new Vector2(1, 0.5f), new Vector2(100, 2) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(2, float.MinValue), new Vector2(float.MaxValue, 0.5f), new Vector2(float.MaxValue, float.NegativeInfinity), new Vector2(1, float.MaxValue) },
+                new[] { new Vector2(0, 1), new Vector2(0, float.NegativeInfinity), new Vector2(float.Epsilon, 1), new Vector2(1, 0.5f) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(float.Epsilon, 0.5f), new Vector2(float.Epsilon, 100), new Vector2(float.MaxValue, float.NegativeInfinity), new Vector2(1, float.MaxValue) },
+                new[] { new Vector2(0, 1), new Vector2(0, float.NegativeInfinity), new Vector2(float.Epsilon, 1), new Vector2(1, 0.5f) },
+            },
+            new object[]
+            {
+                new[] { new Vector2(-0.1f, 2), new Vector2(0, 0), new Vector2(0.5f, -0.1f) },
+                new[] { new Vector2(-10, 2), new Vector2(-0.5f, 0.1f), new Vector2(0.5f, 0.5f) }
+            },
+            new object[]
+            {
+                new[] { new Vector2(-10, 1), new Vector2(0.1f, 0), new Vector2(-0.5f, 2) },
+                new[] { new Vector2(-1, 2), new Vector2(-0.1f, -0.5f), new Vector2(0.1f, 0) }
+            },
+            new object[]
+            {
+                new[] { new Vector2(-1, 0.5f), new Vector2(0.1f, 0.1f), new Vector2(0, 1) },
+                new[] { new Vector2(-2, -0.5f), new Vector2(0.1f, 0.1f), new Vector2(-0.1f, 1) }
+            }
+        };
+
+        [TestCaseSource(nameof(fuzzedEdgeCases))]
+        public void TestFuzzedEdgeCases(Vector2[] clipVertices, Vector2[] subjectVertices)
+        {
+            var clipPolygon = new SimpleConvexPolygon(clipVertices);
+            var subjectPolygon = new SimpleConvexPolygon(subjectVertices);
+
+            clip(clipPolygon, subjectPolygon);
+        }
+
         private Span<Vector2> clip(SimpleConvexPolygon clipPolygon, SimpleConvexPolygon subjectPolygon)
             => new ConvexPolygonClipper<SimpleConvexPolygon, SimpleConvexPolygon>(ref clipPolygon, ref subjectPolygon).Clip();
 

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 
@@ -56,7 +57,7 @@ namespace osu.Framework.Tests.Polygons
             new object[] { new Line(up_1, origin), new Line(origin, up_1), false, 0f },
             new object[] { new Line(origin, up_1), new Line(up_1, origin), false, 0f },
             new object[] { new Line(up_1, origin), new Line(up_1, origin), false, 0f },
-            // Colinear touching
+            // Collinear touching
             new object[] { new Line(origin, up_1), new Line(origin, down_1), false, 0f },
             new object[] { new Line(origin, up_1), new Line(down_1, origin), false, 0f },
         };
@@ -68,6 +69,13 @@ namespace osu.Framework.Tests.Polygons
 
             Assert.That(success, Is.EqualTo(expectedResult));
             Assert.That(t, Is.EqualTo(expectedT));
+        }
+
+        [Test]
+        public void TestCollinearPointNotInRightHalfPlane()
+        {
+            Line line = new Line(new Vector2(-0.5f, 0.1f), new Vector2(-10, 2));
+            Assert.That(new Vector2(0.5f, -0.1f).InRightHalfPlaneOf(line), Is.False);
         }
     }
 }

--- a/osu.Framework/Graphics/Primitives/SimpleConvexPolygon.cs
+++ b/osu.Framework/Graphics/Primitives/SimpleConvexPolygon.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osuTK;
 
 namespace osu.Framework.Graphics.Primitives
@@ -20,5 +21,7 @@ namespace osu.Framework.Graphics.Primitives
         public ReadOnlySpan<Vector2> GetVertices() => vertices;
 
         public int MaxClipVertices => vertices.Length * 2;
+
+        public override string ToString() => $"{{ {string.Join(", ", vertices.Select(v => $"({v.X}, {v.Y})"))} }}";
     }
 }

--- a/osu.Framework/Graphics/Vector2Extensions.cs
+++ b/osu.Framework/Graphics/Vector2Extensions.cs
@@ -99,16 +99,14 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Determines whether a point is within the right half-plane of a line.
+        /// Determines whether a point is within the right half-plane of a line in the traditional cartesian coordinate system.
         /// </summary>
         /// <param name="line">The line.</param>
         /// <param name="point">The point.</param>
-        /// <returns>Whether <paramref name="point"/> is in the right half-plane of <paramref name="line"/>.
-        /// If the point is colinear to the line, it is said to be in the right half-plane of the line.
-        /// </returns>
+        /// <returns>Whether <paramref name="point"/> is in the right half-plane of <paramref name="line"/>. Collinear points are never in the right half-plane of the line. </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool InRightHalfPlaneOf(this Vector2 point, in Line line)
             => (line.EndPoint.X - line.StartPoint.X) * (point.Y - line.StartPoint.Y)
-                - (line.EndPoint.Y - line.StartPoint.Y) * (point.X - line.StartPoint.X) <= 0;
+                - (line.EndPoint.Y - line.StartPoint.Y) * (point.X - line.StartPoint.X) < 0;
     }
 }

--- a/osu.Framework/Utils/ConvexPolygonClipper.cs
+++ b/osu.Framework/Utils/ConvexPolygonClipper.cs
@@ -29,8 +29,9 @@ namespace osu.Framework.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetClipBufferSize()
         {
-            // There can only be at most two intersections for each of the subject's vertices
-            return subjectPolygon.GetVertices().Length * 2;
+            // Assume every line can intersect every other line.
+            // This clipper cannot handle concavity, however this allows for edge cases to be handled gracefully.
+            return subjectPolygon.GetVertices().Length * clipPolygon.GetVertices().Length;
         }
 
         /// <summary>


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/17215

Although I'm not entirely sure on what's causing the above issue, I believe it will be fixed based on running the new fuzzing test for 1hr with no failures. It generates many millions of polygons; concave, convex, lines, etc, and then performs clipping on them.

To be honest, this is a bit of a workaround because I can't really find that much documentation on these edge cases nor can I find documentation of others using a fixed buffer size as we're doing. I can only assume that using a fixed buffer size for this algorithm is incorrect.

There are two fixes applied here:
1. Increasing the total buffer size to assume every line can be intersected with every other.
2. Making collinear points not be counted as being "in the right half plane of the line".

# Concavity

Assuming that every line can be intersected with every other line implies concavity. This isn't something that this clipper can handle, but at least it will fail gracefully. This is the only fix required for https://github.com/ppy/osu/issues/17215.

# Sharing of vertices

One case where the buffer size is exceeded seems to be when a corner of the two polygons is shared. For example the clipping and subject polygons:
```
s: (-1, 2), (-0.1, -0.5), (0.1, 0)
c: (-10, 1), (0.1, 0), (-0.5, 2)
```
![image](https://user-images.githubusercontent.com/1329837/171398667-ced6b56a-0731-49d2-ba82-b0033863aeff.png)

Generates the clipped vertices:
```
(-0.9726362, 1.9502487),
(0.1, 0),
(0.1, 0),
(0.100000024, 0),
(0.100000024, -2.1287374E-09),
(-0.29404524, 0.039014377),
(-0.98174477, 1.94929)
```
This happens because the following code can add duplicate vertices to the array in this case:
https://github.com/ppy/osu-framework/blob/7d5c372a591bb4275f667228f3ec2ecf25d19a1e/osu.Framework/Utils/ConvexPolygonClipper.cs#L127-L136
Handling this doesn't seem intuitive since the same issue can occur in the next iteration - the end point of one line becomes the start point of the next.

It should be noted at this point, that I'm using a pretty bog-standard implementation of the [Sutherland-Hodgman algorithm](https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm) which has no mention of how to handle such cases.

# Collinear point edge case

I found a floating point precision edge case with lines that are _not_ collinear in one part of code that _are_ collinear in another part of code. This is demonstrated by the polygons and resultant clipping area:
```
p1: (-10,2),(-0.5,0.1),(0.5,0.5)
p2: (-0.1,2),(0,0),(0.5,-0.1)
clip: (0,0),(-0.028776987,0.5755397),(0.3212766,0.525532),(0.3461539,0.43846154),(-0.0147058815,0.29411763),(0,0),(0.5,-0.1)
```
![image](https://user-images.githubusercontent.com/1329837/171393658-ccba0228-0202-487f-8b53-8093b934dff4.png)

Note how there's a section below the black-shaded part that is not in the intersection of the two areas. This is caused by the bottom-most lines of the two polygons:
```
1: (-0.5, 0.1) -> (-10, 2)
2: (0.5, -0.1) -> (0, 0)
```
![image](https://user-images.githubusercontent.com/1329837/171391034-5921c2a0-ea50-431e-932b-21a800b0a0f0.png)

Graphically, these appear as if they're collinear, however based on the calculations of `Vector2Extensions.InRightHalfPlaneOf()`, you'd find that the start of line 1 is to the right of line 2, and the end of line 1 is to the left of line 2. This is a pretty "basic" float precision issue, but has the catastrophic consequence of making it seem like we should be able to find a single point of intersection between these two lines.

As a bit of background to understand this, think about two line segments that you could extend in virtual space to infinity. The line segments themselves don't need to be intersecting, but we can say that there's a single point of intersection if one point extended to infinity from one line appears to _left_ of the second line, and another point from that same line appears to the _right_ of the second line.  
If this is true, then we can find a parameter `t` representing the point of intersection of the two line segments. This parameter can be outside the range `[0,1]` for if the two line segments aren't intersecting.

By this theory we expect to be able to find the parameter `t` for the case above. This is done via the `Line.TryIntersectWith()` method, but what you'll find is that this method returns a parameter of 0! This is hitting the `denominator = 0` case of this method, implying that the lines are collinear and that we don't have a single point of intersection:
https://github.com/ppy/osu-framework/blob/7d5c372a591bb4275f667228f3ec2ecf25d19a1e/osu.Framework/Graphics/Primitives/Line.cs#L106-L121

This has bad effects for the convex clipper leading to the above result, but collinear lines don't matter all that much in the first place. So the fix I've gone with is to simply stop treating collinear points as being in the right half-plane of lines, resulting in the fixed clipping area:
![image](https://user-images.githubusercontent.com/1329837/171397392-367b5250-caa5-4157-a959-7dd578105080.png)