### PR TITLE
Throw `OperationCanceledException` when `Perform`ing a `WebRequest`after `Abort`

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -295,9 +295,7 @@ namespace osu.Framework.Tests.IO
             bool hasThrown = false;
             request.Failed += exception => hasThrown = exception != null;
 
-#pragma warning disable 4014
-            request.PerformAsync();
-#pragma warning restore 4014
+            Task.Run(() => request.PerformAsync());
 
             Assert.DoesNotThrow(request.Abort);
 
@@ -324,9 +322,7 @@ namespace osu.Framework.Tests.IO
             bool hasThrown = false;
             request.Failed += exception => hasThrown = exception != null;
 
-#pragma warning disable 4014
-            request.PerformAsync();
-#pragma warning restore 4014
+            Task.Run(() => request.PerformAsync());
 
             Assert.DoesNotThrow(request.Abort);
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -238,7 +238,12 @@ namespace osu.Framework.IO.Network
         public async Task PerformAsync(CancellationToken cancellationToken = default)
         {
             if (Completed)
+            {
+                if (Aborted)
+                    throw new OperationCanceledException($"The {nameof(WebRequest)} has been aborted.");
+
                 throw new InvalidOperationException($"The {nameof(WebRequest)} has already been run.");
+            }
 
             try
             {


### PR DESCRIPTION
This allows identifying this scenario in client usage. This can be used to fix the issue seen at https://github.com/ppy/osu/issues/18524#issuecomment-1144428852, where the flow is:

- Game makes request
- Game cancels request before `Perform` fires its `Task`'d `PerformAsync` 
- `WebRequest` reports invalid operation

I'm not sure about the exception types here. Should we also throw an `OperationCanceled` from the `Perform` flow, rather than `TaskCanceled` that comes from .NET itself?

osu-side relevant fix would be something like https://github.com/ppy/osu/compare/master...peppy:web-request-canceled-fix?expand=1