### PR TITLE
Clear textbox selection when setting via `Text` or `Current`

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -766,6 +766,35 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("text container moved back", () => textBox.TextContainerBounds.TopLeft.X < PaddedTextBox.LEFT_RIGHT_PADDING);
         }
 
+        [Test]
+        public void TestSetTextSelection()
+        {
+            TextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new BasicTextBox
+                {
+                    Size = new Vector2(300, 40),
+                    Text = "initial text",
+                });
+            });
+
+            AddStep("click on textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("set text", () => textBox.Text = "a longer string of text");
+            // ideally, this should check the caret/selection position, but that is not exposed in TextBox.
+            AddAssert("nothing selected", () => textBox.SelectedText == string.Empty);
+
+            AddStep("select all", () => InputManager.Keys(PlatformAction.SelectAll));
+            AddStep("set text via current", () => textBox.Text = "short text");
+            AddAssert("nothing selected", () => textBox.SelectedText == string.Empty);
+        }
+
         private void prependString(InsertableTextBox textBox, string text)
         {
             InputManager.Keys(PlatformAction.MoveBackwardLine);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -935,7 +935,6 @@ namespace osu.Framework.Graphics.UserInterface
             // `FinalizeImeComposition()` crashes if textbox isn't fully loaded.
             if (IsLoaded) FinalizeImeComposition(false);
 
-            int startBefore = selectionStart;
             selectionStart = selectionEnd = 0;
 
             TextFlow?.Clear();
@@ -943,8 +942,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             // insert string and fast forward any transforms (generally when replacing the full content of a textbox we don't want any kind of fade etc.).
             insertString(value, d => d.FinishTransforms());
-
-            selectionStart = Math.Clamp(startBefore, 0, text.Length);
 
             endTextChange(beganChange);
             cursorAndLayout.Invalidate();


### PR DESCRIPTION
- Closes #5170

Not really sure what the existing code was doing. `insertString()` will move the caret to the expected position (end of text).
Includes some very rudimentary tests.