### PR TITLE
Support nullable reference types for dependency injection

### DIFF
--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using JetBrains.Annotations;
 using NUnit.Framework;
@@ -318,6 +319,20 @@ namespace osu.Framework.Tests.Dependencies
             });
         }
 
+        [Test]
+        public void TestResolveWithNullableReferenceTypes()
+        {
+            var dependencies = new DependencyContainer();
+            var receiver = new Receiver14();
+
+            // Throws with missing non-nullable dependency.
+            Assert.Throws<DependencyNotRegisteredException>(() => dependencies.Inject(receiver));
+
+            // Cache the non-nullable dependency.
+            dependencies.CacheAs(new BaseObject());
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+        }
+
         private interface IBaseInterface
         {
         }
@@ -435,5 +450,16 @@ namespace osu.Framework.Tests.Dependencies
             [BackgroundDependencyLoader(true)]
             private void load(int testObject) => TestObject = testObject;
         }
+
+#nullable enable
+        [SuppressMessage("ReSharper", "UnusedParameter.Local")]
+        private class Receiver14
+        {
+            [BackgroundDependencyLoader]
+            private void load(BaseObject nonNullObject, DerivedObject? nullableObject)
+            {
+            }
+        }
+#nullable disable
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -189,6 +189,25 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(bindable.Value, receiver.Obj2.Value);
         }
 
+        [Test]
+        public void TestResolveNullableWithNullableReferenceTypes()
+        {
+            var receiver = new Receiver17();
+            Assert.DoesNotThrow(() => createDependencies().Inject(receiver));
+        }
+
+        [Test]
+        public void TestResolveNonNullWithNullableReferenceTypes()
+        {
+            var receiver = new Receiver18();
+
+            // Throws with non-nullable dependency not cached.
+            Assert.Throws<DependencyNotRegisteredException>(() => createDependencies().Inject(receiver));
+
+            // Does not throw with the non-nullable dependency cached.
+            Assert.DoesNotThrow(() => createDependencies(new Bindable<int>(10)).Inject(receiver));
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -306,5 +325,19 @@ namespace osu.Framework.Tests.Dependencies
             [Resolved]
             public IBindable<int> Obj2 { get; private set; }
         }
+
+#nullable enable
+        private class Receiver17
+        {
+            [Resolved]
+            public Bindable<int>? Obj { get; private set; }
+        }
+
+        private class Receiver18
+        {
+            [Resolved]
+            public Bindable<int> Obj { get; private set; } = null!;
+        }
+#nullable disable
     }
 }

--- a/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
@@ -17,6 +17,7 @@ namespace osu.Framework.Tests.Extensions
     [TestFixture]
     [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
     [SuppressMessage("ReSharper", "ValueParameterNotUsed")]
+    [SuppressMessage("ReSharper", "UnusedParameter.Local")]
     public class TestIsNullableTypeExtensions
     {
         private const BindingFlags binding_flags = BindingFlags.Instance | BindingFlags.NonPublic;

--- a/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
@@ -1,0 +1,143 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using NUnit.Framework;
+using osu.Framework.Extensions.TypeExtensions;
+
+#pragma warning disable CS8618
+#pragma warning disable CS0649
+
+namespace osu.Framework.Tests.Extensions
+{
+    [TestFixture]
+    [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
+    [SuppressMessage("ReSharper", "ValueParameterNotUsed")]
+    public class TestIsNullableTypeExtensions
+    {
+        private const BindingFlags binding_flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+        private int nonNullValueField;
+        private int? nullableValueField;
+
+        private int nonNullValueGetSetProperty { get; set; }
+        private int? nullableValueGetSetProperty { get; set; }
+
+        private int nonNullValueGetProperty { get; }
+        private int? nullableValueGetProperty { get; }
+
+        private int nonNullValueSetProperty { set { } }
+        private int? nullableValueSetProperty { set { } }
+
+        private object nonNullReferenceField;
+        private object? nullableReferenceField;
+
+        private object nonNullReferenceGetSetProperty { get; set; }
+        private object? nullableReferenceGetSetProperty { get; set; }
+
+        private object nonNullReferenceGetProperty { get; }
+        private object? nullableReferenceGetProperty { get; }
+
+        private object nonNullReferenceSetProperty { set { } }
+        private object? nullableReferenceSetProperty { set { } }
+
+#nullable disable
+        private object nonNullReferenceFieldWithoutNullableReferenceTypes;
+#nullable enable
+
+        private event Action nonNullEvent;
+        private event Action? nullableEvent;
+
+        private void testValueParamMethod(int param1, int? param2) { }
+        private void testReferenceParamMethod(object param1, object? param2) { }
+
+        [Test]
+        public void TestNonNullValueField() => Assert.False(GetType().GetField(nameof(nonNullValueField), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableValueField() => Assert.True(GetType().GetField(nameof(nullableValueField), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullValueGetSetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullValueGetSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableValueGetSetProperty() => Assert.True(GetType().GetProperty(nameof(nullableValueGetSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullValueGetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullValueGetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableValueGetProperty() => Assert.True(GetType().GetProperty(nameof(nullableValueGetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullValueSetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullValueSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableValueSetProperty() => Assert.True(GetType().GetProperty(nameof(nullableValueSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceField() => Assert.False(GetType().GetField(nameof(nonNullReferenceField), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableReferenceField() => Assert.True(GetType().GetField(nameof(nullableReferenceField), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceGetSetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullReferenceGetSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableReferenceGetSetProperty() => Assert.True(GetType().GetProperty(nameof(nullableReferenceGetSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceGetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullReferenceGetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableReferenceGetProperty() => Assert.True(GetType().GetProperty(nameof(nullableReferenceGetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceSetProperty() => Assert.False(GetType().GetProperty(nameof(nonNullReferenceSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableReferenceSetProperty() => Assert.True(GetType().GetProperty(nameof(nullableReferenceSetProperty), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceFieldWithoutNullableReferenceTypes()
+            => Assert.False(GetType().GetField(nameof(nonNullReferenceFieldWithoutNullableReferenceTypes), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNonNullEvent() => Assert.False(GetType().GetEvent(nameof(nonNullEvent), binding_flags).IsNullable());
+
+        [Test]
+        public void TestNullableEvent() => Assert.True(GetType().GetEvent(nameof(nullableEvent), binding_flags).IsNullable());
+
+        [Test]
+        public void TestValueParameters()
+        {
+            var parameters = GetType().GetMethod(nameof(testValueParamMethod), binding_flags)!.GetParameters();
+            Assert.False(parameters[0].IsNullable());
+            Assert.True(parameters[1].IsNullable());
+        }
+
+        [Test]
+        public void TestReferenceParameters()
+        {
+            var parameters = GetType().GetMethod(nameof(testReferenceParamMethod), binding_flags)!.GetParameters();
+            Assert.False(parameters[0].IsNullable());
+            Assert.True(parameters[1].IsNullable());
+        }
+
+        [Test]
+        public void TestNonNullValueType() => Assert.False(typeof(int).IsNullable());
+
+        [Test]
+        public void TestNullableValueType() => Assert.True(typeof(int?).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceType() => Assert.False(typeof(object).IsNullable());
+
+        // typeof cannot be used on "object?".
+    }
+}

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -58,8 +58,8 @@ namespace osu.Framework.Allocation
                     Debug.Assert(attribute != null);
 
                     bool permitNulls = attribute.permitNulls;
-                    var parameterGetters = method.GetParameters().Select(p => p.ParameterType)
-                                                 .Select(t => getDependency(t, type, permitNulls || t.IsNullable())).ToArray();
+                    var parameterGetters = method.GetParameters()
+                                                 .Select(parameter => getDependency(parameter.ParameterType, type, permitNulls || parameter.IsNullable())).ToArray();
 
                     return (target, dc) =>
                     {

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Allocation
                     cacheInfo = new CacheInfo(cacheInfo.Name ?? property.Name, attribute.Parent);
                 }
 
-                var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull || property.PropertyType.IsNullable(), cacheInfo);
+                var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull || property.IsNullable(), cacheInfo);
 
                 activators.Add((target, dc) => property.SetValue(target, fieldGetter(dc)));
             }


### PR DESCRIPTION
```csharp
#nullable enable

class MyDrawable : Drawable
{
    // Non-null dependency.
    [Resolved]
    private object NonNullDependency { get; set; } = null!;

    // Nullable dependency.
    // [Resolved(CanBeNull = true)] : Not required anymore!
    [Resolved]
    private object? NullableDependency { get; set; } 

    // [BackgroundDependencyLoader(true)] : Not required anymore!
    [BackgroundDependencyLoader]
    private void load(object param1, object? param2)
    {
    }
}
```
This is only supplementary behaviour - supplying the nullable parameters of `[Resolved]` and `[BackgroundDependencyLoader]` preserves the previous functionality of injecting nulls.