### PR TITLE
Prevent ConvexPolygonClipper from outputting duplicate vertices

### DIFF
--- a/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
@@ -241,6 +241,16 @@ namespace osu.Framework.Tests.Polygons
                 false);
         }
 
+        [Test]
+        public void TestCollinear()
+        {
+            var clipPolygon = new SimpleConvexPolygon(new[] { new Vector2(-1, 0.5f), new Vector2(0.1f, 0.1f), new Vector2(0, 1) });
+            var subjectPolygon = new SimpleConvexPolygon(new[] { new Vector2(-2, -0.5f), new Vector2(0.1f, 0.1f), new Vector2(-0.1f, 1) });
+
+            var result = clip(clipPolygon, subjectPolygon).ToArray();
+            Assert.That(result.Length, Is.EqualTo(4));
+        }
+
         private static object[] fuzzedEdgeCases => new object[]
         {
             new object[]

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -77,5 +77,12 @@ namespace osu.Framework.Tests.Polygons
             Line line = new Line(new Vector2(-0.5f, 0.1f), new Vector2(-10, 2));
             Assert.That(new Vector2(0.5f, -0.1f).InRightHalfPlaneOf(line), Is.False);
         }
+
+        [Test]
+        public void TestCollinearPointNotInLeftHalfPlane()
+        {
+            Line line = new Line(new Vector2(-0.5f, 0.1f), new Vector2(-10, 2));
+            Assert.That(new Vector2(0.5f, -0.1f).InLeftHalfPlaneOf(line), Is.False);
+        }
     }
 }

--- a/osu.Framework/Graphics/Vector2Extensions.cs
+++ b/osu.Framework/Graphics/Vector2Extensions.cs
@@ -108,5 +108,16 @@ namespace osu.Framework.Graphics
         public static bool InRightHalfPlaneOf(this Vector2 point, in Line line)
             => (line.EndPoint.X - line.StartPoint.X) * (point.Y - line.StartPoint.Y)
                 - (line.EndPoint.Y - line.StartPoint.Y) * (point.X - line.StartPoint.X) < 0;
+
+        /// <summary>
+        /// Determines whether a point is within the left half-plane of a line in the traditional cartesian coordinate system.
+        /// </summary>
+        /// <param name="line">The line.</param>
+        /// <param name="point">The point.</param>
+        /// <returns>Whether <paramref name="point"/> is in the left half-plane of <paramref name="line"/>. Collinear points are never in the left half-plane of the line. </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool InLeftHalfPlaneOf(this Vector2 point, in Line line)
+            => (line.EndPoint.X - line.StartPoint.X) * (point.Y - line.StartPoint.Y)
+                - (line.EndPoint.Y - line.StartPoint.Y) * (point.X - line.StartPoint.X) > 0;
     }
 }

--- a/osu.Framework/Utils/ConvexPolygonClipper.cs
+++ b/osu.Framework/Utils/ConvexPolygonClipper.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Utils
         {
             if (endVertex.InRightHalfPlaneOf(clipEdge))
             {
-                if (!startVertex.InRightHalfPlaneOf(clipEdge))
+                if (startVertex.InLeftHalfPlaneOf(clipEdge))
                 {
                     clipEdge.TryIntersectWith(ref startVertex, ref endVertex, out float t);
                     buffer[bufferIndex++] = clipEdge.At(t);


### PR DESCRIPTION
As suggested in https://github.com/ppy/osu-framework/pull/5219#issuecomment-1145356172