### PR TITLE
Improve scrolling/dragging experience on singular scroll containers

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -479,7 +479,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 InputManager.PressButton(MouseButton.Left);
 
                 // Required for the dragging state to be set correctly.
-                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(10f, 0f)));
+                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(20f, 0f)));
             });
 
             AddStep("Move mouse up", () => InputManager.MoveMouseTo(scrollContainer.ScreenSpaceDrawQuad.Centre - new Vector2(0, 1000)));
@@ -525,7 +525,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 InputManager.PressButton(MouseButton.Left);
 
                 // Required for the dragging state to be set correctly.
-                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(10f, 0f)));
+                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(20f, 0f)));
             });
 
             AddStep("Move mouse diagonally up", () => InputManager.MoveMouseTo(scrollContainer.ScreenSpaceDrawQuad.Centre - new Vector2(1000, 1000)));
@@ -539,6 +539,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("Nest vertical scroll inside of horizontal", () =>
             {
                 Remove(scrollContainer);
+
                 Add(horizontalScrollContainer = new BasicScrollContainer(Direction.Horizontal)
                 {
                     Anchor = Anchor.Centre,
@@ -563,7 +564,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 InputManager.PressButton(MouseButton.Left);
 
                 // Required for the dragging state to be set correctly.
-                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(10f, 0f)));
+                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(20f, 0f)));
             });
 
             AddStep("Move mouse diagonally up", () => InputManager.MoveMouseTo(scrollContainer.ScreenSpaceDrawQuad.Centre - new Vector2(1000, 1000)));

--- a/osu.Framework/Graphics/Containers/IScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/IScrollContainer.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Containers
+{
+    public interface IScrollContainer : IContainer
+    {
+        /// <summary>
+        /// The direction in which scrolling is supported.
+        /// </summary>
+        Direction ScrollDirection { get; }
+    }
+}

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -13,7 +13,7 @@ using osuTK.Input;
 
 namespace osu.Framework.Graphics.Containers
 {
-    public abstract class ScrollContainer<T> : Container<T>, DelayedLoadWrapper.IOnScreenOptimisingContainer, IKeyBindingHandler<PlatformAction>
+    public abstract class ScrollContainer<T> : Container<T>, IScrollContainer, DelayedLoadWrapper.IOnScreenOptimisingContainer, IKeyBindingHandler<PlatformAction>
         where T : Drawable
     {
         /// <summary>
@@ -164,10 +164,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        /// <summary>
-        /// The direction in which scrolling is supported.
-        /// </summary>
-        protected readonly Direction ScrollDirection;
+        public Direction ScrollDirection { get; }
 
         /// <summary>
         /// The direction in which scrolling is supported, converted to an int for array index lookups.
@@ -247,6 +244,7 @@ namespace osu.Framework.Graphics.Containers
 
             if (dragWasMostlyHorizontal != (ScrollDirection == Direction.Horizontal))
                 return false;
+            }
 
             lastDragTime = Time.Current;
             averageDragDelta = averageDragTime = 0;

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -240,10 +240,13 @@ namespace osu.Framework.Graphics.Containers
             if (IsDragging || e.Button != MouseButton.Left || Content.AliveInternalChildren.Count == 0)
                 return false;
 
-            bool dragWasMostlyHorizontal = Math.Abs(e.Delta.X) > Math.Abs(e.Delta.Y);
+            var parentScrollContainer = this.FindClosestParent<IScrollContainer>();
 
-            if (dragWasMostlyHorizontal != (ScrollDirection == Direction.Horizontal))
-                return false;
+            if (parentScrollContainer != null && parentScrollContainer.ScrollDirection != ScrollDirection)
+            {
+                bool dragWasMostlyHorizontal = Math.Abs(e.Delta.X) > Math.Abs(e.Delta.Y);
+                if (dragWasMostlyHorizontal != (ScrollDirection == Direction.Horizontal))
+                    return false;
             }
 
             lastDragTime = Time.Current;
@@ -366,12 +369,17 @@ namespace osu.Framework.Graphics.Containers
             if (Content.AliveInternalChildren.Count == 0)
                 return false;
 
-            bool scrollWasMostlyHorizontal = Math.Abs(e.ScrollDelta.X) > Math.Abs(e.ScrollDelta.Y);
+            var parentScrollContainer = this.FindClosestParent<IScrollContainer>();
 
-            // For horizontal scrolling containers, vertical scroll is also used to perform horizontal traversal.
-            // Due to this, we only block horizontal scroll in vertical containers, but not vice-versa.
-            if (scrollWasMostlyHorizontal && ScrollDirection == Direction.Vertical)
-                return false;
+            if (parentScrollContainer != null && parentScrollContainer.ScrollDirection != ScrollDirection)
+            {
+                bool scrollWasMostlyHorizontal = Math.Abs(e.ScrollDelta.X) > Math.Abs(e.ScrollDelta.Y);
+
+                // For horizontal scrolling containers, vertical scroll is also used to perform horizontal traversal.
+                // Due to this, we only block horizontal scroll in vertical containers, but not vice-versa.
+                if (scrollWasMostlyHorizontal && ScrollDirection == Direction.Vertical)
+                    return false;
+            }
 
             bool isPrecise = e.IsPrecise;
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Caching;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Layout;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Input;
@@ -171,6 +172,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected int ScrollDim => ScrollDirection == Direction.Horizontal ? 0 : 1;
 
+        private readonly LayoutValue<IScrollContainer> parentScrollContainerCache = new LayoutValue<IScrollContainer>(Invalidation.Parent);
+
+        private IScrollContainer parentScrollContainer => parentScrollContainerCache.IsValid
+            ? parentScrollContainerCache.Value
+            : parentScrollContainerCache.Value = this.FindClosestParent<IScrollContainer>();
+
         /// <summary>
         /// Creates a scroll container.
         /// </summary>
@@ -195,6 +202,8 @@ namespace osu.Framework.Graphics.Containers
             Scrollbar.Hide();
             Scrollbar.Dragged = onScrollbarMovement;
             ScrollbarAnchor = scrollDirection == Direction.Vertical ? Anchor.TopRight : Anchor.BottomLeft;
+
+            AddLayout(parentScrollContainerCache);
         }
 
         private float lastUpdateDisplayableContent = -1;
@@ -239,8 +248,6 @@ namespace osu.Framework.Graphics.Containers
         {
             if (IsDragging || e.Button != MouseButton.Left || Content.AliveInternalChildren.Count == 0)
                 return false;
-
-            var parentScrollContainer = this.FindClosestParent<IScrollContainer>();
 
             if (parentScrollContainer != null && parentScrollContainer.ScrollDirection != ScrollDirection)
             {
@@ -368,8 +375,6 @@ namespace osu.Framework.Graphics.Containers
         {
             if (Content.AliveInternalChildren.Count == 0)
                 return false;
-
-            var parentScrollContainer = this.FindClosestParent<IScrollContainer>();
 
             if (parentScrollContainer != null && parentScrollContainer.ScrollDirection != ScrollDirection)
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18550

In #5118, scroll containers have changed to not accept drags/scrolls when containing a greater horizontal component, but that produces a bad UX as seen in https://github.com/ppy/osu/issues/18550, especially on dragging where starting a horizontal drag then continuing vertically no longer works.

Now the new behaviour will only happen when the scroll container is nested inside of another scroll container that accepts the other direction. 