### PR TITLE
Fix synchronisation context disassociating scheduler on execution mode changes

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
@@ -21,6 +22,9 @@ namespace osu.Framework.Tests.Visual.Drawables
     {
         [Resolved]
         private GameHost host { get; set; }
+
+        [Resolved]
+        private FrameworkConfigManager config { get; set; }
 
         private AsyncPerformingBox box;
 
@@ -192,6 +196,29 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddStep("trigger", () => box.ReleaseAsyncLoadCompleteLock());
             AddUntilStep("has spun", () => box.Rotation == 0);
+        }
+
+        [Test]
+        public void TestExecutionMode()
+        {
+            AddStep("add box", () => Child = box = new AsyncPerformingBox(true));
+            AddAssert("not spun", () => box.Rotation == 0);
+
+            AddStep("toggle execution mode", () => toggleExecutionMode());
+
+            AddStep("trigger", () => box.ReleaseAsyncLoadCompleteLock());
+            AddUntilStep("has spun", () => box.Rotation == 180);
+
+            AddStep("revert execution mode", () => toggleExecutionMode());
+
+            void toggleExecutionMode()
+            {
+                var executionMode = config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode);
+
+                executionMode.Value = executionMode.Value == ExecutionMode.MultiThreaded
+                    ? ExecutionMode.SingleThread
+                    : ExecutionMode.MultiThreaded;
+            }
         }
 
         public class AsyncPerformingBox : Box

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -483,8 +483,6 @@ namespace osu.Framework.Threading
                 Debug.Assert(state.Value == GameThreadState.Running);
                 Debug.Assert(exitState == GameThreadState.Exited || exitState == GameThreadState.Paused);
 
-                synchronizationContext.DisassociateGameThread();
-
                 Thread = null;
                 OnSuspended();
 
@@ -493,6 +491,8 @@ namespace osu.Framework.Threading
                     case GameThreadState.Exited:
                         Monitor?.Dispose();
                         initializedEvent?.Dispose();
+
+                        synchronizationContext.DisassociateGameThread();
 
                         OnExit();
                         break;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18569

[As discussed in discord](https://discord.com/channels/188630481301012481/188630652340404224/982717832649375764), the scheduler shouldn't be disassociated when changing execution modes, since the `GameThread` instance is preserved on that case, only the underlying thread is reinstantiated.