### PR TITLE
Fix and cleanup android touch handling

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Android.App;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/9996

The problem described in https://github.com/ppy/osu/issues/9996#issuecomment-1116245041 occurs because framework treated `ACTION_CANCEL` as only cancelling the 0th pointer (`ActionIndex` would always return `0`). [`ACTION_CANCEL`](https://developer.android.com/reference/android/view/MotionEvent#ACTION_CANCEL) and [`ACTION_UP`](https://developer.android.com/reference/android/view/MotionEvent#ACTION_UP) now properly apply to every pointer.

Turns out `getActionIndex()`/`ActionIndex` is only valid for `ACTION_POINTER_DOWN` and `ACTION_POINTER_UP` events:
https://developer.android.com/reference/android/view/MotionEvent#ACTION_POINTER_DOWN
> Use [getActionIndex()](https://developer.android.com/reference/android/view/MotionEvent#getActionIndex()) to retrieve the index of the pointer that changed.

On my device, the usual order of touch motion events is (with `Move` events sprinkled in):
1. `Down` when the screen is touched for the first time
2. `PointerDown` when pressing with second, third, etc. finger
3. `PointerUp` when any of the fingers are released
4. `Up` when the last finger is released
5. Alternatively, android can report `Cancel` instead of `Up`