### PR TITLE
Reset shader stack every frame to silence assertion

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using JetBrains.Annotations;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Textures;
@@ -141,8 +142,6 @@ namespace osu.Framework.Graphics.OpenGL
         {
             ResetId++;
 
-            Trace.Assert(shader_stack.Count == 0);
-
             reset_scheduler.Update();
 
             stat_expensive_operations_queued.Value = expensive_operation_queue.Count;
@@ -163,6 +162,11 @@ namespace osu.Framework.Graphics.OpenGL
             foreach (var b in batch_reset_list)
                 b.ResetCounters();
             batch_reset_list.Clear();
+
+            currentShader?.Unbind();
+            currentShader = null;
+            shader_stack.Clear();
+            GL.UseProgram(0);
 
             viewport_stack.Clear();
             ortho_stack.Clear();
@@ -903,18 +907,15 @@ namespace osu.Framework.Graphics.OpenGL
             ScheduleDisposal(GL.DeleteFramebuffer, frameBuffer);
         }
 
-        private static int currentShader;
+        private static readonly Stack<Shader> shader_stack = new Stack<Shader>();
+        private static Shader currentShader;
 
-        private static readonly Stack<int> shader_stack = new Stack<int>();
-
-        public static void UseProgram(int? shader)
+        public static void UseProgram([CanBeNull] Shader shader)
         {
             ThreadSafety.EnsureDrawThread();
 
             if (shader != null)
-            {
-                shader_stack.Push(shader.Value);
-            }
+                shader_stack.Push(shader);
             else
             {
                 shader_stack.Pop();
@@ -924,16 +925,17 @@ namespace osu.Framework.Graphics.OpenGL
                     return;
             }
 
-            int s = shader ?? shader_stack.Peek();
+            shader ??= shader_stack.Peek();
 
-            if (currentShader == s) return;
+            if (currentShader == shader)
+                return;
 
             FrameStatistics.Increment(StatisticsCounterType.ShaderBinds);
 
             FlushCurrentBatch();
 
-            GL.UseProgram(s);
-            currentShader = s;
+            GL.UseProgram(shader);
+            currentShader = shader;
         }
 
         internal static void SetUniform<T>(IUniformWithValue<T> uniform)


### PR DESCRIPTION
If a `DrawNode` causes an exception after a shader is bound, and the exception is "allowed" via overriding `GameHost.ExceptionThrown`, then the next draw iteration will throw an assert in `GLWrapper.Reset()`.

Can be tested via the following:
```diff
diff --git a/osu.Framework.Tests/Program.cs b/osu.Framework.Tests/Program.cs
index 8fb25e4db1..65257ea49c 100644
--- a/osu.Framework.Tests/Program.cs
+++ b/osu.Framework.Tests/Program.cs
@@ -17,6 +17,13 @@ public static void Main(string[] args)

             using (GameHost host = Host.GetSuitableDesktopHost(@"visual-tests", new HostOptions { PortableInstallation = portable }))
             {
+                bool allowException = true;
+                host.ExceptionThrown += _ =>
+                {
+                    allowException = !allowException;
+                    return !allowException;
+                };
+
                 if (benchmark)
                     host.Run(new AutomatedVisualTestGame());
                 else
diff --git a/osu.Framework/Utils/ConvexPolygonClipper.cs b/osu.Framework/Utils/ConvexPolygonClipper.cs
index a0de4e79e7..90f92fb05c 100644
--- a/osu.Framework/Utils/ConvexPolygonClipper.cs
+++ b/osu.Framework/Utils/ConvexPolygonClipper.cs
@@ -9,6 +9,11 @@

 namespace osu.Framework.Utils
 {
+    public static class ExceptionStatics
+    {
+        public static bool ExceptionThrown;
+    }
+
     public readonly ref struct ConvexPolygonClipper<TClip, TSubject>
         where TClip : IConvexPolygon
         where TSubject : IConvexPolygon
@@ -48,6 +53,12 @@ public int GetClipBufferSize()
         /// <returns>A clockwise-ordered set of vertices representing the result of clipping <see cref="subjectPolygon"/> by <see cref="clipPolygon"/>.</returns>
         public Span<Vector2> Clip(in Span<Vector2> buffer)
         {
+            if (!ExceptionStatics.ExceptionThrown)
+            {
+                ExceptionStatics.ExceptionThrown = true;
+                throw new InvalidOperationException();
+            }
+
             if (buffer.Length < GetClipBufferSize())
             {
                 throw new ArgumentException($"Clip buffer must have a length of {GetClipBufferSize()}, but was {buffer.Length}."
```

Logs from master (**game crashes to desktop**):
```
[runtime] 2022-06-06 02:13:54 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 02:13:54 [error]: System.InvalidOperationException: Operation is not valid due to the current state of the object.
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Utils.ConvexPolygonClipper`2.Clip(Span`1& buffer) in /home/smgi/Repos/osu-framework/osu.Framework/Utils/ConvexPolygonClipper.cs:line 59
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Sprites.SpriteDrawNode.BlitOpaqueInterior(Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs:line 75
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Sprites.SpriteDrawNode.DrawOpaqueInterior(Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs:line 105
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.DrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/DrawNode.cs:line 121
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Platform.GameHost.DrawFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 484
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Threading.GameThread.processFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Threading/GameThread.cs:line 452
[runtime] 2022-06-06 02:13:54 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 02:13:54 [error]: NUnit.Framework.AssertionException
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Logging.ThrowingTraceListener.Fail(String message) in /home/smgi/Repos/osu-framework/osu.Framework/Logging/ThrowingTraceListener.cs:line 23
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.TraceInternal.Fail(String message)
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.Trace.Assert(Boolean condition)
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.OpenGL.GLWrapper.Reset(Vector2 size) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/OpenGL/GLWrapper.cs:line 144
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Platform.GameHost.DrawFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 473
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Threading.GameThread.processFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Threading/GameThread.cs:line 452
Unhandled exception. [runtime] 2022-06-06 02:13:54 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 02:13:54 [error]: NUnit.Framework.AssertionException
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Logging.ThrowingTraceListener.Fail(String message) in /home/smgi/Repos/osu-framework/osu.Framework/Logging/ThrowingTraceListener.cs:line 23
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.TraceInternal.Fail(String message)
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.Trace.Assert(Boolean condition)
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.OpenGL.GLWrapper.Reset(Vector2 size) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/OpenGL/GLWrapper.cs:line 144
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Platform.GameHost.DrawFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 473
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Threading.GameThread.processFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Threading/GameThread.cs:line 452
[runtime] 2022-06-06 02:13:54 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 02:13:54 [error]: NUnit.Framework.AssertionException
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Logging.ThrowingTraceListener.Fail(String message) in /home/smgi/Repos/osu-framework/osu.Framework/Logging/ThrowingTraceListener.cs:line 23
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.TraceInternal.Fail(String message)
[runtime] 2022-06-06 02:13:54 [error]: at System.Diagnostics.Trace.Assert(Boolean condition)
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Graphics.OpenGL.GLWrapper.Reset(Vector2 size) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/OpenGL/GLWrapper.cs:line 144
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Platform.GameHost.DrawFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 473
[runtime] 2022-06-06 02:13:54 [error]: at osu.Framework.Threading.GameThread.processFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Threading/GameThread.cs:line 452
```

Logs from this PR (**game continues running**):
```
[runtime] 2022-06-06 02:15:28 [error]: An unhandled error has occurred.
[runtime] 2022-06-06 02:15:28 [error]: System.InvalidOperationException: Operation is not valid due to the current state of the object.
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Utils.ConvexPolygonClipper`2.Clip(Span`1& buffer) in /home/smgi/Repos/osu-framework/osu.Framework/Utils/ConvexPolygonClipper.cs:line 59
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Sprites.SpriteDrawNode.BlitOpaqueInterior(Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs:line 75
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Sprites.SpriteDrawNode.DrawOpaqueInterior(Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs:line 105
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.DrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/DrawNode.cs:line 121
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Graphics.Containers.CompositeDrawable.CompositeDrawableDrawNode.DrawOpaqueInteriorSubTree(DepthValue depthValue, Action`1 vertexAction) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs:line 213
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Platform.GameHost.DrawFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 484
[runtime] 2022-06-06 02:15:28 [error]: at osu.Framework.Threading.GameThread.processFrame() in /home/smgi/Repos/osu-framework/osu.Framework/Threading/GameThread.cs:line 452
[runtime] 2022-06-06 02:15:28 [verbose]: 🔸 Step #2 VariousTextBoxes
[runtime] 2022-06-06 02:15:28 [verbose]: 💨 TextBox(TestSceneTextBox) VariousTextBoxes
[runtime] 2022-06-06 02:15:28 [verbose]: 🔸 Step #3 [SetUp]
[runtime] 2022-06-06 02:15:29 [verbose]: 🔸 Step #4 add textboxes
```