### PR TITLE
Attempt to fix `TestSceneVideo` incorrectly failing due to intermittent state changes

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -103,7 +103,6 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("make video hidden", () => video.Hide());
 
             AddWaitStep("wait a bit", 10);
-
             AddUntilStep("decoding stopped", () => video.State == VideoDecoder.DecoderState.Ready);
 
             AddStep("reset decode state", () => didDecode = false);
@@ -125,6 +124,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);
 
+            AddWaitStep("wait a bit", 10);
             AddUntilStep("decoding stopped", () => video.State == VideoDecoder.DecoderState.Ready);
 
             AddStep("reset decode state", () => didDecode = false);


### PR DESCRIPTION
This was already added in the test method above the one I've fixed.  Basically during decode the decoder is constantly switching between `Running` and `Ready`, so checking for `Ready` just once doesn't guarantee the full decode process has stopped.


https://user-images.githubusercontent.com/191335/172117884-89ee17a1-293d-4e4f-81d0-1d1451ea30c4.mp4


https://github.com/ppy/osu-framework/runs/6750920076?check_suite_focus=true