### PR TITLE
Rename "unlimited" to "basically unlimited" and add sane frame limiter

### DIFF
--- a/osu.Framework/Configuration/FrameSync.cs
+++ b/osu.Framework/Configuration/FrameSync.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Configuration
         [Description("8x refresh rate")]
         Limit8x,
 
-        [Description("Unlimited")]
+        [Description("Basically unlimited")]
         Unlimited,
     }
 }

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -20,8 +20,8 @@ namespace osu.Framework.Threading
     /// </summary>
     public class GameThread
     {
-        internal const double DEFAULT_ACTIVE_HZ = 1000;
-        internal const double DEFAULT_INACTIVE_HZ = 60;
+        internal const int DEFAULT_ACTIVE_HZ = 1000;
+        internal const int DEFAULT_INACTIVE_HZ = 60;
 
         /// <summary>
         /// The name of this thread.


### PR DESCRIPTION
This was already discussed internally and agreed on.

I'd also like to change the remaining options to be more in line with stable (ie. have an "optimised" setting that keeps update fps around 500 regardless of refresh rate), but that's for another day.

---

Games using osu!framework can generally run at *very* high frame rates when not much is going on.

This can be counter-productive due to the induced allocation and GPU overhead.
 - Allocation overhead can lead to excess garbage collection
 - GPU overhead can lead to unexpected pipeline blocking (and stutters as a result).
   Also, in general graphics card manufacturers do not test their hardware at insane frame rates and therefore drivers are not optimised to handle this kind of throughput.
 - We only harvest input at 1000hz, so running any higher has zero benefits.

We limit things to the same rate we poll input at, to keep both gamers and their systems happy and (more) stutter-free.