### PR TITLE
Let BASS read stream data ahead of time to reduce audio stuttering

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -189,7 +189,7 @@ namespace osu.Framework.Audio.Sample
             if (hasChannel)
                 return;
 
-            channel = Bass.SampleGetChannel(sample.SampleId, BassFlags.SampleChannelStream | BassFlags.Decode);
+            channel = Bass.SampleGetChannel(sample.SampleId, BassFlags.SampleChannelStream | BassFlags.Decode | BassFlags.AsyncFile);
 
             if (!hasChannel)
                 return;

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -151,7 +151,7 @@ namespace osu.Framework.Audio.Track
 
             fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(dataStream));
 
-            BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan;
+            BassFlags flags = (Preview ? 0 : BassFlags.Decode | BassFlags.Prescan) | BassFlags.AsyncFile;
             int stream = Bass.CreateStream(StreamSystem.NoBuffer, flags, fileCallbacks.Callbacks, fileCallbacks.Handle);
 
             bitrate = (int)Math.Round(Bass.ChannelGetAttribute(stream, ChannelAttribute.Bitrate));


### PR DESCRIPTION
- Closes #5237 

After deep investigation, enabling mixer buffering avoids some of the stuttering at the cost of playback latency (see [explanation](https://discord.com/channels/188630481301012481/589331078574112768/984492141919240192)), therefore it is not desired to enable it for o!f and we can still continue without it.

The stuttering occurs when opening song select or switching between beatmaps in osu!, and looks to generally happen due to gen1/gen2 collections (meaning you can manually cause a stutter by pressing "Clear all caches" in game settings).

Instead, a flag is now used for streams (and samples with `SampleChannelStream`) for having data buffered internally ahead-of-time to read without getting stalled by CLR being stuck due to GC collection or otherwise.

It is also generally recommended for low latency output as well, but most useful for having data buffered on BASS's side:
![](https://media.discordapp.net/attachments/589331078574112768/984947483278987314/unknown.png)
See [flags documentation in `BASS_StreamCreateFileUser`](http://www.un4seen.com/doc/#bass/BASS_StreamCreateFileUser.html).

The buffer can also be configured using [`BASS_CONFIG_ASYNCFILE_BUFFER`](http://www.un4seen.com/doc/#bass/BASS_CONFIG_ASYNCFILE_BUFFER.html).

~~This brings up the question of whether we should still keep `AsyncBufferStream`, but I'm unsure about removing it immediately in this PR as it would require further testing.~~ (maybe not, see [discord](https://discord.com/channels/188630481301012481/589331078574112768/984973320887881728))