### PR TITLE
Make nullability checking more defined

### DIFF
--- a/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using NUnit.Framework;
@@ -138,6 +139,9 @@ namespace osu.Framework.Tests.Extensions
 
         [Test]
         public void TestNonNullReferenceType() => Assert.False(typeof(object).IsNullable());
+
+        [Test]
+        public void TestNonNullReferenceTypeWithGenerics() => Assert.False(typeof(IEnumerable<string>).IsNullable());
 
         // typeof cannot be used on "object?".
     }

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -101,7 +101,7 @@ namespace osu.Framework.Extensions.TypeExtensions
         /// <see cref="IsNullable(EventInfo)"/>, <see cref="IsNullable(PropertyInfo)"/>, <see cref="IsNullable(FieldInfo)"/>, or <see cref="IsNullable(ParameterInfo)"/>,
         /// in order to properly handle events/properties/fields/parameters.
         /// </remarks>
-        public static bool IsNullable(this Type type) => type.GetUnderlyingNullableType() != null;
+        public static bool IsNullable(this Type type) => type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(Nullable<>);
 
         /// <summary>
         /// Gets the underlying type of a <see cref="Nullable{T}"/>.
@@ -111,11 +111,13 @@ namespace osu.Framework.Extensions.TypeExtensions
         /// <returns>The underlying type, or null if one does not exist.</returns>
         public static Type GetUnderlyingNullableType(this Type type)
         {
-            if (!type.IsGenericType)
-                return null;
+            if (IsNullable(type))
+            {
+                // ReSharper disable once ConvertClosureToMethodGroup (see: https://github.com/dotnet/runtime/issues/33747)
+                return underlying_type_cache.GetOrAdd(type, t => Nullable.GetUnderlyingType(t));
+            }
 
-            // ReSharper disable once ConvertClosureToMethodGroup (see: https://github.com/dotnet/runtime/issues/33747)
-            return underlying_type_cache.GetOrAdd(type, t => Nullable.GetUnderlyingType(t));
+            return type;
         }
 
         /// <summary>

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Extensions.TypeExtensions
                 return underlying_type_cache.GetOrAdd(type, t => Nullable.GetUnderlyingType(t));
             }
 
-            return type;
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently, checking nullability only takes in account whether a given type is a generic or not. This check is very lossy as it may return true to other generic types even if its not `Nullable<>` and does not reflect the XML doc for `IsNullable`. The change makes it so that it properly checks if the type is a `Nullable<>`.