### PR TITLE
Suppress `SwapBuffers()` failures on android

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -242,18 +242,25 @@ namespace osu.Framework.Android
             return new AndroidInputConnection(this, true);
         }
 
+        private static readonly Logger logger = Logger.GetLogger(LoggingTarget.Runtime);
+
         public override void SwapBuffers()
         {
             try
             {
                 base.SwapBuffers();
             }
-            catch
+            catch (GraphicsContextException ex)
             {
-                // sometimes buffers will spontaneously fail to swap just before the activity is suspended to background
-                // or just after it has been resumed, but will continue operating correctly after that transitionary period.
+                // sometimes buffers will spontaneously fail to swap with BAD_SURFACE
+                // just before the activity is suspended to background or just after it has been resumed,
+                // but will continue operating correctly after that transitionary period.
                 // despite some testing it is unclear which view callback can be used to tell whether it is safe to swap buffers,
-                // so for now just catch and suppress errors.
+                // so for now just catch and suppress these errors.
+                if (ex.Message.Contains("BAD_SURFACE", StringComparison.Ordinal))
+                    logger.Add($"BAD_SURFACE failure in {nameof(SwapBuffers)} suppressed", LogLevel.Verbose, ex);
+                else
+                    throw;
             }
         }
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -242,6 +242,21 @@ namespace osu.Framework.Android
             return new AndroidInputConnection(this, true);
         }
 
+        public override void SwapBuffers()
+        {
+            try
+            {
+                base.SwapBuffers();
+            }
+            catch
+            {
+                // sometimes buffers will spontaneously fail to swap just before the activity is suspended to background
+                // or just after it has been resumed, but will continue operating correctly after that transitionary period.
+                // despite some testing it is unclear which view callback can be used to tell whether it is safe to swap buffers,
+                // so for now just catch and suppress errors up to a threshold.
+            }
+        }
+
         #region Events
 
         /// <summary>

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -253,7 +253,7 @@ namespace osu.Framework.Android
                 // sometimes buffers will spontaneously fail to swap just before the activity is suspended to background
                 // or just after it has been resumed, but will continue operating correctly after that transitionary period.
                 // despite some testing it is unclear which view callback can be used to tell whether it is safe to swap buffers,
-                // so for now just catch and suppress errors up to a threshold.
+                // so for now just catch and suppress errors.
             }
         }
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -242,8 +242,6 @@ namespace osu.Framework.Android
             return new AndroidInputConnection(this, true);
         }
 
-        private static readonly Logger logger = Logger.GetLogger(LoggingTarget.Runtime);
-
         public override void SwapBuffers()
         {
             try
@@ -258,7 +256,7 @@ namespace osu.Framework.Android
                 // despite some testing it is unclear which view callback can be used to tell whether it is safe to swap buffers,
                 // so for now just catch and suppress these errors.
                 if (ex.Message.Contains("BAD_SURFACE", StringComparison.Ordinal))
-                    logger.Add($"BAD_SURFACE failure in {nameof(SwapBuffers)} suppressed", LogLevel.Verbose, ex);
+                    Logger.Log($"BAD_SURFACE failure in {nameof(SwapBuffers)} suppressed");
                 else
                     throw;
             }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.Android" Version="1.0.187" />
+    <PackageReference Include="ppy.osuTK.Android" Version="1.0.192" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\arm64-v8a\*.so" />

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -61,7 +61,7 @@
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.187" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.192" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.187" />
+    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.192" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="ManagedBass.Mix" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.187" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.192" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.563-alpha" />
 


### PR DESCRIPTION
Workaround for the other crash described in #4994.

For reasons that are currently unclear, sometimes `SwapBuffers()` calls on android fail with `BAD_SURFACE` just before the game activity is suspended, and just after the game activity is resumed - but if given ample time to recover from the initial failures after resume, the game will continue functioning as usual.

As a temporary solution, suppress `SwapBuffers()` failures. The ideal solution would be to hook onto one of the many callbacks of
`GLSurfaceView`, but in testing it does not appear that the obvious ones fit the bill.