### PR TITLE
Clean up `FrameStatisticsDisplay` and add exception to track down `NaN`

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -15,6 +15,7 @@ using osu.Framework.Threading;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Input.Events;
 using osuTK;
@@ -346,6 +347,21 @@ namespace osu.Framework.Graphics.Performance
             base.OnKeyUp(e);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            if (running)
+            {
+                while (monitor.PendingFrames.TryDequeue(out FrameStatistics frame))
+                {
+                    applyFrame(frame);
+                    frameTimeDisplay.NewFrame(frame);
+                    monitor.FramesPool.Return(frame);
+                }
+            }
+        }
+
         private void applyFrameGC(FrameStatistics frame)
         {
             foreach (int gcLevel in frame.GarbageCollections)
@@ -379,12 +395,6 @@ namespace osu.Framework.Graphics.Performance
             }
         }
 
-        private void applyFrameCounts(FrameStatistics frame)
-        {
-            foreach (var pair in frame.Counts)
-                counterBars[pair.Key].Value = pair.Value;
-        }
-
         private void applyFrame(FrameStatistics frame)
         {
             if (state == FrameStatisticsMode.Full)
@@ -393,22 +403,8 @@ namespace osu.Framework.Graphics.Performance
                 applyFrameTime(frame);
             }
 
-            applyFrameCounts(frame);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (running)
-            {
-                while (monitor.PendingFrames.TryDequeue(out FrameStatistics frame))
-                {
-                    applyFrame(frame);
-                    frameTimeDisplay.NewFrame(frame);
-                    monitor.FramesPool.Return(frame);
-                }
-            }
+            foreach (var pair in frame.Counts)
+                counterBars[pair.Key].Value = pair.Value;
         }
 
         private Color4 getColour(PerformanceCollectionType type)
@@ -553,7 +549,6 @@ namespace osu.Framework.Graphics.Performance
 
             private double height;
             private double velocity;
-            private const double acceleration = 0.000001;
             private const float bar_width = 6;
 
             private long value;
@@ -562,6 +557,8 @@ namespace osu.Framework.Graphics.Performance
             {
                 set
                 {
+                    Debug.Assert(value >= 0); // Log10 will NaN for negative values.
+
                     this.value = value;
                     height = Math.Log10(value + 1) / amount_count_steps;
                 }
@@ -596,15 +593,19 @@ namespace osu.Framework.Graphics.Performance
             {
                 base.Update();
 
+                const double acceleration = 0.000001;
+
                 double elapsedTime = Time.Elapsed;
-                double movement = velocity * Time.Elapsed + 0.5 * acceleration * elapsedTime * elapsedTime;
-                double newHeight = Math.Max(height, box.Height - movement);
+
+                double change = velocity * elapsedTime + 0.5 * acceleration * elapsedTime * elapsedTime;
+                double newHeight = Math.Max(height, box.Height - change);
+
                 box.Height = (float)newHeight;
 
                 if (newHeight <= height)
                     velocity = 0;
                 else
-                    velocity += Time.Elapsed * acceleration;
+                    velocity += elapsedTime * acceleration;
 
                 if (expanded)
                     text.Text = $@"{Label}: {NumberFormatter.PrintWithSiSuffix(value)}";

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -28,7 +28,13 @@ namespace osu.Framework.Statistics
 
         internal static void Increment(StatisticsCounterType type) => ++COUNTERS[(int)type];
 
-        internal static void Add(StatisticsCounterType type, long amount) => COUNTERS[(int)type] += amount;
+        internal static void Add(StatisticsCounterType type, long amount)
+        {
+            if (amount < 0)
+                throw new ArgumentException($"Statistics counter {type} was attempted to be decremented via {nameof(Add)} call.", nameof(amount));
+
+            COUNTERS[(int)type] += amount;
+        }
     }
 
     internal enum PerformanceCollectionType


### PR DESCRIPTION
See https://sentry.ppy.sh/share/issue/8af58e085ca14af4a7bfd15beeef62b1/.

This is the only variable I can see which can cause a `NaN`. Throwing will mean the game still may crash (although potentially not, since it will only fire once rather than every frame), but also mean we can track down the faulty flow.

I've checked each call to `Add` and can't find anything immediately. Welcome others to double-check.