### PR TITLE
Suppress touch inputs with NaN coordinates on android

### DIFF
--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -58,8 +58,8 @@ namespace osu.Framework.Android.Input
                 // MotionEventActions.Down arrives at the beginning of a touch event chain and implies the 0th pointer is pressed.
                 // ActionIndex is generally not valid here.
                 case MotionEventActions.Down:
-                    touch = getEventTouch(touchEvent, 0);
-                    PendingInputs.Enqueue(new TouchInput(touch, true));
+                    if (tryGetEventTouch(touchEvent, 0, out touch))
+                        PendingInputs.Enqueue(new TouchInput(touch, true));
                     break;
 
                 // events that apply only to the ActionIndex pointer (other pointers' states remain unchanged)
@@ -67,8 +67,8 @@ namespace osu.Framework.Android.Input
                 case MotionEventActions.PointerUp:
                     if (touchEvent.ActionIndex < TouchState.MAX_TOUCH_COUNT)
                     {
-                        touch = getEventTouch(touchEvent, touchEvent.ActionIndex);
-                        PendingInputs.Enqueue(new TouchInput(touch, touchEvent.ActionMasked == MotionEventActions.PointerDown));
+                        if (tryGetEventTouch(touchEvent, touchEvent.ActionIndex, out touch))
+                            PendingInputs.Enqueue(new TouchInput(touch, touchEvent.ActionMasked == MotionEventActions.PointerDown));
                     }
 
                     break;
@@ -79,8 +79,8 @@ namespace osu.Framework.Android.Input
                 case MotionEventActions.Cancel:
                     for (int i = 0; i < Math.Min(touchEvent.PointerCount, TouchState.MAX_TOUCH_COUNT); i++)
                     {
-                        touch = getEventTouch(touchEvent, i);
-                        PendingInputs.Enqueue(new TouchInput(touch, touchEvent.ActionMasked == MotionEventActions.Move));
+                        if (tryGetEventTouch(touchEvent, i, out touch))
+                            PendingInputs.Enqueue(new TouchInput(touch, touchEvent.ActionMasked == MotionEventActions.Move));
                     }
 
                     break;
@@ -93,11 +93,41 @@ namespace osu.Framework.Android.Input
 
         protected override void OnHover(MotionEvent hoverEvent)
         {
-            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = getEventPosition(hoverEvent) });
+            if (tryGetEventPosition(hoverEvent, 0, out var position))
+                PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = position });
             PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, hoverEvent.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
         }
 
-        private Touch getEventTouch(MotionEvent e, int index) => new Touch((TouchSource)e.GetPointerId(index), getEventPosition(e, index));
-        private Vector2 getEventPosition(MotionEvent e, int index = 0) => new Vector2(e.GetX(index) * View.ScaleX, e.GetY(index) * View.ScaleY);
+        private bool tryGetEventTouch(MotionEvent e, int index, out Touch touch)
+        {
+            if (tryGetEventPosition(e, index, out var position))
+            {
+                touch = new Touch((TouchSource)e.GetPointerId(index), position);
+                return true;
+            }
+            else
+            {
+                touch = new Touch();
+                return false;
+            }
+        }
+
+        private bool tryGetEventPosition(MotionEvent e, int index, out Vector2 position)
+        {
+            float x = e.GetX(index);
+            float y = e.GetY(index);
+
+            // in empirical testing, `MotionEvent.Get{X,Y}()` methods can return NaN positions early on in the android activity's lifetime.
+            // these nonsensical inputs then cause issues later down the line when they are converted into framework inputs.
+            // as there is really nothing to recover from such inputs, drop them entirely.
+            if (float.IsNaN(x) || float.IsNaN(y))
+            {
+                position = Vector2.Zero;
+                return false;
+            }
+
+            position = new Vector2(x * View.ScaleX, y * View.ScaleY);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Closes #5243

In empirical testing, `MotionEvent.Get{X,Y}()` methods can return NaN positions early on in the android activity's lifetime. These nonsensical inputs then cause issues later down the line when they are converted into framework inputs.

As there is really nothing to recover from such inputs, drop them entirely.

---

Paper trail of how this was found, alongside with [patch to confirm faulty operation of `Get{X,Y}()`](https://github.com/ppy/osu-framework/issues/5243#issuecomment-1155083318) is in the issue thread.

I've tested: framework test scenes for multitouch, game-side reproduction scenario and game-side gameplay, briefly. Doesn't look like I broke anything, but I welcome re-testing.

Threading mode has no bearing on this, I checked. This can be reproduced single-threaded just the same.