### PR TITLE
Indicate some `Storage` methods as must-use

### DIFF
--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -40,7 +40,11 @@ namespace osu.Framework.Tests.IO
 
             using (var storage = new TemporaryNativeStorage(guid))
             {
-                Assert.Throws<ArgumentException>(() => storage.GetStream("../test"));
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    using var x = storage.GetStream("../test");
+                });
+
                 Assert.Throws<ArgumentException>(() => storage.GetStorageForDirectory("../"));
             }
         }

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.IO;
 
 namespace osu.Framework.Platform
@@ -115,6 +116,7 @@ namespace osu.Framework.Platform
         /// </remarks>
         /// <param name="path">The path of the file to create or overwrite.</param>
         /// <returns>A stream associated with the requested path. Will only exist at the specified location after the stream is disposed.</returns>
+        [Pure]
         public Stream CreateFileSafely(string path)
         {
             string temporaryPath = Path.Combine(Path.GetDirectoryName(path), $"_{Path.GetFileName(path)}_{Guid.NewGuid()}");
@@ -129,6 +131,7 @@ namespace osu.Framework.Platform
         /// <param name="access">The access requirements.</param>
         /// <param name="mode">The mode in which the file should be opened.</param>
         /// <returns>A stream associated with the requested path.</returns>
+        [Pure]
         public abstract Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate);
 
         /// <summary>


### PR DESCRIPTION
`[Pure]` seems to be as useful as JetBrains' own `[MustUseReturnValue]` here, so I'm going with it.