### PR TITLE
Only apply `AsyncFile` flag to non-windows platforms for now

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -187,7 +187,15 @@ namespace osu.Framework.Audio.Sample
             if (hasChannel)
                 return;
 
-            channel = Bass.SampleGetChannel(sample.SampleId, BassFlags.SampleChannelStream | BassFlags.Decode | BassFlags.AsyncFile);
+            BassFlags flags = BassFlags.SampleChannelStream | BassFlags.Decode;
+
+            // While this shouldn't cause issues, we've had a small subset of users reporting issues on windows.
+            // To keep things working let's only apply to other platforms until we know more.
+            // See https://github.com/ppy/osu/issues/18652.
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+                flags |= BassFlags.AsyncFile;
+
+            channel = Bass.SampleGetChannel(sample.SampleId, flags);
 
             if (!hasChannel)
                 return;

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -149,7 +149,14 @@ namespace osu.Framework.Audio.Track
 
             fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(dataStream));
 
-            BassFlags flags = (Preview ? 0 : BassFlags.Decode | BassFlags.Prescan) | BassFlags.AsyncFile;
+            BassFlags flags = (Preview ? 0 : BassFlags.Decode | BassFlags.Prescan);
+
+            // While this shouldn't cause issues, we've had a small subset of users reporting issues on windows.
+            // To keep things working let's only apply to other platforms until we know more.
+            // See https://github.com/ppy/osu/issues/18652.
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+                flags |= BassFlags.AsyncFile;
+
             int stream = Bass.CreateStream(StreamSystem.NoBuffer, flags, fileCallbacks.Callbacks, fileCallbacks.Handle);
 
             bitrate = (int)Math.Round(Bass.ChannelGetAttribute(stream, ChannelAttribute.Bitrate));


### PR DESCRIPTION
Closes #18652.

Doing this to get a hotfix release out. Will report the issue to BassIan to get more information surrounding how it is implemented and how this could happen.

Reasoning for still having this enabled on other platforms: We haven't had anyone report an issue yet, but I'd like to continue testing to get more insight into where the issue is occurring. If it's only happening on windows I think we should keep using the flag elsewhere until it's reported as being an issue. For one, it fixes very rare stutters on macOS for me.