### PR TITLE
Show hidden items in DirectorySelectors

### DIFF
--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -12,6 +12,13 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
+        protected override Button CreateHiddenToggleButton() => new BasicButton
+        {
+            Text = "Toggle Hidden Items",
+            Action = ShowHiddenItems.Toggle,
+            AutoSizeAxes = Axes.Both
+        };
+
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new BasicDirectorySelectorParentDirectory(directory);

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Button CreateHiddenToggleButton() => new BasicButton
+        protected override Drawable CreateHiddenToggleButton() => new BasicButton
         {
             Size = new Vector2(200, 25),
             Text = "Toggle hidden items",

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using osu.Framework.Graphics.Containers;
+using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -14,9 +15,9 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override Button CreateHiddenToggleButton() => new BasicButton
         {
+            Size = new Vector2(200, 25),
             Text = "Toggle hidden items",
             Action = ShowHiddenItems.Toggle,
-            AutoSizeAxes = Axes.Both
         };
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override Button CreateHiddenToggleButton() => new BasicButton
         {
-            Text = "Toggle Hidden Items",
+            Text = "Toggle hidden items",
             Action = ShowHiddenItems.Toggle,
             AutoSizeAxes = Axes.Both
         };

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
@@ -45,7 +45,11 @@ namespace osu.Framework.Graphics.UserInterface
             protected override IconUsage? Icon => Directory.Name.Contains(Path.DirectorySeparatorChar) ? base.Icon : null;
 
             public BreadcrumbDisplayDirectory(DirectoryInfo directory, string displayName = null)
-                : base(directory, displayName, false)
+                : base(directory, displayName)
+            {
+            }
+
+            protected override void ApplyHiddenState()
             {
             }
 

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics.UserInterface
             protected override IconUsage? Icon => Directory.Name.Contains(Path.DirectorySeparatorChar) ? base.Icon : null;
 
             public BreadcrumbDisplayDirectory(DirectoryInfo directory, string displayName = null)
-                : base(directory, displayName)
+                : base(directory, displayName, false)
             {
             }
 

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
@@ -49,7 +49,8 @@ namespace osu.Framework.Graphics.UserInterface
             {
             }
 
-            protected override void ApplyHiddenState()
+            // this method is suppressed to ensure the breadcrumbs of hidden directories are presented the same way as non-hidden directories
+            protected sealed override void ApplyHiddenState()
             {
             }
 

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
@@ -19,8 +19,8 @@ namespace osu.Framework.Graphics.UserInterface
             Font = FrameworkFont.Regular.With(size: FONT_SIZE)
         };
 
-        public BasicDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
-            : base(directory, displayName)
+        public BasicDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null, bool reduceHiddenItemOpacity = true)
+            : base(directory, displayName, reduceHiddenItemOpacity)
         {
         }
     }

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
@@ -19,8 +19,8 @@ namespace osu.Framework.Graphics.UserInterface
             Font = FrameworkFont.Regular.With(size: FONT_SIZE)
         };
 
-        public BasicDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null, bool reduceHiddenItemOpacity = true)
-            : base(directory, displayName, reduceHiddenItemOpacity)
+        public BasicDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
+            : base(directory, displayName)
         {
         }
     }

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected override IconUsage? Icon => FontAwesome.Solid.Folder;
 
         public BasicDirectorySelectorParentDirectory(DirectoryInfo directory)
-            : base(directory, "..")
+            : base(directory, "..", false)
         {
         }
     }

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
@@ -13,7 +13,11 @@ namespace osu.Framework.Graphics.UserInterface
         protected override IconUsage? Icon => FontAwesome.Solid.Folder;
 
         public BasicDirectorySelectorParentDirectory(DirectoryInfo directory)
-            : base(directory, "..", false)
+            : base(directory, "..")
+        {
+        }
+
+        protected override void ApplyHiddenState()
         {
         }
     }

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
@@ -17,7 +17,8 @@ namespace osu.Framework.Graphics.UserInterface
         {
         }
 
-        protected override void ApplyHiddenState()
+        // this method is suppressed to ensure that parent directories that are also hidden directories are presented the same way as non-hidden parent directories
+        protected sealed override void ApplyHiddenState()
         {
         }
     }

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -6,6 +6,7 @@
 using System.IO;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -15,9 +16,9 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override Button CreateHiddenToggleButton() => new BasicButton
         {
+            Size = new Vector2(200, 25),
             Text = "Toggle hidden items",
             Action = ShowHiddenItems.Toggle,
-            AutoSizeAxes = Axes.Both
         };
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Button CreateHiddenToggleButton() => new BasicButton
+        protected override Drawable CreateHiddenToggleButton() => new BasicButton
         {
             Size = new Vector2(200, 25),
             Text = "Toggle hidden items",

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override Button CreateHiddenToggleButton() => new BasicButton
         {
-            Text = "Toggle Hidden Items",
+            Text = "Toggle hidden items",
             Action = ShowHiddenItems.Toggle,
             AutoSizeAxes = Axes.Both
         };

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -13,6 +13,13 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
+        protected override Button CreateHiddenToggleButton() => new BasicButton
+        {
+            Text = "Toggle Hidden Items",
+            Action = ShowHiddenItems.Toggle,
+            AutoSizeAxes = Axes.Both
+        };
+
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);
 
         protected override DirectorySelectorDirectory CreateParentDirectoryItem(DirectoryInfo directory) => new BasicDirectorySelectorParentDirectory(directory);

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -32,6 +32,14 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected abstract DirectorySelectorBreadcrumbDisplay CreateBreadcrumb();
 
+        /// <summary>
+        /// Create a button that toggles the display of hidden items.
+        /// </summary>
+        /// <remarks>
+        /// Unless overridden, a toggle button will not be added.
+        /// </remarks>
+        protected virtual Button CreateHiddenToggleButton() => null;
+
         protected abstract DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null);
 
         /// <summary>
@@ -67,6 +75,7 @@ namespace osu.Framework.Graphics.UserInterface
                 RowDimensions = new[]
                 {
                     new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(GridSizeMode.AutoSize),
                     new Dimension(),
                 },
                 Content = new[]
@@ -74,6 +83,10 @@ namespace osu.Framework.Graphics.UserInterface
                     new Drawable[]
                     {
                         CreateBreadcrumb()
+                    },
+                    new Drawable[]
+                    {
+                        CreateHiddenToggleButton()
                     },
                     new Drawable[]
                     {

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osuTK;
@@ -21,6 +22,8 @@ namespace osu.Framework.Graphics.UserInterface
     public abstract class DirectorySelector : CompositeDrawable
     {
         private FillFlowContainer directoryFlow;
+
+        protected readonly BindableBool ShowHiddenItems = new BindableBool(true);
 
         protected abstract ScrollContainer<Drawable> CreateScrollContainer();
 
@@ -90,6 +93,7 @@ namespace osu.Framework.Graphics.UserInterface
             };
 
             CurrentPath.BindValueChanged(updateDisplay, true);
+            ShowHiddenItems.ValueChanged += _ => CurrentPath.TriggerChange();
         }
 
         /// <summary>
@@ -167,7 +171,8 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 foreach (var dir in path.GetDirectories().OrderBy(d => d.Name))
                 {
-                    items.Add(CreateDirectoryItem(dir));
+                    if (ShowHiddenItems.Value || !dir.Attributes.HasFlagFast(FileAttributes.Hidden))
+                        items.Add(CreateDirectoryItem(dir));
                 }
 
                 return true;

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -75,18 +75,31 @@ namespace osu.Framework.Graphics.UserInterface
                 RowDimensions = new[]
                 {
                     new Dimension(GridSizeMode.AutoSize),
-                    new Dimension(GridSizeMode.AutoSize),
                     new Dimension(),
                 },
                 Content = new[]
                 {
                     new Drawable[]
                     {
-                        CreateBreadcrumb()
-                    },
-                    new Drawable[]
-                    {
-                        CreateHiddenToggleButton()
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            ColumnDimensions = new[]
+                            {
+                                new Dimension(),
+                                new Dimension(GridSizeMode.AutoSize),
+                            },
+                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                            Content = new[]
+                            {
+                                new Drawable[]
+                                {
+                                    CreateBreadcrumb(),
+                                    CreateHiddenToggleButton()
+                                }
+                            }
+                        }
                     },
                     new Drawable[]
                     {

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -105,8 +105,8 @@ namespace osu.Framework.Graphics.UserInterface
                 }
             };
 
-            CurrentPath.BindValueChanged(updateDisplay, true);
-            ShowHiddenItems.ValueChanged += _ => CurrentPath.TriggerChange();
+            ShowHiddenItems.ValueChanged += _ => updateDisplay();
+            CurrentPath.BindValueChanged(_ => updateDisplay(), true);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private bool directoryChanging;
 
-        private void updateDisplay(ValueChangedEvent<DirectoryInfo> directory)
+        private void updateDisplay()
         {
             if (directoryChanging)
                 return;
@@ -127,7 +127,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 directoryFlow.Clear();
 
-                var newDirectory = directory.NewValue;
+                var newDirectory = CurrentPath.Value;
                 bool notifyError = false;
                 ICollection<DirectorySelectorItem> items = Array.Empty<DirectorySelectorItem>();
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.UserInterface
     {
         private FillFlowContainer directoryFlow;
 
-        protected readonly BindableBool ShowHiddenItems = new BindableBool(true);
+        protected readonly BindableBool ShowHiddenItems = new BindableBool();
 
         protected abstract ScrollContainer<Drawable> CreateScrollContainer();
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osuTK;
@@ -168,8 +167,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 foreach (var dir in path.GetDirectories().OrderBy(d => d.Name))
                 {
-                    if (!dir.Attributes.HasFlagFast(FileAttributes.Hidden))
-                        items.Add(CreateDirectoryItem(dir));
+                    items.Add(CreateDirectoryItem(dir));
                 }
 
                 return true;

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <remarks>
         /// Unless overridden, a toggle button will not be added.
         /// </remarks>
-        protected virtual Button CreateHiddenToggleButton() => null;
+        protected virtual Drawable CreateHiddenToggleButton() => Empty();
 
         protected abstract DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null);
 
@@ -93,7 +93,7 @@ namespace osu.Framework.Graphics.UserInterface
                             RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
                             Content = new[]
                             {
-                                new Drawable[]
+                                new[]
                                 {
                                     CreateBreadcrumb(),
                                     CreateHiddenToggleButton()

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
             catch (UnauthorizedAccessException)
             {
-                // checking attributes on access-controled directories will throw an error so we handle it here to prevent a crash
+                // checking attributes on access-controlled directories will throw an error so we handle it here to prevent a crash
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.UserInterface
             : base(displayName)
         {
             Directory = directory;
-            if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false)
+            if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                 ApplyHiddenState();
         }
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -23,8 +23,14 @@ namespace osu.Framework.Graphics.UserInterface
             : base(displayName)
         {
             Directory = directory;
-            if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
-                ApplyHiddenState();
+
+            try
+            {
+                if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
+                    ApplyHiddenState();
+            }
+
+            catch { }
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -29,7 +30,10 @@ namespace osu.Framework.Graphics.UserInterface
                 if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                     ApplyHiddenState();
             }
-            catch { }
+            catch (UnauthorizedAccessException)
+            {
+                // checking attributes on access-controled directories will throw an error so we handle it here to prevent a crash
+            }
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -14,18 +14,17 @@ namespace osu.Framework.Graphics.UserInterface
     public abstract class DirectorySelectorDirectory : DirectorySelectorItem
     {
         protected readonly DirectoryInfo Directory;
-        protected override bool? ReduceOpacity => isHiddenDirectoryWithReducedOpacity;
-        private readonly bool isHiddenDirectoryWithReducedOpacity;
         protected override string FallbackName => Directory.Name;
 
         [Resolved]
         private Bindable<DirectoryInfo> currentDirectory { get; set; }
 
-        protected DirectorySelectorDirectory(DirectoryInfo directory, string displayName = null, bool reduceHiddenDirectoryOpacity = false)
+        protected DirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
             : base(displayName)
         {
             Directory = directory;
-            isHiddenDirectoryWithReducedOpacity = (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false) && reduceHiddenDirectoryOpacity;
+            if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false)
+                ApplyHiddenState();
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -7,21 +7,25 @@ using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Graphics.UserInterface
 {
     public abstract class DirectorySelectorDirectory : DirectorySelectorItem
     {
         protected readonly DirectoryInfo Directory;
+        protected override bool? ReduceOpacity => isHiddenDirectoryWithReducedOpacity;
+        private readonly bool isHiddenDirectoryWithReducedOpacity;
         protected override string FallbackName => Directory.Name;
 
         [Resolved]
         private Bindable<DirectoryInfo> currentDirectory { get; set; }
 
-        protected DirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
+        protected DirectorySelectorDirectory(DirectoryInfo directory, string displayName = null, bool reduceHiddenDirectoryOpacity = false)
             : base(displayName)
         {
             Directory = directory;
+            isHiddenDirectoryWithReducedOpacity = (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false) && reduceHiddenDirectoryOpacity;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -29,7 +29,6 @@ namespace osu.Framework.Graphics.UserInterface
                 if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                     ApplyHiddenState();
             }
-
             catch { }
         }
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
@@ -25,6 +25,11 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract string FallbackName { get; }
 
         /// <summary>
+        /// Whether this <see cref="DirectorySelectorItem"/> is a hidden item and should have reduced opacity on its <see cref="Drawable"/>.
+        /// </summary>
+        protected abstract bool? ReduceOpacity { get; }
+
+        /// <summary>
         /// The icon of this <see cref="DirectorySelectorItem"/> to use.
         /// </summary>
         protected abstract IconUsage? Icon { get; }
@@ -52,6 +57,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Margin = new MarginPadding { Vertical = 2, Horizontal = 5 },
                 Direction = FillDirection.Horizontal,
                 Spacing = new Vector2(5),
+                Alpha = (ReduceOpacity ?? false) ? 0.5f : 1f,
             };
 
             if (Icon.HasValue)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
@@ -25,11 +25,6 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract string FallbackName { get; }
 
         /// <summary>
-        /// Whether this <see cref="DirectorySelectorItem"/> should have reduced opacity on its <see cref="Drawable"/>.
-        /// </summary>
-        protected abstract bool? ReduceOpacity { get; }
-
-        /// <summary>
         /// The icon of this <see cref="DirectorySelectorItem"/> to use.
         /// </summary>
         protected abstract IconUsage? Icon { get; }
@@ -46,6 +41,12 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected virtual SpriteText CreateSpriteText() => new SpriteText();
 
+        /// <summary>
+        /// Called when this <see cref="DirectorySelectorItem"/> is a representation of a hidden item.
+        /// Used to customize the appearance of hidden items.
+        /// </summary>
+        protected virtual void ApplyHiddenState() => Alpha = 0.5f;
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -57,7 +58,6 @@ namespace osu.Framework.Graphics.UserInterface
                 Margin = new MarginPadding { Vertical = 2, Horizontal = 5 },
                 Direction = FillDirection.Horizontal,
                 Spacing = new Vector2(5),
-                Alpha = (ReduceOpacity ?? false) ? 0.5f : 1f,
             };
 
             if (Icon.HasValue)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract string FallbackName { get; }
 
         /// <summary>
-        /// Whether this <see cref="DirectorySelectorItem"/> is a hidden item and should have reduced opacity on its <see cref="Drawable"/>.
+        /// Whether this <see cref="DirectorySelectorItem"/> should have reduced opacity on its <see cref="Drawable"/>.
         /// </summary>
         protected abstract bool? ReduceOpacity { get; }
 

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -49,8 +49,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 foreach (var file in files.OrderBy(d => d.Name))
                 {
-                    if (!file.Attributes.HasFlagFast(FileAttributes.Hidden))
-                        items.Add(CreateFileItem(file));
+                    items.Add(CreateFileItem(file));
                 }
 
                 return true;
@@ -79,6 +78,7 @@ namespace osu.Framework.Graphics.UserInterface
                 return true;
             }
 
+            protected override bool? ReduceOpacity => File?.Attributes.HasFlagFast(FileAttributes.Hidden);
             protected override string FallbackName => File.Name;
         }
     }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -87,7 +87,6 @@ namespace osu.Framework.Graphics.UserInterface
                     if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                         ApplyHiddenState();
                 }
-
                 catch { }
             }
         }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -78,8 +78,13 @@ namespace osu.Framework.Graphics.UserInterface
                 return true;
             }
 
-            protected override bool? ReduceOpacity => File?.Attributes.HasFlagFast(FileAttributes.Hidden);
             protected override string FallbackName => File.Name;
+
+            protected DirectoryListingFile()
+            {
+                if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false)
+                    ApplyHiddenState();
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -49,7 +49,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                 foreach (var file in files.OrderBy(d => d.Name))
                 {
-                    items.Add(CreateFileItem(file));
+                    if (ShowHiddenItems.Value || !file.Attributes.HasFlagFast(FileAttributes.Hidden))
+                        items.Add(CreateFileItem(file));
                 }
 
                 return true;

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -82,8 +82,13 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected DirectoryListingFile()
             {
-                if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
-                    ApplyHiddenState();
+                try
+                {
+                    if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
+                        ApplyHiddenState();
+                }
+
+                catch { }
             }
         }
     }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -87,7 +87,10 @@ namespace osu.Framework.Graphics.UserInterface
                     if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                         ApplyHiddenState();
                 }
-                catch { }
+                catch (UnauthorizedAccessException)
+                {
+                    // checking attributes on access-controled files will throw an error so we handle it here to prevent a crash
+                }
             }
         }
     }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -70,6 +70,16 @@ namespace osu.Framework.Graphics.UserInterface
             protected DirectoryListingFile(FileInfo file)
             {
                 File = file;
+
+                try
+                {
+                    if (File?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
+                        ApplyHiddenState();
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // checking attributes on access-controlled files will throw an error so we handle it here to prevent a crash
+                }
             }
 
             protected override bool OnClick(ClickEvent e)
@@ -79,19 +89,6 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             protected override string FallbackName => File.Name;
-
-            protected DirectoryListingFile()
-            {
-                try
-                {
-                    if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
-                        ApplyHiddenState();
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    // checking attributes on access-controlled files will throw an error so we handle it here to prevent a crash
-                }
-            }
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Graphics.UserInterface
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    // checking attributes on access-controled files will throw an error so we handle it here to prevent a crash
+                    // checking attributes on access-controlled files will throw an error so we handle it here to prevent a crash
                 }
             }
         }

--- a/osu.Framework/Graphics/UserInterface/FileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/FileSelector.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected DirectoryListingFile()
             {
-                if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) ?? false)
+                if (currentFile?.Value.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                     ApplyHiddenState();
             }
         }


### PR DESCRIPTION
Discussed in ppy/osu#15759, resolves ppy/osu#18573.

This change includes hidden items in `DirectorySelector` dialogues and provides a way to reduce their opacity to distinguish them from non-hidden items.

I elected to make opacity reduction a defaulted constructor argument for `DirectorySelectorDirectory` to avoid making any breaking changes, but this could be changed to a property to force implementations to state their opacity preference explicitly.

I've only tested this on Linux with dotfiles, would appreciate someone checking it on macOS and Windows (though I can't immediately think of anything that would be different).