### PR TITLE
Work around macOS agent regression affecting iOS CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,12 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
+      # macOS agents recently have empty NuGet config files, resulting in restore failures,
+      # see https://github.com/actions/virtual-environments/issues/5768
+      # Add the global nuget package source manually for now.
+      - name: Setup NuGet.Config
+        run: echo '<configuration><packageSources><add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" /></packageSources></configuration>' > ~/.config/NuGet/NuGet.Config
+
       # Contrary to seemingly any other msbuild, msbuild running on macOS/Mono
       # cannot accept .sln(f) files as arguments.
       # Build just the iOS framework project for now.


### PR DESCRIPTION
Recently, the macOS agents have bumped NuGet, and in return broke both Android and iOS CI from passing beyond the restore step. Android was fixed by reverting back to Windows agent, but iOS was left broken.

However, [the issue has since been reported to `virtual-environments`](https://github.com/actions/virtual-environments/issues/5768), and [a workaround was brought up in there as well](https://github.com/actions/virtual-environments/issues/5768#issuecomment-1159364290). The workaround looks to work for us therefore I'm PR'ing it to bring iOS CI back.

An alternative would be providing project-level `nuget.config` files, but we don't really use any other package sources so I refrained from doing that.