### PR TITLE
Use new static HashData methods for .NET 6+ targets

### DIFF
--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
@@ -141,7 +141,9 @@
     <ImageAsset Include="Assets.xcassets\Contents.json">
       <Visible>false</Visible>
     </ImageAsset>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -267,6 +267,9 @@ namespace osu.Framework.Extensions
         /// <returns>A lower-case hex string representation of the hash (64 characters).</returns>
         public static string ComputeSHA2Hash(this string str)
         {
+#if NET6_0_OR_GREATER
+            return SHA256.HashData(Encoding.UTF8.GetBytes(str)).toLowercaseHex();
+#endif
             using (var alg = SHA256.Create())
                 return alg.ComputeHash(Encoding.UTF8.GetBytes(str)).toLowercaseHex();
         }
@@ -285,6 +288,9 @@ namespace osu.Framework.Extensions
 
         public static string ComputeMD5Hash(this string input)
         {
+#if NET6_0_OR_GREATER
+            return MD5.HashData(Encoding.UTF8.GetBytes(input)).toLowercaseHex();
+#endif
             using (var md5 = MD5.Create())
                 return md5.ComputeHash(Encoding.UTF8.GetBytes(input)).toLowercaseHex();
         }

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -269,9 +269,10 @@ namespace osu.Framework.Extensions
         {
 #if NET6_0_OR_GREATER
             return SHA256.HashData(Encoding.UTF8.GetBytes(str)).toLowercaseHex();
-#endif
+#else
             using (var alg = SHA256.Create())
                 return alg.ComputeHash(Encoding.UTF8.GetBytes(str)).toLowercaseHex();
+#endif
         }
 
         public static string ComputeMD5Hash(this Stream stream)
@@ -290,9 +291,10 @@ namespace osu.Framework.Extensions
         {
 #if NET6_0_OR_GREATER
             return MD5.HashData(Encoding.UTF8.GetBytes(input)).toLowercaseHex();
-#endif
+#else
             using (var md5 = MD5.Create())
                 return md5.ComputeHash(Encoding.UTF8.GetBytes(input)).toLowercaseHex();
+#endif
         }
 
         public static DisplayIndex GetIndex(this DisplayDevice display)


### PR DESCRIPTION
Use the new static one-shot APIs introduced in .NET 5 to improve performance and allocations.

Benchmark numbers on my Windows machine:
Before:
|    Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|---------- |-----------:|---------:|---------:|-------:|----------:|
| StringMD5 |   905.6 ns | 13.56 ns | 12.68 ns | 0.0839 |     352 B |
| StringSHA | 1,060.0 ns |  2.35 ns |  2.19 ns | 0.1068 |     448 B |

After:
|    Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|---------- |---------:|--------:|--------:|-------:|----------:|
| StringMD5 | 648.2 ns | 9.07 ns | 8.04 ns | 0.0439 |     184 B |
| StringSHA | 820.9 ns | 4.85 ns | 4.30 ns | 0.0629 |     264 B |