### PR TITLE
Fix potential exception when calling `FinishTransforms` results in child changes

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -360,7 +360,10 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 if (InternalChildren.Count != 1)
-                    throw new InvalidOperationException($"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(InternalChildren)} (currently {InternalChildren.Count})!");
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(InternalChildren)} (currently {InternalChildren.Count})!");
+                }
 
                 return InternalChildren[0];
             }
@@ -1333,8 +1336,9 @@ namespace osu.Framework.Graphics.Containers
 
             if (propagateChildren)
             {
-                foreach (var c in internalChildren)
-                    c.FinishTransforms(true, targetMember);
+                // use for over foreach as collection may grow due to abort / completion events.
+                for (int i = 0; i < internalChildren.Count; i++)
+                    internalChildren[i].FinishTransforms(true, targetMember);
             }
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1336,7 +1336,9 @@ namespace osu.Framework.Graphics.Containers
 
             if (propagateChildren)
             {
-                // use for over foreach as collection may grow due to abort / completion events.
+                // Use for over foreach as collection may grow due to abort / completion events.
+                // Note that this may mean that in the addition of elements being removed,
+                // `FinishTransforms` may not be called on all items.
                 for (int i = 0; i < internalChildren.Count; i++)
                     internalChildren[i].FinishTransforms(true, targetMember);
             }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -226,7 +226,7 @@ namespace osu.Framework.Graphics.Transforms
             }
             else
             {
-                // collection may grow due to abort / completion events.
+                // use for over foreach as collection may grow due to abort / completion events.
                 for (int i = 0; i < targetGroupingTrackers.Count; i++)
                     targetGroupingTrackers[i].FinishTransforms();
             }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -226,7 +226,9 @@ namespace osu.Framework.Graphics.Transforms
             }
             else
             {
-                // use for over foreach as collection may grow due to abort / completion events.
+                // Use for over foreach as collection may grow due to abort / completion events.
+                // Note that this may mean that in the addition of elements being removed,
+                // `FinishTransforms` may not be called on all items.
                 for (int i = 0; i < targetGroupingTrackers.Count; i++)
                     targetGroupingTrackers[i].FinishTransforms();
             }


### PR DESCRIPTION
As seen at https://sentry.ppy.sh/share/issue/8d469f0003bd446eb4bda7865b2e9bc9/.

Can probably figure out a repro case if test coverage is seen as beneficial, but it's obvious how this could happen (and the inline comment should guard against regression).