### PR TITLE
Ban usage of `ManualResetEventSlim.Wait()` without a timeout value

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -7,3 +7,4 @@ F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see h
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
 M:System.Guid.#ctor;Probably meaning to use Guid.NewGuid() instead. If actually wanting empty, use Guid.Empty.
 P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetResultSafely() to ensure we avoid deadlocks.
+M:System.Threading.ManualResetEventSlim.Wait();Specify a timeout to avoid waiting forever.

--- a/osu.Framework.Benchmarks/GameBenchmark.cs
+++ b/osu.Framework.Benchmarks/GameBenchmark.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
@@ -111,7 +112,9 @@ namespace osu.Framework.Benchmarks
 
             public override void RunMainLoop()
             {
-                RunOnce.Wait();
+                if (!RunOnce.Wait(10000))
+                    throw new TimeoutException("Run request didn't arrive for a long time");
+
                 RunSingleFrame();
                 RunOnce.Reset();
 

--- a/osu.Framework.Tests/Containers/TestSceneCompositeMutability.cs
+++ b/osu.Framework.Tests/Containers/TestSceneCompositeMutability.cs
@@ -169,12 +169,14 @@ namespace osu.Framework.Tests.Containers
             [BackgroundDependencyLoader]
             private void load()
             {
-                LoadingEvent.Wait();
+                if (!LoadingEvent.Wait(10000))
+                    throw new TimeoutException("Load took too long");
 
                 OnLoading?.Invoke();
                 OnLoading = null;
 
-                ReadyEvent.Wait();
+                if (!ReadyEvent.Wait(10000))
+                    throw new TimeoutException("Ready took too long");
             }
 
             public override bool UpdateSubTree()

--- a/osu.Framework.Tests/IO/BackgroundGameHeadlessGameHost.cs
+++ b/osu.Framework.Tests/IO/BackgroundGameHeadlessGameHost.cs
@@ -33,7 +33,8 @@ namespace osu.Framework.Tests.IO
 
             Task.Factory.StartNew(() => Run(testGame), TaskCreationOptions.LongRunning);
 
-            testGame.HasProcessed.Wait();
+            if (!testGame.HasProcessed.Wait(10000))
+                throw new TimeoutException("Game took too long to process a frame");
         }
 
         private class TestGame : Game

--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -112,7 +112,8 @@ namespace osu.Framework.Tests.Platform
 
                         await clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).ConfigureAwait(false);
 
-                        received.Wait();
+                        if (!received.Wait(10000))
+                            throw new TimeoutException("Message was not received in a timely fashion");
                     }
                 }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithLoading.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithLoading.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -177,7 +178,8 @@ namespace osu.Framework.Tests.Visual.Drawables
             [BackgroundDependencyLoader]
             private void load()
             {
-                AllowLoad.Wait();
+                if (!AllowLoad.Wait(10000))
+                    throw new TimeoutException("Load was not allowed in a timely fashion");
             }
         }
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -223,7 +223,10 @@ namespace osu.Framework.Tests.Visual.Sprites
                 TotalInitiatedLookups++;
 
                 if (blocking && name == blockingName)
-                    resetEvent.Wait();
+                {
+                    if (!resetEvent.Wait(10000))
+                        throw new TimeoutException("Load was not allowed in a timely fashion.");
+                }
 
                 TotalCompletedLookups++;
                 return getFunc("sample-texture");

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -562,7 +562,9 @@ namespace osu.Framework.Platform
                 });
 
                 // this is required as attempting to use a TaskCompletionSource blocks the thread calling SetResult on some configurations.
-                await Task.Run(completionEvent.Wait).ConfigureAwait(false);
+                // ReSharper disable once AccessToDisposedClosure
+                if (!await Task.Run(() => completionEvent.Wait(5000)).ConfigureAwait(false))
+                    throw new TimeoutException("Screenshot data did not arrive in a timely fashion");
 
                 var image = Image.LoadPixelData<Rgba32>(pixelData.Memory.Span, width, height);
                 image.Mutate(c => c.Flip(FlipMode.Vertical));
@@ -1122,7 +1124,9 @@ namespace osu.Framework.Platform
                 case ExecutionState.Stopping:
                 case ExecutionState.Stopped:
                     // Delay disposal until the game has exited
-                    stoppedEvent.Wait();
+                    if (!stoppedEvent.Wait(60000))
+                        throw new InvalidOperationException("Game stuck in runnning state.");
+
                     break;
             }
 


### PR DESCRIPTION
Adds timeouts and exceptions when timeouts are exceeded.