### PR TITLE
Enable NRT on `IHasCustomTooltip` interface

### DIFF
--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
@@ -24,20 +22,21 @@ namespace osu.Framework.Graphics.Cursor
         /// <summary>
         /// Tooltip text that shows when hovering the drawable.
         /// </summary>
-        object TooltipContent { get; }
+        object? TooltipContent { get; }
     }
 
     /// <inheritdoc />
     public interface IHasCustomTooltip<TContent> : IHasCustomTooltip
+        where TContent : class
     {
         ITooltip IHasCustomTooltip.GetCustomTooltip() => GetCustomTooltip();
 
         /// <inheritdoc cref="IHasCustomTooltip.GetCustomTooltip"/>
         new ITooltip<TContent> GetCustomTooltip();
 
-        object IHasCustomTooltip.TooltipContent => TooltipContent;
+        object? IHasCustomTooltip.TooltipContent => TooltipContent;
 
         /// <inheritdoc cref="IHasCustomTooltip.TooltipContent"/>
-        new TContent TooltipContent { get; }
+        new TContent? TooltipContent { get; }
     }
 }


### PR DESCRIPTION
Probably should be applied to all interfaces asap as it leads to weirdness in usages otherwise.