### PR TITLE
Disallow usage of `string.To{Upper,Lower}()` without explicit culture

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -8,3 +8,5 @@ M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() 
 M:System.Guid.#ctor;Probably meaning to use Guid.NewGuid() instead. If actually wanting empty, use Guid.Empty.
 P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetResultSafely() to ensure we avoid deadlocks.
 M:System.Threading.ManualResetEventSlim.Wait();Specify a timeout to avoid waiting forever.
+M:System.String.ToLower();string.ToLower() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToLowerInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.
+M:System.String.ToUpper();string.ToUpper() changes behaviour depending on CultureInfo.CurrentCulture. Use string.ToUpperInvariant() instead. If wanting culture-sensitive behaviour, explicitly provide CultureInfo.CurrentCulture or use LocalisableString.

--- a/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Globalization;
 using System.Linq;
 using Foundation;
 using osu.Framework.Input.Handlers;

--- a/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTextFieldKeyboardHandler.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.iOS.Input
                 default:
                     if (char.IsLetter(c))
                     {
-                        string keyName = c.ToString().ToUpper();
+                        string keyName = c.ToString().ToUpper(CultureInfo.CurrentCulture);
                         if (Enum.TryParse(keyName, out Key result))
                             return result;
                     }

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Logging
 
         private readonly GlobalStatistic<int> logCount;
 
-        private static readonly HashSet<string> reserved_names = new HashSet<string>(Enum.GetNames(typeof(LoggingTarget)).Select(n => n.ToLower()));
+        private static readonly HashSet<string> reserved_names = new HashSet<string>(Enum.GetNames(typeof(LoggingTarget)).Select(n => n.ToLowerInvariant()));
 
         private Logger(LoggingTarget target = LoggingTarget.Runtime)
             : this(target.ToString(), false)
@@ -99,7 +99,7 @@ namespace osu.Framework.Logging
 
         private Logger(string name, bool checkedReserved)
         {
-            name = name.ToLower();
+            name = name.ToLowerInvariant();
 
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentException("The name of a logger must be non-null and may not contain only white space.", nameof(name));
@@ -254,7 +254,7 @@ namespace osu.Framework.Logging
         {
             lock (static_sync_lock)
             {
-                string nameLower = name.ToLower();
+                string nameLower = name.ToLowerInvariant();
 
                 if (!static_loggers.TryGetValue(nameLower, out Logger l))
                 {
@@ -312,7 +312,7 @@ namespace osu.Framework.Logging
             IEnumerable<string> lines = logOutput
                                         .Replace(@"\r\n", @"\n")
                                         .Split('\n')
-                                        .Select(s => $@"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)} [{level.ToString().ToLower()}]: {s.Trim()}");
+                                        .Select(s => $@"{DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)} [{level.ToString().ToLowerInvariant()}]: {s.Trim()}");
 
             if (outputToListeners)
             {
@@ -341,7 +341,7 @@ namespace osu.Framework.Logging
                     {
                         if (bypassRateLimit || debugOutputRollingTime.RequestEntry())
                         {
-                            consoleLog($"[{Name.ToLower()}] {line}");
+                            consoleLog($"[{Name.ToLowerInvariant()}] {line}");
 
                             if (!bypassRateLimit && debugOutputRollingTime.IsAtLimit)
                                 consoleLog($"Console output is being limited. Please check {Filename} for full logs.");

--- a/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
@@ -39,6 +39,9 @@ namespace osu.Framework.Platform.SDL2
 
             // SDL_GetKeyName() returned a unicode character that would be produced if that key was pressed.
             // consumers expect an uppercase letter.
+            // `.ToUpper()` with current culture may be slightly inaccurate if the framework locale
+            // is different from the locale of the keyboard layout being used,
+            // but we have no means to detect this anyway, as SDL doesn't provide the name of the layout.
             return name.ToUpper(CultureInfo.CurrentCulture);
         }
 

--- a/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Globalization;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using SDL2;
@@ -38,7 +39,7 @@ namespace osu.Framework.Platform.SDL2
 
             // SDL_GetKeyName() returned a unicode character that would be produced if that key was pressed.
             // consumers expect an uppercase letter.
-            return name.ToUpper();
+            return name.ToUpper(CultureInfo.CurrentCulture);
         }
 
         /// <summary>

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Statistics
 
             logger = new Lazy<Logger>(() =>
             {
-                var l = Logger.GetLogger($"performance-{threadName?.ToLower() ?? "unknown"}");
+                var l = Logger.GetLogger($"performance-{threadName?.ToLowerInvariant() ?? "unknown"}");
                 l.OutputToListeners = false;
                 return l;
             });


### PR DESCRIPTION
Due to it relying on ambient current culture. Vaguely related to https://github.com/ppy/osu/issues/18729. I intend to apply this over there too later.

No major breakage here (though I did see a `performance-ınput.log`, that's dotless i, in my testing).