### PR TITLE
Add environment variable flag to cause until steps to never timeout

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         private int invocations;
 
-        private const int max_attempt_milliseconds = 10000;
+        private static readonly int max_attempt_milliseconds = Environment.GetEnvironmentVariable("OSU_TESTS_NO_TIMEOUT") == "1" ? int.MaxValue : 10000;
 
         public override int RequiredRepetitions => success ? 0 : int.MaxValue;
 


### PR DESCRIPTION
Setting `OSU_TESTS_NO_TIMEOUT` to `1` will call any `UntilStep`s to run forever. This can allow attaching a debugger or performing a memory dump to investigate edge case scenarios.

Tested manually to work as expected.