### PR TITLE
Early-return on `GetDescription`/`GetLocalisableDescription` if already string type

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
@@ -51,6 +51,13 @@ namespace osu.Framework.Tests.Localisation
             Assert.Throws<InvalidOperationException>(() => EnumD.Item1.GetLocalisableDescription());
         }
 
+        [Test]
+        public void TestLocalisableStringDescription()
+        {
+            object description = TestStrings.Romanisable;
+            Assert.AreEqual(description, description.GetLocalisableDescription());
+        }
+
         public enum EnumA
         {
             Item1,
@@ -65,7 +72,7 @@ namespace osu.Framework.Tests.Localisation
             Item1,
 
             [LocalisableDescription(typeof(TestStrings), nameof(TestStrings.B))]
-            Item2
+            Item2,
         }
 
         public enum EnumC
@@ -90,6 +97,8 @@ namespace osu.Framework.Tests.Localisation
             public static LocalisableString A => "Localised A";
 
             public static readonly LocalisableString B = "Localised B";
+
+            public static LocalisableString Romanisable => new RomanisableString("Original", "Romanised");
 
             public LocalisableString Instance => string.Empty;
         }

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -181,12 +181,21 @@ namespace osu.Framework.Extensions
         ///   </item>
         /// </list>
         /// </summary>
+        /// <remarks>
+        /// If the passed value is already of type <see cref="LocalisableString"/>, it will be returned.
+        /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// When the <see cref="LocalisableDescriptionAttribute.Name"/> specified in the <see cref="LocalisableDescriptionAttribute"/>
         /// does not match any of the existing members in <see cref="LocalisableDescriptionAttribute.DeclaringType"/>.
         /// </exception>
         public static LocalisableString GetLocalisableDescription<T>(this T value)
         {
+            if (value is LocalisableString localisable)
+                return localisable;
+
+            if (value is string description)
+                return description;
+
             MemberInfo type;
 
             if (value is Enum)
@@ -224,8 +233,14 @@ namespace osu.Framework.Extensions
         ///   </item>
         /// </list>
         /// </summary>
+        /// <remarks>
+        /// If the passed value is already of type <see cref="string"/>, it will be returned.
+        /// </remarks>
         public static string GetDescription(this object value)
         {
+            if (value is string description)
+                return description;
+
             Type type = value as Type ?? value.GetType();
             return type.GetField(value.ToString())?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
         }


### PR DESCRIPTION
This is implicitly what `GetDescription` does, but `GetLocalisableDescription` fails with returning a `string`-backed `LocalisableString` instead of the actual localised string data (since it's falling back to the `GetDescription` branch).

Instead, now `GetDescription` and `GetLocalisableDescription` explicitly check if the type is already string and return the value instead of going through reflection.

This came up in https://github.com/ppy/osu/pull/18803#discussion_r903224609 where the method is trying to do too much just to display a localisable string with upper case. We might end up not relying on `LocalisableString`-typed tab items, but leaving this PR out just to match behaviour with `GetDescription` at least.