### PR TITLE
Validate transform values before queuing to drawable

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
@@ -65,6 +67,20 @@ namespace osu.Framework.Tests.Visual.Drawables
             });
 
             AddAssert("finalize triggered", () => finalizeTriggered);
+        }
+
+        [Test]
+        public void TestValidation()
+        {
+            AddStep("Animate", () =>
+            {
+                setup();
+                animate();
+            });
+
+            AddStep("nan width", () => Assert.Throws<ArgumentException>(() => boxes[0].ResizeWidthTo(float.NaN)));
+            AddStep("nan width sequence", () => Assert.Throws<ArgumentException>(() => boxes[0].FadeIn(200).ResizeWidthTo(float.NaN)));
+            AddStep("zero child size", () => Assert.Throws<ArgumentException>(() => boxes[0].TransformRelativeChildSizeTo(Vector2.Zero)));
         }
 
         private void setup()

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1723,8 +1723,13 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newSize">The coordinate space to tween to.</param>
         /// <param name="duration">The tween duration.</param>
         /// <param name="easing">The tween easing.</param>
-        protected TransformSequence<CompositeDrawable> TransformRelativeChildSizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None) =>
-            this.TransformTo(nameof(RelativeChildSize), newSize, duration, easing);
+        protected TransformSequence<CompositeDrawable> TransformRelativeChildSizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
+        {
+            if (newSize.X == 0 || newSize.Y == 0)
+                throw new ArgumentException($@"{nameof(newSize)} must be non-zero, but is {newSize}.", nameof(newSize));
+
+            return this.TransformTo(nameof(RelativeChildSize), newSize, duration, easing);
+        }
 
         /// <summary>
         /// Tweens the <see cref="RelativeChildOffset"/> of this <see cref="CompositeDrawable"/>.

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -163,22 +163,16 @@ namespace osu.Framework.Graphics
 
             return transform;
 
-            static bool isFinite(object value)
+            static bool isFinite(TValue value)
             {
-                switch (value)
-                {
-                    case float floatValue:
-                        return float.IsFinite(floatValue);
-
-                    case double doubleValue:
-                        return double.IsFinite(doubleValue);
-
-                    case Vector2 vectorValue:
-                        return Validation.IsFinite(vectorValue);
-
-                    case MarginPadding marginPaddingValue:
-                        return Validation.IsFinite(marginPaddingValue);
-                }
+                if (typeof(TValue) == typeof(float))
+                    return float.IsFinite((float)(object)value);
+                if (typeof(TValue) == typeof(double))
+                    return double.IsFinite((double)(object)value);
+                if (typeof(TValue) == typeof(Vector2))
+                    return Validation.IsFinite((Vector2)(object)value);
+                if (typeof(TValue) == typeof(MarginPadding))
+                    return Validation.IsFinite((MarginPadding)(object)value);
 
                 return true;
             }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -701,7 +701,12 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> TransformRelativeChildSizeTo<T, TEasing>(this T container, Vector2 newSize, double duration, in TEasing easing)
             where T : class, IContainer
             where TEasing : IEasingFunction
-            => container.TransformTo(nameof(container.RelativeChildSize), newSize, duration, easing);
+        {
+            if (newSize.X == 0 || newSize.Y == 0)
+                throw new ArgumentException($@"{nameof(newSize)} must be non-zero, but is {newSize}.", nameof(newSize));
+
+            return container.TransformTo(nameof(container.RelativeChildSize), newSize, duration, easing);
+        }
 
         /// <summary>
         /// Smoothly adjusts <see cref="IContainer.RelativeChildOffset"/> over time.

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -143,6 +143,9 @@ namespace osu.Framework.Graphics
             where TThis : class, ITransformable
             where TEasing : IEasingFunction
         {
+            if (!isFinite(newValue))
+                throw new ArgumentException($"{nameof(newValue)} must be finite, but is {newValue}.", nameof(newValue));
+
             if (duration < 0)
                 throw new ArgumentOutOfRangeException(nameof(duration), $"{nameof(duration)} must be positive.");
 
@@ -159,6 +162,26 @@ namespace osu.Framework.Graphics
             transform.Easing = easing;
 
             return transform;
+
+            static bool isFinite(object value)
+            {
+                switch (value)
+                {
+                    case float floatValue:
+                        return float.IsFinite(floatValue);
+
+                    case double doubleValue:
+                        return double.IsFinite(doubleValue);
+
+                    case Vector2 vectorValue:
+                        return Validation.IsFinite(vectorValue);
+
+                    case MarginPadding marginPaddingValue:
+                        return Validation.IsFinite(marginPaddingValue);
+                }
+
+                return true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Closes #5258 

On master, queuing transforms with invalid/infinite value only throws during the next update pass, rather than immediately on queue. This makes it impossible to figure out the root cause of the issue behind providing NaN transforms.

This should cover most, if not all, cases of invalid new values, with https://github.com/ppy/osu-framework/commit/f84c08ae5787948c41fd95ee49ed327e533fdbab pushed to handle `RelativeChildSize`'s special case of not allowing zero values.

Haven't overthought the logic too much, was initially going to consider throwing on every `TransformTo` usage (i.e. `ResizeTo`/`ScaleTo`/`MoveTo`/etc.), but realized I'm essentially checking the same thing over and over again everywhere, and NaN values cannot be interpolated, so I went with throwing on `PopulateTransform` instead (which should cover all sorts of transforms).

Basic test coverage included as well to ensure exceptions are thrown immediately.

- Stand-alone transform exception (e.g. `this.ResizeWidthTo(NaN)`):

```
TearDown : System.ArgumentException : newValue must be finite, but is NaN. (Parameter 'newValue')
--TearDown
   at osu.Framework.Graphics.TransformableExtensions.PopulateTransform[TValue,TEasing,TThis](TThis t, Transform`3 transform, TValue newValue, Double duration, TEasing& easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 147
   at osu.Framework.Graphics.TransformableExtensions.MakeTransform[TThis,TEasing,TValue](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 109
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 55
   at osu.Framework.Graphics.TransformableExtensions.ResizeWidthTo[T,TEasing](T drawable, Single newWidth, Double duration, TEasing& easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 630
   at osu.Framework.Graphics.TransformableExtensions.ResizeWidthTo[T](T drawable, Single newWidth, Double duration, Easing easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 394
   at osu.Framework.Tests.Visual.Drawables.TestSceneTransformSequence.<TestValidation>b__5_1() in /Users/salman/Projects/osu-framework/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs:line 81
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0() in /Users/salman/Projects/osu-framework/osu.Framework/Testing/Drawables/Steps/SingleStepButton.cs:line 19
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/Drawables/Steps/StepButton.cs:line 124
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestScene.cs:line 203
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 89
   at osu.Framework.Testing.TestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 32
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit() in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestScene.cs:line 424
```

- Sequence transform exception (e.g. `this.FadeIn(200).ResizeWidthTo(NaN)`)

```
TearDown : System.ArgumentException : newValue must be finite, but is NaN. (Parameter 'newValue')
--TearDown
   at osu.Framework.Graphics.TransformableExtensions.PopulateTransform[TValue,TEasing,TThis](TThis t, Transform`3 transform, TValue newValue, Double duration, TEasing& easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 147
   at osu.Framework.Graphics.TransformableExtensions.MakeTransform[TThis,TEasing,TValue](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 109
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 55
   at osu.Framework.Graphics.TransformableExtensions.ResizeWidthTo[T,TEasing](T drawable, Single newWidth, Double duration, TEasing& easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 630
   at osu.Framework.Graphics.TransformSequenceExtensions.<>c__DisplayClass45_0`2.<ResizeWidthTo>b__0(T o) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformSequenceExtensions.cs:line 378
   at osu.Framework.Graphics.Transforms.TransformSequence`1.Append(Generator childGenerator) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/Transforms/TransformSequence.cs:line 130
   at osu.Framework.Graphics.TransformSequenceExtensions.ResizeWidthTo[T,TEasing](TransformSequence`1 t, Single newWidth, Double duration, TEasing easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformSequenceExtensions.cs:line 378
   at osu.Framework.Graphics.TransformSequenceExtensions.ResizeWidthTo[T](TransformSequence`1 t, Single newWidth, Double duration, Easing easing) in /Users/salman/Projects/osu-framework/osu.Framework/Graphics/TransformSequenceExtensions.cs:line 152
   at osu.Framework.Tests.Visual.Drawables.TestSceneTransformSequence.<TestValidation>b__5_1() in /Users/salman/Projects/osu-framework/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs:line 82
   at osu.Framework.Testing.Drawables.Steps.SingleStepButton.<.ctor>b__1_0() in /Users/salman/Projects/osu-framework/osu.Framework/Testing/Drawables/Steps/SingleStepButton.cs:line 19
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/Drawables/Steps/StepButton.cs:line 124
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestScene.cs:line 203
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 89
   at osu.Framework.Testing.TestSceneTestRunner.RunTestBlocking(TestScene test) in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 32
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit() in /Users/salman/Projects/osu-framework/osu.Framework/Testing/TestScene.cs:line 424
```