### PR TITLE
Revert making `TextureLoaderStore` ctor internal for now

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Graphics.Textures
     {
         private IResourceStore<byte[]> store { get; }
 
-        internal TextureLoaderStore(IResourceStore<byte[]> store)
+        public TextureLoaderStore(IResourceStore<byte[]> store)
         {
             this.store = store;
             (store as ResourceStore<byte[]>)?.AddExtension(@"png");


### PR DESCRIPTION
Rationale: https://github.com/ppy/osu/pull/18830#issuecomment-1165556056

Probably the right change to make in the long run, just too early for the time being.