### PR TITLE
Fix `TripleBuffer` sleeping too long at high frame rates

### DIFF
--- a/osu.Framework.Tests/Graphics/TripleBufferTest.cs
+++ b/osu.Framework.Tests/Graphics/TripleBufferTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Graphics/TripleBufferTest.cs
+++ b/osu.Framework.Tests/Graphics/TripleBufferTest.cs
@@ -65,21 +65,21 @@ namespace osu.Framework.Tests.Graphics
                 var obj = new TestObject(i);
                 ManualResetEventSlim resetEventSlim = new ManualResetEventSlim();
 
-                var readTask = Task.Run(() =>
+                var readTask = Task.Factory.StartNew(() =>
                 {
                     resetEventSlim.Set();
                     using (var buffer = tripleBuffer.GetForRead())
                         Assert.That(buffer?.Object, Is.EqualTo(obj));
-                });
+                }, TaskCreationOptions.LongRunning);
 
-                Task.Run(() =>
+                Task.Factory.StartNew(() =>
                 {
                     resetEventSlim.Wait(1000);
                     Thread.Sleep(10);
 
                     using (var buffer = tripleBuffer.GetForWrite())
                         buffer.Object = obj;
-                });
+                }, TaskCreationOptions.LongRunning);
 
                 readTask.WaitSafely();
             }

--- a/osu.Framework.Tests/Graphics/TripleBufferTest.cs
+++ b/osu.Framework.Tests/Graphics/TripleBufferTest.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+
+namespace osu.Framework.Tests.Graphics
+{
+    [TestFixture]
+    public class TripleBufferTest
+    {
+        [Test]
+        public void TestWriteOnly()
+        {
+            var tripleBuffer = new TripleBuffer<TestObject>();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                using (tripleBuffer.GetForWrite())
+                {
+                }
+            }
+        }
+
+        [Test]
+        public void TestReadOnly()
+        {
+            var tripleBuffer = new TripleBuffer<TestObject>();
+
+            using (var buffer = tripleBuffer.GetForRead())
+                Assert.That(buffer, Is.Null);
+        }
+
+        [Test]
+        public void TestWriteThenRead()
+        {
+            var tripleBuffer = new TripleBuffer<TestObject>();
+
+            for (int i = 0; i < 1000; i++)
+            {
+                var obj = new TestObject(i);
+
+                using (var buffer = tripleBuffer.GetForWrite())
+                    buffer.Object = obj;
+
+                using (var buffer = tripleBuffer.GetForRead())
+                    Assert.That(buffer?.Object, Is.EqualTo(obj));
+            }
+
+            using (var buffer = tripleBuffer.GetForRead())
+                Assert.That(buffer, Is.Null);
+        }
+
+        [Test]
+        public void TestReadSaturated()
+        {
+            var tripleBuffer = new TripleBuffer<TestObject>();
+
+            for (int i = 0; i < 10; i++)
+            {
+                var obj = new TestObject(i);
+
+                var readTask = Task.Run(() =>
+                {
+                    using (var buffer = tripleBuffer.GetForRead())
+                        Assert.That(buffer?.Object, Is.EqualTo(obj));
+                });
+
+                Task.Run(() =>
+                {
+                    Thread.Sleep(50);
+                    using (var buffer = tripleBuffer.GetForWrite())
+                        buffer.Object = obj;
+                });
+
+                readTask.WaitSafely();
+            }
+        }
+
+        private class TestObject
+        {
+            private readonly int i;
+
+            public TestObject(int i)
+            {
+                this.i = i;
+            }
+
+            public override string ToString()
+            {
+                return $"{base.ToString()} {i}";
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Graphics/TripleBufferTest.cs
+++ b/osu.Framework.Tests/Graphics/TripleBufferTest.cs
@@ -63,16 +63,20 @@ namespace osu.Framework.Tests.Graphics
             for (int i = 0; i < 10; i++)
             {
                 var obj = new TestObject(i);
+                ManualResetEventSlim resetEventSlim = new ManualResetEventSlim();
 
                 var readTask = Task.Run(() =>
                 {
+                    resetEventSlim.Set();
                     using (var buffer = tripleBuffer.GetForRead())
                         Assert.That(buffer?.Object, Is.EqualTo(obj));
                 });
 
                 Task.Run(() =>
                 {
-                    Thread.Sleep(50);
+                    resetEventSlim.Wait(1000);
+                    Thread.Sleep(10);
+
                     using (var buffer = tripleBuffer.GetForWrite())
                         buffer.Object = obj;
                 });

--- a/osu.Framework/Allocation/ObjectUsage.cs
+++ b/osu.Framework/Allocation/ObjectUsage.cs
@@ -12,17 +12,22 @@ namespace osu.Framework.Allocation
         where T : class
     {
         public T Object;
-        public int Index;
-
-        public long FrameId;
-
-        internal Action<ObjectUsage<T>, UsageType> Finish;
 
         public UsageType Usage;
+
+        public readonly int Index;
 
         public readonly ManualResetEventSlim ResetEvent = new ManualResetEventSlim();
 
         public bool Consumed;
+
+        internal readonly Action<ObjectUsage<T>, UsageType> Finish;
+
+        public ObjectUsage(int index, Action<ObjectUsage<T>, UsageType> finish)
+        {
+            Index = index;
+            Finish = finish;
+        }
 
         public void Dispose()
         {

--- a/osu.Framework/Allocation/ObjectUsage.cs
+++ b/osu.Framework/Allocation/ObjectUsage.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Threading;
 
 namespace osu.Framework.Allocation
 {
@@ -17,21 +16,17 @@ namespace osu.Framework.Allocation
 
         public readonly int Index;
 
-        public readonly ManualResetEventSlim ResetEvent = new ManualResetEventSlim();
+        private readonly Action<ObjectUsage<T>> finish;
 
-        public bool Consumed;
-
-        internal readonly Action<ObjectUsage<T>, UsageType> Finish;
-
-        public ObjectUsage(int index, Action<ObjectUsage<T>, UsageType> finish)
+        public ObjectUsage(int index, Action<ObjectUsage<T>> finish)
         {
             Index = index;
-            Finish = finish;
+            this.finish = finish;
         }
 
         public void Dispose()
         {
-            Finish?.Invoke(this, Usage);
+            finish?.Invoke(this);
         }
     }
 

--- a/osu.Framework/Allocation/ObjectUsage.cs
+++ b/osu.Framework/Allocation/ObjectUsage.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Threading;
 
 namespace osu.Framework.Allocation
 {
@@ -18,6 +19,10 @@ namespace osu.Framework.Allocation
         internal Action<ObjectUsage<T>, UsageType> Finish;
 
         public UsageType Usage;
+
+        public readonly ManualResetEventSlim ResetEvent = new ManualResetEventSlim();
+
+        public bool Consumed;
 
         public void Dispose()
         {

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Threading;
 
@@ -22,9 +21,11 @@ namespace osu.Framework.Allocation
 
         private readonly ManualResetEventSlim writeCompletedEvent = new ManualResetEventSlim();
 
+        private const int buffer_count = 3;
+
         public TripleBuffer()
         {
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < buffer_count; i++)
                 buffers[i] = new ObjectUsage<T>(i, finishUsage);
         }
 
@@ -71,7 +72,7 @@ namespace osu.Framework.Allocation
 
         private ObjectUsage<T> getNextWriteBuffer()
         {
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < buffer_count - 1; i++)
             {
                 if (i == activeReadIndex) continue;
                 if (i == lastCompletedWriteIndex) continue;
@@ -79,7 +80,7 @@ namespace osu.Framework.Allocation
                 return buffers[i];
             }
 
-            throw new InvalidOperationException();
+            return buffers[buffer_count - 1];
         }
 
         private void finishUsage(ObjectUsage<T> obj)

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading;
 
@@ -36,7 +34,7 @@ namespace osu.Framework.Allocation
             }
         }
 
-        public ObjectUsage<T> Get(UsageType usage)
+        public ObjectUsage<T>? Get(UsageType usage)
         {
             switch (usage)
             {
@@ -54,10 +52,10 @@ namespace osu.Framework.Allocation
                     lock (buffers)
                     {
                         read = lastWrite;
-                        buffers[read].Usage = UsageType.Read;
-                    }
 
-                    return buffers[read];
+                        buffers[read].Usage = UsageType.Read;
+                        return buffers[read];
+                    }
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(usage), "Unsupported usage type");
@@ -68,7 +66,7 @@ namespace osu.Framework.Allocation
         {
             lock (buffers)
             {
-                while (buffers[write]?.Usage == UsageType.Read || write == lastWrite)
+                while (buffers[write].Usage == UsageType.Read || write == lastWrite)
                     write = (write + 1) % 3;
             }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -447,11 +447,8 @@ namespace osu.Framework.Platform
             Root.UpdateSubTree();
             Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 
-            using (var buffer = DrawRoots.Get(UsageType.Write))
-            {
-                Debug.Assert(buffer != null);
+            using (var buffer = DrawRoots.GetForWrite())
                 buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false);
-            }
         }
 
         private readonly DepthValue depthValue = new DepthValue();
@@ -463,9 +460,9 @@ namespace osu.Framework.Platform
 
             while (ExecutionState == ExecutionState.Running)
             {
-                using (var buffer = DrawRoots.Get(UsageType.Read))
+                using (var buffer = DrawRoots.GetForRead())
                 {
-                    if (buffer?.Object == null)
+                    if (buffer == null)
                         break;
 
                     using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))


### PR DESCRIPTION
Previous version was using `Thread.Sleep(1)` when waiting on data, but with two threads running at roughly the same frame rate this would result in highly inefficient synchronisation. Using `ManualResetEventSlim` allows spinning for quick resolution cases.

Hopefully the changes should be self-explanatory and the code should be pretty straightforwards. Went through a few iterations to get to this point, have left some commits along the way to show different approaches leading up to the final one.

I've only tested this on macOS so far, which shows an increase of draw FPS from 500 to 900 with "Basically Unlimited" setting.

Addresses concerns raised at https://github.com/ppy/osu/discussions/18814.
