### PR TITLE
Fix overlay containers handling click and double-click events

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
@@ -138,13 +138,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     return true;
                 }
 
-                return true;
-            }
-
-            protected override bool OnMouseDown(MouseDownEvent e)
-            {
-                base.OnMouseDown(e);
-                return true;
+                return false;
             }
 
             protected override void PopIn()

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -45,6 +45,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool DragBlocksClick => false;
 
+        protected override bool OnHover(HoverEvent e) => BlockPositionalInput;
         protected override bool OnMouseDown(MouseDownEvent e) => BlockPositionalInput;
         protected override bool OnScroll(ScrollEvent e) => BlockScrollInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
     }

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -45,24 +45,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool DragBlocksClick => false;
 
-        protected override bool Handle(UIEvent e)
-        {
-            switch (e)
-            {
-                case ScrollEvent:
-                    if (BlockScrollInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-                        return true;
-
-                    break;
-
-                case MouseEvent:
-                    if (BlockPositionalInput)
-                        return true;
-
-                    break;
-            }
-
-            return base.Handle(e);
-        }
+        protected override bool OnMouseDown(MouseDownEvent e) => BlockPositionalInput;
+        protected override bool OnScroll(ScrollEvent e) => BlockScrollInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
     }
 }


### PR DESCRIPTION
All mouse events are limited to the `ButtonDownInputQueue`, which is determined by which drawable handles `MouseDownEvent`. Therefore `OverlayContainer`s don't need to handle all mouse events, but only `MouseDownEvent` to block positional input from propagating outside its hierarchy.

The previous logic was causing clicks and double-clicks to be handled as well, which in turn result in next clicks targeted at UI controls being blocked by the handled double click.

It was also handling drag start events, which marks this as a breaking change for any `OverlayContainer` implementation which was handling drag events without `OnDragStart` (there's none osu!-side).

- Closes https://github.com/ppy/osu/issues/18838