### PR TITLE
Avoid retriving every `CultureInfo` on startup

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1011,7 +1011,14 @@ namespace osu.Framework.Platform
 
                 try
                 {
+                    // After dropping netstandard we can use `predefinedOnly` override.
+                    // See https://github.com/dotnet/runtime/pull/1261/files
                     culture = CultureInfo.GetCultureInfo(locale.NewValue);
+
+                    // This is best-effort for now to catch cases where dotnet is creating cultures.
+                    // See https://github.com/dotnet/runtime/blob/5877e8b713742b6d80bd1aa9819094be029e3e1f/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs#L341-L345
+                    if (culture.ThreeLetterWindowsLanguageName == "ZZZ")
+                        culture = CultureInfo.InvariantCulture;
                 }
                 catch (Exception e)
                 {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1007,7 +1007,17 @@ namespace osu.Framework.Platform
             threadLocale = Config.GetBindable<string>(FrameworkSetting.Locale);
             threadLocale.BindValueChanged(locale =>
             {
-                var culture = CultureInfo.GetCultures(CultureTypes.AllCultures).FirstOrDefault(c => c.Name.Equals(locale.NewValue, StringComparison.OrdinalIgnoreCase)) ?? CultureInfo.InvariantCulture;
+                CultureInfo culture;
+
+                try
+                {
+                    culture = CultureInfo.GetCultureInfo(locale.NewValue);
+                }
+                catch (Exception e)
+                {
+                    Logger.Log($"Culture for {locale.NewValue} could not be found ({e})");
+                    culture = CultureInfo.InvariantCulture;
+                }
 
                 CultureInfo.DefaultThreadCurrentCulture = culture;
                 CultureInfo.DefaultThreadCurrentUICulture = culture;


### PR DESCRIPTION
`GetCultureInfo` is both case insensitive and caches lookups. Meanwhile, whatever we were calling...

![Timeline64_2022-06-26_12-17-14](https://user-images.githubusercontent.com/191335/175797932-6ac5d10d-0991-44f3-9787-0043706f4c7a.png)
