### PR TITLE
Avoid div-by-zero in waveform resampling code

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using ManagedBass;
 using osu.Framework.Utils;
 using osu.Framework.Audio.Callbacks;
@@ -181,6 +182,7 @@ namespace osu.Framework.Audio.Track
         /// <param name="pointCount">The number of points the resulting <see cref="Waveform"/> should contain.</param>
         /// <param name="cancellationToken">The token to cancel the task.</param>
         /// <returns>An async task for the generation of the <see cref="Waveform"/>.</returns>
+        [ItemNotNull]
         public async Task<Waveform> GenerateResampledAsync(int pointCount, CancellationToken cancellationToken = default)
         {
             if (pointCount < 0) throw new ArgumentOutOfRangeException(nameof(pointCount));
@@ -207,6 +209,9 @@ namespace osu.Framework.Audio.Track
 
                 for (int i = 0; i < filter.Length; ++i)
                 {
+                    if (cancellationToken.IsCancellationRequested)
+                        return new Waveform(null);
+
                     filter[i] = (float)Blur.EvalGaussian(i, pointsPerGeneratedPoint);
                 }
 
@@ -219,7 +224,8 @@ namespace osu.Framework.Audio.Track
 
                 while (originalPointIndex < points.Count)
                 {
-                    if (cancellationToken.IsCancellationRequested) break;
+                    if (cancellationToken.IsCancellationRequested)
+                        return new Waveform(null);
 
                     int startIndex = (int)originalPointIndex - kernelWidth;
                     int endIndex = (int)originalPointIndex + kernelWidth;

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -241,12 +241,15 @@ namespace osu.Framework.Audio.Track
                         point.HighIntensity += weight * points[j].HighIntensity;
                     }
 
-                    // Means
-                    for (int c = 0; c < channels; c++)
-                        point.Amplitude[c] /= totalWeight;
-                    point.LowIntensity /= totalWeight;
-                    point.MidIntensity /= totalWeight;
-                    point.HighIntensity /= totalWeight;
+                    if (totalWeight > 0)
+                    {
+                        // Means
+                        for (int c = 0; c < channels; c++)
+                            point.Amplitude[c] /= totalWeight;
+                        point.LowIntensity /= totalWeight;
+                        point.MidIntensity /= totalWeight;
+                        point.HighIntensity /= totalWeight;
+                    }
 
                     generatedPoints.Add(point);
 


### PR DESCRIPTION
```csharp
2022-06-26 06:20:32 [error]: An unobserved error has occurred.
2022-06-26 06:20:32 [error]: System.DivideByZeroException: Attempted to divide by zero.
2022-06-26 06:20:32 [error]: at osu.Framework.Audio.Track.Waveform.<>c__DisplayClass13_0.<.ctor>b__0()
2022-06-26 06:20:32 [error]: at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
2022-06-26 06:20:32 [error]: --- End of stack trace from previous location ---
2022-06-26 06:20:32 [error]: at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
2022-06-26 06:20:32 [error]: --- End of stack trace from previous location ---
2022-06-26 06:20:32 [error]: at osu.Framework.Audio.Track.Waveform.GenerateResampledAsync(Int32 pointCount, CancellationToken cancellationToken)
2022-06-26 06:20:32 [error]: An unobserved error has occurred.
```