### PR TITLE
Disable ugly green border when using hardware keyboard on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -94,6 +94,9 @@ namespace osu.Framework.Android
             // this needs to happen in the constructor
             Focusable = true;
             FocusableInTouchMode = true;
+
+            // disable ugly green border when view is focused via hardware keyboard/mouse.
+            DefaultFocusHighlightEnabled = false;
         }
 
         protected override void CreateFrameBuffer()


### PR DESCRIPTION
https://developer.android.com/reference/android/view/View#getDefaultFocusHighlightEnabled()

The green border in question, shown when pressing keys on a hardware keyboard when a textbox is focused:
(Can also be seen in https://github.com/ppy/osu-framework/issues/4373)

<details>
  <summary>Tall image</summary>

  ![Screenshot_2022-06-27-18-24-49-36_fca46a2731136e673b8638a972bc0192](https://user-images.githubusercontent.com/16479013/175990291-e1888020-0677-4b69-8405-7e1c8097f058.jpg)
  
</details>
