### PR TITLE
Fix pressing keys on a hardware keyboard showing the software keyboard

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -267,6 +267,7 @@ namespace osu.Framework.Android
             textInputActive = true;
             Activity.RunOnUiThread(() =>
             {
+                inputMethodManager.RestartInput(this); // this syncs the Android input method state with `OnCreateInputConnection()`.
                 RequestFocus();
                 inputMethodManager?.ShowSoftInput(this, 0);
             });
@@ -277,6 +278,7 @@ namespace osu.Framework.Android
             textInputActive = false;
             Activity.RunOnUiThread(() =>
             {
+                inputMethodManager.RestartInput(this);
                 inputMethodManager?.HideSoftInputFromWindow(WindowToken, HideSoftInputFlags.None);
                 ClearFocus();
             });

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -64,6 +64,8 @@ namespace osu.Framework.Android
 
         private readonly Game game;
 
+        private InputMethodManager inputMethodManager;
+
         public AndroidGameView(AndroidGameActivity activity, Game game)
             : base(activity)
         {
@@ -97,6 +99,8 @@ namespace osu.Framework.Android
 
             // disable ugly green border when view is focused via hardware keyboard/mouse.
             DefaultFocusHighlightEnabled = false;
+
+            inputMethodManager = Activity.GetSystemService(Context.InputMethodService) as InputMethodManager;
         }
 
         protected override void CreateFrameBuffer()
@@ -245,6 +249,24 @@ namespace osu.Framework.Android
             outAttrs.ImeOptions = ImeFlags.NoExtractUi | ImeFlags.NoFullscreen;
             outAttrs.InputType = InputTypes.TextVariationVisiblePassword | InputTypes.TextFlagNoSuggestions;
             return new AndroidInputConnection(this, true);
+        }
+
+        internal void StartTextInput()
+        {
+            Activity.RunOnUiThread(() =>
+            {
+                RequestFocus();
+                inputMethodManager?.ShowSoftInput(this, 0);
+            });
+        }
+
+        internal void StopTextInput()
+        {
+            Activity.RunOnUiThread(() =>
+            {
+                inputMethodManager?.HideSoftInputFromWindow(WindowToken, HideSoftInputFlags.None);
+                ClearFocus();
+            });
         }
 
         public override void SwapBuffers()

--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -1,24 +1,18 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using Android.Content;
 using Android.Views;
-using Android.Views.InputMethods;
 using osu.Framework.Input;
 
 namespace osu.Framework.Android.Input
 {
-    public class AndroidTextInput : TextInputSource
+    internal class AndroidTextInput : TextInputSource
     {
         private readonly AndroidGameView view;
-        private readonly InputMethodManager inputMethodManager;
 
         public AndroidTextInput(AndroidGameView view)
         {
             this.view = view;
-            inputMethodManager = view.Activity.GetSystemService(Context.InputMethodService) as InputMethodManager;
         }
 
         private void commitText(string text)
@@ -36,33 +30,19 @@ namespace osu.Framework.Android.Input
         {
             view.KeyDown += keyDown;
             view.CommitText += commitText;
-
-            view.Activity.RunOnUiThread(() =>
-            {
-                view.RequestFocus();
-                inputMethodManager?.ShowSoftInput(view, 0);
-            });
+            view.StartTextInput();
         }
 
         protected override void EnsureTextInputActivated(bool allowIme)
         {
-            view.Activity.RunOnUiThread(() =>
-            {
-                view.RequestFocus();
-                inputMethodManager?.ShowSoftInput(view, 0);
-            });
+            view.StartTextInput();
         }
 
         protected override void DeactivateTextInput()
         {
             view.KeyDown -= keyDown;
             view.CommitText -= commitText;
-
-            view.Activity.RunOnUiThread(() =>
-            {
-                inputMethodManager?.HideSoftInputFromWindow(view.WindowToken, HideSoftInputFlags.None);
-                view.ClearFocus();
-            });
+            view.StopTextInput();
         }
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/17561
- Closes https://github.com/ppy/osu/issues/6282 
   - can't repro, but not returning `null` and forcing `OnCheckIsTextEditor() => true` is the probable cause

[By default](https://user-images.githubusercontent.com/16479013/176005749-ecb6a979-1772-4d1a-99ef-d5808fcfe2d8.png), Android will show the software keyboard while text input is active even if a hardware keyboard is connected. And since we were always returning a valid `IInputConnection`, Android would "conveniently" show the software keyboard when any hardware keys are pressed.

Pressing keys will (re)focus the current view and probe `OnCreateInputConnection()` to see if the input method is to be activated.

The [docs](https://developer.android.com/reference/android/view/View#onCreateInputConnection(android.view.inputmethod.EditorInfo)) specify to return `null` when input methods are not supported by a specific `View`. Since we have only one `View`, returning `null` here means to disable text input for the time being (until a textbox is focused and `AndroidTextInput` is activated).