### PR TITLE
Fix backspace not working properly with hardware keyboards

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -140,6 +140,13 @@ namespace osu.Framework.Android
 
                 default:
                     KeyDown?.Invoke(keyCode, e);
+
+                    // Releasing backspace on a physical keyboard when text input is active will not send a key up event.
+                    // Manually send one to prevent the key from getting stuck.
+                    // This does mean that key repeat is handled by the OS, instead of by the usual `InputManager` handling.
+                    if (keyCode == Keycode.Del && e.IsFromSource(InputSourceType.Keyboard) && textInputActive)
+                        KeyUp?.Invoke(Keycode.Del, new KeyEvent(e.DownTime, e.EventTime, KeyEventActions.Up, Keycode.Del, 0, e.MetaState, e.DeviceId, e.ScanCode, e.Flags, e.Source));
+
                     return true;
             }
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/17803

Depends on:
- [x] #5274 (for `textInputActive`)

Android basically doesn't send the key up event for backspace. Really strange behaviour, I guess they expect text boxes not to care about key up events and instead rely on native key repeat.

Key up events works just find when text input is disabled (a.k.a. when `OnCreateInputConnection()` returns `null`).