### PR TITLE
Allow initial locale mappings to be added in a single call

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -59,6 +59,32 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestConfigSettingRetainedWhenAddingLocaleMappings()
+        {
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
+
+            // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
+            manager.AddLocaleMappings(new[]
+            {
+                new LocaleMapping("po", new FakeStorage("po-OP")),
+                new LocaleMapping("wa", new FakeStorage("wa-NG"))
+            });
+
+            Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
+
+            var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
+
+            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
+            manager.AddLocaleMappings(new[]
+            {
+                new LocaleMapping("ja-JP", new FakeStorage("ja-JP"))
+            });
+
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
+        }
+
+        [Test]
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
@@ -122,7 +148,8 @@ namespace osu.Framework.Tests.Localisation
 
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
-            var formattedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, interpolation: $"The {arg_0} fallback should only matches argument count"));
+            var formattedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN,
+                interpolation: $"The {arg_0} fallback should only matches argument count"));
 
             Assert.AreEqual(expectedResult, formattedText.Value);
         }

--- a/osu.Framework/Localisation/LocaleMapping.cs
+++ b/osu.Framework/Localisation/LocaleMapping.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// Maps a localisation store to a lookup string.
+    /// Used by <see cref="LocalisationManager"/>.
+    /// </summary>
+    public class LocaleMapping
+    {
+        public readonly string Name;
+        public readonly ILocalisationStore Storage;
+
+        /// <summary>
+        /// Create a locale mapping from a localisation store.
+        /// </summary>
+        /// <param name="store">The store to be used.</param>
+        public LocaleMapping(ILocalisationStore store)
+        {
+            Name = store.EffectiveCulture.Name;
+            Storage = store;
+        }
+
+        /// <summary>
+        /// Create a locale mapping with a custom lookup name.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="store">The store to be used.</param>
+        public LocaleMapping(string name, ILocalisationStore store)
+        {
+            Name = name;
+            Storage = store;
+        }
+    }
+}

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -28,6 +28,23 @@ namespace osu.Framework.Localisation
             configPreferUnicode.BindValueChanged(_ => UpdateLocalisationParameters(), true);
         }
 
+        /// <summary>
+        /// Add multiple locale mappings. Should be used to add all available languages at initialisation.
+        /// </summary>
+        /// <param name="mappings">All available locale mappings.</param>
+        public void AddLocaleMappings(IEnumerable<LocaleMapping> mappings)
+        {
+            locales.AddRange(mappings);
+            configLocale.TriggerChange();
+        }
+
+        /// <summary>
+        /// Add a single language to this manager.
+        /// </summary>
+        /// <remarks>
+        /// Use <see cref="AddLocaleMappings"/> as a more efficient way of bootstrapping all available locales.</remarks>
+        /// <param name="language">The culture name to be added. Generally should match <see cref="CultureInfo.Name"/>.</param>
+        /// <param name="storage">A storage providing localisations for the specified language.</param>
         public void AddLanguage(string language, ILocalisationStore storage)
         {
             locales.Add(new LocaleMapping(language, storage));
@@ -102,17 +119,5 @@ namespace osu.Framework.Localisation
         /// </remarks>
         /// <returns>The resultant <see cref="LocalisationParameters"/>.</returns>
         protected virtual LocalisationParameters CreateLocalisationParameters() => new LocalisationParameters(currentLocale?.Storage, configPreferUnicode.Value);
-
-        private class LocaleMapping
-        {
-            public readonly string Name;
-            public readonly ILocalisationStore Storage;
-
-            public LocaleMapping(string name, ILocalisationStore storage)
-            {
-                Name = name;
-                Storage = storage;
-            }
-        }
     }
 }


### PR DESCRIPTION
Noticed that each language added would trigger a bindable change, causing a re-fetch of the current language. Can get kind of expensive, especially as more languages are added.