### PR TITLE
Move joystick-axis-to-button simulation out of `JoystickHandler`

### DIFF
--- a/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
@@ -64,11 +64,8 @@ namespace osu.Framework.Input.Handlers.Joystick
         /// <summary>
         /// Enqueues a <see cref="JoystickAxisInput"/> taking into account the axis deadzone.
         /// </summary>
-        private void enqueueJoystickAxisChanged(JoystickAxis axis)
-        {
-            float value = rescaleByDeadzone(axis.Value);
-            enqueueJoystickEvent(new JoystickAxisInput(new JoystickAxis(axis.Source, value)));
-        }
+        private void enqueueJoystickAxisChanged(JoystickAxisSource source, float value) =>
+            enqueueJoystickEvent(new JoystickAxisInput(new JoystickAxis(source, rescaleByDeadzone(value))));
 
         private float rescaleByDeadzone(float axisValue)
         {

--- a/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Input.Handlers.Joystick
             Precision = 0.005f,
         };
 
-        private readonly JoystickButton[] axisDirectionButtons = new JoystickButton[(int)JoystickAxisSource.AxisCount];
-
         public override string Description => "Joystick / Gamepad";
 
         public override bool IsActive => true;
@@ -65,30 +63,10 @@ namespace osu.Framework.Input.Handlers.Joystick
 
         /// <summary>
         /// Enqueues a <see cref="JoystickAxisInput"/> taking into account the axis deadzone.
-        /// Also enqueues <see cref="JoystickButtonInput"/> events depending on whether the axis has changed direction.
         /// </summary>
         private void enqueueJoystickAxisChanged(JoystickAxis axis)
         {
             float value = rescaleByDeadzone(axis.Value);
-
-            int index = (int)axis.Source;
-            var currentButton = axisDirectionButtons[index];
-            var expectedButton = getAxisButtonForInput(index, value);
-
-            // if a directional button is pressed and does not match that for the new axis direction, release it
-            if (currentButton != 0 && expectedButton != currentButton)
-            {
-                enqueueJoystickButtonUp(currentButton);
-                axisDirectionButtons[index] = currentButton = 0;
-            }
-
-            // if we expect a directional button to be pressed, and it is not, press it
-            if (expectedButton != 0 && expectedButton != currentButton)
-            {
-                enqueueJoystickButtonDown(expectedButton);
-                axisDirectionButtons[index] = expectedButton;
-            }
-
             enqueueJoystickEvent(new JoystickAxisInput(new JoystickAxis(axis.Source, value)));
         }
 
@@ -102,17 +80,6 @@ namespace osu.Framework.Input.Handlers.Joystick
             // rescale the given axis value such that the edge of the deadzone is considered the "new zero".
             float absoluteRescaled = (absoluteValue - DeadzoneThreshold.Value) / (1f - DeadzoneThreshold.Value);
             return Math.Sign(axisValue) * absoluteRescaled;
-        }
-
-        private static JoystickButton getAxisButtonForInput(int axisIndex, float axisValue)
-        {
-            if (axisValue > 0)
-                return JoystickButton.FirstAxisPositive + axisIndex;
-
-            if (axisValue < 0)
-                return JoystickButton.FirstAxisNegative + axisIndex;
-
-            return 0;
         }
     }
 }

--- a/osu.Framework/Input/StateChanges/JoystickAxisInput.cs
+++ b/osu.Framework/Input/StateChanges/JoystickAxisInput.cs
@@ -43,9 +43,46 @@ namespace osu.Framework.Input.StateChanges
                 if (oldValue == a.Value || (a.Value != 0 && Precision.AlmostEquals(oldValue, a.Value)))
                     continue;
 
+                applyButtonInputsIfNeeded(state, handler, a);
+
                 state.Joystick.AxesValues[(int)a.Source] = a.Value;
                 handler.HandleInputStateChange(new JoystickAxisChangeEvent(state, this, a, oldValue));
             }
+        }
+
+        /// <summary>
+        /// Applies <see cref="JoystickButtonInput"/> events depending on whether the axis has changed direction.
+        /// </summary>
+        private void applyButtonInputsIfNeeded(InputState state, IInputStateChangeHandler handler, JoystickAxis axis)
+        {
+            int index = (int)axis.Source;
+            var currentButton = state.Joystick.AxisDirectionButtons[index];
+            var expectedButton = getAxisButtonForInput(index, axis.Value);
+
+            // if a directional button is pressed and does not match that for the new axis direction, release it
+            if (currentButton != 0 && expectedButton != currentButton)
+            {
+                new JoystickButtonInput(currentButton, false).Apply(state, handler);
+                state.Joystick.AxisDirectionButtons[index] = currentButton = 0;
+            }
+
+            // if we expect a directional button to be pressed, and it is not, press it
+            if (expectedButton != 0 && expectedButton != currentButton)
+            {
+                new JoystickButtonInput(expectedButton, true).Apply(state, handler);
+                state.Joystick.AxisDirectionButtons[index] = expectedButton;
+            }
+        }
+
+        private static JoystickButton getAxisButtonForInput(int axisIndex, float axisValue)
+        {
+            if (axisValue > 0)
+                return JoystickButton.FirstAxisPositive + axisIndex;
+
+            if (axisValue < 0)
+                return JoystickButton.FirstAxisNegative + axisIndex;
+
+            return 0;
         }
     }
 }

--- a/osu.Framework/Input/States/JoystickState.cs
+++ b/osu.Framework/Input/States/JoystickState.cs
@@ -20,6 +20,11 @@ namespace osu.Framework.Input.States
         public readonly float[] AxesValues = new float[MAX_AXES];
 
         /// <summary>
+        /// Currently simulated <see cref="JoystickButton"/> for each <see cref="JoystickAxis"/>. <c>0</c> if no button press is simulated.
+        /// </summary>
+        internal readonly JoystickButton[] AxisDirectionButtons = new JoystickButton[MAX_AXES];
+
+        /// <summary>
         /// Retrieves all <see cref="JoystickAxis"/> with their current value (regardless of inactive ones).
         /// </summary>
         public IEnumerable<JoystickAxis> GetAxes() =>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -629,7 +629,7 @@ namespace osu.Framework.Platform
         {
             // SDL reports axis values in the range short.MinValue to short.MaxValue, so we scale and clamp it to the range of -1f to 1f
             float clamped = Math.Clamp((float)axisValue / short.MaxValue, -1f, 1f);
-            JoystickAxisChanged?.Invoke(new JoystickAxis(axisSource, clamped));
+            JoystickAxisChanged?.Invoke(axisSource, clamped);
         }
 
         private void enqueueJoystickButtonInput(JoystickButton button, bool isPressed)
@@ -1619,7 +1619,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked when a joystick axis changes.
         /// </summary>
-        public event Action<JoystickAxis> JoystickAxisChanged;
+        public event Action<JoystickAxisSource, float> JoystickAxisChanged;
 
         /// <summary>
         /// Invoked when the user presses a button on a joystick.


### PR DESCRIPTION
This will allow `AndroidJoystickHandler` (coming soon) to reuse this logic without code duplication.
Inheritance is not an option as `AndroidInputHandler` is used on Android.

This code does look a bit dubious as `JoystickButtonInput.Apply` is called within `JoystickAxisInput.Apply`, but the current order of events is preserved.

`KeyCombination` does have a similar [scroll delta to button](https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Input/Bindings/KeyCombination.cs#L619-L632) conversion, but putting the logic there will break existing `JoystickButton.JoystickAxisN` usages.