### PR TITLE
Reduce overhead of transform processing when no transforms are present in a drawable

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTransformUpdate.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTransformUpdate.cs
@@ -14,6 +14,7 @@ namespace osu.Framework.Benchmarks
     public class BenchmarkTransformUpdate : BenchmarkTest
     {
         private TestBox target;
+        private TestBox targetNoTransforms;
 
         public override void SetUp()
         {
@@ -23,7 +24,8 @@ namespace osu.Framework.Benchmarks
 
             ManualClock clock;
 
-            target = new TestBox { Clock = new FramedClock(clock = new ManualClock()) };
+            targetNoTransforms = new TestBox { Clock = new FramedClock(clock = new ManualClock()) };
+            target = new TestBox { Clock = new FramedClock(clock) };
 
             // transform one target member over a long period
             target.RotateTo(360, transforms_count * 2);
@@ -34,6 +36,13 @@ namespace osu.Framework.Benchmarks
 
             clock.CurrentTime = target.LatestTransformEndTime;
             target.Clock.ProcessFrame();
+        }
+
+        [Benchmark]
+        public void UpdateTransformsWithNonePresent()
+        {
+            for (int i = 0; i < 10000; i++)
+                targetNoTransforms.UpdateTransforms();
         }
 
         [Benchmark]

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -104,13 +104,13 @@ namespace osu.Framework.Graphics.Transforms
 
         private TargetGroupingTransformTracker getTrackerFor(string targetMember)
         {
-            if (targetGroupingTrackers == null)
-                return null;
-
-            foreach (var t in targetGroupingTrackers)
+            if (targetGroupingTrackers != null)
             {
-                if (t.TargetMembers.Contains(targetMember))
-                    return t;
+                foreach (var t in targetGroupingTrackers)
+                {
+                    if (t.TargetMembers.Contains(targetMember))
+                        return t;
+                }
             }
 
             return null;
@@ -118,19 +118,23 @@ namespace osu.Framework.Graphics.Transforms
 
         private TargetGroupingTransformTracker getTrackerForGrouping(string targetGrouping, bool createIfNotExisting)
         {
-            targetGroupingTrackers ??= new List<TargetGroupingTransformTracker>();
-
-            foreach (var t in targetGroupingTrackers)
+            if (targetGroupingTrackers != null)
             {
-                if (t.TargetGrouping == targetGrouping)
-                    return t;
+                foreach (var t in targetGroupingTrackers)
+                {
+                    if (t.TargetGrouping == targetGrouping)
+                        return t;
+                }
             }
 
             if (!createIfNotExisting)
                 return null;
 
             var tracker = new TargetGroupingTransformTracker(this, targetGrouping);
+
+            targetGroupingTrackers ??= new List<TargetGroupingTransformTracker>();
             targetGroupingTrackers.Add(tracker);
+
             return tracker;
         }
 
@@ -192,10 +196,10 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
-            EnsureTransformMutationAllowed();
-
             if (targetGroupingTrackers == null)
                 return;
+
+            EnsureTransformMutationAllowed();
 
             if (targetMember != null)
             {
@@ -236,10 +240,10 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            EnsureTransformMutationAllowed();
-
             if (targetGroupingTrackers == null)
                 return;
+
+            EnsureTransformMutationAllowed();
 
             if (targetMember != null)
             {


### PR DESCRIPTION
As noticed by @smoogipoo during multiplayer spectator profiling, `updateTransforms` can become quite expensive as it is called millions of times. Even in cases where there are actually not transforms on drawables.

Before:

|                          Method |     Mean |   Error |  StdDev | Allocated |
|-------------------------------- |---------:|--------:|--------:|----------:|
| UpdateTransformsWithNonePresent | 101.2 us | 0.31 us | 0.25 us |         - |
| UpdateTransformsWithManyPresent | 383.3 us | 2.21 us | 2.07 us |       1 B |

After:

|                          Method |       Mean |     Error |    StdDev | Allocated |
|-------------------------------- |-----------:|----------:|----------:|----------:|
| UpdateTransformsWithNonePresent |   5.091 us | 0.0303 us | 0.0269 us |         - |
| UpdateTransformsWithManyPresent | 353.660 us | 6.8759 us | 9.6390 us |       1 B |

Testing on 30s of the same beatmap:

![WindowsTerminal_2022-07-01_03-39-08](https://user-images.githubusercontent.com/191335/176754217-e6a712a8-db77-40ea-b178-a875ac774842.png)

Note that this will have a larger effect on multiplayer spectator than what is seen in these profiling results.

There's a few other similar cases where I think we need to similarly shortcut to avoid every-frame overheads (`CheckChildLife` is another seemingly expensive / often visited method). Here's a list of function call counts during autoplay (take the timings with a grain of salt as this was using tracing collection):

![unknown](https://user-images.githubusercontent.com/191335/176754800-9398c1ab-728b-495c-a668-fbf70606deca.png)
