### PR TITLE
Add support for joysticks/gamepads on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.IO;
 using Android.App;
@@ -55,6 +53,7 @@ namespace osu.Framework.Android
                 new AndroidMouseHandler(gameView),
                 new AndroidKeyboardHandler(gameView),
                 new AndroidTouchHandler(gameView),
+                new AndroidJoystickHandler(gameView),
                 new MidiHandler()
             };
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -182,7 +182,10 @@ namespace osu.Framework.Android
         [STAThread]
         public void RenderGame()
         {
-            LayoutChange += (_, __) => updateSafeArea();
+            // request focus so that joystick input can immediately work.
+            RequestFocus();
+
+            LayoutChange += (_, _) => updateSafeArea();
             updateSafeArea();
 
             Host = new AndroidGameHost(this);
@@ -287,7 +290,6 @@ namespace osu.Framework.Android
             {
                 inputMethodManager.RestartInput(this);
                 inputMethodManager?.HideSoftInputFromWindow(WindowToken, HideSoftInputFlags.None);
-                ClearFocus();
             });
         }
 

--- a/osu.Framework.Android/Input/AndroidInputExtensions.cs
+++ b/osu.Framework.Android/Input/AndroidInputExtensions.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Android.Views;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Input;
 using osuTK.Input;
 
 namespace osu.Framework.Android.Input
@@ -57,6 +56,164 @@ namespace osu.Framework.Android.Input
             }
 
             button = MouseButton.LastButton;
+            return false;
+        }
+
+        public static bool TryGetJoystickButton(this Keycode keycode, out JoystickButton button)
+        {
+            switch (keycode)
+            {
+                case Keycode.DpadUp:
+                    button = JoystickButton.GamePadDPadUp;
+                    return true;
+
+                case Keycode.DpadDown:
+                    button = JoystickButton.GamePadDPadDown;
+                    return true;
+
+                case Keycode.DpadLeft:
+                    button = JoystickButton.GamePadDPadLeft;
+                    return true;
+
+                case Keycode.DpadRight:
+                    button = JoystickButton.GamePadDPadRight;
+                    return true;
+
+                case Keycode.ButtonA:
+                    button = JoystickButton.GamePadA;
+                    return true;
+
+                case Keycode.ButtonB:
+                    button = JoystickButton.GamePadB;
+                    return true;
+
+                case Keycode.ButtonC:
+                    button = JoystickButton.Button14; // generic button
+                    return true;
+
+                case Keycode.ButtonX:
+                    button = JoystickButton.GamePadX;
+                    return true;
+
+                case Keycode.ButtonY:
+                    button = JoystickButton.GamePadY;
+                    return true;
+
+                case Keycode.ButtonZ:
+                    button = JoystickButton.Button15; // generic button
+                    return true;
+
+                case Keycode.ButtonL1:
+                    button = JoystickButton.GamePadLeftShoulder;
+                    return true;
+
+                case Keycode.ButtonR1:
+                    button = JoystickButton.GamePadRightShoulder;
+                    return true;
+
+                case Keycode.ButtonL2:
+                    button = JoystickButton.GamePadLeftTrigger;
+                    return true;
+
+                case Keycode.ButtonR2:
+                    button = JoystickButton.GamePadRightTrigger;
+                    return true;
+
+                case Keycode.ButtonThumbl:
+                    button = JoystickButton.GamePadLeftStick;
+                    return true;
+
+                case Keycode.ButtonThumbr:
+                    button = JoystickButton.GamePadRightStick;
+                    return true;
+
+                case Keycode.ButtonStart:
+                    button = JoystickButton.GamePadStart;
+                    return true;
+
+                case Keycode.ButtonSelect:
+                    button = JoystickButton.GamePadBack;
+                    return true;
+
+                case Keycode.ButtonMode:
+                    button = JoystickButton.Button16; // generic button
+                    return true;
+            }
+
+            if (keycode >= Keycode.Button1 && keycode <= Keycode.Button16)
+            {
+                // JoystickButtons 1-16 are used above.
+                button = JoystickButton.Button17 + (keycode - Keycode.Button1);
+                return true;
+            }
+
+            button = JoystickButton.FirstButton;
+            return false;
+        }
+
+        /// <summary>
+        /// All axes supported by <see cref="TryGetJoystickAxisSource"/>.
+        /// </summary>
+        public static readonly IEnumerable<Axis> ALL_AXES = new[]
+        {
+            Axis.X,
+            Axis.Y,
+            Axis.Ltrigger,
+            Axis.Z,
+            Axis.Rz,
+            Axis.Rtrigger,
+            Axis.Rx,
+            Axis.Ry,
+            Axis.Rudder,
+            Axis.Wheel,
+        };
+
+        public static bool TryGetJoystickAxisSource(this Axis axis, out JoystickAxisSource joystickAxis)
+        {
+            switch (axis)
+            {
+                case Axis.X:
+                    joystickAxis = JoystickAxisSource.GamePadLeftStickX;
+                    return true;
+
+                case Axis.Y:
+                    joystickAxis = JoystickAxisSource.GamePadLeftStickY;
+                    return true;
+
+                case Axis.Ltrigger:
+                    joystickAxis = JoystickAxisSource.GamePadLeftTrigger;
+                    return true;
+
+                case Axis.Z:
+                    joystickAxis = JoystickAxisSource.GamePadRightStickX;
+                    return true;
+
+                case Axis.Rz:
+                    joystickAxis = JoystickAxisSource.GamePadRightStickY;
+                    return true;
+
+                case Axis.Rtrigger:
+                    joystickAxis = JoystickAxisSource.GamePadRightTrigger;
+                    return true;
+
+                case Axis.Rx:
+                    joystickAxis = JoystickAxisSource.Axis7;
+                    return true;
+
+                case Axis.Ry:
+                    joystickAxis = JoystickAxisSource.Axis8;
+                    return true;
+
+                case Axis.Rudder:
+                    joystickAxis = JoystickAxisSource.Axis9;
+                    return true;
+
+                case Axis.Wheel:
+                    joystickAxis = JoystickAxisSource.Axis10;
+                    return true;
+            }
+
+            joystickAxis = JoystickAxisSource.AxisCount;
             return false;
         }
     }

--- a/osu.Framework.Android/Input/AndroidInputExtensions.cs
+++ b/osu.Framework.Android/Input/AndroidInputExtensions.cs
@@ -282,6 +282,13 @@ namespace osu.Framework.Android.Input
             Axis.Wheel,
         };
 
+        /// <summary>
+        /// Returns the corresponding <see cref="JoystickAxisSource"/> for an <see cref="Axis"/>.
+        /// </summary>
+        /// <returns><c>true</c> if provided <paramref name="axis"/> maps to a <see cref="JoystickAxisSource"/>.</returns>
+        /// <remarks>
+        /// <see cref="Axis.Gas"/> and <see cref="Axis.Brake"/> are deliberately excluded as those axes are 1:1 mirrors of the <see cref="Axis.Rtrigger"/> and <see cref="Axis.Ltrigger"/>.
+        /// </remarks>
         public static bool TryGetJoystickAxisSource(this Axis axis, out JoystickAxisSource joystickAxis)
         {
             switch (axis)

--- a/osu.Framework.Android/Input/AndroidInputExtensions.cs
+++ b/osu.Framework.Android/Input/AndroidInputExtensions.cs
@@ -173,25 +173,30 @@ namespace osu.Framework.Android.Input
             return false;
         }
 
-        public static bool TryGetJoystickButton(this Keycode keycode, out JoystickButton button)
+        public static bool TryGetJoystickButton(this KeyEvent e, out JoystickButton button)
         {
+            var keycode = e.KeyCode;
+
+            if (keycode >= Keycode.Button1 && keycode <= Keycode.Button16)
+            {
+                // JoystickButtons 1-16 are used below.
+                button = JoystickButton.Button17 + (keycode - Keycode.Button1);
+                return true;
+            }
+
             switch (keycode)
             {
+                // Dpad keycodes are _not_ joystick buttons, but are instead used for arrow keys on a keyboard.
+                // as evident from KeyEvent.isGamePadButton():
+                // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/view/KeyEvent.java;l=1899-1936;drc=11e61ab1fd1f868ee8ddd6fc86662f4f09df1a6a
                 case Keycode.DpadUp:
-                    button = JoystickButton.GamePadDPadUp;
-                    return true;
-
                 case Keycode.DpadDown:
-                    button = JoystickButton.GamePadDPadDown;
-                    return true;
-
                 case Keycode.DpadLeft:
-                    button = JoystickButton.GamePadDPadLeft;
-                    return true;
-
                 case Keycode.DpadRight:
-                    button = JoystickButton.GamePadDPadRight;
-                    return true;
+                case Keycode.Back when e.Source == InputSourceType.Keyboard:
+                default:
+                    button = JoystickButton.FirstButton;
+                    return false;
 
                 case Keycode.ButtonA:
                     button = JoystickButton.GamePadA;
@@ -254,16 +259,6 @@ namespace osu.Framework.Android.Input
                     button = JoystickButton.Button16; // generic button
                     return true;
             }
-
-            if (keycode >= Keycode.Button1 && keycode <= Keycode.Button16)
-            {
-                // JoystickButtons 1-16 are used above.
-                button = JoystickButton.Button17 + (keycode - Keycode.Button1);
-                return true;
-            }
-
-            button = JoystickButton.FirstButton;
-            return false;
         }
 
         /// <summary>

--- a/osu.Framework.Android/Input/AndroidInputExtensions.cs
+++ b/osu.Framework.Android/Input/AndroidInputExtensions.cs
@@ -245,6 +245,7 @@ namespace osu.Framework.Android.Input
                     button = JoystickButton.GamePadStart;
                     return true;
 
+                case Keycode.Back:
                 case Keycode.ButtonSelect:
                     button = JoystickButton.GamePadBack;
                     return true;

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Android.Input
         /// <param name="inputEvent">The <see cref="InputEvent"/> to check.</param>
         /// <returns><c>true</c> if the <paramref name="inputEvent"/>'s <see cref="InputSourceType"/> matches <see cref="HandledEventSources"/>.</returns>
         /// <remarks>Should be checked before handling events.</remarks>
-        private bool shouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
+        protected virtual bool ShouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
         {
             return inputEvent != null && eventSourceBitmask.HasFlagFast(inputEvent.Source);
         }
@@ -137,7 +137,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleCapturedPointer(object sender, View.CapturedPointerEventArgs e)
         {
-            if (shouldHandleEvent(e.Event))
+            if (ShouldHandleEvent(e.Event))
             {
                 OnCapturedPointer(e.Event);
                 e.Handled = true;
@@ -149,7 +149,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleGenericMotion(object sender, View.GenericMotionEventArgs e)
         {
-            if (shouldHandleEvent(e.Event))
+            if (ShouldHandleEvent(e.Event))
             {
                 OnGenericMotion(e.Event);
                 e.Handled = true;
@@ -161,7 +161,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleHover(object sender, View.HoverEventArgs e)
         {
-            if (shouldHandleEvent(e.Event))
+            if (ShouldHandleEvent(e.Event))
             {
                 OnHover(e.Event);
                 e.Handled = true;
@@ -173,7 +173,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleKeyDown(Keycode keycode, KeyEvent e)
         {
-            if (shouldHandleEvent(e))
+            if (ShouldHandleEvent(e))
             {
                 OnKeyDown(keycode, e);
             }
@@ -184,7 +184,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleKeyUp(Keycode keycode, KeyEvent e)
         {
-            if (shouldHandleEvent(e))
+            if (ShouldHandleEvent(e))
             {
                 OnKeyUp(keycode, e);
             }
@@ -195,7 +195,7 @@ namespace osu.Framework.Android.Input
         /// </summary>
         protected void HandleTouch(object sender, View.TouchEventArgs e)
         {
-            if (shouldHandleEvent(e.Event))
+            if (ShouldHandleEvent(e.Event))
             {
                 OnTouch(e.Event);
                 e.Handled = true;

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -17,6 +17,9 @@ namespace osu.Framework.Android.Input
     /// </summary>
     public abstract class AndroidInputHandler : InputHandler
     {
+        /// <inheritdoc cref="AndroidInputExtensions.HISTORY_CURRENT"/>
+        protected const int HISTORY_CURRENT = AndroidInputExtensions.HISTORY_CURRENT;
+
         /// <summary>
         /// The <see cref="InputSourceType"/>s that this <see cref="AndroidInputHandler"/> will handle.
         /// </summary>

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Android.Input
             InputSourceType.Dpad,
             InputSourceType.Gamepad,
             InputSourceType.Joystick,
-            // joysticks sometimes present themselves as a keyboard (in addition to Gamepad) when buttons are pressed. see `ShouldHandleEvent`
+            // joysticks sometimes present themselves as a keyboard in OnKey{Up,Down} events.
             InputSourceType.Keyboard
         };
 
@@ -65,26 +65,17 @@ namespace osu.Framework.Android.Input
             return true;
         }
 
-        /// <remarks>See xmldoc <see cref="AndroidKeyboardHandler.ShouldHandleEvent"/></remarks>
-        protected override bool ShouldHandleEvent(InputEvent? inputEvent)
-            => base.ShouldHandleEvent(inputEvent)
-               && (inputEvent.Source != InputSourceType.Keyboard
-                   // explicitly handle gamepad keycodes from "keyboards" (every gamepad button except the D-pad ones are included).
-                   // D-pad keycodes are overloaded; covering arrow keys on a keyboard, synthesized trackball (Android hardware feature from 2009) events,
-                   // and joystick/gamepad D-pads (according to the docs, but not yet seen in practice)
-                   || (inputEvent is KeyEvent keyEvent && KeyEvent.IsGamepadButton(keyEvent.KeyCode)));
-
         protected override void OnKeyDown(Keycode keycode, KeyEvent e)
         {
-            if (keycode.TryGetJoystickButton(out var button))
+            if (e.TryGetJoystickButton(out var button))
                 enqueueButtonDown(button);
-            else
+            else if (e.Source != InputSourceType.Keyboard) // keyboard only events are handled in AndroidKeyboardHandler.
                 Logger.Log($"Unknown joystick keycode: {keycode}");
         }
 
         protected override void OnKeyUp(Keycode keycode, KeyEvent e)
         {
-            if (keycode.TryGetJoystickButton(out var button))
+            if (e.TryGetJoystickButton(out var button))
                 enqueueButtonUp(button);
         }
 

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -66,7 +66,13 @@ namespace osu.Framework.Android.Input
         }
 
         /// <remarks>See xmldoc <see cref="AndroidKeyboardHandler.ShouldHandleEvent"/></remarks>
-        protected override bool ShouldHandleEvent(InputEvent? inputEvent) => base.ShouldHandleEvent(inputEvent) && inputEvent.Source != InputSourceType.Keyboard;
+        protected override bool ShouldHandleEvent(InputEvent? inputEvent)
+            => base.ShouldHandleEvent(inputEvent)
+               && (inputEvent.Source != InputSourceType.Keyboard
+                   // explicitly handle gamepad keycodes from "keyboards" (every gamepad button except the D-pad ones are included).
+                   // D-pad keycodes are overloaded; covering arrow keys on a keyboard, synthesized trackball (Android hardware feature from 2009) events,
+                   // and joystick/gamepad D-pads (according to the docs, but not yet seen in practice)
+                   || (inputEvent is KeyEvent keyEvent && KeyEvent.IsGamepadButton(keyEvent.KeyCode)));
 
         protected override void OnKeyDown(Keycode keycode, KeyEvent e)
         {

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -144,7 +144,9 @@ namespace osu.Framework.Android.Input
         {
             if (!axis.TryGetJoystickAxisSource(out var joystickAxisSource))
             {
-                if (historyPosition == HISTORY_CURRENT)
+                // Brake and Gas axes mirror the left and right trigger respectively, so they are not included in TryGetJoystickAxisSource to avoid double-reporting.
+                // don't log as they're not handled on purpose.
+                if (axis != Axis.Brake && axis != Axis.Gas && historyPosition == HISTORY_CURRENT)
                     Logger.Log($"Unknown joystick axis: {axis}");
 
                 return;

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -1,0 +1,181 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using Android.Views;
+using osu.Framework.Bindables;
+using osu.Framework.Input;
+using osu.Framework.Input.Handlers.Joystick;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+
+namespace osu.Framework.Android.Input
+{
+    public class AndroidJoystickHandler : AndroidInputHandler
+    {
+        public BindableFloat DeadzoneThreshold { get; } = new BindableFloat(0.1f)
+        {
+            MinValue = 0,
+            MaxValue = 0.95f,
+            Precision = 0.005f,
+        };
+
+        public override string Description => "Joystick / Gamepad";
+
+        public override bool IsActive => true;
+
+        protected override IEnumerable<InputSourceType> HandledEventSources => new[]
+        {
+            InputSourceType.Dpad,
+            InputSourceType.Gamepad,
+            InputSourceType.Joystick,
+            // joysticks sometimes present themselves as a keyboard (in addition to Gamepad) when buttons are pressed. see `ShouldHandleEvent`
+            InputSourceType.Keyboard
+        };
+
+        public AndroidJoystickHandler(AndroidGameView view)
+            : base(view)
+        {
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    View.GenericMotion += HandleGenericMotion;
+                    View.KeyDown += HandleKeyDown;
+                    View.KeyUp += HandleKeyUp;
+                }
+                else
+                {
+                    View.GenericMotion -= HandleGenericMotion;
+                    View.KeyDown -= HandleKeyDown;
+                    View.KeyUp -= HandleKeyUp;
+                }
+            }, true);
+
+            return true;
+        }
+
+        /// <remarks>See xmldoc <see cref="AndroidKeyboardHandler.ShouldHandleEvent"/></remarks>
+        protected override bool ShouldHandleEvent(InputEvent? inputEvent) => base.ShouldHandleEvent(inputEvent) && inputEvent.Source != InputSourceType.Keyboard;
+
+        protected override void OnGenericMotion(MotionEvent genericMotionEvent)
+        {
+            switch (genericMotionEvent.Action)
+            {
+                case MotionEventActions.Move:
+                    // PointerCount / GetPointerId is probably related to number of joysticks connected. framework only handles one joystick, so coalesce instead of handling separately.
+                    for (int i = 0; i < genericMotionEvent.PointerCount; i++)
+                    {
+                        var motionRanges = genericMotionEvent.Device?.MotionRanges;
+
+                        enqueueInput(motionRanges != null && motionRanges.Count > 0
+                            ? new JoystickAxisInput(getJoystickAxesForMotionRange(genericMotionEvent, i, motionRanges))
+                            : new JoystickAxisInput(getAllJoystickAxes(genericMotionEvent, i)));
+
+                        foreach (var input in getDpadInputs(genericMotionEvent, i))
+                            enqueueInput(input);
+                    }
+
+                    break;
+            }
+        }
+
+        protected override void OnKeyDown(Keycode keycode, KeyEvent e)
+        {
+            if (keycode.TryGetJoystickButton(out var button))
+                enqueueInput(new JoystickButtonInput(button, true));
+        }
+
+        protected override void OnKeyUp(Keycode keycode, KeyEvent e)
+        {
+            if (keycode.TryGetJoystickButton(out var button))
+                enqueueInput(new JoystickButtonInput(button, false));
+        }
+
+        private IEnumerable<JoystickAxis> getJoystickAxesForMotionRange(MotionEvent motionEvent, int pointerIndex, IEnumerable<InputDevice.MotionRange> motionRanges)
+        {
+            foreach (var motionRange in motionRanges)
+            {
+                if (tryGetJoystickAxis(motionEvent, pointerIndex, motionRange.Axis, out var joystickAxis))
+                    yield return joystickAxis;
+            }
+        }
+
+        private IEnumerable<JoystickAxis> getAllJoystickAxes(MotionEvent motionEvent, int pointerIndex)
+        {
+            foreach (var axis in AndroidInputExtensions.ALL_AXES)
+            {
+                if (tryGetJoystickAxis(motionEvent, pointerIndex, axis, out var joystickAxis))
+                    yield return joystickAxis;
+            }
+        }
+
+        private bool tryGetJoystickAxis(MotionEvent motionEvent, int pointerIndex, Axis axis, out JoystickAxis joystickAxis)
+        {
+            if (!axis.TryGetJoystickAxisSource(out var joystickAxisSource))
+            {
+                if (axis != Axis.HatX && axis != Axis.HatY)
+                    Logger.Log($"Unknown joystick axis: {axis}");
+
+                joystickAxis = new JoystickAxis();
+                return false;
+            }
+
+            float value = motionEvent.GetAxisValue(axis, pointerIndex);
+
+            if (float.IsNaN(value))
+            {
+                joystickAxis = new JoystickAxis();
+                return false;
+            }
+
+            value = JoystickHandler.RescaleByDeadzone(value, DeadzoneThreshold.Value);
+
+            joystickAxis = new JoystickAxis(joystickAxisSource, value);
+            return true;
+        }
+
+        private float lastDpadX;
+        private float lastDpadY;
+
+        private IEnumerable<JoystickButtonInput> getDpadInputs(MotionEvent motionEvent, int pointerIndex)
+        {
+            float x = motionEvent.GetAxisValue(Axis.HatX, pointerIndex);
+
+            if (x != lastDpadX)
+            {
+                if (x == 0) yield return new JoystickButtonInput(lastDpadX > 0 ? JoystickButton.GamePadDPadRight : JoystickButton.GamePadDPadLeft, false);
+                if (x > 0) yield return new JoystickButtonInput(JoystickButton.GamePadDPadRight, true);
+                if (x < 0) yield return new JoystickButtonInput(JoystickButton.GamePadDPadLeft, true);
+
+                lastDpadX = x;
+            }
+
+            float y = motionEvent.GetAxisValue(Axis.HatY, pointerIndex);
+
+            if (y != lastDpadY)
+            {
+                if (y == 0) yield return new JoystickButtonInput(lastDpadY > 0 ? JoystickButton.GamePadDPadDown : JoystickButton.GamePadDPadUp, false);
+                if (y > 0) yield return new JoystickButtonInput(JoystickButton.GamePadDPadDown, true);
+                if (y < 0) yield return new JoystickButtonInput(JoystickButton.GamePadDPadUp, true);
+
+                lastDpadY = y;
+            }
+        }
+
+        private void enqueueInput(IInput input)
+        {
+            PendingInputs.Enqueue(input);
+            FrameStatistics.Increment(StatisticsCounterType.JoystickEvents);
+        }
+    }
+}

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -72,6 +72,8 @@ namespace osu.Framework.Android.Input
         {
             if (keycode.TryGetJoystickButton(out var button))
                 enqueueButtonDown(button);
+            else
+                Logger.Log($"Unknown joystick keycode: {keycode}");
         }
 
         protected override void OnKeyUp(Keycode keycode, KeyEvent e)

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using Android.Views;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.StateChanges;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK.Input;
 
@@ -44,19 +44,14 @@ namespace osu.Framework.Android.Input
 
         public override bool IsActive => true;
 
-        /// <remarks>
-        /// Android might send Dpad events as <see cref="InputSourceType.Keyboard"/> or'd with <see cref="InputSourceType.Gamepad"/>.
-        /// Both <see cref="GetKeyCodeAsKey"/> and <see cref="AndroidInputExtensions.TryGetJoystickButton"/> handle Dpad (eg. <see cref="Keycode.DpadUp"/>) keycodes,
-        /// so the additional check ensures only one handler handles them.
-        /// </remarks>
-        protected override bool ShouldHandleEvent(InputEvent? inputEvent) => base.ShouldHandleEvent(inputEvent) && !inputEvent.Source.HasFlagFast(InputSourceType.Gamepad);
-
         protected override void OnKeyDown(Keycode keycode, KeyEvent e)
         {
             var key = GetKeyCodeAsKey(keycode);
 
             if (key != Key.Unknown)
                 PendingInputs.Enqueue(new KeyboardKeyInput(key, true));
+            else if (!KeyEvent.IsGamepadButton(keycode)) // gamepad buttons are handled in AndroidJoystickHandler
+                Logger.Log($"Unknown keyboard keycode: {keycode}");
         }
 
         protected override void OnKeyUp(Keycode keycode, KeyEvent e)

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using Android.Views;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osuTK.Input;
@@ -44,6 +43,13 @@ namespace osu.Framework.Android.Input
         }
 
         public override bool IsActive => true;
+
+        /// <remarks>
+        /// Android might send Dpad events as <see cref="InputSourceType.Keyboard"/> or'd with <see cref="InputSourceType.Gamepad"/>.
+        /// Both <see cref="GetKeyCodeAsKey"/> and <see cref="AndroidInputExtensions.TryGetJoystickButton"/> handle Dpad (eg. <see cref="Keycode.DpadUp"/>) keycodes,
+        /// so the additional check ensures only one handler handles them.
+        /// </remarks>
+        protected override bool ShouldHandleEvent(InputEvent? inputEvent) => base.ShouldHandleEvent(inputEvent) && !inputEvent.Source.HasFlagFast(InputSourceType.Gamepad);
 
         protected override void OnKeyDown(Keycode keycode, KeyEvent e)
         {

--- a/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
@@ -65,17 +65,17 @@ namespace osu.Framework.Input.Handlers.Joystick
         /// Enqueues a <see cref="JoystickAxisInput"/> taking into account the axis deadzone.
         /// </summary>
         private void enqueueJoystickAxisChanged(JoystickAxisSource source, float value) =>
-            enqueueJoystickEvent(new JoystickAxisInput(new JoystickAxis(source, rescaleByDeadzone(value))));
+            enqueueJoystickEvent(new JoystickAxisInput(new JoystickAxis(source, RescaleByDeadzone(value, DeadzoneThreshold.Value))));
 
-        private float rescaleByDeadzone(float axisValue)
+        internal static float RescaleByDeadzone(float axisValue, float deadzoneThreshold)
         {
             float absoluteValue = Math.Abs(axisValue);
 
-            if (absoluteValue < DeadzoneThreshold.Value)
+            if (absoluteValue < deadzoneThreshold)
                 return 0;
 
             // rescale the given axis value such that the edge of the deadzone is considered the "new zero".
-            float absoluteRescaled = (absoluteValue - DeadzoneThreshold.Value) / (1f - DeadzoneThreshold.Value);
+            float absoluteRescaled = (absoluteValue - deadzoneThreshold) / (1f - deadzoneThreshold);
             return Math.Sign(axisValue) * absoluteRescaled;
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/discussions/18856
- Closes https://github.com/ppy/osu-framework/issues/2863
   - tablet support still missing https://github.com/ppy/osu/issues/17382

Initial implementation based on https://developer.android.com/training/game-controllers/controller-input.
Axis and button values taken from there and by manually inspecting the android Keycode enum and docs.

During initial osu!-side testing I noticed that D-pad events were being dropped (on song select, where the game lags the most). The cause was not properly handling `MotionEvent` [batching](https://developer.android.com/reference/android/view/MotionEvent#batching), something that has already come up in [`AndroidMouseHandler`](https://github.com/ppy/osu-framework/blob/193238a90215b0e97ac2aa244ed7d30edc0a9880/osu.Framework.Android/Input/AndroidMouseHandler.cs#L224-L228). In fixing this, I refactored joystick, mouse and touch to use proper batching for all `MotionEvent`s.

Mouse and touch refactor is coming in a separate PR, but the groundwork has been laid out in this one: `HandleHistoricallyPerPointer` and `TryGetPosition` have been added, but currently remain unused.

---

Tested on a USB Xbox 360 controller clone, everything except the guide button works (Android doesn't provide a mapping for that). For my specific controller, D-pad inputs where reported exclusively trough `OnGenericMotion` &rarr; `Axis.HatX`/`Axis.HatY` and not in `OnKeyDown/Up`.

The same controller reported different `Device.MotionRanges` on different devices:
- Realme 6, Android 11: the list was non-null, but was empty
- LG G7 Fit, Android 9:  the list was populated with the expected axes (including `Gas` and `Brake`)

`availableAxes` can adapt to both of these scenarios, and properly excludes `Gas` and `Brake`.