### PR TITLE
Allow disabling forced GC during test runs

### DIFF
--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -424,9 +424,12 @@ namespace osu.Framework.Testing
             runner.RunTestBlocking(this);
             checkForErrors();
 
-            // Force any unobserved exceptions to fire against the current test run.
-            // Without this they could be delayed until a future test scene is running, making tracking down the cause difficult.
-            collectAndFireUnobserved();
+            if (Environment.GetEnvironmentVariable("OSU_FRAMEWORK_TESTS_NO_FORCED_GC") != "1")
+            {
+                // Force any unobserved exceptions to fire against the current test run.
+                // Without this they could be delayed until a future test scene is running, making tracking down the cause difficult.
+                collectAndFireUnobserved();
+            }
         }
 
         [OneTimeTearDown]

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -424,7 +424,7 @@ namespace osu.Framework.Testing
             runner.RunTestBlocking(this);
             checkForErrors();
 
-            if (Environment.GetEnvironmentVariable("OSU_FRAMEWORK_TESTS_NO_FORCED_GC") != "1")
+            if (Environment.GetEnvironmentVariable("OSU_TESTS_NO_FORCED_GC") != "1")
             {
                 // Force any unobserved exceptions to fire against the current test run.
                 // Without this they could be delayed until a future test scene is running, making tracking down the cause difficult.


### PR DESCRIPTION
I'm not saying we should do this, but I want the flexibility to experiment with it. Once we have things in a stable state, it may make sense to disable for Github Actions to improve performance of test runs (from recollection, about 40% faster) and enable only when an issue comes up, or as a background runner on teamcity or otherwise.