### PR TITLE
Fix `TextureLoaderStore` not always appending extensions to lookups

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -229,7 +229,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 }
 
                 TotalCompletedLookups++;
-                return getFunc("sample-texture");
+                return getFunc("sample-texture.png");
             }
 
             public void Reset()

--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -19,13 +19,13 @@ namespace osu.Framework.Graphics.Textures
     /// </summary>
     public class TextureLoaderStore : IResourceStore<TextureUpload>
     {
-        private IResourceStore<byte[]> store { get; }
+        private readonly ResourceStore<byte[]> store;
 
         public TextureLoaderStore(IResourceStore<byte[]> store)
         {
-            this.store = store;
-            (store as ResourceStore<byte[]>)?.AddExtension(@"png");
-            (store as ResourceStore<byte[]>)?.AddExtension(@"jpg");
+            this.store = new ResourceStore<byte[]>(store);
+            this.store.AddExtension(@"png");
+            this.store.AddExtension(@"jpg");
         }
 
         public Task<TextureUpload> GetAsync(string name, CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/18989

Tournament texture storage [uses a `StorageBackedResourceStore`](https://github.com/ppy/osu/blob/1ccfd69690c45aaad0057877aa5642896646d3d7/osu.Game.Tournament/TournamentGameBase.cs#L65), which is not of type `ResourceStore`, therefore `TextureLoaderStore` can't append the image extensions and fail lookups:

https://github.com/ppy/osu-framework/blob/e918d33889a39c4895c01bcca384e88c89b52a57/osu.Framework/Graphics/Textures/TextureLoaderStore.cs#L24-L29

This is a regression from https://github.com/ppy/osu-framework/pull/5240, since prior to that PR, [`TextureStore` appends extensions as well](https://github.com/ppy/osu-framework/blob/84758b770872e8f332ae0e5503206c5a941c89bb/osu.Framework/Graphics/Textures/TextureStore.cs#L44-L45) (this is also the reason why previously texture store sometimes looks up textures with double extensions, i.e. `texture.jpg.png`).

Instead, I've changed `TextureLoaderStore` to explicitly construct a resource store and add the given store along with the right extensions there, rather than safely cast and silently fail.

Note that `SampleStore` and `TrackStore` suffer from the same issue, which would fail similarly if constructed with a non-`ResourceStore<T>` store (e.g. `StorageBackedResourceStore`).