### PR TITLE
Use null-forgiving operator for `AsNonNull` rather than assertion

### DIFF
--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
 
 namespace osu.Framework.Extensions.ObjectExtensions
 {
@@ -23,6 +24,7 @@ namespace osu.Framework.Extensions.ObjectExtensions
         public static T AsNonNull<T>(this T? obj)
             where T : class
         {
+            Trace.Assert(obj != null);
             Debug.Assert(obj != null);
             return obj;
         }

--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using NUnit.Framework;
 
 namespace osu.Framework.Extensions.ObjectExtensions
 {
@@ -24,9 +22,7 @@ namespace osu.Framework.Extensions.ObjectExtensions
         public static T AsNonNull<T>(this T? obj)
             where T : class
         {
-            Trace.Assert(obj != null);
-            Debug.Assert(obj != null);
-            return obj;
+            return obj!;
         }
 
         /// <summary>


### PR DESCRIPTION
~~Turns out `AsNonNull` never works osu!-side, due to the asserts being made for debug configuration only. Haven't checked if this works as expected when packaging framework yet (blocking until I confirm).~~

~~Alternative would be to explicitly throw exception, but not sure what's best fit for this.~~

I've been confused into thinking that `AsNonNull` should throw when the instance is null, but the intention behind it is to silently return the instance as non-nullable regardless of whether it's null (i.e. act exactly like a null-forgiving operator).

PR'ing this just to clear that confusion up.