### PR TITLE
Remove noisy MIDI handler log output

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -216,8 +216,6 @@ namespace osu.Framework.Input.Handlers.Midi
 
         private void dispatchEvent(byte eventType, byte key, byte velocity)
         {
-            Logger.Log($"Handling MIDI event {eventType:X2}:{key:X2}:{velocity:X2}");
-
             // Low nibble only contains channel data in note on/off messages
             // Ignore to receive messages from all channels
             switch (eventType & 0xF0)
@@ -234,17 +232,17 @@ namespace osu.Framework.Input.Handlers.Midi
                     break;
             }
 
-            void noteOff()
-            {
-                Logger.Log($"NoteOff: {(MidiKey)key}/{velocity / 128f:P}");
-                PendingInputs.Enqueue(new MidiKeyInput((MidiKey)key, 0, false));
-                FrameStatistics.Increment(StatisticsCounterType.MidiEvents);
-            }
-
             void noteOn()
             {
                 Logger.Log($"NoteOn: {(MidiKey)key}/{velocity / 128f:P}");
                 PendingInputs.Enqueue(new MidiKeyInput((MidiKey)key, velocity, true));
+                FrameStatistics.Increment(StatisticsCounterType.MidiEvents);
+            }
+
+            void noteOff()
+            {
+                Logger.Log($"NoteOff: {(MidiKey)key}/{velocity / 128f:P}");
+                PendingInputs.Enqueue(new MidiKeyInput((MidiKey)key, 0, false));
                 FrameStatistics.Increment(StatisticsCounterType.MidiEvents);
             }
         }

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -234,14 +234,12 @@ namespace osu.Framework.Input.Handlers.Midi
 
             void noteOn()
             {
-                Logger.Log($"NoteOn: {(MidiKey)key}/{velocity / 128f:P}");
                 PendingInputs.Enqueue(new MidiKeyInput((MidiKey)key, velocity, true));
                 FrameStatistics.Increment(StatisticsCounterType.MidiEvents);
             }
 
             void noteOff()
             {
-                Logger.Log($"NoteOff: {(MidiKey)key}/{velocity / 128f:P}");
                 PendingInputs.Enqueue(new MidiKeyInput((MidiKey)key, 0, false));
                 FrameStatistics.Increment(StatisticsCounterType.MidiEvents);
             }


### PR DESCRIPTION
MIDI devices generally send traffic such as clock sync data, which we don't care about. For me, if I have my midi controller connected this creates a flow of 2-3 logger messages per second.

Uploading JetBrains Rider-EAP 2022-07-06 at 05.12.44.mp4…


