### PR TITLE
Reduce `Scheduler` overhead when no tasks are pending

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkScheduler.cs
+++ b/osu.Framework.Benchmarks/BenchmarkScheduler.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkScheduler : BenchmarkTest
+    {
+        private Scheduler scheduler = null!;
+        private Scheduler schedulerWithEveryUpdate = null!;
+        private Scheduler schedulerWithManyDelayed = null!;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            scheduler = new Scheduler();
+
+            schedulerWithEveryUpdate = new Scheduler();
+            schedulerWithEveryUpdate.AddDelayed(() => { }, 0, true);
+
+            schedulerWithManyDelayed = new Scheduler();
+            for (int i = 0; i < 1000; i++)
+                schedulerWithManyDelayed.AddDelayed(() => { }, int.MaxValue);
+        }
+
+        [Benchmark]
+        public void UpdateEmptyScheduler()
+        {
+            for (int i = 0; i < 1000; i++)
+                scheduler.Update();
+        }
+
+        [Benchmark]
+        public void UpdateSchedulerWithManyDelayed()
+        {
+            for (int i = 0; i < 1000; i++)
+                schedulerWithManyDelayed.Update();
+        }
+
+        [Benchmark]
+        public void UpdateSchedulerWithEveryUpdate()
+        {
+            for (int i = 0; i < 1000; i++)
+                schedulerWithEveryUpdate.Update();
+        }
+
+        [Benchmark]
+        public void UpdateSchedulerWithManyAdded()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                scheduler.Add(() => { });
+                scheduler.Update();
+            }
+        }
+    }
+}

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Threading
                 lock (queueLock)
                 {
                     if (hasTimedTasks) queueTimedTasks();
-                    if (hasPerUpdateTasks) queuePerUpdateTasks();
+                    if (perUpdateTasks.Count > 0) queuePerUpdateTasks();
                 }
             }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -109,8 +109,8 @@ namespace osu.Framework.Threading
             {
                 lock (queueLock)
                 {
-                    if (hasTimedTasks) queueTimedTasks();
-                    if (perUpdateTasks.Count > 0) queuePerUpdateTasks();
+                    queueTimedTasks();
+                    queuePerUpdateTasks();
                 }
             }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Threading
         /// Run any pending work tasks.
         /// </summary>
         /// <returns>The number of tasks that were run.</returns>
-        public virtual int Update()
+        public int Update()
         {
             lock (queueLock)
             {

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -123,7 +123,6 @@ namespace osu.Framework.Threading
 
             while (getNextTask(out ScheduledDelegate sd))
             {
-                //todo: error handling
                 sd.RunTaskInternal();
 
                 TotalTasksRun++;


### PR DESCRIPTION
A common scenario is that a drawable will use a `Schedule` call once then become mostly inactive. The `Scheduler` that was used for this call stays remnant, and has quite a large overhead due to the locking in `Scheduler.Update`. This aims to reduce that overhead considerably.

## Benchmark

Before:

|                         Method |        Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------- |------------:|----------:|----------:|-------:|----------:|
|           UpdateEmptyScheduler |    82.15 us |  0.662 us |  0.553 us |      - |         - |
| UpdateSchedulerWithManyDelayed | 1,389.42 us | 20.222 us | 17.926 us |      - |       3 B |
| UpdateSchedulerWithEveryUpdate |   147.62 us |  2.294 us |  2.034 us |      - |         - |
|   UpdateSchedulerWithManyAdded |   144.63 us |  2.354 us |  2.087 us | 6.8359 |  80,000 B |


After:

|                         Method |         Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------------- |-------------:|-----------:|-----------:|-------:|----------:|
|           UpdateEmptyScheduler |     2.831 us |  0.0498 us |  0.0441 us |      - |         - |
| UpdateSchedulerWithManyDelayed | 2,148.074 us | 30.7526 us | 28.7660 us |      - |       6 B |
| UpdateSchedulerWithEveryUpdate |   104.743 us |  1.6779 us |  1.5695 us |      - |         - |
|   UpdateSchedulerWithManyAdded |    81.094 us |  1.5121 us |  1.4144 us | 6.8359 |  80,000 B |

I have... no idea why `WithManyDelayed` is showing a performance regression. There's no reason it should be. Maybe @smoogipoo will have a better immediate idea? I've tried multiple runs and it's always showing the same numbers..

## Real world (song select, idle)

Before:

![JetBrains Rider-EAP 2022-07-06 at 08 07 22](https://user-images.githubusercontent.com/191335/177502137-605ce4da-bc71-49b6-92e2-6b6055e67f9a.png)

After:

![JetBrains Rider-EAP 2022-07-06 at 08 06 10](https://user-images.githubusercontent.com/191335/177502152-becf3b3b-63e2-4a4c-b5f6-a889cefd57e4.png)

