### PR TITLE
Remove class constraint on AsNonNull()

### DIFF
--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -19,11 +19,8 @@ namespace osu.Framework.Extensions.ObjectExtensions
         /// <param name="obj">The nullable object.</param>
         /// <typeparam name="T">The type of the object.</typeparam>
         /// <returns>The non-nullable object corresponding to <paramref name="obj"/>.</returns>
-        public static T AsNonNull<T>(this T? obj)
-            where T : class
-        {
-            return obj!;
-        }
+        [return: NotNullIfNotNull("obj")]
+        public static T AsNonNull<T>(this T? obj) => obj!;
 
         /// <summary>
         /// If the given object is null.


### PR DESCRIPTION
This change is the only exact combination of things I can find that replicates the inspections provided by `!`.

My tests are:
```
#nullable enable
    object a = new object();
    object a1 = a!;
    object a2 = a.AsNonNull();
    Debug.Assert(a1 == null);
    Debug.Assert(a2 == null);

    object? b = new object();
    object b1 = b!;
    object b2 = b.AsNonNull();
    Debug.Assert(b1 == null);
    Debug.Assert(b2 == null);

    object? c = null;
    object c1 = c!;
    object c2 = c.AsNonNull();
    Debug.Assert(c1 == null);
    Debug.Assert(c2 == null);

    int d = 5;
    int d1 = d!;
    int d2 = d.AsNonNull();
    Debug.Assert(d1 == null);
    Debug.Assert(d2 == null);

    int? e = 5;
    int? e1 = e!;
    int? e2 = e.AsNonNull();
    Debug.Assert(e1 == null);
    Debug.Assert(e2 == null);

    int? f = null;
    int? f1 = f!;
    int? f2 = f.AsNonNull();
    Debug.Assert(f1 == null);
    Debug.Assert(f2 == null);
#nullable disable
```

Here's a comparison leading to my results. Open each image in a tab to see the differences.

Master: https://user-images.githubusercontent.com/1329837/177527783-e7616647-4a80-488c-8a04-83aa02c60919.png
Removing the T type: https://user-images.githubusercontent.com/1329837/177527683-a5b72f6e-21b3-4420-99c0-287c9bc5f456.png
Trying `[return: NotNull]`: https://user-images.githubusercontent.com/1329837/177528220-c924e752-ec75-43b5-80ab-caf94f4c775e.png
Using `[return: NotNullIfNotNull("obj")]`: https://user-images.githubusercontent.com/1329837/177528133-07c0629d-eba0-4e92-ba70-504c37e60948.png

