### PR TITLE
Fix `DrawVisualiser` blocking positional input while not searching

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Graphics.Visualisation
         private readonly InfoOverlay overlay;
         private InputManager inputManager;
 
+        protected override bool BlockPositionalInput => Searching;
+
         public DrawVisualiser()
         {
             RelativeSizeAxes = Axes.Both;
@@ -318,8 +320,6 @@ namespace osu.Framework.Graphics.Visualisation
                 drawableInspector.InspectedDrawable.Value = newHighlight.Target;
             }
         }
-
-        protected override bool OnMouseDown(MouseDownEvent e) => Searching;
 
         protected override bool OnClick(ClickEvent e)
         {


### PR DESCRIPTION
Fixes draw visualiser taking hover away from components when open. Regressed in #5268 since the events changed to be handled per-method rather than at `Handle` (which `DrawVisualiser` has overriden).