### PR TITLE
Touch support for desktop platforms

### DIFF
--- a/osu.Framework/Input/Handlers/Touch/TouchHandler.cs
+++ b/osu.Framework/Input/Handlers/Touch/TouchHandler.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
+using osu.Framework.Statistics;
 
 namespace osu.Framework.Input.Handlers.Touch
 {
@@ -48,7 +49,7 @@ namespace osu.Framework.Input.Handlers.Touch
         private void enqueueTouch(Input.Touch touch, bool activate)
         {
             PendingInputs.Enqueue(new TouchInput(touch, activate));
-            // FrameStatistics.Increment(StatisticsCounterType.TouchEvents);
+            FrameStatistics.Increment(StatisticsCounterType.TouchEvents);
         }
     }
 }

--- a/osu.Framework/Input/Handlers/Touch/TouchHandler.cs
+++ b/osu.Framework/Input/Handlers/Touch/TouchHandler.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Input.Handlers.Touch
+{
+    public class TouchHandler : InputHandler
+    {
+        public override bool IsActive => true;
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            if (!(host.Window is SDL2DesktopWindow window))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    window.TouchDown += handleTouchDown;
+                    window.TouchUp += handleTouchUp;
+                }
+                else
+                {
+                    window.TouchDown -= handleTouchDown;
+                    window.TouchUp -= handleTouchUp;
+                }
+            }, true);
+
+            return true;
+        }
+
+        private void handleTouchDown(Input.Touch touch)
+        {
+            enqueueTouch(touch, true);
+        }
+
+        private void handleTouchUp(Input.Touch touch)
+        {
+            enqueueTouch(touch, false);
+        }
+
+        private void enqueueTouch(Input.Touch touch, bool activate)
+        {
+            PendingInputs.Enqueue(new TouchInput(touch, activate));
+            // FrameStatistics.Increment(StatisticsCounterType.TouchEvents);
+        }
+    }
+}

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -15,6 +15,7 @@ using osu.Framework.Input.Handlers.Joystick;
 using osu.Framework.Input.Handlers.Keyboard;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Input.Handlers.Touch;
 
 namespace osu.Framework.Platform
 {
@@ -116,6 +117,7 @@ namespace osu.Framework.Platform
                 new Input.Handlers.Tablet.OpenTabletDriverHandler(),
 #endif
                 new MouseHandler(),
+                new TouchHandler(),
                 new JoystickHandler(),
                 new MidiHandler(),
             };

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -898,6 +898,7 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_EventType.SDL_FINGERUP:
                     TouchUp?.Invoke(touch);
+                    activeTouches[(int)existingSource] = null;
                     break;
             }
         }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1691,8 +1691,14 @@ namespace osu.Framework.Platform
         /// </summary>
         public event Action<JoystickButton> JoystickButtonUp;
 
+        /// <summary>
+        /// Invoked when a finger moves or touches a touchscreen.
+        /// </summary>
         public event Action<Touch> TouchDown;
 
+        /// <summary>
+        /// Invoked when a finger leaves the touchscreen.
+        /// </summary>
         public event Action<Touch> TouchUp;
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -491,7 +491,7 @@ namespace osu.Framework.Platform
             SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_IME_SHOW_UI, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, "0");
-            // SDL.SDL_SetHint(SDL.SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+            SDL.SDL_SetHint(SDL.SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
             // we want text input to only be active when SDL2DesktopWindowTextInput is active.
             // SDL activates it by default on some platforms: https://github.com/libsdl-org/SDL/blob/release-2.0.16/src/video/SDL_video.c#L573-L582

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -489,6 +489,7 @@ namespace osu.Framework.Platform
             SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_IME_SHOW_UI, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, "0");
+            // SDL.SDL_SetHint(SDL.SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
             // we want text input to only be active when SDL2DesktopWindowTextInput is active.
             // SDL activates it by default on some platforms: https://github.com/libsdl-org/SDL/blob/release-2.0.16/src/video/SDL_video.c#L573-L582
@@ -841,6 +842,27 @@ namespace osu.Framework.Platform
 
         private void handleTouchFingerEvent(SDL.SDL_TouchFingerEvent evtTfinger)
         {
+            var source = (TouchSource)evtTfinger.fingerId;
+
+            if (source > TouchSource.Touch10)
+                return;
+
+            float x = evtTfinger.x * Size.Width;
+            float y = evtTfinger.y * Size.Height;
+
+            var touch = new Touch(source, new Vector2(x, y));
+
+            switch ((SDL.SDL_EventType)evtTfinger.type)
+            {
+                case SDL.SDL_EventType.SDL_FINGERDOWN:
+                case SDL.SDL_EventType.SDL_FINGERMOTION:
+                    TouchDown?.Invoke(touch);
+                    break;
+
+                case SDL.SDL_EventType.SDL_FINGERUP:
+                    TouchUp?.Invoke(touch);
+                    break;
+            }
         }
 
         private void handleControllerDeviceEvent(SDL.SDL_ControllerDeviceEvent evtCdevice)
@@ -1630,6 +1652,10 @@ namespace osu.Framework.Platform
         /// Invoked when the user releases a button on a joystick.
         /// </summary>
         public event Action<JoystickButton> JoystickButtonUp;
+
+        public event Action<Touch> TouchDown;
+
+        public event Action<Touch> TouchUp;
 
         /// <summary>
         /// Invoked when the user drops a file into the window.

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -48,11 +48,24 @@ namespace osu.Framework.Platform.Windows.Native
         public const long MI_WP_SIGNATURE_MASK = 0xFFFFFF00;
 
         /// <summary>
+        /// Flag distinguishing touch input from mouse input in <see cref="WM_INPUT"/> events.
+        /// </summary>
+        /// <remarks>
+        /// https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
+        /// <para>Additionally, the eighth bit, masked by 0x80, is used to differentiate touch input from pen input (0 = pen, 1 = touch).</para>
+        /// </remarks>
+        private const long touch_flag = 0x80;
+
+        /// <summary>
         /// https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
         /// </summary>
         /// <param name="dw"><see cref="GetMessageExtraInfo"/> for the current <see cref="WM_INPUT"/> event.</param>
         /// <returns><c>true</c> if this <see cref="WM_INPUT"/> event is from a finger touch, <c>false</c> if it's from mouse or pen input.</returns>
-        public static bool IsTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) == 0x80;
+        public static bool IsTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && HasTouchFlag(dw);
+
+        /// <param name="extraInformation"><see cref="RawMouse.ExtraInformation"/> or <see cref="GetMessageExtraInfo"/></param>
+        /// <returns>Whether <paramref name="extraInformation"/> has the <see cref="touch_flag"/> set.</returns>
+        public static bool HasTouchFlag(long extraInformation) => (extraInformation & touch_flag) == touch_flag;
 
         [DllImport("user32.dll", SetLastError = false)]
         public static extern long GetMessageExtraInfo();

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -47,7 +47,8 @@ namespace osu.Framework.Platform.Windows.Native
         public const long MI_WP_SIGNATURE = 0xFF515700;
         public const long MI_WP_SIGNATURE_MASK = 0xFFFFFF00;
 
-        private static bool isTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) != 0;
+        // https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
+        private static bool isTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) == 0x80;
 
         [DllImport("user32.dll", SetLastError = false)]
         private static extern long GetMessageExtraInfo();

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -48,23 +48,10 @@ namespace osu.Framework.Platform.Windows.Native
         public const long MI_WP_SIGNATURE_MASK = 0xFFFFFF00;
 
         // https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
-        private static bool isTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) == 0x80;
+        public static bool IsTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) == 0x80;
 
         [DllImport("user32.dll", SetLastError = false)]
-        private static extern long GetMessageExtraInfo();
-
-        /// <summary>
-        /// Whether the current mouse messages is sourced from a touch device (generated for touchscreens).
-        /// </summary>
-        public static bool IsMouseMessageSourceTouch()
-        {
-            long extraInfo = GetMessageExtraInfo();
-
-            if (isTouchEvent(extraInfo))
-                return true;
-
-            return (extraInfo & 0x82) == 0x82;
-        }
+        public static extern long GetMessageExtraInfo();
     }
 
     /// <summary>

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -47,7 +47,11 @@ namespace osu.Framework.Platform.Windows.Native
         public const long MI_WP_SIGNATURE = 0xFF515700;
         public const long MI_WP_SIGNATURE_MASK = 0xFFFFFF00;
 
-        // https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
+        /// <summary>
+        /// https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages
+        /// </summary>
+        /// <param name="dw"><see cref="GetMessageExtraInfo"/> for the current <see cref="WM_INPUT"/> event.</param>
+        /// <returns><c>true</c> if this <see cref="WM_INPUT"/> event is from a finger touch, <c>false</c> if it's from mouse or pen input.</returns>
         public static bool IsTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) == 0x80;
 
         [DllImport("user32.dll", SetLastError = false)]

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -43,6 +43,27 @@ namespace osu.Framework.Platform.Windows.Native
         public const int SM_YVIRTUALSCREEN = 77;
         public const int SM_CXVIRTUALSCREEN = 78;
         public const int SM_CYVIRTUALSCREEN = 79;
+
+        public const long MI_WP_SIGNATURE = 0xFF515700;
+        public const long MI_WP_SIGNATURE_MASK = 0xFFFFFF00;
+
+        private static bool isTouchEvent(long dw) => (dw & MI_WP_SIGNATURE_MASK) == MI_WP_SIGNATURE && (dw & 0x80) != 0;
+
+        [DllImport("user32.dll", SetLastError = false)]
+        private static extern long GetMessageExtraInfo();
+
+        /// <summary>
+        /// Whether the current mouse messages is sourced from a touch device (generated for touchscreens).
+        /// </summary>
+        public static bool IsMouseMessageSourceTouch()
+        {
+            long extraInfo = GetMessageExtraInfo();
+
+            if (isTouchEvent(extraInfo))
+                return true;
+
+            return (extraInfo & 0x82) == 0x82;
+        }
     }
 
     /// <summary>

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Platform.Windows
             if (message != Native.Input.WM_INPUT)
                 return IntPtr.Zero;
 
-            if (Native.Input.IsMouseMessageSourceTouch())
+            if (Native.Input.IsTouchEvent(Native.Input.GetMessageExtraInfo()))
                 return IntPtr.Zero;
 
             int payloadSize = sizeof(RawInputData);

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -65,6 +65,7 @@ namespace osu.Framework.Platform.Windows
                 return IntPtr.Zero;
 
             if (Native.Input.IsTouchEvent(Native.Input.GetMessageExtraInfo()))
+                // sometimes GetMessageExtraInfo returns 0, so additionally, mouse.ExtraInformation is checked below.
                 // touch events are handled by TouchHandler
                 return IntPtr.Zero;
 
@@ -76,6 +77,10 @@ namespace osu.Framework.Platform.Windows
                 return IntPtr.Zero;
 
             var mouse = data.Mouse;
+
+            // `ExtraInformation` doens't have the MI_WP_SIGNATURE set, so we have to rely solely on the touch flag.
+            if (Native.Input.HasTouchFlag(mouse.ExtraInformation))
+                return IntPtr.Zero;
 
             //TODO: this isn't correct.
             if (mouse.ExtraInformation > 0)

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -64,6 +64,9 @@ namespace osu.Framework.Platform.Windows
             if (message != Native.Input.WM_INPUT)
                 return IntPtr.Zero;
 
+            if (Native.Input.IsMouseMessageSourceTouch())
+                return IntPtr.Zero;
+
             int payloadSize = sizeof(RawInputData);
 
             Native.Input.GetRawInputData((IntPtr)lParam, RawInputCommand.Input, out var data, ref payloadSize, sizeof(RawInputHeader));

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -65,6 +65,7 @@ namespace osu.Framework.Platform.Windows
                 return IntPtr.Zero;
 
             if (Native.Input.IsTouchEvent(Native.Input.GetMessageExtraInfo()))
+                // touch events are handled by TouchHandler
                 return IntPtr.Zero;
 
             int payloadSize = sizeof(RawInputData);

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -88,5 +88,6 @@ namespace osu.Framework.Statistics
         JoystickEvents,
         MidiEvents,
         TabletEvents,
+        TouchEvents,
     }
 }

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -23,6 +23,7 @@ namespace osu.Framework.Threading
             StatisticsCounterType.JoystickEvents,
             StatisticsCounterType.MidiEvents,
             StatisticsCounterType.TabletEvents,
+            StatisticsCounterType.TouchEvents,
         };
 
         protected override void PrepareForWork()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/1514
- Closes https://github.com/ppy/osu-framework/issues/5033
- Closes https://github.com/ppy/osu/issues/18889

Touch currently uses [mouse emulation](https://github.com/libsdl-org/SDL/blob/6a2e6c82a0764a00123447d93999ebe14d509aa8/include/SDL_hints.h#L1367-L1376) on desktop platforms. This PR sets the correct flag and implements [`SDL_TouchFingerEvent`](https://wiki.libsdl.org/SDL_TouchFingerEvent) handling. Windows also emulates mouse events for touch, and those events have also been properly ignored in `WindowsMouseHandler`.

Initial testing [by peppy on discord](https://discord.com/channels/188630481301012481/589331078574112768/993813779160760340).

Raw input touch event detection [inspired](https://github.com/libsdl-org/SDL/blob/85bbf8eec9f5e422447807b6cabec8c9ec0859d9/src/video/windows/SDL_windowsevents.c#L825) [by](https://github.com/libsdl-org/SDL/blob/85bbf8eec9f5e422447807b6cabec8c9ec0859d9/src/video/windows/SDL_windowsevents.c#L521-L537) [SDL](https://github.com/libsdl-org/SDL/blob/85bbf8eec9f5e422447807b6cabec8c9ec0859d9/src/video/windows/SDL_windowsevents.c#L509-L511) and confirmed by [Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/tablet/system-events-and-mouse-messages). (The `0x82` check seems to be unnecessary, as it's already covered by `0x80`.)

`getTouchSource` / `assignNextAvailableTouchSource` logic taken from iOS touch handler.