### PR TITLE
Fix waveform generation function not freeing bass stream after usage

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -13,6 +13,7 @@ using ManagedBass;
 using osu.Framework.Utils;
 using osu.Framework.Audio.Callbacks;
 using osu.Framework.Extensions;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Audio.Track
 {
@@ -81,7 +82,10 @@ namespace osu.Framework.Audio.Track
             {
                 // for the time being, this code cannot run if there is no bass device available.
                 if (Bass.CurrentDevice <= 0)
+                {
+                    Logger.Log("Failed to read waveform as no bass device is available.");
                     return;
+                }
 
                 fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(data));
 

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -204,14 +204,14 @@ namespace osu.Framework.Graphics.Audio
             // It will stop unnecessary task churn if invalidation is occuring often.
             resampledPointCount = requiredPointCount;
 
-            Logger.Log($"Waveform resampling with {requiredPointCount} points...");
-
             cancelSource = new CancellationTokenSource();
             var token = cancelSource.Token;
 
             Waveform.GenerateResampledAsync(resampledPointCount.Value, token)
                     .ContinueWith(task =>
                     {
+                        Logger.Log($"Waveform resampled with {requiredPointCount:N0} points (original {Waveform.GetPoints().Count:N0})...");
+
                         var resampled = task.GetResultSafely();
 
                         var points = resampled.GetPoints();
@@ -219,8 +219,6 @@ namespace osu.Framework.Graphics.Audio
                         double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
                         double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
                         double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
-
-                        Logger.Log($"Waveform resample complete with {points.Count} points.");
 
                         Schedule(() =>
                         {

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -192,7 +192,7 @@ namespace osu.Framework.Graphics.Audio
         private void queueRegeneration() => Scheduler.AddOnce(() =>
         {
             int requiredPointCount = (int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution);
-            if (requiredPointCount == resampledPointCount)
+            if (requiredPointCount == resampledPointCount && !cancelSource.IsCancellationRequested)
                 return;
 
             cancelGeneration();


### PR DESCRIPTION
Also fixes a few other things I noticed along the way.

See breadcrumbs in https://sentry.ppy.sh/organizations/ppy/issues/92/events/ae89bc05396e436d9d91ca3e55123fb1/?project=2&query=is%3Aunresolved&sort=user&statsPeriod=14d for reference. Not sure this will fix the issue but I really want better diagnostic output regardless.