### PR TITLE
Refactor `DirectorySelector` to allow custom layouts

### DIFF
--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -5,7 +5,6 @@
 
 using System.IO;
 using osu.Framework.Graphics.Containers;
-using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -13,11 +12,10 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new BasicButton
+        protected override Drawable CreateHiddenToggleButton() => new BasicCheckbox
         {
-            Size = new Vector2(200, 25),
-            Text = "Toggle hidden items",
-            Action = ShowHiddenItems.Toggle,
+            LabelText = "Show hidden items",
+            Current = { BindTarget = ShowHiddenItems }
         };
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelector.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new BasicCheckbox
+        protected override Drawable CreateHiddenItemToggle() => new BasicCheckbox
         {
             LabelText = "Show hidden items",
             Current = { BindTarget = ShowHiddenItems }

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new BasicCheckbox
+        protected override Drawable CreateHiddenItemToggle() => new BasicCheckbox
         {
             LabelText = "Show hidden items",
             Current = { BindTarget = ShowHiddenItems }

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -14,11 +13,10 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected override DirectorySelectorBreadcrumbDisplay CreateBreadcrumb() => new BasicDirectorySelectorBreadcrumbDisplay();
 
-        protected override Drawable CreateHiddenToggleButton() => new BasicButton
+        protected override Drawable CreateHiddenToggleButton() => new BasicCheckbox
         {
-            Size = new Vector2(200, 25),
-            Text = "Toggle hidden items",
-            Action = ShowHiddenItems.Toggle,
+            LabelText = "Show hidden items",
+            Current = { BindTarget = ShowHiddenItems }
         };
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BasicDirectorySelectorDirectory(directory, displayName);

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -75,31 +75,18 @@ namespace osu.Framework.Graphics.UserInterface
                 RowDimensions = new[]
                 {
                     new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(GridSizeMode.AutoSize),
                     new Dimension(),
                 },
                 Content = new[]
                 {
                     new Drawable[]
                     {
-                        new GridContainer
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            ColumnDimensions = new[]
-                            {
-                                new Dimension(),
-                                new Dimension(GridSizeMode.AutoSize),
-                            },
-                            RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
-                            Content = new[]
-                            {
-                                new[]
-                                {
-                                    CreateBreadcrumb(),
-                                    CreateHiddenToggleButton()
-                                }
-                            }
-                        }
+                        CreateBreadcrumb()
+                    },
+                    new[]
+                    {
+                        CreateHiddenToggleButton()
                     },
                     new Drawable[]
                     {
@@ -115,7 +102,7 @@ namespace osu.Framework.Graphics.UserInterface
                             };
                         })
                     }
-                }
+                },
             };
 
             ShowHiddenItems.ValueChanged += _ => updateDisplay();

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.UserInterface
                     },
                     new[]
                     {
-                        CreateHiddenToggleButton()
+                        CreateHiddenItemToggle()
                     },
                     new Drawable[]
                     {
@@ -89,12 +89,12 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract DirectorySelectorBreadcrumbDisplay CreateBreadcrumb();
 
         /// <summary>
-        /// Create a button that toggles the display of hidden items.
+        /// Create a drawable that toggles the display of hidden items.
         /// </summary>
         /// <remarks>
-        /// Unless overridden, a toggle button will not be added.
+        /// Unless overridden, a toggle will not be added.
         /// </remarks>
-        protected virtual Drawable CreateHiddenToggleButton() => Empty();
+        protected virtual Drawable CreateHiddenItemToggle() => Empty();
 
         protected abstract DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null);
 

--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -25,6 +25,49 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected readonly BindableBool ShowHiddenItems = new BindableBool();
 
+        /// <summary>
+        /// Create the content to be displayed in this <see cref="DirectorySelector"/>.
+        /// </summary>
+        /// <returns>The content to be displayed in this <see cref="DirectorySelector"/>.</returns>
+        protected virtual Drawable CreateDirectorySelectorContainer()
+        {
+            return new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                RowDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(),
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        CreateBreadcrumb()
+                    },
+                    new[]
+                    {
+                        CreateHiddenToggleButton()
+                    },
+                    new Drawable[]
+                    {
+                        CreateScrollContainer().With(d =>
+                        {
+                            d.RelativeSizeAxes = Axes.Both;
+                            d.Child = directoryFlow = new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Y,
+                                RelativeSizeAxes = Axes.X,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(2),
+                            };
+                        })
+                    }
+                },
+            };
+        }
+
         protected abstract ScrollContainer<Drawable> CreateScrollContainer();
 
         /// <summary>
@@ -69,41 +112,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             initialPath ??= gameHost.InitialFileSelectorPath;
 
-            InternalChild = new GridContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                RowDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.AutoSize),
-                    new Dimension(GridSizeMode.AutoSize),
-                    new Dimension(),
-                },
-                Content = new[]
-                {
-                    new Drawable[]
-                    {
-                        CreateBreadcrumb()
-                    },
-                    new[]
-                    {
-                        CreateHiddenToggleButton()
-                    },
-                    new Drawable[]
-                    {
-                        CreateScrollContainer().With(d =>
-                        {
-                            d.RelativeSizeAxes = Axes.Both;
-                            d.Child = directoryFlow = new FillFlowContainer
-                            {
-                                AutoSizeAxes = Axes.Y,
-                                RelativeSizeAxes = Axes.X,
-                                Direction = FillDirection.Vertical,
-                                Spacing = new Vector2(2),
-                            };
-                        })
-                    }
-                },
-            };
+            InternalChild = CreateDirectorySelectorContainer();
 
             ShowHiddenItems.ValueChanged += _ => updateDisplay();
             CurrentPath.BindValueChanged(_ => updateDisplay(), true);


### PR DESCRIPTION
Necessary for the application of https://github.com/ppy/osu/pull/19048#discussion_r918566267.

Also changes basic implementations to use `BasicCheckbox` instead of `BasicButton` so the toggle's current state is observable.