### PR TITLE
Fix running Bass tests causing deadlocks on Linux

### DIFF
--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -65,8 +65,6 @@ namespace osu.Framework.Tests.Audio
         {
             RunOnAudioThread(() =>
             {
-                Mixer.Update();
-
                 foreach (var c in components)
                     c.Update();
             });

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using ManagedBass;
 using osu.Framework.Audio;
@@ -27,15 +26,17 @@ namespace osu.Framework.Tests.Audio
         internal readonly TrackStore TrackStore;
         internal readonly SampleStore SampleStore;
 
-        private readonly List<AudioComponent> components = new List<AudioComponent>();
+        private readonly AudioCollectionManager<AudioComponent> allComponents = new AudioCollectionManager<AudioComponent>();
+        private readonly AudioCollectionManager<AudioComponent> mixerComponents = new AudioCollectionManager<AudioComponent>();
 
         public BassTestComponents(bool init = true)
         {
             if (init)
                 Init();
 
-            Mixer = CreateMixer();
+            allComponents.AddItem(mixerComponents);
 
+            Mixer = CreateMixer();
             Resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
             TrackStore = new TrackStore(Resources, Mixer);
             SampleStore = new SampleStore(Resources, Mixer);
@@ -52,22 +53,22 @@ namespace osu.Framework.Tests.Audio
             Bass.Init(0);
         }
 
-        public void Add(params AudioComponent[] component) => components.AddRange(component);
+        public void Add(params AudioComponent[] component)
+        {
+            foreach (var c in component)
+                allComponents.AddItem(c);
+        }
 
         internal BassAudioMixer CreateMixer()
         {
             var mixer = new BassAudioMixer(Mixer, "Test mixer");
-            components.Insert(0, mixer);
+            mixerComponents.AddItem(mixer);
             return mixer;
         }
 
         public void Update()
         {
-            RunOnAudioThread(() =>
-            {
-                foreach (var c in components)
-                    c.Update();
-            });
+            RunOnAudioThread(() => allComponents.Update());
         }
 
         public void RunOnAudioThread(Action action)
@@ -93,6 +94,9 @@ namespace osu.Framework.Tests.Audio
 
         public void Dispose()
         {
+            allComponents.Dispose();
+            allComponents.Update(); // Actually runs the disposal.
+
             // See AudioThread.FreeDevice().
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
                 Bass.Free();

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -455,6 +455,8 @@ namespace osu.Framework.Audio.Track
             if (IsDisposed)
                 return;
 
+            cleanUpSyncs();
+
             if (activeStream != 0)
             {
                 isRunning = false;
@@ -468,12 +470,6 @@ namespace osu.Framework.Audio.Track
 
             fileCallbacks?.Dispose();
             fileCallbacks = null;
-
-            stopCallback?.Dispose();
-            stopCallback = null;
-
-            endCallback?.Dispose();
-            endCallback = null;
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
I'm still in talks with Ian since this shouldn't be happening anyway, but what's happening is that Bass will call `Bass_Free()` on application exit (i.e. after all user code has exited) and deadlock because we haven't removed the track syncs.

I don't think there's any reason for us to not remove the syncs on disposal. But not only were we not removing the track syncs - the tests weren't disposing the components at all.

The deadlocks can be reproed on Linux by starting `TrackBassTest.TestBitrate` with debugger attached.