### PR TITLE
Free Bass device 0 on Linux

### DIFF
--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -96,10 +96,7 @@ namespace osu.Framework.Tests.Audio
         {
             allComponents.Dispose();
             allComponents.Update(); // Actually runs the disposal.
-
-            // See AudioThread.FreeDevice().
-            if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
-                Bass.Free();
+            Bass.Free();
         }
     }
 }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -129,7 +129,7 @@ namespace osu.Framework.Threading
 
             int selectedDevice = Bass.CurrentDevice;
 
-            if (canFreeDevice(deviceId) && canSelectDevice(deviceId))
+            if (canSelectDevice(deviceId))
             {
                 Bass.CurrentDevice = deviceId;
                 Bass.Free();
@@ -154,11 +154,5 @@ namespace osu.Framework.Threading
                 Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
             }
         }
-
-        /// <summary>
-        /// Whether a device can be freed.
-        /// On Linux, freeing device 0 is disallowed as it can cause deadlocks which don't surface immediately.
-        /// </summary>
-        private static bool canFreeDevice(int deviceId) => deviceId != 0 || RuntimeInfo.OS != RuntimeInfo.Platform.Linux;
     }
 }


### PR DESCRIPTION
This was added in https://github.com/ppy/osu-framework/commit/ddf3fc212414bc5f741ef00da521a77c917f680e, but I'm not sure it's necessary since the switch to BassMix. If platform-specific deadlocks return a result of this revert, then I hope we can report and get them fixed. Test that both o!f and osu! tests pass with this change.