### PR TITLE
Prefer `~/Library/Application Support` as user storage path on macOS

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -28,6 +28,8 @@ namespace osu.Framework.Platform.MacOS
         {
             get
             {
+                yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Library", "Application Support");
+
                 string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
 
                 if (!string.IsNullOrEmpty(xdg))


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19093

Wasn't aware there is fallback support for user storage paths, that makes switching to the new path much easier. Looks to work as intended on testing.