### PR TITLE
Remove flush-to-disk operation on non-Windows platforms for lower overhead

### DIFF
--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -99,6 +99,9 @@ namespace osu.Framework.Platform
                     return File.Open(path, FileMode.Open, access, FileShare.Read);
 
                 default:
+                    // this was added to work around some hardware writing zeroes to a file
+                    // before writing actual content, causing corrupt files to exist on disk.
+                    // as of .NET 6, flushing is very expensive on macOS so this is limited to only Windows.
                     if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                         return new FlushingStream(path, mode, access);
 

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -99,7 +99,10 @@ namespace osu.Framework.Platform
                     return File.Open(path, FileMode.Open, access, FileShare.Read);
 
                 default:
-                    return new FlushingStream(path, mode, access);
+                    if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+                        return new FlushingStream(path, mode, access);
+
+                    return new FileStream(path, mode, access);
             }
         }
 

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -183,7 +183,8 @@ namespace osu.Framework.Platform
                     // this was added to work around some hardware writing zeroes to a file
                     // before writing actual content, causing corrupt files to exist on disk.
                     // as of .NET 6, flushing is very expensive on macOS so this is limited to only Windows,
-                    // but it may be entirely unnecessary due to the temporary file copying performed on this class.
+                    // but it may also be entirely unnecessary due to the temporary file copying performed on this class.
+                    // see: https://github.com/ppy/osu-framework/issues/5231
                     if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                     {
                         try

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -160,7 +160,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Uses a temporary file to ensure a file is written to completion before existing at its specified location.
         /// </summary>
-        private class SafeWriteStream : FlushingStream
+        private class SafeWriteStream : FileStream
         {
             private readonly string temporaryPath;
             private readonly string finalPath;
@@ -178,6 +178,22 @@ namespace osu.Framework.Platform
 
             protected override void Dispose(bool disposing)
             {
+                if (!isDisposed)
+                {
+                    if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
+                    {
+                        try
+                        {
+                            Flush(true);
+                        }
+                        catch
+                        {
+                            // this may fail due to a lower level file access issue.
+                            // we don't want to throw in disposal though.
+                        }
+                    }
+                }
+
                 base.Dispose(disposing);
 
                 if (!isDisposed)

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -180,6 +180,10 @@ namespace osu.Framework.Platform
             {
                 if (!isDisposed)
                 {
+                    // this was added to work around some hardware writing zeroes to a file
+                    // before writing actual content, causing corrupt files to exist on disk.
+                    // as of .NET 6, flushing is very expensive on macOS so this is limited to only Windows,
+                    // but it may be entirely unnecessary due to the temporary file copying performed on this class.
                     if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                     {
                         try


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/19116
- See discussion on [Discord](https://discord.com/channels/188630481301012481/188630652340404224/997304567526080583)

The operation was initially added to fix a Windows-specific issue regarding zeros being written to the file, and after switching to .NET 6, the behaviour of the operation changed on macOS to become much stronger / more expensive (see https://github.com/dotnet/runtime/pull/44443).

We do not want this overhead on non-Windows platforms as there has been no signs of such issues occurring there, therefore the flush-to-disk operation is now limited to Windows platforms (we may eventually not need flushing at all on `SafeWriteStream`, see https://github.com/ppy/osu-framework/issues/5231).