### PR TITLE
Fix zero width textbox throwing in `updateImeWindowPosition()`

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1570,8 +1570,17 @@ namespace osu.Framework.Graphics.UserInterface
             float start = getPositionAt(startIndex) - textContainerPosX + LeftRightPadding;
             float end = getPositionAt(endIndex) - textContainerPosX + LeftRightPadding;
 
-            start = Math.Clamp(start, LeftRightPadding, DrawWidth - LeftRightPadding);
-            end = Math.Clamp(end, LeftRightPadding, DrawWidth - LeftRightPadding);
+            if (LeftRightPadding <= DrawWidth - LeftRightPadding)
+            {
+                start = Math.Clamp(start, LeftRightPadding, DrawWidth - LeftRightPadding);
+                end = Math.Clamp(end, LeftRightPadding, DrawWidth - LeftRightPadding);
+            }
+            else
+            {
+                // DrawWidth is probably zero/invalid, sane fallback instead of throwing in Math.Clamp
+                start = 0;
+                end = 0;
+            }
 
             var compositionTextRectangle = new RectangleF
             {


### PR DESCRIPTION
`Math.Clamp` could fail if the usable text area was considered negative ($\textup{DrawWidth} - 2 \times \textup{LeftRightPadding} < 0$).

Spotted on [discord](https://discord.com/channels/188630481301012481/589331078574112768/998512357166809239):
```c
System.ArgumentException: '16' cannot be greater than -16.
   at System.Math.ThrowMinMaxException[T](T min, T max)
   at osu.Framework.Graphics.UserInterface.TextBox.updateImeWindowPosition()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```
