### PR TITLE
Fix `OverlayContainer` no longer blocking mouse move events

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
@@ -51,6 +51,63 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         [TestCase(true)]
         [TestCase(false)]
+        public void TestPositionalBlocking(bool isBlocking)
+        {
+            AddStep("create container", () =>
+            {
+                Child = parentContainer = new ParentContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        overlayContainer = new TestFocusedOverlayContainer(blockPositionalInput: isBlocking)
+                    }
+                };
+            });
+
+            AddStep("show", () => overlayContainer.Show());
+
+            AddAssert("has focus", () => overlayContainer.HasFocus);
+
+            int initialMoveCount = 0;
+            int initialHoverCount = 0;
+
+            AddStep("move inside", () =>
+            {
+                initialMoveCount = parentContainer.MouseMoveReceived;
+                initialHoverCount = parentContainer.HoverReceived;
+                InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.Centre);
+            });
+
+            if (isBlocking)
+            {
+                AddAssert("move not received by parent", () =>
+                    parentContainer.MouseMoveReceived == initialMoveCount &&
+                    parentContainer.HoverReceived == initialHoverCount);
+
+                AddStep("move outside", () => InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.TopLeft - new Vector2(20)));
+
+                // we block positional input screen-wide, therefore parent should still not receive input outside overlay's bounds.
+                AddAssert("move not received by parent", () =>
+                    parentContainer.MouseMoveReceived == initialMoveCount &&
+                    parentContainer.HoverReceived == initialHoverCount);
+            }
+            else
+            {
+                AddAssert("move and hover received by parent", () =>
+                    parentContainer.MouseMoveReceived == ++initialMoveCount &&
+                    parentContainer.HoverReceived == ++initialHoverCount);
+
+                AddStep("move outside", () => InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.TopLeft - new Vector2(20)));
+
+                AddAssert("only move received by parent", () =>
+                    parentContainer.MouseMoveReceived == ++initialMoveCount &&
+                    parentContainer.HoverReceived == initialHoverCount);
+            }
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
         public void TestScrollBlocking(bool isBlocking)
         {
             AddStep("create container", () =>
@@ -96,14 +153,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             protected override bool StartHidden { get; }
 
-            protected override bool BlockPositionalInput => true;
+            protected override bool BlockPositionalInput { get; }
 
             protected override bool BlockNonPositionalInput => false;
 
             protected override bool BlockScrollInput { get; }
 
-            public TestFocusedOverlayContainer(bool startHidden = true, bool blockScrollInput = true)
+            public TestFocusedOverlayContainer(bool startHidden = true, bool blockPositionalInput = true, bool blockScrollInput = true)
             {
+                BlockPositionalInput = blockPositionalInput;
                 BlockScrollInput = blockScrollInput;
 
                 StartHidden = startHidden;
@@ -128,7 +186,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             public int FireCount { get; private set; }
 
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => BlockPositionalInput || base.ReceivePositionalInputAt(screenSpacePos);
 
             protected override bool OnClick(ClickEvent e)
             {
@@ -161,7 +219,21 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
     public class ParentContainer : Container
     {
+        public int HoverReceived;
+        public int MouseMoveReceived;
         public int ScrollReceived;
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            HoverReceived++;
+            return base.OnHover(e);
+        }
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            MouseMoveReceived++;
+            return base.OnMouseMove(e);
+        }
 
         protected override bool OnScroll(ScrollEvent e)
         {

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -47,6 +47,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnHover(HoverEvent e) => BlockPositionalInput;
         protected override bool OnMouseDown(MouseDownEvent e) => BlockPositionalInput;
+        protected override bool OnMouseMove(MouseMoveEvent e) => BlockPositionalInput;
         protected override bool OnScroll(ScrollEvent e) => BlockScrollInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
     }
 }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/19213
- Alternative to https://github.com/ppy/osu/pull/19217

Another regression by https://github.com/ppy/osu-framework/pull/5268, `OnMouseMove` should not propagate to parent if the overlay blocks positional input.