### PR TITLE
Fix bad access to `Waveform.GetPoints()` if waveform changes during regeneration

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -292,11 +292,7 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public async Task<List<Point>> GetPointsAsync()
         {
-            if (readTask == null)
-                return points;
-
             await readTask.ConfigureAwait(false);
-
             return points;
         }
 

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -74,12 +74,13 @@ namespace osu.Framework.Audio.Track
         /// Constructs a new <see cref="Waveform"/> from provided audio data.
         /// </summary>
         /// <param name="data">The sample data stream. If null, an empty waveform is constructed.</param>
-        public Waveform(Stream data)
+        public Waveform([CanBeNull] Stream data)
         {
-            if (data == null) return;
-
             readTask = Task.Run(() =>
             {
+                if (data == null)
+                    return;
+
                 // for the time being, this code cannot run if there is no bass device available.
                 if (Bass.CurrentDevice < 0)
                 {

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -300,23 +300,14 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.
         /// </summary>
-        public int GetChannels()
-        {
-            readTask?.WaitSafely();
-
-            return channels;
-        }
+        public int GetChannels() => GetChannelsAsync().GetResultSafely();
 
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.
         /// </summary>
         public async Task<int> GetChannelsAsync()
         {
-            if (readTask == null)
-                return channels;
-
             await readTask.ConfigureAwait(false);
-
             return channels;
         }
 

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL;

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -197,7 +197,9 @@ namespace osu.Framework.Graphics.Audio
 
             cancelGeneration();
 
-            if (Waveform == null)
+            var resampleWaveform = Waveform;
+
+            if (resampleWaveform == null)
                 return;
 
             // This should be set before the operation is run.
@@ -207,35 +209,34 @@ namespace osu.Framework.Graphics.Audio
             cancelSource = new CancellationTokenSource();
             var token = cancelSource.Token;
 
-            Waveform.GenerateResampledAsync(resampledPointCount.Value, token)
-                    .ContinueWith(task =>
-                    {
-                        Logger.Log($"Waveform resampled with {requiredPointCount:N0} points (original {Waveform.GetPoints().Count:N0})...");
+            resampleWaveform.GenerateResampledAsync(resampledPointCount.Value, token).ContinueWith(task =>
+            {
+                Logger.Log($"Waveform resampled with {requiredPointCount:N0} points (original {resampleWaveform.GetPoints().Count:N0})...");
 
-                        var resampled = task.GetResultSafely();
+                var resampled = task.GetResultSafely();
 
-                        var points = resampled.GetPoints();
-                        int channels = resampled.GetChannels();
-                        double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
-                        double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
-                        double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
+                var points = resampled.GetPoints();
+                int channels = resampled.GetChannels();
+                double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
+                double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
+                double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
 
-                        Schedule(() =>
-                        {
-                            if (token.IsCancellationRequested)
-                                return;
+                Schedule(() =>
+                {
+                    if (token.IsCancellationRequested)
+                        return;
 
-                            resampledPoints = points;
-                            resampledChannels = channels;
-                            resampledMaxHighIntensity = maxHighIntensity;
-                            resampledMaxMidIntensity = maxMidIntensity;
-                            resampledMaxLowIntensity = maxLowIntensity;
-                            resampledVersion = InvalidationID;
+                    resampledPoints = points;
+                    resampledChannels = channels;
+                    resampledMaxHighIntensity = maxHighIntensity;
+                    resampledMaxMidIntensity = maxMidIntensity;
+                    resampledMaxLowIntensity = maxLowIntensity;
+                    resampledVersion = InvalidationID;
 
-                            OnWaveformRegenerated(resampled);
-                            Invalidate(Invalidation.DrawNode);
-                        });
-                    }, token);
+                    OnWaveformRegenerated(resampled);
+                    Invalidate(Invalidation.DrawNode);
+                });
+            }, token);
         });
 
         private void cancelGeneration()


### PR DESCRIPTION
Was so focused on the `task.GetResultSafely()` line that I missed the issue being in the `Logger` call itself. The outer waveform could change during the async `ContinueWith` operation, which would cause undefined behaviour. Note that this was an issue before the logger call was added – it was only brought to light by the recent failures. Probably leading to weirdness in other ways.

Closes https://github.com/ppy/osu-framework/issues/5314