### PR TITLE
Fix unsafe value access in `WaveformGraph` async resampling logic

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -211,7 +211,7 @@ namespace osu.Framework.Graphics.Audio
 
             Task.Run(async () =>
             {
-                var resampled = await originalWaveform.GenerateResampledAsync(resampledPointCount.Value, token).ConfigureAwait(false);
+                var resampled = await originalWaveform.GenerateResampledAsync(requiredPointCount, token).ConfigureAwait(false);
 
                 int originalPointCount = (await originalWaveform.GetPointsAsync().ConfigureAwait(false)).Count;
 


### PR DESCRIPTION
As seen in game-side [test failures](https://github.com/ppy/osu/runs/7413532468?check_suite_focus=true).

Prior to #5316, accessing `resampledPointCount.Value` is safe since it's within the same thread it's updated in, but after moving it to `Task.Run`, the field can be changed in the update thread while the async task hasn't ran yet, resulting in a null value access during task execution.

Adding a test case for this doesn't seem that easy since it involves manipulating time spent inside internal executions, so I bailed off for now.