### PR TITLE
Add constrained assertions

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/AssertButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/AssertButton.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 using osuTK.Graphics;
 
 namespace osu.Framework.Testing.Drawables.Steps
@@ -14,10 +15,12 @@ namespace osu.Framework.Testing.Drawables.Steps
         public Func<bool> Assertion;
         public string ExtendedDescription;
         public StackTrace CallStack;
+        private readonly Func<string> getFailureMessage;
 
-        public AssertButton(bool isSetupStep = false)
+        public AssertButton(bool isSetupStep = false, Func<string> getFailureMessage = null)
             : base(isSetupStep)
         {
+            this.getFailureMessage = getFailureMessage;
             Action += checkAssert;
             LightColour = Color4.OrangeRed;
         }
@@ -27,7 +30,19 @@ namespace osu.Framework.Testing.Drawables.Steps
             if (Assertion())
                 Success();
             else
-                throw new TracedException($"{Text} {ExtendedDescription}", CallStack);
+            {
+                StringBuilder builder = new StringBuilder();
+
+                builder.Append(Text);
+
+                if (!string.IsNullOrEmpty(ExtendedDescription))
+                    builder.Append($" {ExtendedDescription}");
+
+                if (getFailureMessage != null)
+                    builder.Append($": {getFailureMessage()}");
+
+                throw new TracedException(builder.ToString(), CallStack);
+            }
         }
 
         public override string ToString() => "Assert: " + base.ToString();

--- a/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Text;
 using osu.Framework.Graphics;
 using osuTK.Graphics;
 
@@ -32,7 +33,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         private Stopwatch elapsedTime;
 
-        public UntilStepButton(Func<bool> waitUntilTrueDelegate, bool isSetupStep = false)
+        public UntilStepButton(Func<bool> waitUntilTrueDelegate, bool isSetupStep = false, Func<string> getFailureMessage = null)
             : base(isSetupStep)
         {
             updateText();
@@ -53,7 +54,16 @@ namespace osu.Framework.Testing.Drawables.Steps
                     Success();
                 }
                 else if (!Debugger.IsAttached && elapsedTime.ElapsedMilliseconds >= max_attempt_milliseconds)
-                    throw new TimeoutException($"\"{Text}\" timed out");
+                {
+                    StringBuilder builder = new StringBuilder();
+
+                    builder.Append($"\"{Text}\" timed out");
+
+                    if (getFailureMessage != null)
+                        builder.Append($": {getFailureMessage()}");
+
+                    throw new TimeoutException(builder.ToString());
+                }
 
                 Action?.Invoke();
             };


### PR DESCRIPTION
I want to start figuring out why failures such as https://github.com/ppy/osu/runs/7573977900?check_suite_focus=true occur.

This PR adds constrained assertions, which allows for more details to be output when assertions fail.

Testing:
```csharp
public class TestSceneOutput : TestScene
{
    private const int value_1 = 1000;
    private const int value_2 = 2000;

    [Test]
    public void TestAssert()
    {
        AddAssert($"{nameof(value_1)} almost equals {nameof(value_2)}", () => value_1, () => Is.EqualTo(value_2).Within(100));
    }

    [Test]
    public void TestUntilStep()
    {
        AddUntilStep($"{nameof(value_1)} almost equals {nameof(value_2)}", () => value_1, () => Is.EqualTo(value_2).Within(100));
    }
}
```

```
$ dotnet test --filter "TestSceneOutput"

  Determining projects to restore...
  All projects are up-to-date for restore.
  osu.Framework -> /home/smgi/Repos/osu-framework/osu.Framework/bin/Debug/net6.0/osu.Framework.dll
  osu.Framework.Tests -> /home/smgi/Repos/osu-framework/osu.Framework.Tests/bin/Debug/net6.0/osu.Framework.Tests.dll
Test run for /home/smgi/Repos/osu-framework/osu.Framework.Tests/bin/Debug/net6.0/osu.Framework.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.3.0-preview-20220610-03 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Failed TestAssert [54 ms]
  Error Message:
   TearDown : osu.Framework.Testing.Drawables.Steps.AssertButton+TracedException : value_1 almost equals value_2: Expected: 2000 +/- 100
  But was:  1000
  Off by:   1000.0d

  Stack Trace:
  --TearDown
   at osu.Framework.Threading.ScheduledDelegate.InvokeTask()
   at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal()
   at osu.Framework.Threading.Scheduler.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChild(Drawable c)
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Platform.HeadlessGameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.processFrame()
   at osu.Framework.Threading.GameThread.RunSingleFrame()
   at osu.Framework.Threading.GameThread.<createThread>g__runWork|66_0()
   at System.Threading.Thread.StartHelper.Callback(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Thread.StartCallback()

  Standard Output Messages:
 [runtime] 2022-07-29 07:59:08 [verbose]: 💨 Class: TestSceneOutput
 [runtime] 2022-07-29 07:59:08 [verbose]: 🔶 Test:  TestAssert
 [runtime] 2022-07-29 07:59:08 [verbose]: 🔸 Step #1 value_1 almost equals value_2
 [runtime] 2022-07-29 07:59:08 [verbose]: 💥 Failed
 [runtime] 2022-07-29 07:59:08 [verbose]: ⏳ Currently loading components (0)
 [runtime] 2022-07-29 07:59:08 [verbose]: 🧵 Task schedulers
 [runtime] 2022-07-29 07:59:08 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
 [runtime] 2022-07-29 07:59:08 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
 [runtime] 2022-07-29 07:59:08 [verbose]: 🎱 Thread pool
 [runtime] 2022-07-29 07:59:08 [verbose]: worker:          min 32     max 32,767 available 32,766
 [runtime] 2022-07-29 07:59:08 [verbose]: completion:      min 32     max 1,000  available 1,000


  Failed TestUntilStep [10 s]
  Error Message:
   TearDown : System.TimeoutException : "value_1 almost equals value_2" timed out: Expected: 2000 +/- 100
  But was:  1000
  Off by:   1000.0d

  Stack Trace:
  --TearDown
   at osu.Framework.Testing.Drawables.Steps.UntilStepButton.<>c__DisplayClass11_0.<.ctor>b__0() in /home/smgi/Repos/osu-framework/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs:line 65
   at osu.Framework.Testing.Drawables.Steps.StepButton.PerformStep(Boolean userTriggered) in /home/smgi/Repos/osu-framework/osu.Framework/Testing/Drawables/Steps/StepButton.cs:line 124
   at osu.Framework.Testing.TestScene.runNextStep(Action onCompletion, Action`1 onError, Func`2 stopCondition) in /home/smgi/Repos/osu-framework/osu.Framework/Testing/TestScene.cs:line 204
--- End of stack trace from previous location ---
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.RunTestBlocking(TestScene test) in /home/smgi/Repos/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 89
   at osu.Framework.Testing.TestSceneTestRunner.RunTestBlocking(TestScene test) in /home/smgi/Repos/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 32
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit() in /home/smgi/Repos/osu-framework/osu.Framework/Testing/TestScene.cs:line 473
  Standard Output Messages:
 [runtime] 2022-07-29 07:59:08 [verbose]: 💨 Class: TestSceneOutput
 [runtime] 2022-07-29 07:59:08 [verbose]: 🔶 Test:  TestUntilStep
 [runtime] 2022-07-29 07:59:08 [verbose]: 🔸 Step #1 value_1 almost equals value_2
 [runtime] 2022-07-29 07:59:18 [verbose]: 💥 Failed (on attempt 49,182)
 [runtime] 2022-07-29 07:59:18 [verbose]: ⏳ Currently loading components (0)
 [runtime] 2022-07-29 07:59:18 [verbose]: 🧵 Task schedulers
 [runtime] 2022-07-29 07:59:18 [verbose]: LoadComponentsAsync (standard) concurrency:4 running:0 pending:0
 [runtime] 2022-07-29 07:59:18 [verbose]: LoadComponentsAsync (long load) concurrency:4 running:0 pending:0
 [runtime] 2022-07-29 07:59:18 [verbose]: 🎱 Thread pool
 [runtime] 2022-07-29 07:59:18 [verbose]: worker:          min 32     max 32,767 available 32,766
 [runtime] 2022-07-29 07:59:18 [verbose]: completion:      min 32     max 1,000  available 1,000



Failed!  - Failed:     2, Passed:     1, Skipped:     0, Total:     3, Duration: 10 s - /home/smgi/Repos/osu-framework/osu.Framework.Tests/bin/Debug/net6.0/osu.Framework.Tests.dll (net6.0)
```