### PR TITLE
Internalise vertex batches and expose via `IVertexBatch`

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Vertices;
@@ -325,7 +324,7 @@ namespace osu.Framework.Graphics.Audio
                 }
             }
 
-            private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(1000, 10);
+            private IVertexBatch<TexturedVertex2D> vertexBatch;
 
             public override void Draw(IRenderer renderer)
             {
@@ -333,6 +332,8 @@ namespace osu.Framework.Graphics.Audio
 
                 if (texture?.Available != true || points == null || points.Count == 0)
                     return;
+
+                vertexBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(1000, 10);
 
                 shader.Bind();
                 texture.TextureGL.Bind();
@@ -411,7 +412,7 @@ namespace osu.Framework.Graphics.Audio
             {
                 base.Dispose(isDisposing);
 
-                vertexBatch.Dispose();
+                vertexBatch?.Dispose();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Batches;
 using osuTK;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Colour;
@@ -65,7 +64,7 @@ namespace osu.Framework.Graphics.Containers
             /// <summary>
             /// The vertex batch used for child quads during the back-to-front pass.
             /// </summary>
-            private QuadBatch<TexturedVertex2D> quadBatch;
+            private IVertexBatch<TexturedVertex2D> quadBatch;
 
             private int sourceChildrenCount;
 
@@ -171,18 +170,18 @@ namespace osu.Framework.Graphics.Containers
 
             private bool mayHaveOwnVertexBatch(int amountChildren) => forceLocalVertexBatch || amountChildren >= min_amount_children_to_warrant_batch;
 
-            private void updateQuadBatch()
+            private void updateQuadBatch(IRenderer renderer)
             {
                 if (Children == null)
                     return;
 
                 if (quadBatch == null && mayHaveOwnVertexBatch(sourceChildrenCount))
-                    quadBatch = new QuadBatch<TexturedVertex2D>(100, 1000);
+                    quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(100, 1000);
             }
 
             public override void Draw(IRenderer renderer)
             {
-                updateQuadBatch();
+                updateQuadBatch(renderer);
 
                 // Prefer to use own vertex batch instead of the parent-owned one.
                 if (quadBatch != null)
@@ -233,7 +232,7 @@ namespace osu.Framework.Graphics.Containers
                 // Assume that if we can't increment the depth value, no child can, thus nothing will be drawn.
                 if (canIncrement)
                 {
-                    updateQuadBatch();
+                    updateQuadBatch(renderer);
 
                     // Prefer to use own vertex batch instead of the parent-owned one.
                     if (quadBatch != null)

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.OpenGL.Batches;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.OpenGL;
 using osuTK;
 using System;
 using System.Collections.Generic;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -34,11 +33,8 @@ namespace osu.Framework.Graphics.Lines
             private float radius;
             private IShader pathShader;
 
-            // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
-            // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
-            // grouping of vertices into primitives.
-            private readonly LinearBatch<TexturedVertex3D> halfCircleBatch = new LinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
-            private readonly QuadBatch<TexturedVertex3D> quadBatch = new QuadBatch<TexturedVertex3D>(200, 10);
+            private IVertexBatch<TexturedVertex3D> halfCircleBatch;
+            private IVertexBatch<TexturedVertex3D> quadBatch;
 
             public PathDrawNode(Path source)
                 : base(source)
@@ -211,6 +207,12 @@ namespace osu.Framework.Graphics.Lines
                 if (texture?.Available != true || segments.Count == 0)
                     return;
 
+                // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
+                // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
+                // grouping of vertices into primitives.
+                halfCircleBatch ??= renderer.CreateLinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
+                quadBatch ??= renderer.CreateQuadBatch<TexturedVertex3D>(200, 10);
+
                 GLWrapper.PushDepthInfo(DepthInfo.Default);
 
                 // Blending is removed to allow for correct blending between the wedges of the path.
@@ -231,8 +233,8 @@ namespace osu.Framework.Graphics.Lines
             {
                 base.Dispose(isDisposing);
 
-                halfCircleBatch.Dispose();
-                quadBatch.Dispose();
+                halfCircleBatch?.Dispose();
+                quadBatch?.Dispose();
             }
         }
     }

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -5,7 +5,6 @@
 
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Textures;
-using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL;
 using osuTK;
 using System;
@@ -210,7 +209,7 @@ namespace osu.Framework.Graphics.Lines
                 // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
                 // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
                 // grouping of vertices into primitives.
-                halfCircleBatch ??= renderer.CreateLinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
+                halfCircleBatch ??= renderer.CreateLinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveTopology.Triangles);
                 quadBatch ??= renderer.CreateQuadBatch<TexturedVertex3D>(200, 10);
 
                 GLWrapper.PushDepthInfo(DepthInfo.Default);

--- a/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
@@ -5,12 +5,12 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
-using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL.Vertices;
+using osuTK.Graphics.ES30;
 
-namespace osu.Framework.Graphics.Batches
+namespace osu.Framework.Graphics.OpenGL.Batches
 {
-    public class LinearBatch<T> : VertexBatch<T>
+    internal class LinearBatch<T> : VertexBatch<T>
         where T : struct, IEquatable<T>, IVertex
     {
         private readonly PrimitiveType type;

--- a/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
@@ -6,6 +6,7 @@
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Graphics.Rendering;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL.Batches
@@ -15,10 +16,34 @@ namespace osu.Framework.Graphics.OpenGL.Batches
     {
         private readonly PrimitiveType type;
 
-        public LinearBatch(int size, int maxBuffers, PrimitiveType type)
+        public LinearBatch(int size, int maxBuffers, PrimitiveTopology topology)
             : base(size, maxBuffers)
         {
-            this.type = type;
+            switch (topology)
+            {
+                case PrimitiveTopology.Points:
+                    type = PrimitiveType.Points;
+                    break;
+
+                case PrimitiveTopology.Lines:
+                    type = PrimitiveType.Lines;
+                    break;
+
+                case PrimitiveTopology.LineStrip:
+                    type = PrimitiveType.LineStrip;
+                    break;
+
+                case PrimitiveTopology.Triangles:
+                    type = PrimitiveType.Triangles;
+                    break;
+
+                case PrimitiveTopology.TriangleStrip:
+                    type = PrimitiveType.TriangleStrip;
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unsupported vertex topology: {topology}.", nameof(topology));
+            }
         }
 
         protected override VertexBuffer<T> CreateVertexBuffer() => new LinearVertexBuffer<T>(Size, type, BufferUsageHint.DynamicDraw);

--- a/osu.Framework/Graphics/OpenGL/Batches/QuadBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/QuadBatch.cs
@@ -8,9 +8,9 @@ using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
 
-namespace osu.Framework.Graphics.Batches
+namespace osu.Framework.Graphics.OpenGL.Batches
 {
-    public class QuadBatch<T> : VertexBatch<T>
+    internal class QuadBatch<T> : VertexBatch<T>
         where T : struct, IEquatable<T>, IVertex
     {
         public QuadBatch(int size, int maxBuffers)

--- a/osu.Framework/Graphics/OpenGL/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/VertexBatch.cs
@@ -6,15 +6,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Statistics;
 
-namespace osu.Framework.Graphics.Batches
+namespace osu.Framework.Graphics.OpenGL.Batches
 {
-    public abstract class VertexBatch<T> : IVertexBatch<T>
+    internal abstract class VertexBatch<T> : IVertexBatch<T>
         where T : struct, IEquatable<T>, IVertex
     {
         public List<VertexBuffer<T>> VertexBuffers = new List<VertexBuffer<T>>();

--- a/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
@@ -23,12 +23,12 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     /// <summary>
     /// This type of vertex buffer lets the ith vertex be referenced by the ith index.
     /// </summary>
-    public class LinearVertexBuffer<T> : VertexBuffer<T>
+    internal class LinearVertexBuffer<T> : VertexBuffer<T>
         where T : struct, IEquatable<T>, IVertex
     {
         private readonly int amountVertices;
 
-        internal LinearVertexBuffer(int amountVertices, PrimitiveType type, BufferUsageHint usage)
+        public LinearVertexBuffer(int amountVertices, PrimitiveType type, BufferUsageHint usage)
             : base(amountVertices, usage)
         {
             this.amountVertices = amountVertices;

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         public static int MaxAmountIndices;
     }
 
-    public class QuadVertexBuffer<T> : VertexBuffer<T>
+    internal class QuadVertexBuffer<T> : VertexBuffer<T>
         where T : struct, IEquatable<T>, IVertex
     {
         private readonly int amountIndices;
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// </summary>
         public const int MAX_QUADS = ushort.MaxValue / indices_per_quad;
 
-        internal QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
+        public QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
             : base(amountQuads * TextureGLSingle.VERTICES_PER_QUAD, usage)
         {
             amountIndices = amountQuads * indices_per_quad;

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -13,7 +13,7 @@ using SixLabors.ImageSharp.Memory;
 
 namespace osu.Framework.Graphics.OpenGL.Buffers
 {
-    public abstract class VertexBuffer<T> : IVertexBuffer, IDisposable
+    internal abstract class VertexBuffer<T> : IVertexBuffer, IDisposable
         where T : struct, IEquatable<T>, IVertex
     {
         protected static readonly int STRIDE = VertexUtils<DepthWrappingVertex<T>>.STRIDE;

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Development;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Threading;
@@ -98,7 +97,7 @@ namespace osu.Framework.Graphics.OpenGL
         private static readonly List<IVertexBuffer> vertex_buffers_in_use = new List<IVertexBuffer>();
 
         private static readonly Stack<IVertexBatch<TexturedVertex2D>> quad_batches = new Stack<IVertexBatch<TexturedVertex2D>>();
-        private static readonly QuadBatch<TexturedVertex2D> default_quad_batch = new QuadBatch<TexturedVertex2D>(100, 1000);
+        private static IVertexBatch<TexturedVertex2D> defaultQuadBatch;
 
         public static bool IsInitialized { get; private set; }
 
@@ -118,6 +117,8 @@ namespace osu.Framework.Graphics.OpenGL
 
             GL.Disable(EnableCap.StencilTest);
             GL.Enable(EnableCap.Blend);
+
+            defaultQuadBatch = host.Renderer.CreateQuadBatch<TexturedVertex2D>(100, 1000);
 
             IsInitialized = true;
 
@@ -184,7 +185,7 @@ namespace osu.Framework.Graphics.OpenGL
             scissor_offset_stack.Clear();
 
             quad_batches.Clear();
-            quad_batches.Push(default_quad_batch);
+            quad_batches.Push(defaultQuadBatch);
 
             BindFrameBuffer(DefaultFrameBuffer);
 

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -1,11 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Graphics.OpenGL.Batches;
+using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Rendering;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL
 {
     public class OpenGLRenderer : IRenderer
     {
+        public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveType primitiveType) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
+            => new LinearBatch<TVertex>(size, maxBuffers, primitiveType);
+
+        public IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
+            => new QuadBatch<TVertex>(size, maxBuffers);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -5,14 +5,13 @@ using System;
 using osu.Framework.Graphics.OpenGL.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Rendering;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL
 {
     public class OpenGLRenderer : IRenderer
     {
-        public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveType primitiveType) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
-            => new LinearBatch<TVertex>(size, maxBuffers, primitiveType);
+        public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
+            => new LinearBatch<TVertex>(size, maxBuffers, topology);
 
         public IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
             => new QuadBatch<TVertex>(size, maxBuffers);

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -4,11 +4,11 @@
 #nullable disable
 
 using System;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
 using osuTK;
 using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.OpenGL.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Textures;
 

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -1,6 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osuTK.Graphics.ES30;
+
 namespace osu.Framework.Graphics.Rendering
 {
     /// <summary>
@@ -8,5 +12,23 @@ namespace osu.Framework.Graphics.Rendering
     /// </summary>
     public interface IRenderer
     {
+        public const int VERTICES_PER_QUAD = 4;
+
+        public const int VERTICES_PER_TRIANGLE = 4;
+
+        /// <summary>
+        /// Creates a new linear vertex batch, accepting vertices and drawing as a given primitive type.
+        /// </summary>
+        /// <param name="size">Number of quads.</param>
+        /// <param name="maxBuffers">Maximum number of vertex buffers.</param>
+        /// <param name="primitiveType">The type of primitive the vertices are drawn as.</param>
+        IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveType primitiveType) where TVertex : unmanaged, IEquatable<TVertex>, IVertex;
+
+        /// <summary>
+        /// Creates a new quad vertex batch, accepting vertices and drawing as quads.
+        /// </summary>
+        /// <param name="size">Number of quads.</param>
+        /// <param name="maxBuffers">Maximum number of vertex buffers.</param>
+        IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : unmanaged, IEquatable<TVertex>, IVertex;
     }
 }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Vertices;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -21,8 +20,8 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         /// <param name="size">Number of quads.</param>
         /// <param name="maxBuffers">Maximum number of vertex buffers.</param>
-        /// <param name="primitiveType">The type of primitive the vertices are drawn as.</param>
-        IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveType primitiveType) where TVertex : unmanaged, IEquatable<TVertex>, IVertex;
+        /// <param name="topology">The type of primitive the vertices are drawn as.</param>
+        IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology) where TVertex : unmanaged, IEquatable<TVertex>, IVertex;
 
         /// <summary>
         /// Creates a new quad vertex batch, accepting vertices and drawing as quads.

--- a/osu.Framework/Graphics/Rendering/PrimitiveTopology.cs
+++ b/osu.Framework/Graphics/Rendering/PrimitiveTopology.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Rendering
+{
+    public enum PrimitiveTopology
+    {
+        Points,
+        Lines,
+        LineStrip,
+        Triangles,
+        TriangleStrip
+    }
+}

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -6,12 +6,12 @@
 using System;
 using System.IO;
 using osu.Framework.Extensions.EnumExtensions;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.OpenGL.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Textures;
 using osuTK.Graphics.ES30;
 using osuTK;
 using System;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics;
 using osu.Framework.Extensions.MatrixExtensions;
@@ -24,7 +23,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected new CircularProgress Source => (CircularProgress)base.Source;
 
-        private LinearBatch<TexturedVertex2D> halfCircleBatch;
+        private IVertexBatch<TexturedVertex2D> halfCircleBatch;
 
         private float angle;
         private float innerRadius = 1;
@@ -57,7 +56,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         private static readonly Vector2 origin = new Vector2(0.5f, 0.5f);
 
-        private void updateVertexBuffer()
+        private void updateVertexBuffer(IRenderer renderer)
         {
             const float start_angle = 0;
 
@@ -74,7 +73,7 @@ namespace osu.Framework.Graphics.UserInterface
                 halfCircleBatch?.Dispose();
 
                 // Amount of points is multiplied by 2 to account for each part requiring two vertices.
-                halfCircleBatch = new LinearBatch<TexturedVertex2D>(amountPoints * 2, 1, PrimitiveType.TriangleStrip);
+                halfCircleBatch = renderer.CreateLinearBatch<TexturedVertex2D>(amountPoints * 2, 1, PrimitiveType.TriangleStrip);
             }
 
             Matrix3 transformationMatrix = DrawInfo.Matrix;
@@ -156,7 +155,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             texture.TextureGL.Bind();
 
-            updateVertexBuffer();
+            updateVertexBuffer(renderer);
 
             Shader.Unbind();
         }

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using osu.Framework.Graphics.Textures;
-using osuTK.Graphics.ES30;
 using osuTK;
 using System;
 using osu.Framework.Graphics.Primitives;
@@ -73,7 +72,7 @@ namespace osu.Framework.Graphics.UserInterface
                 halfCircleBatch?.Dispose();
 
                 // Amount of points is multiplied by 2 to account for each part requiring two vertices.
-                halfCircleBatch = renderer.CreateLinearBatch<TexturedVertex2D>(amountPoints * 2, 1, PrimitiveType.TriangleStrip);
+                halfCircleBatch = renderer.CreateLinearBatch<TexturedVertex2D>(amountPoints * 2, 1, PrimitiveTopology.TriangleStrip);
             }
 
             Matrix3 transformationMatrix = DrawInfo.Matrix;


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/5324

- Makes `VertexBatch`,`VertexBuffer`, et-al `internal` and moves them to the OpenGL namespace.
- Exposes methods to create `IVertexBatch<T>` via `IRenderer`.
- Adds `PrimitiveTopology`, replacing the OpenGL-specific `PrimitiveType`.

# vNext

## `QuadBatch<T>` and `LinearBatch<T>` are no longer exposed

They should instead be created via the `IRenderer` and stored as an `IVertexBatch<T>` :

```diff
class MyDrawNode : DrawNode
{
-   private readonly QuadBatch<TexturedVertex2D> myBatch = new QuadBatch<TexturedVertex2D>(1, 1);
+   private IVertexBatch<TexturedVertex2D> myBatch;

    public override void Draw(IRenderer renderer)
    {
        base.Draw(renderer);

+       myBatch ??= renderer.CreateQuadBatch<TexturedVertex2D>(1, 1);
    }

    protected override void Dispose(bool disposing)
    {
        base.Dispose(disposing);
        batch?.Dispose();
    }
}
```

## OpenGL-specific `PrimitiveType` no longer used to create vertex batches

The new `PrimitiveTopology` enumeration should be used instead.