### PR TITLE
Fix `ModelBackedDrawable` attempting to mutate children after disposal

### DIFF
--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -46,8 +46,7 @@ namespace osu.Framework.Graphics.Containers
 
                 model = value;
 
-                if (IsLoaded)
-                    updateDrawable();
+                Scheduler.AddOnce(updateDrawable);
             }
         }
 
@@ -90,7 +89,7 @@ namespace osu.Framework.Graphics.Containers
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            updateDrawable();
+            Scheduler.AddOnce(updateDrawable);
         }
 
         private void updateDrawable()


### PR DESCRIPTION
This is mostly guarding against misuse of the component, but seems good
to have at a framework level to avoid crashes.

Guards against a potential update of the model property post-disposal
causing an actual crash.

https://sentry.ppy.sh/share/issue/ceaf54b7da61445faac5675cc0a4fa44/