### PR TITLE
Unify usages of `GetCultureInfo` and fix `LocalisationManager` throwing on invalid culture

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLocalisedBindableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisedBindableString.cs
@@ -25,6 +25,7 @@ namespace osu.Framework.Benchmarks
         [GlobalCleanup]
         public void GlobalCleanup()
         {
+            manager.Dispose();
             storage.Dispose();
         }
 

--- a/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
+++ b/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
@@ -16,6 +16,7 @@ namespace osu.Framework.Tests.Localisation
         [TestCase("en-US", true, "en-US")]
         [TestCase("invalid name", false, invariant_culture)]
         [TestCase(current_culture, true, current_culture)]
+        [TestCase("ko_KR", false, invariant_culture)]
         public void TestTryGetCultureInfo(string name, bool expectedReturnValue, string expectedCultureName)
         {
             CultureInfo expectedCulture;

--- a/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
+++ b/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+using NUnit.Framework;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Tests.Localisation
+{
+    [TestFixture]
+    public class CultureInfoHelperTest
+    {
+        private const string invariant_culture = "invariant";
+        private const string current_culture = "";
+
+        [TestCase("en-US", true, "en-US")]
+        [TestCase("invalid name", false, invariant_culture)]
+        [TestCase(current_culture, true, current_culture)]
+        public void TestTryGetCultureInfo(string name, bool expectedReturnValue, string expectedCultureName)
+        {
+            CultureInfo expectedCulture;
+
+            switch (expectedCultureName)
+            {
+                case invariant_culture:
+                    expectedCulture = CultureInfo.InvariantCulture;
+                    break;
+
+                case current_culture:
+                    expectedCulture = CultureInfo.CurrentCulture;
+                    break;
+
+                default:
+                    expectedCulture = CultureInfo.GetCultureInfo(expectedCultureName);
+                    break;
+            }
+
+            bool retVal = CultureInfoHelper.TryGetCultureInfo(name, out var culture);
+
+            Assert.That(retVal, Is.EqualTo(expectedReturnValue));
+            Assert.That(culture, Is.EqualTo(expectedCulture));
+        }
+    }
+}

--- a/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
+++ b/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
@@ -10,12 +10,11 @@ namespace osu.Framework.Tests.Localisation
     [TestFixture]
     public class CultureInfoHelperTest
     {
-        private const string invariant_culture = "invariant";
-        private const string current_culture = "";
+        private const string invariant_culture = "";
 
         [TestCase("en-US", true, "en-US")]
         [TestCase("invalid name", false, invariant_culture)]
-        [TestCase(current_culture, true, current_culture)]
+        [TestCase(invariant_culture, true, invariant_culture)]
         [TestCase("ko_KR", false, invariant_culture)]
         public void TestTryGetCultureInfo(string name, bool expectedReturnValue, string expectedCultureName)
         {
@@ -25,10 +24,6 @@ namespace osu.Framework.Tests.Localisation
             {
                 case invariant_culture:
                     expectedCulture = CultureInfo.InvariantCulture;
-                    break;
-
-                case current_culture:
-                    expectedCulture = CultureInfo.CurrentCulture;
                     break;
 
                 default:

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -31,10 +31,18 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("en", new FakeStorage("en"));
         }
 
+        [TearDown]
+        public void Teardown()
+        {
+            manager?.Dispose();
+            config?.Dispose();
+        }
+
         [Test]
         public void TestNoLanguagesAdded()
         {
             // reinitialise without the default language
+            manager.Dispose();
             manager = new LocalisationManager(config);
 
             var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));

--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -73,7 +73,7 @@ namespace osu.Framework.Tests.Localisation
             });
 
             AddUntilStep("wait for query", () => cultures.Count == 3);
-            AddAssert($"culture is {name}", () => cultures.All(c => c.Name == name));
+            AddAssert($"culture is {name}", () => cultures.Select(c => c.Name), () => Is.All.EqualTo(name));
         }
 
         private void assertThreadCulture(string name)

--- a/osu.Framework.Tests/Visual/Localisation/TestSceneTextFlowContainerLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneTextFlowContainerLocalisation.cs
@@ -74,6 +74,12 @@ namespace osu.Framework.Tests.Visual.Localisation
             }));
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            manager?.Dispose();
+            base.Dispose(isDisposing);
+        }
+
         [Test]
         public void TestTextFlowLocalisation()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -259,6 +259,12 @@ namespace osu.Framework.Tests.Visual.Sprites
 
                 config.SetValue(FrameworkSetting.Locale, "ja");
             }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                localisation?.Dispose();
+                base.Dispose(isDisposing);
+            }
         }
 
         private class FakeFrameworkConfigManager : FrameworkConfigManager

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -56,6 +56,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
             return dependencies;
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            manager?.Dispose();
+            base.Dispose(isDisposing);
+        }
+
         private const string goodbye = "goodbye";
 
         [SetUp]

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -447,6 +447,9 @@ namespace osu.Framework
 
             localFonts?.Dispose();
             localFonts = null;
+
+            Localisation?.Dispose();
+            Localisation = null;
         }
     }
 }

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -10,17 +10,11 @@ namespace osu.Framework.Localisation
         /// <summary>
         /// Wrapper around <see cref="CultureInfo.GetCultureInfo(string)"/> providing common behaviour and exception handling.
         /// </summary>
-        /// <param name="name">Name of the culture, or empty string for <see cref="CultureInfo.CurrentCulture"/>.</param>
-        /// <param name="culture">The <see cref="CultureInfo"/> with the specified <paramref name="name"/>, or <see cref="CultureInfo.InvariantCulture"/> on failure.</param>
+        /// <param name="name">Name of the culture.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> with the specified <paramref name="name"/>.</param>
         /// <returns>Whether the culture was successfully retrieved and a is .NET/OS predefined culture.</returns>
         public static bool TryGetCultureInfo(string name, out CultureInfo culture)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                culture = CultureInfo.CurrentCulture;
-                return true;
-            }
-
             try
             {
 #if NET6_0_OR_GREATER

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
+
+namespace osu.Framework.Localisation
+{
+    public static class CultureInfoHelper
+    {
+        /// <summary>
+        /// Wrapper around <see cref="CultureInfo.GetCultureInfo(string)"/> providing common behaviour and exception handling.
+        /// </summary>
+        /// <param name="name">Name of the culture, or empty string for <see cref="CultureInfo.CurrentCulture"/>.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/> with the specified <paramref name="name"/>, or <see cref="CultureInfo.InvariantCulture"/> on failure.</param>
+        /// <returns>Whether the culture was successfully retrieved and a is .NET/OS predefined culture.</returns>
+        public static bool TryGetCultureInfo(string name, out CultureInfo culture)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                culture = CultureInfo.CurrentCulture;
+                return true;
+            }
+
+            try
+            {
+#if NET6_0_OR_GREATER
+                culture = CultureInfo.GetCultureInfo(name, predefinedOnly: true);
+#else
+                culture = CultureInfo.GetCultureInfo(name);
+
+                // This is best-effort for now to catch cases where dotnet is creating cultures.
+                // See https://github.com/dotnet/runtime/blob/5877e8b713742b6d80bd1aa9819094be029e3e1f/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs#L341-L345
+                if (culture.ThreeLetterWindowsLanguageName == "ZZZ")
+                {
+                    culture = CultureInfo.InvariantCulture;
+                    return false;
+                }
+#endif
+                return true;
+            }
+            catch (CultureNotFoundException)
+            {
+                culture = CultureInfo.InvariantCulture;
+                return false;
+            }
+        }
+    }
+}

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Localisation
                 culture = CultureInfo.GetCultureInfo(name, predefinedOnly: true);
 #else
                 culture = CultureInfo.GetCultureInfo(name);
-
+#endif
                 // This is best-effort for now to catch cases where dotnet is creating cultures.
                 // See https://github.com/dotnet/runtime/blob/5877e8b713742b6d80bd1aa9819094be029e3e1f/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs#L341-L345
                 if (culture.ThreeLetterWindowsLanguageName == "ZZZ")
@@ -35,7 +35,7 @@ namespace osu.Framework.Localisation
                     culture = CultureInfo.InvariantCulture;
                     return false;
                 }
-#endif
+
                 return true;
             }
             catch (CultureNotFoundException)

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -92,7 +92,17 @@ namespace osu.Framework.Localisation
 
             if (currentLocale == null)
             {
-                var culture = string.IsNullOrEmpty(locale.NewValue) ? CultureInfo.CurrentCulture : new CultureInfo(locale.NewValue);
+                if (!CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out var culture))
+                {
+                    if (locale.OldValue == locale.NewValue)
+                        // equal values mean invalid locale on startup, no real way to recover other than to set to default.
+                        configLocale.SetDefault();
+                    else
+                        // revert to the old locale if the new one is invalid.
+                        configLocale.Value = locale.OldValue;
+
+                    return;
+                }
 
                 for (var c = culture; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
                 {

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using osu.Framework.Bindables;
@@ -8,7 +9,7 @@ using osu.Framework.Configuration;
 
 namespace osu.Framework.Localisation
 {
-    public partial class LocalisationManager
+    public partial class LocalisationManager : IDisposable
     {
         public IBindable<LocalisationParameters> CurrentParameters => currentParameters;
 
@@ -119,5 +120,18 @@ namespace osu.Framework.Localisation
         /// </remarks>
         /// <returns>The resultant <see cref="LocalisationParameters"/>.</returns>
         protected virtual LocalisationParameters CreateLocalisationParameters() => new LocalisationParameters(currentLocale?.Storage, configPreferUnicode.Value);
+
+        protected virtual void Dispose(bool disposing)
+        {
+            currentParameters.UnbindAll();
+            configLocale.UnbindAll();
+            configPreferUnicode.UnbindAll();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -92,7 +92,13 @@ namespace osu.Framework.Localisation
 
             if (currentLocale == null)
             {
-                if (!CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out var culture))
+                CultureInfo culture;
+
+                if (string.IsNullOrEmpty(locale.NewValue))
+                {
+                    culture = CultureInfo.CurrentCulture;
+                }
+                else if (!CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out culture))
                 {
                     if (locale.OldValue == locale.NewValue)
                         // equal values mean invalid locale on startup, no real way to recover other than to set to default.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -44,6 +44,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Serialization;
 using osu.Framework.IO.Stores;
+using osu.Framework.Localisation;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
 using Size = System.Drawing.Size;
@@ -1008,24 +1009,8 @@ namespace osu.Framework.Platform
             threadLocale = Config.GetBindable<string>(FrameworkSetting.Locale);
             threadLocale.BindValueChanged(locale =>
             {
-                CultureInfo culture;
-
-                try
-                {
-                    // After dropping netstandard we can use `predefinedOnly` override.
-                    // See https://github.com/dotnet/runtime/pull/1261/files
-                    culture = CultureInfo.GetCultureInfo(locale.NewValue);
-
-                    // This is best-effort for now to catch cases where dotnet is creating cultures.
-                    // See https://github.com/dotnet/runtime/blob/5877e8b713742b6d80bd1aa9819094be029e3e1f/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs#L341-L345
-                    if (culture.ThreeLetterWindowsLanguageName == "ZZZ")
-                        culture = CultureInfo.InvariantCulture;
-                }
-                catch (Exception e)
-                {
-                    Logger.Log($"Culture for {locale.NewValue} could not be found ({e})");
-                    culture = CultureInfo.InvariantCulture;
-                }
+                // return value of TryGet ignored as the failure case gives expected results (CultureInfo.InvariantCulture)
+                CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out var culture);
 
                 CultureInfo.DefaultThreadCurrentCulture = culture;
                 CultureInfo.DefaultThreadCurrentUICulture = culture;


### PR DESCRIPTION
- Closes #5328 

`CultureInfoHelper.TryGetCultureInfo` unifies the two usages of `GetCultureInfo`/`new CultureInfo`, fixing `LocalisationManager` crashing on startup when an invalid culture is set.

`CultureInfo.GetCultureInfo` still sometimes fabricates cultures when using `predefinedOnly: true` so the `ZZZ` check will have to remain.