### PR TITLE
Fix crash when minimising while fullscreen on windows

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -593,6 +593,11 @@ namespace osu.Framework.Platform
             SDL.SDL_GL_GetDrawableSize(SDLWindowHandle, out int w, out int h);
             SDL.SDL_GetWindowSize(SDLWindowHandle, out int actualW, out int _);
 
+            // When minimised on windows, values may be zero.
+            // If we receive zeroes for either of these, it seems safe to completely ignore them.
+            if (actualW <= 0 || w <= 0)
+                return;
+
             Scale = (float)w / actualW;
             Size = new Size(w, h);
 


### PR DESCRIPTION
SDL behaviour looks to have changed when calling `SDL_GetWindowSize` while minimised from a fullscreen state. This fixes crashes due to div-by-zero propagating into the draw hierarchy.

Haven't investigated in detail why this happened, but the fix seems solid enough to get out as a hotfix.