### PR TITLE
Generate and upload symbol packages to nuget

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -133,6 +133,8 @@ Task("PackFramework")
             ArgumentCustomization = args => {
                 args.Append($"/p:Version={version}");
                 args.Append($"/p:GenerateDocumentationFile=true");
+                args.Append("/p:IncludeSymbols=true");
+                args.Append("/p:SymbolPackageFormat=snupkg");
 
                 return args;
             }


### PR DESCRIPTION
Theoretically, this should just work™

Following the guide on https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

I've tested that the build script generates a `snupkg` artifact.