### PR TITLE
Refactor exceptions thrown from vertex buffer construction

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/LinearBatch.cs
@@ -5,7 +5,6 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osuTK.Graphics.ES30;
 
@@ -16,34 +15,10 @@ namespace osu.Framework.Graphics.OpenGL.Batches
     {
         private readonly PrimitiveType type;
 
-        public LinearBatch(OpenGLRenderer renderer, int size, int maxBuffers, PrimitiveTopology topology)
+        public LinearBatch(OpenGLRenderer renderer, int size, int maxBuffers, PrimitiveType type)
             : base(renderer, size, maxBuffers)
         {
-            switch (topology)
-            {
-                case PrimitiveTopology.Points:
-                    type = PrimitiveType.Points;
-                    break;
-
-                case PrimitiveTopology.Lines:
-                    type = PrimitiveType.Lines;
-                    break;
-
-                case PrimitiveTopology.LineStrip:
-                    type = PrimitiveType.LineStrip;
-                    break;
-
-                case PrimitiveTopology.Triangles:
-                    type = PrimitiveType.Triangles;
-                    break;
-
-                case PrimitiveTopology.TriangleStrip:
-                    type = PrimitiveType.TriangleStrip;
-                    break;
-
-                default:
-                    throw new ArgumentException($"Unsupported vertex topology: {topology}.", nameof(topology));
-            }
+            this.type = type;
         }
 
         protected override VertexBuffer<T> CreateVertexBuffer(OpenGLRenderer renderer) => new LinearVertexBuffer<T>(renderer, Size, type, BufferUsageHint.DynamicDraw);

--- a/osu.Framework/Graphics/OpenGL/Batches/QuadBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/QuadBatch.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Graphics.OpenGL.Batches
         public QuadBatch(OpenGLRenderer renderer, int size, int maxBuffers)
             : base(renderer, size, maxBuffers)
         {
-            if (size > QuadVertexBuffer<T>.MAX_QUADS)
-                throw new OverflowException($"Attempted to initialise a {nameof(QuadVertexBuffer<T>)} with more than {nameof(QuadVertexBuffer<T>)}.{nameof(QuadVertexBuffer<T>.MAX_QUADS)} quads ({QuadVertexBuffer<T>.MAX_QUADS}).");
         }
 
         protected override VertexBuffer<T> CreateVertexBuffer(OpenGLRenderer renderer) => new QuadVertexBuffer<T>(renderer, Size, BufferUsageHint.DynamicDraw);

--- a/osu.Framework/Graphics/OpenGL/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/VertexBatch.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -36,9 +35,6 @@ namespace osu.Framework.Graphics.OpenGL.Batches
 
         protected VertexBatch(OpenGLRenderer renderer, int bufferSize, int maxBuffers)
         {
-            // Vertex buffers of size 0 don't make any sense. Let's not blindly hope for good behavior of OpenGL.
-            Trace.Assert(bufferSize > 0);
-
             Size = bufferSize;
             this.renderer = renderer;
             this.maxBuffers = maxBuffers;

--- a/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osuTK.Graphics.ES30;
 
@@ -33,6 +34,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         {
             this.amountVertices = amountVertices;
             Type = type;
+
+            Debug.Assert(amountVertices <= MAX_VERTICES);
         }
 
         protected override void Initialise()

--- a/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
@@ -46,8 +46,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             {
                 ushort[] indices = new ushort[amountVertices];
 
-                for (ushort i = 0; i < amountVertices; i++)
-                    indices[i] = i;
+                for (int i = 0; i < amountVertices; i++)
+                    indices[i] = (ushort)i;
 
                 Renderer.BindBuffer(BufferTarget.ElementArrayBuffer, LinearIndexData.EBO_ID);
                 GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(amountVertices * sizeof(ushort)), indices, BufferUsageHint.StaticDraw);

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             : base(renderer, amountQuads * IRenderer.VERTICES_PER_QUAD, usage)
         {
             amountIndices = amountQuads * indices_per_quad;
-            Debug.Assert(amountIndices <= ushort.MaxValue);
+            Debug.Assert(amountIndices <= MAX_VERTICES);
         }
 
         protected override void Initialise()

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -49,9 +49,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             {
                 ushort[] indices = new ushort[amountIndices];
 
-                for (ushort i = 0, j = 0; j < amountIndices; i += IRenderer.VERTICES_PER_QUAD, j += indices_per_quad)
+                for (int i = 0, j = 0; j < amountIndices; i += IRenderer.VERTICES_PER_QUAD, j += indices_per_quad)
                 {
-                    indices[j] = i;
+                    indices[j] = (ushort)i;
                     indices[j + 1] = (ushort)(i + 1);
                     indices[j + 2] = (ushort)(i + 3);
                     indices[j + 3] = (ushort)(i + 2);

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -16,6 +16,11 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     internal abstract class VertexBuffer<T> : IVertexBuffer, IDisposable
         where T : struct, IEquatable<T>, IVertex
     {
+        /// <summary>
+        /// The maximum number of vertices supported by this buffer.
+        /// </summary>
+        public const int MAX_VERTICES = ushort.MaxValue;
+
         protected static readonly int STRIDE = VertexUtils<DepthWrappingVertex<T>>.STRIDE;
 
         protected readonly OpenGLRenderer Renderer;

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -891,10 +891,32 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
-            => new LinearBatch<TVertex>(this, size, maxBuffers, OpenGLUtils.ToPrimitiveType(topology));
+        {
+            if (size <= 0)
+                throw new ArgumentException("Linear batch size must be > 0.", nameof(size));
+
+            if (size > LinearVertexBuffer<TVertex>.MAX_VERTICES)
+                throw new ArgumentException($"Linear batch may not have more than {LinearVertexBuffer<TVertex>.MAX_VERTICES} vertices.", nameof(size));
+
+            if (maxBuffers <= 0)
+                throw new ArgumentException("Maximum number of buffers must be > 0.", nameof(maxBuffers));
+
+            return new LinearBatch<TVertex>(this, size, maxBuffers, OpenGLUtils.ToPrimitiveType(topology));
+        }
 
         public IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
-            => new QuadBatch<TVertex>(this, size, maxBuffers);
+        {
+            if (size <= 0)
+                throw new ArgumentException("Quad batch size must be > 0.", nameof(size));
+
+            if (size > QuadVertexBuffer<TVertex>.MAX_QUADS)
+                throw new ArgumentException($"Quad batch may not have more than {QuadVertexBuffer<TVertex>.MAX_QUADS} quads.", nameof(size));
+
+            if (maxBuffers <= 0)
+                throw new ArgumentException("Maximum number of buffers must be > 0.", nameof(maxBuffers));
+
+            return new QuadBatch<TVertex>(this, size, maxBuffers);
+        }
 
         void IRenderer.SetUniform<T>(IUniformWithValue<T> uniform)
         {

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -891,7 +891,7 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
-            => new LinearBatch<TVertex>(this, size, maxBuffers, topology);
+            => new LinearBatch<TVertex>(this, size, maxBuffers, OpenGLUtils.ToPrimitiveType(topology));
 
         public IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : unmanaged, IEquatable<TVertex>, IVertex
             => new QuadBatch<TVertex>(this, size, maxBuffers);

--- a/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Rendering;
+using osuTK.Graphics.ES30;
+
+namespace osu.Framework.Graphics.OpenGL
+{
+    internal static class OpenGLUtils
+    {
+        public static PrimitiveType ToPrimitiveType(PrimitiveTopology topology)
+        {
+            switch (topology)
+            {
+                case PrimitiveTopology.Points:
+                    return PrimitiveType.Points;
+
+                case PrimitiveTopology.Lines:
+                    return PrimitiveType.Lines;
+
+                case PrimitiveTopology.LineStrip:
+                    return PrimitiveType.LineStrip;
+
+                case PrimitiveTopology.Triangles:
+                    return PrimitiveType.Triangles;
+
+                case PrimitiveTopology.TriangleStrip:
+                    return PrimitiveType.TriangleStrip;
+
+                default:
+                    throw new ArgumentException($"Unsupported vertex topology: {topology}.", nameof(topology));
+            }
+        }
+    }
+}


### PR DESCRIPTION
While investigating https://sentry.ppy.sh/organizations/ppy/issues/5729/events/906dabeba7884d34a0ef448030f72ce8/?end=2022-08-11T03%3A10%3A59&project=2&query=firstRelease%3Aosu%402022.810.2&sort=freq&start=2022-08-10T08%3A52%3A00#exception, I found that exceptions are thrown kinda weirdly. They're sometimes completely missing (`LinearVertexBuffer`, `size <= 0` check), or trace assertions (`VertexBatch`), or even the incorrect type (`QuadBatch`).

This is just cleaning this up. At this point I can only imagine the error above happen via the ctor exiting early, so the `VertexBuffer` assertion is suspect. Possibly in combination with https://github.com/ppy/osu-framework/pull/5349 causing the `CircularProgressDrawNode` to pass in <=0 values triggering the `VertexBatch` assertion.