### PR TITLE
Add stencil support for renderers

### DIFF
--- a/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.UserInterface;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Graphics
+{
+    public class TestSceneStencil : FrameworkTestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load(TextureStore textures)
+        {
+            Container circlesContainer;
+
+            Child = new StencilDrawable
+            {
+                RelativeSizeAxes = Axes.Both,
+                Background = new Sprite
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = textures.Get("sample-texture")
+                },
+                Stencil = circlesContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                }
+            };
+
+            const float circle_radius = 0.05f;
+            const float spacing = 0.01f;
+
+            for (float xPos = 0; xPos < 1; xPos += circle_radius + spacing)
+            {
+                for (float yPos = 0; yPos < 1; yPos += circle_radius + spacing)
+                {
+                    circlesContainer.Add(new CircularProgress
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(circle_radius),
+                        RelativePositionAxes = Axes.Both,
+                        Position = new Vector2(xPos, yPos),
+                        Current = { Value = 1 }
+                    });
+                }
+            }
+        }
+
+        private class StencilDrawable : CompositeDrawable
+        {
+            public Drawable Background
+            {
+                set => backgroundContainer.Child = value;
+            }
+
+            public Drawable Stencil
+            {
+                set => stencilContainer.Child = value;
+            }
+
+            private readonly Container backgroundContainer;
+            private readonly Container stencilContainer;
+
+            public StencilDrawable()
+            {
+                InternalChildren = new Drawable[]
+                {
+                    backgroundContainer = new Container { RelativeSizeAxes = Axes.Both },
+                    stencilContainer = new Container { RelativeSizeAxes = Axes.Both }
+                };
+            }
+
+            protected override DrawNode CreateDrawNode() => new StencilDrawNode(this);
+        }
+
+        private class StencilDrawNode : DrawNode, ICompositeDrawNode
+        {
+            public StencilDrawNode(IDrawable source)
+                : base(source)
+            {
+            }
+
+            public override void Draw(IRenderer renderer)
+            {
+                base.Draw(renderer);
+
+                // No depth testing.
+                renderer.PushDepthInfo(new DepthInfo(false));
+
+                drawStencil(renderer, Children[1]);
+                drawBackground(renderer, Children[0]);
+
+                renderer.PopDepthInfo();
+            }
+
+            private void drawStencil(IRenderer renderer, DrawNode drawNode)
+            {
+                // Populate the stencil buffer with 255 in places defined by the draw node.
+                renderer.PushStencilInfo(new StencilInfo(
+                    stencilTest: true,
+                    testFunction: DepthStencilFunction.Always,
+                    255,
+                    passed: StencilOperation.Replace));
+
+                // Don't write colour.
+                renderer.SetBlend(new BlendingParameters
+                {
+                    Source = BlendingType.Zero,
+                    Destination = BlendingType.One,
+                    SourceAlpha = BlendingType.Zero,
+                    DestinationAlpha = BlendingType.One,
+                });
+
+                drawNode.Draw(renderer);
+
+                renderer.PopStencilInfo();
+                renderer.SetBlend(DrawColourInfo.Blending);
+            }
+
+            private void drawBackground(IRenderer renderer, DrawNode drawNode)
+            {
+                // Only pass the stencil test where the stencil buffer value is 255.
+                renderer.PushStencilInfo(new StencilInfo(
+                    stencilTest: true,
+                    testFunction: DepthStencilFunction.Equal,
+                    mask: 255,
+                    testValue: 255,
+                    stencilFailed: StencilOperation.Keep,
+                    passed: StencilOperation.Keep
+                ));
+
+                drawNode.Draw(renderer);
+
+                renderer.PopStencilInfo();
+            }
+
+            public List<DrawNode> Children { get; set; } = new List<DrawNode>();
+
+            public bool AddChildDrawNodes => true;
+        }
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -738,7 +738,7 @@ namespace osu.Framework.Graphics.OpenGL
         {
             stencilStack.Push(stencilInfo);
 
-            if ( CurrentStencilInfo.Equals(stencilInfo) )
+            if (CurrentStencilInfo.Equals(stencilInfo))
                 return;
 
             CurrentStencilInfo = stencilInfo;
@@ -752,7 +752,7 @@ namespace osu.Framework.Graphics.OpenGL
             stencilStack.Pop();
             StencilInfo stencilInfo = stencilStack.Peek();
 
-            if ( CurrentStencilInfo.Equals(stencilInfo) )
+            if (CurrentStencilInfo.Equals(stencilInfo))
                 return;
 
             CurrentStencilInfo = stencilInfo;
@@ -763,7 +763,7 @@ namespace osu.Framework.Graphics.OpenGL
         {
             flushCurrentBatch();
 
-            if ( stencilInfo.StencilTest )
+            if (stencilInfo.StencilTest)
             {
                 GL.Enable(EnableCap.StencilTest);
                 GL.StencilFunc(stencilInfo.TestFunction, stencilInfo.TestValue, stencilInfo.Mask);

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -64,6 +64,7 @@ namespace osu.Framework.Graphics.OpenGL
         public Vector2I ScissorOffset { get; private set; }
         public Matrix4 ProjectionMatrix { get; private set; }
         public DepthInfo CurrentDepthInfo { get; private set; }
+        public StencilInfo CurrentStencilInfo { get; private set; }
         public WrapMode CurrentWrapModeS { get; private set; }
         public WrapMode CurrentWrapModeT { get; private set; }
         public bool IsMaskingActive => maskingStack.Count > 1;
@@ -92,6 +93,7 @@ namespace osu.Framework.Graphics.OpenGL
         private readonly Stack<MaskingInfo> maskingStack = new Stack<MaskingInfo>();
         private readonly Stack<RectangleI> scissorRectStack = new Stack<RectangleI>();
         private readonly Stack<DepthInfo> depthStack = new Stack<DepthInfo>();
+        private readonly Stack<StencilInfo> stencilStack = new Stack<StencilInfo>();
         private readonly Stack<Vector2I> scissorOffsetStack = new Stack<Vector2I>();
         private readonly Stack<IShader> shaderStack = new Stack<IShader>();
         private readonly Stack<bool> scissorStateStack = new Stack<bool>();
@@ -181,6 +183,7 @@ namespace osu.Framework.Graphics.OpenGL
             scissorRectStack.Clear();
             frameBufferStack.Clear();
             depthStack.Clear();
+            stencilStack.Clear();
             scissorStateStack.Clear();
             scissorOffsetStack.Clear();
 
@@ -209,6 +212,7 @@ namespace osu.Framework.Graphics.OpenGL
             }, true);
 
             PushDepthInfo(DepthInfo.Default);
+            PushStencilInfo(StencilInfo.Default);
             Clear(new ClearInfo(Color4.Black));
 
             freeUnusedVertexBuffers();
@@ -728,6 +732,45 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.Disable(EnableCap.DepthTest);
 
             GL.DepthMask(depthInfo.WriteDepth);
+        }
+
+        public void PushStencilInfo(StencilInfo stencilInfo)
+        {
+            stencilStack.Push(stencilInfo);
+
+            if ( CurrentStencilInfo.Equals(stencilInfo) )
+                return;
+
+            CurrentStencilInfo = stencilInfo;
+            setStencilInfo(stencilInfo);
+        }
+
+        public void PopStencilInfo()
+        {
+            Trace.Assert(stencilStack.Count > 1);
+
+            stencilStack.Pop();
+            StencilInfo stencilInfo = stencilStack.Peek();
+
+            if ( CurrentStencilInfo.Equals(stencilInfo) )
+                return;
+
+            CurrentStencilInfo = stencilInfo;
+            setStencilInfo(CurrentStencilInfo);
+        }
+
+        private void setStencilInfo(StencilInfo stencilInfo)
+        {
+            flushCurrentBatch();
+
+            if ( stencilInfo.StencilTest )
+            {
+                GL.Enable(EnableCap.StencilTest);
+                GL.StencilFunc(stencilInfo.TestFunction, stencilInfo.TestValue, stencilInfo.Mask);
+                GL.StencilOp(stencilInfo.StencilTestFailOperation, stencilInfo.DepthTestFailOperation, stencilInfo.TestPassedOperation);
+            }
+            else
+                GL.Disable(EnableCap.StencilTest);
         }
 
         public void ScheduleExpensiveOperation(ScheduledDelegate operation)

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -766,8 +766,8 @@ namespace osu.Framework.Graphics.OpenGL
             if (stencilInfo.StencilTest)
             {
                 GL.Enable(EnableCap.StencilTest);
-                GL.StencilFunc(stencilInfo.TestFunction, stencilInfo.TestValue, stencilInfo.Mask);
-                GL.StencilOp(stencilInfo.StencilTestFailOperation, stencilInfo.DepthTestFailOperation, stencilInfo.TestPassedOperation);
+                GL.StencilFunc(OpenGLUtils.ToStencilFunction(stencilInfo.TestFunction), stencilInfo.TestValue, stencilInfo.Mask);
+                GL.StencilOp(OpenGLUtils.ToStencilOperation(stencilInfo.StencilTestFailOperation), OpenGLUtils.ToStencilOperation(stencilInfo.DepthTestFailOperation), OpenGLUtils.ToStencilOperation(stencilInfo.TestPassedOperation));
             }
             else
                 GL.Disable(EnableCap.StencilTest);

--- a/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLRenderer.cs
@@ -767,7 +767,10 @@ namespace osu.Framework.Graphics.OpenGL
             {
                 GL.Enable(EnableCap.StencilTest);
                 GL.StencilFunc(OpenGLUtils.ToStencilFunction(stencilInfo.TestFunction), stencilInfo.TestValue, stencilInfo.Mask);
-                GL.StencilOp(OpenGLUtils.ToStencilOperation(stencilInfo.StencilTestFailOperation), OpenGLUtils.ToStencilOperation(stencilInfo.DepthTestFailOperation), OpenGLUtils.ToStencilOperation(stencilInfo.TestPassedOperation));
+                GL.StencilOp(
+                    OpenGLUtils.ToStencilOperation(stencilInfo.StencilTestFailOperation),
+                    OpenGLUtils.ToStencilOperation(stencilInfo.DepthTestFailOperation),
+                    OpenGLUtils.ToStencilOperation(stencilInfo.TestPassedOperation));
             }
             else
                 GL.Disable(EnableCap.StencilTest);

--- a/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
@@ -65,5 +65,71 @@ namespace osu.Framework.Graphics.OpenGL
                     throw new ArgumentException($"Unsupported depth test function: {testFunction}.", nameof(testFunction));
             }
         }
+
+        public static StencilFunction ToStencilFunction(DepthStencilFunction testFunction)
+        {
+            switch (testFunction)
+            {
+                case DepthStencilFunction.Never:
+                    return StencilFunction.Never;
+
+                case DepthStencilFunction.LessThan:
+                    return StencilFunction.Less;
+
+                case DepthStencilFunction.LessThanOrEqual:
+                    return StencilFunction.Lequal;
+
+                case DepthStencilFunction.Equal:
+                    return StencilFunction.Equal;
+
+                case DepthStencilFunction.GreaterThanOrEqual:
+                    return StencilFunction.Gequal;
+
+                case DepthStencilFunction.Greater:
+                    return StencilFunction.Greater;
+
+                case DepthStencilFunction.NotEqual:
+                    return StencilFunction.Notequal;
+
+                case DepthStencilFunction.Always:
+                    return StencilFunction.Always;
+
+                default:
+                    throw new ArgumentException($"Unsupported stencil test function: {testFunction}.", nameof(testFunction));
+            }
+        }
+
+        public static StencilOp ToStencilOperation(StencilOperation operation)
+        {
+            switch (operation)
+            {
+                case StencilOperation.Zero:
+                    return StencilOp.Zero;
+
+                case StencilOperation.Invert:
+                    return StencilOp.Invert;
+
+                case StencilOperation.Replace:
+                    return StencilOp.Replace;
+
+                case StencilOperation.Keep:
+                    return StencilOp.Keep;
+
+                case StencilOperation.Increase:
+                    return StencilOp.Incr;
+
+                case StencilOperation.Decrease:
+                    return StencilOp.Decr;
+
+                case StencilOperation.IncreaseWrap:
+                    return StencilOp.IncrWrap;
+
+                case StencilOperation.DecreaseWrap:
+                    return StencilOp.DecrWrap;
+
+                default:
+                    throw new ArgumentException($"Unsupported stencil operation: {operation}.", nameof(operation));
+            }
+        }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -30,6 +30,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public Vector2I ScissorOffset => Vector2I.Zero;
         public Matrix4 ProjectionMatrix => Matrix4.Identity;
         public DepthInfo CurrentDepthInfo => DepthInfo.Default;
+        public StencilInfo CurrentStencilInfo => StencilInfo.Default;
         public WrapMode CurrentWrapModeS => WrapMode.None;
         public WrapMode CurrentWrapModeT => WrapMode.None;
         public bool IsMaskingActive => false;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -126,6 +126,14 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         {
         }
 
+        public void PushStencilInfo(StencilInfo stencilInfo)
+        {
+        }
+
+        public void PopStencilInfo()
+        {
+        }
+
         public void ScheduleExpensiveOperation(ScheduledDelegate operation) => operation.RunTask();
 
         public void ScheduleDisposal<T>(Action<T> disposalAction, T target) => disposalAction(target);

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -235,6 +235,17 @@ namespace osu.Framework.Graphics.Rendering
         void PopDepthInfo();
 
         /// <summary>
+        /// Applies new stencil parameters.
+        /// </summary>
+        /// <param name="stencilInfo">The stencil parameters.</param>
+        void PushStencilInfo (StencilInfo stencilInfo);
+
+        /// <summary>
+        /// Restores the last stencil parameters.
+        /// </summary>
+        void PopStencilInfo ();
+
+        /// <summary>
         /// Schedules an expensive operation to a queue from which a maximum of one operation is performed per frame.
         /// </summary>
         /// <param name="operation">The operation to schedule.</param>

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -238,12 +238,12 @@ namespace osu.Framework.Graphics.Rendering
         /// Applies new stencil parameters.
         /// </summary>
         /// <param name="stencilInfo">The stencil parameters.</param>
-        void PushStencilInfo (StencilInfo stencilInfo);
+        void PushStencilInfo(StencilInfo stencilInfo);
 
         /// <summary>
         /// Restores the last stencil parameters.
         /// </summary>
-        void PopStencilInfo ();
+        void PopStencilInfo();
 
         /// <summary>
         /// Schedules an expensive operation to a queue from which a maximum of one operation is performed per frame.

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -83,6 +83,11 @@ namespace osu.Framework.Graphics.Rendering
         DepthInfo CurrentDepthInfo { get; }
 
         /// <summary>
+        /// The current stencil parameters.
+        /// </summary>
+        StencilInfo CurrentStencilInfo { get; }
+
+        /// <summary>
         /// The current horizontal texture wrap mode.
         /// </summary>
         WrapMode CurrentWrapModeS { get; }

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osuTK.Graphics.ES30;
+
+namespace osu.Framework.Graphics.Rendering
+{
+    public struct StencilInfo : IEquatable<StencilInfo>
+    {
+        /// <summary>
+        /// Whether stencil testing should occur.
+        /// If this is false, no <see cref="StencilOp"/> will occur (use <see cref="StencilFunction.Always"/> instead).
+        /// </summary>
+        public readonly bool StencilTest;
+
+        /// <summary>
+        /// The stencil test function.
+        /// </summary>
+        public readonly StencilFunction TestFunction;
+
+        /// <summary>
+        /// The stencil test value to compare against.
+        /// </summary>
+        public readonly int TestValue;
+
+        /// <summary>
+        /// The stencil mask.
+        /// </summary>
+        public readonly int Mask;
+
+        /// <summary>
+        /// The operation to perform on the stencil buffer in case the stencil test failed.
+        /// </summary>
+        public readonly StencilOp StencilTestFailOperation;
+
+        /// <summary>
+        /// The operation to perform on the stencil buffer in case the depth test failed.
+        /// </summary>
+        public readonly StencilOp DepthTestFailOperation;
+
+        /// <summary>
+        /// The operation to perform on the stencil buffer in case the stencil test passed.
+        /// </summary>
+        public readonly StencilOp TestPassedOperation;
+
+        public StencilInfo(bool stencilTest = false, StencilFunction testFunction = StencilFunction.Always, int testValue = 1, int mask = 0xff,
+            StencilOp stencilFailed = StencilOp.Keep, StencilOp depthFailed = StencilOp.Keep, StencilOp passed = StencilOp.Replace)
+        {
+            StencilTest = stencilTest;
+            TestFunction = testFunction;
+            TestValue = testValue;
+            Mask = mask;
+            StencilTestFailOperation = stencilFailed;
+            DepthTestFailOperation = depthFailed;
+            TestPassedOperation = passed;
+        }
+
+        public bool Equals (StencilInfo other) =>
+            other.StencilTest == StencilTest &&
+            other.TestFunction == TestFunction &&
+            other.TestValue == TestValue &&
+            other.Mask == Mask &&
+            other.StencilTestFailOperation == StencilTestFailOperation &&
+            other.DepthTestFailOperation == DepthTestFailOperation &&
+            other.TestPassedOperation == TestPassedOperation;
+    }
+}

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.Rendering
         public readonly StencilOperation TestPassedOperation;
 
         public StencilInfo(bool stencilTest = true, DepthStencilFunction testFunction = DepthStencilFunction.Always, int testValue = 1, int mask = 0xff,
-                   StencilOperation stencilFailed = StencilOperation.Keep, StencilOperation depthFailed = StencilOperation.Keep, StencilOperation passed = StencilOperation.Replace)
+                           StencilOperation stencilFailed = StencilOperation.Keep, StencilOperation depthFailed = StencilOperation.Keep, StencilOperation passed = StencilOperation.Replace)
         {
             StencilTest = stencilTest;
             TestFunction = testFunction;

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -9,6 +9,11 @@ namespace osu.Framework.Graphics.Rendering
     public struct StencilInfo : IEquatable<StencilInfo>
     {
         /// <summary>
+        /// The default stencil properties.
+        /// </summary>
+        public static StencilInfo Default => new StencilInfo(false);
+
+        /// <summary>
         /// Whether stencil testing should occur.
         /// If this is false, no <see cref="StencilOp"/> will occur (use <see cref="StencilFunction.Always"/> instead).
         /// </summary>

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         public readonly StencilOperation TestPassedOperation;
 
-        public StencilInfo(bool stencilTest = false, DepthStencilFunction testFunction = DepthStencilFunction.Always, int testValue = 1, int mask = 0xff,
+        public StencilInfo(bool stencilTest = true, DepthStencilFunction testFunction = DepthStencilFunction.Always, int testValue = 1, int mask = 0xff,
                    StencilOperation stencilFailed = StencilOperation.Keep, StencilOperation depthFailed = StencilOperation.Keep, StencilOperation passed = StencilOperation.Replace)
         {
             StencilTest = stencilTest;

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.Rendering
             TestPassedOperation = passed;
         }
 
-        public bool Equals (StencilInfo other) =>
+        public bool Equals(StencilInfo other) =>
             other.StencilTest == StencilTest &&
             other.TestFunction == TestFunction &&
             other.TestValue == TestValue &&

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -6,7 +6,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering
 {
-    public struct StencilInfo : IEquatable<StencilInfo>
+    public readonly struct StencilInfo : IEquatable<StencilInfo>
     {
         /// <summary>
         /// The default stencil properties.
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Rendering
         public readonly StencilOp TestPassedOperation;
 
         public StencilInfo(bool stencilTest = false, StencilFunction testFunction = StencilFunction.Always, int testValue = 1, int mask = 0xff,
-            StencilOp stencilFailed = StencilOp.Keep, StencilOp depthFailed = StencilOp.Keep, StencilOp passed = StencilOp.Replace)
+                   StencilOp stencilFailed = StencilOp.Keep, StencilOp depthFailed = StencilOp.Keep, StencilOp passed = StencilOp.Replace)
         {
             StencilTest = stencilTest;
             TestFunction = testFunction;

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -15,14 +14,14 @@ namespace osu.Framework.Graphics.Rendering
 
         /// <summary>
         /// Whether stencil testing should occur.
-        /// If this is false, no <see cref="StencilOp"/> will occur (use <see cref="StencilFunction.Always"/> instead).
+        /// If this is false, no <see cref="StencilOperation"/> will occur (use <see cref="DepthStencilFunction.Always"/> instead).
         /// </summary>
         public readonly bool StencilTest;
 
         /// <summary>
         /// The stencil test function.
         /// </summary>
-        public readonly StencilFunction TestFunction;
+        public readonly DepthStencilFunction TestFunction;
 
         /// <summary>
         /// The stencil test value to compare against.
@@ -37,20 +36,20 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The operation to perform on the stencil buffer when the stencil test fails.
         /// </summary>
-        public readonly StencilOp StencilTestFailOperation;
+        public readonly StencilOperation StencilTestFailOperation;
 
         /// <summary>
         /// The operation to perform on the stencil buffer when the depth test fails.
         /// </summary>
-        public readonly StencilOp DepthTestFailOperation;
+        public readonly StencilOperation DepthTestFailOperation;
 
         /// <summary>
         /// The operation to perform on the stencil buffer when both the stencil and depth tests pass.
         /// </summary>
-        public readonly StencilOp TestPassedOperation;
+        public readonly StencilOperation TestPassedOperation;
 
-        public StencilInfo(bool stencilTest = false, StencilFunction testFunction = StencilFunction.Always, int testValue = 1, int mask = 0xff,
-                   StencilOp stencilFailed = StencilOp.Keep, StencilOp depthFailed = StencilOp.Keep, StencilOp passed = StencilOp.Replace)
+        public StencilInfo(bool stencilTest = false, DepthStencilFunction testFunction = DepthStencilFunction.Always, int testValue = 1, int mask = 0xff,
+                   StencilOperation stencilFailed = StencilOperation.Keep, StencilOperation depthFailed = StencilOperation.Keep, StencilOperation passed = StencilOperation.Replace)
         {
             StencilTest = stencilTest;
             TestFunction = testFunction;

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -35,17 +35,17 @@ namespace osu.Framework.Graphics.Rendering
         public readonly int Mask;
 
         /// <summary>
-        /// The operation to perform on the stencil buffer in case the stencil test failed.
+        /// The operation to perform on the stencil buffer when the stencil test fails.
         /// </summary>
         public readonly StencilOp StencilTestFailOperation;
 
         /// <summary>
-        /// The operation to perform on the stencil buffer in case the depth test failed.
+        /// The operation to perform on the stencil buffer when the depth test fails.
         /// </summary>
         public readonly StencilOp DepthTestFailOperation;
 
         /// <summary>
-        /// The operation to perform on the stencil buffer in case the stencil test passed.
+        /// The operation to perform on the stencil buffer when both the stencil and depth tests pass.
         /// </summary>
         public readonly StencilOp TestPassedOperation;
 

--- a/osu.Framework/Graphics/Rendering/StencilOperation.cs
+++ b/osu.Framework/Graphics/Rendering/StencilOperation.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Rendering
+{
+    public enum StencilOperation
+    {
+        /// <summary>
+        /// Set the stencil buffer to 0.
+        /// </summary>
+        Zero,
+
+        /// <summary>
+        /// Bitwise invert the stencil buffer.
+        /// </summary>
+        Invert,
+
+        /// <summary>
+        /// Do not change the stencil buffer.
+        /// </summary>
+        Keep,
+
+        /// <summary>
+        /// Replce the stenciil buffer with the <see cref="StencilInfo.TestValue"/>.
+        /// </summary>
+        Replace,
+
+        /// <summary>
+        /// Increase the stencil buffer by 1 if it's lower than the maximum value.
+        /// </summary>
+        Increase,
+
+        /// <summary>
+        /// Decrease the stencil buffer by 1 it's higher than 0.
+        /// </summary>
+        Decrease,
+
+        /// <summary>
+        /// Increase the stencil buffer by 1 and wrap to 0 if the result is above the maximum value.
+        /// </summary>
+        IncreaseWrap,
+
+        /// <summary>
+        /// Decrease the stencil buffer by 1 and wrap to maximum value if the result is below 0.
+        /// </summary>
+        DecreaseWrap
+    }
+}

--- a/osu.Framework/Platform/IGraphicsBackend.cs
+++ b/osu.Framework/Platform/IGraphicsBackend.cs
@@ -16,6 +16,11 @@ namespace osu.Framework.Platform
         bool VerticalSync { get; set; }
 
         /// <summary>
+        /// Initialises everything needed to create a window such as backbuffer parameters.
+        /// </summary>
+        void InitialiseBeforeWindowCreation();
+
+        /// <summary>
         /// Initialises the graphics backend, given the current window backend.
         /// It is assumed that the window backend has been initialised.
         /// </summary>

--- a/osu.Framework/Platform/PassthroughGraphicsBackend.cs
+++ b/osu.Framework/Platform/PassthroughGraphicsBackend.cs
@@ -36,6 +36,8 @@ namespace osu.Framework.Platform
 
         public abstract void SwapBuffers();
 
+        public abstract void InitialiseBeforeWindowCreation();
+
         public virtual void Initialise(IWindow window)
         {
             Context = CreateContext();

--- a/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs
@@ -57,6 +57,11 @@ namespace osu.Framework.Platform.SDL2
             return ret;
         }
 
+        public override void InitialiseBeforeWindowCreation()
+        {
+            SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_STENCIL_SIZE, 8);
+        }
+
         public override void Initialise(IWindow window)
         {
             if (!(window is SDL2DesktopWindow sdlWindow))

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -454,6 +454,7 @@ namespace osu.Framework.Platform
                 throw new InvalidOperationException($"Failed to initialise SDL: {SDL.SDL_GetError()}");
             }
 
+            SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_STENCIL_SIZE, 8);
             SDL.SDL_LogSetPriority((int)SDL.SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL.SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL.SDL_LogSetOutputFunction(logOutputDelegate = (_, categoryInt, priority, messagePtr) =>
             {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -454,7 +454,6 @@ namespace osu.Framework.Platform
                 throw new InvalidOperationException($"Failed to initialise SDL: {SDL.SDL_GetError()}");
             }
 
-            SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_STENCIL_SIZE, 8);
             SDL.SDL_LogSetPriority((int)SDL.SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL.SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL.SDL_LogSetOutputFunction(logOutputDelegate = (_, categoryInt, priority, messagePtr) =>
             {
@@ -499,6 +498,7 @@ namespace osu.Framework.Platform
             // so we deactivate it on startup.
             SDL.SDL_StopTextInput();
 
+            graphicsBackend.InitialiseBeforeWindowCreation();
             SDLWindowHandle = SDL.SDL_CreateWindow(title, Position.X, Position.Y, Size.Width, Size.Height, flags);
 
             Exists = true;


### PR DESCRIPTION
This adds `StencilInfo` and appropriate methods to renderers. It also adds an 8-bit stencil buffer to the screen buffers (please doublecheck if all window types have it, I only added it to the SDL window as I have no way to check if the mobile ones or OsuTkWindow work).
This is a part of my work towards #3510 - the even-odd fill algorithm is very easy to implement with a stencil buffer.