### PR TITLE
Fix performing a `Seek` on decouplable clock while coupled and stopped not updating the `CurrentTime`

### DIFF
--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -277,7 +277,7 @@ namespace osu.Framework.Tests.Clocks
         {
             decoupleable.Seek(1000);
 
-            Assert.AreEqual(source.CurrentTime, source.CurrentTime, "Source time should match coupled time.");
+            Assert.AreEqual(source.CurrentTime, decoupleable.CurrentTime, "Source time should match coupled time.");
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed while using this clock to implement a higher-level beatmap clock osu! side.