### PR TITLE
Fix naming of depth stencil function function type

### DIFF
--- a/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/OpenGLUtils.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.OpenGL
                 case DepthStencilFunction.GreaterThanOrEqual:
                     return DepthFunction.Gequal;
 
-                case DepthStencilFunction.Greater:
+                case DepthStencilFunction.GreaterThan:
                     return DepthFunction.Greater;
 
                 case DepthStencilFunction.NotEqual:
@@ -85,7 +85,7 @@ namespace osu.Framework.Graphics.OpenGL
                 case DepthStencilFunction.GreaterThanOrEqual:
                     return StencilFunction.Gequal;
 
-                case DepthStencilFunction.Greater:
+                case DepthStencilFunction.GreaterThan:
                     return StencilFunction.Greater;
 
                 case DepthStencilFunction.NotEqual:

--- a/osu.Framework/Graphics/Rendering/DepthStencilFunction.cs
+++ b/osu.Framework/Graphics/Rendering/DepthStencilFunction.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The test passes when the incoming value is greater than the value in the buffer.
         /// </summary>
-        Greater,
+        GreaterThan,
 
         /// <summary>
         /// The test passes when the incoming value is not equal to the value in the buffer.


### PR DESCRIPTION
Matches `LessThan`, `LessThanOrEqual`, and `GreaterThanOrEqual`.