### PR TITLE
Add an "arbitrary shape" drawable

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
@@ -24,7 +24,8 @@ namespace osu.Framework.Tests.Visual.Drawables
         private List<SpriteIcon> directionGuides = new List<SpriteIcon>();
         private bool isShapeValid;
         private Box boundngBox;
-        public TestSceneArbitraryShape ()
+
+        public TestSceneArbitraryShape()
         {
             Add(new CircularContainer()
             {
@@ -62,7 +63,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             shape.Texture = store.Get(@"sample-texture");
         }
 
-        protected override bool OnClick (ClickEvent e)
+        protected override bool OnClick(ClickEvent e)
         {
             DragHandle handle = new DragHandle() { Position = Content.ToLocalSpace(e.ScreenSpaceMousePosition) };
             handle.Dragged += onHandleDragged;
@@ -72,13 +73,13 @@ namespace osu.Framework.Tests.Visual.Drawables
             return true;
         }
 
-        private void onHandleDragged (DragHandle handle, DragEvent e)
+        private void onHandleDragged(DragHandle handle, DragEvent e)
         {
             handle.Position = Content.ToLocalSpace(e.ScreenSpaceMousePosition);
             isShapeValid = false;
         }
 
-        protected override void Update ()
+        protected override void Update()
         {
             base.Update();
             if (!isShapeValid)
@@ -86,9 +87,9 @@ namespace osu.Framework.Tests.Visual.Drawables
                 int guideIndex = -1;
                 Vector2 lastPoint = Vector2.Zero;
 
-                void addGuide (Vector2 from, Vector2 to)
+                void addGuide(Vector2 from, Vector2 to)
                 {
-                    if ( directionGuides.Count <= guideIndex )
+                    if (directionGuides.Count <= guideIndex)
                     {
                         SpriteIcon guide = new SpriteIcon()
                         {
@@ -135,19 +136,19 @@ namespace osu.Framework.Tests.Visual.Drawables
 
         private class DragHandle : Circle
         {
-            public DragHandle ()
+            public DragHandle()
             {
                 Size = new Vector2(10);
                 Origin = Anchor.Centre;
                 Colour = Colour4.Yellow;
             }
 
-            protected override bool OnDragStart (DragStartEvent e)
+            protected override bool OnDragStart(DragStartEvent e)
             {
                 return true;
             }
 
-            protected override void OnDrag (DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Dragged?.Invoke(this, e);
             }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         Anchor = Anchor.Centre,
                         Colour = Colour4.HotPink.Opacity(0.5f)
                     },
-                    shape = new ArbitraryShape()
+                    shape = new HoverableShape()
                     {
                         Anchor = Anchor.Centre
                     }
@@ -130,6 +130,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             boundngBox.Position = shape.Position;
             boundngBox.Size = shape.Size;
+            shape.Colour = shape.IsHovered ? Colour4.Red : Colour4.White;
         }
 
         private class DragHandle : Circle
@@ -152,6 +153,14 @@ namespace osu.Framework.Tests.Visual.Drawables
             }
 
             public event Action<DragHandle, DragEvent>? Dragged;
+        }
+
+        private class HoverableShape : ArbitraryShape
+        {
+            protected override bool OnHover(HoverEvent e)
+            {
+                return true;
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneArbitraryShape.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneArbitraryShape : FrameworkTestScene
+    {
+        private ArbitraryShape shape;
+        private Dropdown<FillRule> dropdown;
+        private List<DragHandle> handles = new List<DragHandle>();
+        private List<SpriteIcon> directionGuides = new List<SpriteIcon>();
+        private bool isShapeValid;
+        private Box boundngBox;
+        public TestSceneArbitraryShape ()
+        {
+            Add(new CircularContainer()
+            {
+                Masking = true,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box() { Colour = Colour4.Gray, RelativeSizeAxes = Axes.Both },
+                    boundngBox = new Box()
+                    {
+                        Anchor = Anchor.Centre,
+                        Colour = Colour4.HotPink.Opacity(0.5f)
+                    },
+                    shape = new ArbitraryShape()
+                    {
+                        Anchor = Anchor.Centre
+                    }
+                }
+            });
+            Add(dropdown = new BasicDropdown<FillRule>()
+            {
+                Width = 300,
+                Items = Enum.GetValues<FillRule>()
+            });
+
+            dropdown.Current.ValueChanged += v =>
+            {
+                shape.FillRule = v.NewValue;
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(TextureStore store)
+        {
+            shape.Texture = store.Get(@"sample-texture");
+        }
+
+        protected override bool OnClick (ClickEvent e)
+        {
+            DragHandle handle = new DragHandle() { Position = Content.ToLocalSpace(e.ScreenSpaceMousePosition) };
+            handle.Dragged += onHandleDragged;
+            Add(handle);
+            handles.Add(handle);
+            isShapeValid = false;
+            return true;
+        }
+
+        private void onHandleDragged (DragHandle handle, DragEvent e)
+        {
+            handle.Position = Content.ToLocalSpace(e.ScreenSpaceMousePosition);
+            isShapeValid = false;
+        }
+
+        protected override void Update ()
+        {
+            base.Update();
+            if (!isShapeValid)
+            {
+                int guideIndex = -1;
+                Vector2 lastPoint = Vector2.Zero;
+
+                void addGuide (Vector2 from, Vector2 to)
+                {
+                    if ( directionGuides.Count <= guideIndex )
+                    {
+                        SpriteIcon guide = new SpriteIcon()
+                        {
+                            Icon = FontAwesome.Solid.ChevronRight,
+                            Size = new Vector2(20),
+                            Colour = Colour4.HotPink,
+                            Origin = Anchor.Centre
+                        };
+                        directionGuides.Add(guide);
+                        Add(guide);
+
+                    }
+                    directionGuides[guideIndex].Position = (from + to) / 2;
+                    directionGuides[guideIndex].Rotation = MathF.Atan2((to - from).Y, (to - from).X) / MathF.PI * 180;
+                    guideIndex++;
+                }
+
+                shape.ClearVertices();
+                foreach (var i in handles)
+                {
+                    var pos = i.Position - Content.DrawSize / 2;
+                    shape.AddVertex(pos);
+                    if (guideIndex >= 0)
+                    {
+                        addGuide(lastPoint, i.Position);
+                    }
+                    else guideIndex++;
+                    lastPoint = i.Position;
+                }
+                if (handles.Count >= 3)
+                {
+                    addGuide(lastPoint, handles[0].Position);
+                }
+                isShapeValid = true;
+
+            }
+            if (handles.Any())
+                shape.Position = handles[0].Position - Content.DrawSize / 2 - shape.PositionInBoundingBox(handles[0].Position - Content.DrawSize / 2);
+
+            boundngBox.Position = shape.Position;
+            boundngBox.Size = shape.Size;
+        }
+
+        private class DragHandle : Circle
+        {
+            public DragHandle ()
+            {
+                Size = new Vector2(10);
+                Origin = Anchor.Centre;
+                Colour = Colour4.Yellow;
+            }
+
+            protected override bool OnDragStart (DragStartEvent e)
+            {
+                return true;
+            }
+
+            protected override void OnDrag (DragEvent e)
+            {
+                Dragged?.Invoke(this, e);
+            }
+
+            public event Action<DragHandle, DragEvent>? Dragged;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Shapes/ArbitraryShape.cs
+++ b/osu.Framework/Graphics/Shapes/ArbitraryShape.cs
@@ -1,0 +1,286 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Caching;
+using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+
+namespace osu.Framework.Graphics.Shapes
+{
+    /// <summary>
+    /// An arbitrary shape defined by a set of vertices forming a closed curve.
+    /// </summary>
+    public partial class ArbitraryShape : Drawable
+    {
+        public IShader RoundedTextureShader { get; private set; }
+        public IShader TextureShader { get; private set; }
+
+        [Resolved]
+        private IRenderer renderer { get; set; }
+        private ulong verticeInvalidationId = 1;
+
+        public ArbitraryShape()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        private FillRule fillRule = FillRule.NonZero;
+
+        /// <summary>
+        /// Defines how an <see cref="ArbitraryShape"/> should be rendered.
+        /// The default is <see cref="FillRule.NonZero"/>.
+        /// </summary>
+        public FillRule FillRule
+        {
+            get => fillRule;
+            set
+            {
+                if (value == fillRule)
+                    return;
+
+                fillRule = value;
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+        private readonly List<Vector2> vertices = new List<Vector2>();
+
+        public IReadOnlyList<Vector2> Vertices
+        {
+            get => vertices;
+            set
+            {
+                vertices.Clear();
+                vertices.AddRange(value);
+
+                vertexBoundsCache.Invalidate();
+
+                verticeInvalidationId++;
+                Invalidate(Invalidation.DrawSize);
+            }
+        }
+
+        public override Axes RelativeSizeAxes
+        {
+            get => base.RelativeSizeAxes;
+            set
+            {
+                if ((AutoSizeAxes & value) != 0)
+                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
+
+                base.RelativeSizeAxes = value;
+            }
+        }
+
+        private Axes autoSizeAxes;
+
+        /// <summary>
+        /// Controls which <see cref="Axes"/> are automatically sized w.r.t. the bounds of the vertices.
+        /// It is not allowed to manually set <see cref="Size"/> (or <see cref="Width"/> / <see cref="Height"/>)
+        /// on any <see cref="Axes"/> which are automatically sized.
+        /// </summary>
+        public virtual Axes AutoSizeAxes
+        {
+            get => autoSizeAxes;
+            set
+            {
+                if (value == autoSizeAxes)
+                    return;
+
+                if ((RelativeSizeAxes & value) != 0)
+                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
+
+                autoSizeAxes = value;
+                OnSizingChanged();
+            }
+        }
+
+        public override float Width
+        {
+            get
+            {
+                if (AutoSizeAxes.HasFlagFast(Axes.X))
+                    return base.Width = vertexBounds.Width;
+
+                return base.Width;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.X) != 0)
+                    throw new InvalidOperationException($"The width of a {nameof(ArbitraryShape)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Width = value;
+            }
+        }
+
+        public override float Height
+        {
+            get
+            {
+                if (AutoSizeAxes.HasFlagFast(Axes.Y))
+                    return base.Height = vertexBounds.Height;
+
+                return base.Height;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.Y) != 0)
+                    throw new InvalidOperationException($"The height of a {nameof(ArbitraryShape)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Height = value;
+            }
+        }
+
+        public override Vector2 Size
+        {
+            get
+            {
+                if (AutoSizeAxes != Axes.None)
+                    return base.Size = vertexBounds.Size;
+
+                return base.Size;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.Both) != 0)
+                    throw new InvalidOperationException($"The Size of a {nameof(ArbitraryShape)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Size = value;
+            }
+        }
+
+        private readonly Cached<RectangleF> vertexBoundsCache = new Cached<RectangleF>();
+
+        private RectangleF vertexBounds
+        {
+            get
+            {
+                if (vertexBoundsCache.IsValid)
+                    return vertexBoundsCache.Value;
+
+                if (vertices.Count > 0)
+                {
+                    float minX = 0;
+                    float minY = 0;
+                    float maxX = 0;
+                    float maxY = 0;
+
+                    foreach (var v in vertices)
+                    {
+                        minX = Math.Min(minX, v.X);
+                        minY = Math.Min(minY, v.Y);
+                        maxX = Math.Max(maxX, v.X);
+                        maxY = Math.Max(maxY, v.Y);
+                    }
+
+                    return vertexBoundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+                }
+
+                return vertexBoundsCache.Value = new RectangleF(0, 0, 0, 0);
+            }
+        }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            //var localPos = ToLocalSpace(screenSpacePos);
+            //float pathRadiusSquared = PathRadius * PathRadius;
+
+            //foreach ( var t in segments )
+            //{
+            //    if ( t.DistanceSquaredToPoint(localPos) <= pathRadiusSquared )
+            //        return true;
+            //}
+
+            return false;
+        }
+
+        public Vector2 PositionInBoundingBox(Vector2 pos) => pos - vertexBounds.TopLeft;
+
+        public void ClearVertices()
+        {
+            if (vertices.Count == 0)
+                return;
+
+            vertices.Clear();
+
+            vertexBoundsCache.Invalidate();
+
+            verticeInvalidationId++;
+            Invalidate(Invalidation.DrawSize);
+        }
+
+        public void AddVertex(Vector2 pos)
+        {
+            vertices.Add(pos);
+
+            vertexBoundsCache.Invalidate();
+
+            verticeInvalidationId++;
+            Invalidate(Invalidation.DrawSize);
+        }
+
+        private Texture texture;
+
+        public Texture Texture
+        {
+            get => texture ?? renderer?.WhitePixel;
+            set
+            {
+                if (texture == value)
+                    return;
+
+                texture = value;
+
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        protected override DrawNode CreateDrawNode() => new ArbitraryShapeDrawNode(this);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            texture?.Dispose();
+            texture = null;
+        }
+    }
+
+    /// <summary>
+    /// Defines how a shape's fill should be rendered.
+    /// </summary>
+    public enum FillRule
+    {
+        /// <summary>
+        /// A point is considered inside the shape if a ray from it intersects lines formed by the vertices so that
+        /// the difference between clockwise and counterclockwise winding lines is non-zero. This requires a stencil buffer.
+        /// </summary>
+        NonZero,
+
+        /// <summary>
+        /// A point is considered inside the shape if a ray from it intersects lines formed by the vertices an odd number of times
+        /// and outside if it intersects an even number. This requires a stencil buffer.
+        /// </summary>
+        EvenOdd,
+
+        /// <summary>
+        /// The shape is convex and rendered as a triangle fan.
+        /// </summary>
+        Fan
+    }
+}

--- a/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
+++ b/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
@@ -35,12 +35,12 @@ namespace osu.Framework.Graphics.Shapes
 
             private FillRule fillRule;
 
-            public ArbitraryShapeDrawNode (ArbitraryShape source)
+            public ArbitraryShapeDrawNode(ArbitraryShape source)
                 : base(source)
             {
             }
 
-            public override void ApplyState ()
+            public override void ApplyState()
             {
                 base.ApplyState();
 
@@ -105,7 +105,7 @@ namespace osu.Framework.Graphics.Shapes
                 int winding = 0;
                 void setWinding()
                 {
-                    if(winding < 0)
+                    if (winding < 0)
                     {
                         renderer.PushStencilInfo(new StencilInfo(
                             true, DepthStencilFunction.Always, 1,
@@ -120,7 +120,6 @@ namespace osu.Framework.Graphics.Shapes
                         ));
                     }
                 }
-                
                 renderer.PushLocalMatrix(DrawInfo.Matrix);
                 float lastAngle = getAngle(vertices[1] - vertices[0]);
                 for (int i = 2; i < vertices.Count; i++)

--- a/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
+++ b/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Primitives;
+using osuTK.Graphics;
+using System;
+using osu.Framework.Graphics.Colour;
+using System.Linq;
+
+namespace osu.Framework.Graphics.Shapes
+{
+    public partial class ArbitraryShape
+    {
+        private class ArbitraryShapeDrawNode : DrawNode
+        {
+            protected new ArbitraryShape Source => (ArbitraryShape)base.Source;
+
+            private ulong verticeInvalidationId;
+            private readonly List<Vector2> vertices = new List<Vector2>();
+
+            private Quad screenSpaceQuad;
+            private Vector2 drawSize;
+
+            private IShader shader;
+            private IShader roundedShader;
+            private Texture texture;
+
+            private FillRule fillRule;
+
+            public ArbitraryShapeDrawNode (ArbitraryShape source)
+                : base(source)
+            {
+            }
+
+            public override void ApplyState ()
+            {
+                base.ApplyState();
+
+                if (verticeInvalidationId != Source.verticeInvalidationId)
+                {
+                    vertices.Clear();
+                    vertices.AddRange(Source.vertices.Select(x => x - Source.vertexBounds.TopLeft));
+
+                    verticeInvalidationId = Source.verticeInvalidationId;
+                }
+
+                screenSpaceQuad = Source.ScreenSpaceDrawQuad;
+                drawSize = Source.DrawSize;
+
+                texture = Source.Texture;
+                shader = Source.TextureShader;
+                roundedShader = Source.RoundedTextureShader;
+                fillRule = Source.fillRule;
+            }
+
+            public override void Draw(IRenderer renderer)
+            {
+                if (vertices.Count < 3)
+                    return;
+
+                base.Draw(renderer);
+
+                if (fillRule == FillRule.NonZero)
+                    drawNonZero(renderer);
+                else if (fillRule == FillRule.EvenOdd)
+                    drawEvenOdd(renderer);
+                else
+                    drawFan(renderer);
+            }
+
+            private float getAngle(Vector2 diff)
+            {
+                return MathF.Atan2(diff.Y, diff.X);
+            }
+
+            private int getWinding(float from, float to)
+            {
+                float diff = (to - from + MathF.PI) % (MathF.PI * 2);
+                if (diff < 0)
+                    diff += MathF.PI * 2;
+
+                return diff - MathF.PI >= 0 ? 1 : -1;
+            }
+
+            private void drawNonZero(IRenderer renderer)
+            {
+                var activeShader = renderer.IsMaskingActive ? roundedShader : shader;
+                shader.Bind();
+
+                // clear stencil where we will draw
+                renderer.PushStencilInfo(new StencilInfo(stencilTest: true, DepthStencilFunction.Always, 0));
+                renderer.DrawQuad(renderer.WhitePixel, screenSpaceQuad, Color4.Transparent);
+                renderer.PopStencilInfo();
+
+                // we are counting the amount of times a clockwise and counterclockwise triangle was
+                // drawn over a pixel
+                int winding = 0;
+                void setWinding()
+                {
+                    if(winding < 0)
+                    {
+                        renderer.PushStencilInfo(new StencilInfo(
+                            true, DepthStencilFunction.Always, 1,
+                            passed: StencilOperation.DecreaseWrap
+                        ));
+                    }
+                    else
+                    {
+                        renderer.PushStencilInfo(new StencilInfo(
+                            true, DepthStencilFunction.Always, 1,
+                            passed: StencilOperation.IncreaseWrap
+                        ));
+                    }
+                }
+                
+                renderer.PushLocalMatrix(DrawInfo.Matrix);
+                float lastAngle = getAngle(vertices[1] - vertices[0]);
+                for (int i = 2; i < vertices.Count; i++)
+                {
+                    float angle = getAngle(vertices[i] - vertices[0]);
+                    int nextWinding = getWinding(lastAngle, angle);
+                    if (nextWinding != winding)
+                    {
+                        if (winding != 0)
+                            renderer.PopStencilInfo();
+                        winding = nextWinding;
+                        setWinding();
+                    }
+                    lastAngle = angle;
+
+                    renderer.DrawTriangle(renderer.WhitePixel, new Primitives.Triangle(
+                        vertices[0],
+                        vertices[i - 1],
+                        vertices[i]
+                    ), Color4.Transparent);
+                }
+
+                renderer.PopStencilInfo();
+                renderer.PopLocalMatrix();
+
+                shader.Unbind();
+                activeShader.Bind();
+
+                // draw over the stencil
+                renderer.PushStencilInfo(new StencilInfo(stencilTest: true, DepthStencilFunction.NotEqual, 0));
+                renderer.DrawQuad(texture, screenSpaceQuad, DrawColourInfo.Colour);
+                renderer.PopStencilInfo();
+
+                activeShader.Unbind();
+            }
+
+            private void drawEvenOdd(IRenderer renderer)
+            {
+                var activeShader = renderer.IsMaskingActive ? roundedShader : shader;
+                shader.Bind();
+
+                // clear stencil where we will draw
+                renderer.PushStencilInfo(new StencilInfo(stencilTest: true, DepthStencilFunction.Always, 0));
+                renderer.DrawQuad(renderer.WhitePixel, screenSpaceQuad, Color4.Transparent);
+                renderer.PopStencilInfo();
+
+                // even-odd will filp the stencil value each time we draw over the pixel
+                renderer.PushStencilInfo(new StencilInfo(
+                    true, DepthStencilFunction.Always, 1,
+                    passed: StencilOperation.Invert
+                ));
+                renderer.PushLocalMatrix(DrawInfo.Matrix);
+                for (int i = 2; i < vertices.Count; i++)
+                {
+                    renderer.DrawTriangle(renderer.WhitePixel, new Primitives.Triangle(
+                        vertices[0],
+                        vertices[i - 1],
+                        vertices[i]
+                    ), Color4.Transparent);
+                }
+
+                renderer.PopLocalMatrix();
+                renderer.PopStencilInfo();
+
+                shader.Unbind();
+                activeShader.Bind();
+
+                // draw over the stencil
+                renderer.PushStencilInfo(new StencilInfo(stencilTest: true, DepthStencilFunction.NotEqual, 0));
+                renderer.DrawQuad(texture, screenSpaceQuad, DrawColourInfo.Colour);
+                renderer.PopStencilInfo();
+
+                activeShader.Unbind();
+            }
+
+            private Vector2 relativePosition(Vector2 localPos) => Vector2.Divide(localPos, drawSize);
+
+            private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
+                ? ((SRGBColour)DrawColourInfo.Colour).Linear
+                : DrawColourInfo.Colour.Interpolate(relativePosition(localPos)).Linear;
+
+            private void drawFan(IRenderer renderer)
+            {
+                var activeShader = renderer.IsMaskingActive ? roundedShader : shader;
+                activeShader.Bind();
+
+                renderer.PushLocalMatrix(DrawInfo.Matrix);
+                texture.Bind();
+                var vertexAction = renderer.DefaultQuadBatch.AddAction;
+                RectangleF texRect = texture.GetTextureRect();
+                Vector4 texVec = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom);
+                for (int i = 2; i < vertices.Count; i++)
+                {
+                    var v0 = vertices[0];
+                    var v1 = vertices[i - 1];
+                    var v2 = vertices[i];
+                    vertexAction(new TexturedVertex2D
+                    {
+                        Position = v0,
+                        TexturePosition = texRect.Location + texRect.Size * relativePosition(v0),
+                        TextureRect = texVec,
+                        Colour = colourAt(v0)
+                    });
+                    vertexAction(new TexturedVertex2D
+                    {
+                        Position = v1,
+                        TexturePosition = texRect.Location + texRect.Size * relativePosition(v1),
+                        TextureRect = texVec,
+                        Colour = colourAt(v1)
+                    });
+                    vertexAction(new TexturedVertex2D
+                    {
+                        Position = v1,
+                        TexturePosition = texRect.Location + texRect.Size * relativePosition(v1),
+                        TextureRect = texVec,
+                        Colour = colourAt(v1)
+                    });
+                    vertexAction(new TexturedVertex2D
+                    {
+                        Position = v2,
+                        TexturePosition = texRect.Location + texRect.Size * relativePosition(v2),
+                        TextureRect = texVec,
+                        Colour = colourAt(v2)
+                    });
+                }
+
+                renderer.PopLocalMatrix();
+                activeShader.Unbind();
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
+++ b/osu.Framework/Graphics/Shapes/ArbitraryShape_DrawNode.cs
@@ -76,12 +76,12 @@ namespace osu.Framework.Graphics.Shapes
                     drawFan(renderer);
             }
 
-            private float getAngle(Vector2 diff)
+            private static float getAngle(Vector2 diff)
             {
                 return MathF.Atan2(diff.Y, diff.X);
             }
 
-            private int getWinding(float from, float to)
+            private static int getWinding(float from, float to)
             {
                 float diff = (to - from + MathF.PI) % (MathF.PI * 2);
                 if (diff < 0)


### PR DESCRIPTION
Resolves #3510
Allows you to draw a vector-graphics-ish shape defined by a closed curve (of vertices).
There are 3 fill rules to select from: [NonZero](https://en.wikipedia.org/wiki/Nonzero-rule) (default for vector graphics), [EvenOdd](https://en.wikipedia.org/wiki/Even–odd_rule) and Fan (for convex shapes)
![image](https://user-images.githubusercontent.com/40297338/184401408-c76d580c-db80-4540-97f6-7b811022fb6c.png)
![image](https://user-images.githubusercontent.com/40297338/184401362-00e5d2cd-83fb-4aea-9d28-20b3736b322a.png)

The implementation can also check for "insidedness" of a point in the `ReceivePositionalInputAt` method.
Please let me know if the `FillRule` docs are a bit confusing - I don't really know how to word them better so we will need to figure something out together.