### PR TITLE
Attempt to fix NRT on Mono

### DIFF
--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -136,7 +136,7 @@ namespace osu.Framework.Extensions.TypeExtensions
 #if NET6_0_OR_GREATER
             return isNullableInfo(new NullabilityInfoContext().Create(eventInfo));
 #else
-            return false;
+            return checkNullabilityMobile(eventInfo.CustomAttributes);
 #endif
         }
 
@@ -156,7 +156,7 @@ namespace osu.Framework.Extensions.TypeExtensions
 #if NET6_0_OR_GREATER
             return isNullableInfo(new NullabilityInfoContext().Create(parameterInfo));
 #else
-            return false;
+            return checkNullabilityMobile(parameterInfo.CustomAttributes);
 #endif
         }
 
@@ -176,7 +176,7 @@ namespace osu.Framework.Extensions.TypeExtensions
 #if NET6_0_OR_GREATER
             return isNullableInfo(new NullabilityInfoContext().Create(fieldInfo));
 #else
-            return false;
+            return checkNullabilityMobile(fieldInfo.CustomAttributes);
 #endif
         }
 
@@ -196,12 +196,18 @@ namespace osu.Framework.Extensions.TypeExtensions
 #if NET6_0_OR_GREATER
             return isNullableInfo(new NullabilityInfoContext().Create(propertyInfo));
 #else
-            return false;
+            return checkNullabilityMobile(propertyInfo.CustomAttributes);
 #endif
         }
 
 #if NET6_0_OR_GREATER
         private static bool isNullableInfo(NullabilityInfo info) => info.WriteState == NullabilityState.Nullable || info.ReadState == NullabilityState.Nullable;
+#else
+        /// <summary>
+        /// Mono + netstandard2.1 doesn't truly support NullabilityInfo. This falls back to checking the attributes for an internal compiler-generated member.
+        /// </summary>
+        private static bool checkNullabilityMobile(IEnumerable<CustomAttributeData> customAttributes)
+            => RuntimeInfo.IsMobile && customAttributes.Any(a => a.AttributeType?.FullName == "System.Runtime.CompilerServices.NullableAttribute");
 #endif
     }
 


### PR DESCRIPTION
I haven't tested this.

Can someone set up with a mobile deployment pipeline check that:
- These tests run _with_ failures on mobile on master, and _without_ failures on this branch: https://github.com/ppy/osu-framework/blob/master/osu.Framework.Tests/Extensions/TestIsNullableTypeExtensions.cs You'll need to hoist this test up into a visual test and run on the actual device.
- osu! runs fine after reverting this PR and importing a beatmap: https://github.com/ppy/osu/pull/19677/files