### PR TITLE
Make position transfer more reliable when track is stopped

### DIFF
--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -102,6 +102,7 @@ namespace osu.Framework.Tests.Clocks
             decoupleable.ProcessFrame();
 
             Assert.IsFalse(decoupleable.IsRunning, "Coupled should not be running.");
+            Assert.That(decoupleable.CurrentTime, Is.EqualTo(source.CurrentTime));
         }
 
         /// <summary>


### PR DESCRIPTION
This came up when attempting to use coupled mode in the editor (it was using decoupled until now).
When the track finished, the decoupled clock would be at a different `CurrentTime` to the source track (sometimes ahead, sometimes behind it) due to a final value transfer not occurring.

This would in turn cause the track to not loop correctly, as the editor was relying on checking `Current` vs `Length` to check whether playback has finished.

I know this is adding even more complexity to the existing clocks, but right now I'm just trying to get everything working. I'm plannning to probably do a full rewrite of interpolating/decoupling in the future.