### PR TITLE
Add `LocalisableString.IsNullOrEmpty` and `LocalisableString.IsNullOrWhiteSpace`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using NUnit.Framework;
 using osu.Framework.Localisation;
 
@@ -98,6 +99,34 @@ namespace osu.Framework.Tests.Localisation
         public void TestLocalisableStringDoesNotEqualNull()
         {
             testEquals(false, new LocalisableString(), new RomanisableString(makeStringA, makeStringB));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalse")]
+        public void TestIsNullOrEmpty()
+        {
+            Assert.That(LocalisableString.IsNullOrEmpty(null), Is.EqualTo(string.IsNullOrEmpty(null)));
+            Assert.That(LocalisableString.IsNullOrEmpty(string.Empty), Is.EqualTo(string.IsNullOrEmpty(string.Empty)));
+            Assert.That(LocalisableString.IsNullOrEmpty(""), Is.EqualTo(string.IsNullOrEmpty("")));
+            Assert.That(LocalisableString.IsNullOrEmpty(" "), Is.EqualTo(string.IsNullOrEmpty(" ")));
+            Assert.That(LocalisableString.IsNullOrEmpty("a"), Is.EqualTo(string.IsNullOrEmpty("a")));
+
+            Assert.IsTrue(LocalisableString.IsNullOrEmpty(new LocalisableString())); // default(LocalisableString)
+            Assert.IsFalse(LocalisableString.IsNullOrEmpty(new TranslatableString("key", "fallback")));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalse")]
+        public void TestIsNullOrWhiteSpace()
+        {
+            Assert.That(LocalisableString.IsNullOrWhiteSpace(null), Is.EqualTo(string.IsNullOrWhiteSpace(null)));
+            Assert.That(LocalisableString.IsNullOrWhiteSpace(string.Empty), Is.EqualTo(string.IsNullOrWhiteSpace(string.Empty)));
+            Assert.That(LocalisableString.IsNullOrWhiteSpace(""), Is.EqualTo(string.IsNullOrWhiteSpace("")));
+            Assert.That(LocalisableString.IsNullOrWhiteSpace(" "), Is.EqualTo(string.IsNullOrWhiteSpace(" ")));
+            Assert.That(LocalisableString.IsNullOrWhiteSpace("a"), Is.EqualTo(string.IsNullOrWhiteSpace("a")));
+
+            Assert.IsTrue(LocalisableString.IsNullOrWhiteSpace(new LocalisableString())); // default(LocalisableString)
+            Assert.IsFalse(LocalisableString.IsNullOrWhiteSpace(new TranslatableString("key", "fallback")));
         }
 
         private static void testEquals<T>(bool expected, T a, T b)

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace osu.Framework.Localisation
 {
@@ -43,6 +44,53 @@ namespace osu.Framework.Localisation
         /// </summary>
         /// <param name="interpolation">The interpolated string containing format and arguments.</param>
         public static LocalisableString Interpolate(FormattableString interpolation) => new LocalisableFormattableString(interpolation);
+
+        /// <summary>
+        /// Indicates whether the specified <see cref="LocalisableString"/> is <see langword="null"/> or an empty <see langword="string"/>.
+        /// </summary>
+        /// <remarks>
+        /// Will always be false for non-<see langword="string"/> data (e.g. <see cref="TranslatableString"/>).
+        /// </remarks>
+        /// <param name="value">The <see cref="LocalisableString"/> to test.</param>
+        /// <returns><see langword="true"/> if the <paramref name="value"/> parameter is <see langword="null"/> or an empty <see langword="string"/> (&quot;&quot;);
+        /// otherwise, <see langword="false"/>.</returns>
+        public static bool IsNullOrEmpty([NotNullWhen(false)] LocalisableString? value)
+        {
+            if (value is not LocalisableString localisable)
+                return true;
+
+            if (localisable.Data == null)
+                return true;
+
+            if (localisable.Data is not string strData)
+                return false;
+
+            return string.IsNullOrEmpty(strData);
+        }
+
+        /// <summary>
+        /// Indicates whether the specified <see cref="LocalisableString"/> is <see langword="null"/>, an empty <see langword="string"/>,
+        /// or a <see langword="string"/> that consists of only white-space characters.
+        /// </summary>
+        /// <remarks>
+        /// Will always be false for non-<see langword="string"/> data (e.g. <see cref="TranslatableString"/>).
+        /// </remarks>
+        /// <param name="value">The <see cref="LocalisableString"/> to test.</param>
+        /// <returns><see langword="true"/> if the <paramref name="value"/> parameter is <see langword="null"/>, an empty <see langword="string"/> (&quot;&quot;),
+        /// or a <see langword="string"/> that consists of only white-space characters.</returns>
+        public static bool IsNullOrWhiteSpace([NotNullWhen(false)] LocalisableString? value)
+        {
+            if (value is not LocalisableString localisable)
+                return true;
+
+            if (localisable.Data == null)
+                return true;
+
+            if (localisable.Data is not string strData)
+                return false;
+
+            return string.IsNullOrWhiteSpace(strData);
+        }
 
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;


### PR DESCRIPTION
For use in https://github.com/ppy/osu/pull/19695

Matches the interface exposed by `string`: https://source.dot.net/#System.Private.CoreLib/String.cs,486