### PR TITLE
Sourcelink improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,8 +37,4 @@
     <PackageProjectUrl>https://github.com/ppy/osu-framework</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ppy/osu-framework</RepositoryUrl>
   </PropertyGroup>
-  <PropertyGroup Label="Sourcelink3">
-    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
-    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
-  </PropertyGroup>
 </Project>

--- a/build/build.cake
+++ b/build/build.cake
@@ -135,6 +135,7 @@ Task("PackFramework")
                 args.Append($"/p:GenerateDocumentationFile=true");
                 args.Append("/p:IncludeSymbols=true");
                 args.Append("/p:SymbolPackageFormat=snupkg");
+                args.Append("/p:PublishRepositoryUrl=true");
 
                 return args;
             }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="managed-midi" Version="1.9.14" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.11.0" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -16,10 +16,6 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <PackageTags>osu game framework</PackageTags>
   </PropertyGroup>
-  <PropertyGroup Label="Sourcelink3" Condition=" '$(EnableSourceLink)' == 'true' ">
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="managed-midi" Version="1.9.14" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />


### PR DESCRIPTION
While checking to see why Sourcelink isn't working osu!-side, I came up with a few things.

1. Update the package from `1.0.0` to `1.1.1`.
2. Remove embedded PDBs. Embedding PDBs [is not recommended](https://github.com/dotnet/sourcelink#alternative-pdb-distribution) by Microsoft. The downside to this is that we lose local symbolicated debugging support (which is why it was working for me), but we don't ever really debug with a local package anyway so I don't think this will affect us.

Compare:
- https://www.nuget.org/packages/ppy.osu.Framework/2022.818.0
- https://www.nuget.org/packages/smoogipoo.osu.Framework/0.0.0

Notice how my package has a "Download symbols" link. I believe this is the source of the issue - either by embedding the PDBs, or these extra options, nuget wasn't getting the symbols correctly. Or it's possible that the AppVeyor config is busted, though the [last deploy](https://ci.appveyor.com/project/peppy/osu-framework-a4n7e/build/job/txmb0ix479robbd5) indicates that the symbols package was uploaded...

My package also works - you can step into and breakpoint inside osu!framework constructs. But for me it looks up the local files because the file paths are stored along with the PDBs in the source link data, so I'm awaiting further testing by @peppy before unblocking.