### PR TITLE
Fix potential startup crash if resolution/display pair from configuration results in no valid resolution

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1229,12 +1229,29 @@ namespace osu.Framework.Platform
                     break;
 
                 case WindowState.Fullscreen:
-                    var closestMode = getClosestDisplayMode(sizeFullscreen.Value, currentDisplayMode.Value.RefreshRate, currentDisplay.Index);
+                    try
+                    {
+                        var closestMode = getClosestDisplayMode(sizeFullscreen.Value, currentDisplayMode.Value.RefreshRate, currentDisplay.Index);
 
-                    Size = new Size(closestMode.w, closestMode.h);
+                        Size = new Size(closestMode.w, closestMode.h);
 
-                    SDL.SDL_SetWindowDisplayMode(SDLWindowHandle, ref closestMode);
-                    SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN);
+                        SDL.SDL_SetWindowDisplayMode(SDLWindowHandle, ref closestMode);
+                        SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN);
+                    }
+                    catch
+                    {
+                        Logger.Log($"Unable to set specified fullscreen resolution ({sizeFullscreen} on display {windowDisplayIndexBindable}), resetting to defaults and trying again");
+
+                        // If a fullscreen display mode could not be retrieved, fallback to defaults and try again.
+                        if (!sizeFullscreen.IsDefault)
+                        {
+                            sizeFullscreen.SetDefault();
+                            windowDisplayIndexBindable.SetDefault();
+                            updateWindowSpecifics();
+                            return;
+                        }
+                    }
+
                     break;
 
                 case WindowState.FullscreenBorderless:


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/19877#issuecomment-1221438234.

I wasn't able to reproduce what the user was seeing even when trying my best to break it, but have tested the flow works by artifically adding an exception:

```diff
diff --git a/osu.Framework/Platform/SDL2DesktopWindow.cs b/osu.Framework/Platform/SDL2DesktopWindow.cs
index 8ca11367f..d68d8368f 100644
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1233,6 +1233,9 @@ private void updateWindowStateAndSize()
                     {
                         var closestMode = getClosestDisplayMode(sizeFullscreen.Value, currentDisplayMode.Value.RefreshRate, currentDisplay.Index);
 
+                        if (!sizeFullscreen.IsDefault)
+                            throw new InvalidOperationException("test");
+
                         Size = new Size(closestMode.w, closestMode.h);
 
                         SDL.SDL_SetWindowDisplayMode(SDLWindowHandle, ref closestMode);

```