### PR TITLE
Add method to get configuration from a `ConfigManager` for logging purposes

### DIFF
--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Configuration
         /// Get the full configuration for logging purposes.
         /// </summary>
         /// <remarks>
-        /// Excludes any potentially sensitive information via </remarks>
+        /// Excludes any potentially sensitive information via <see cref="CheckLookupContainsPrivateInformation"/>.</remarks>
         /// <returns></returns>
         public virtual IDictionary<TLookup, string> GetCurrentConfigurationForLogging() => ConfigStore
                                                                                            .Where(kvp => !CheckLookupContainsPrivateInformation(kvp.Key))

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
@@ -33,6 +34,23 @@ namespace osu.Framework.Configuration
         {
             this.defaultOverrides = defaultOverrides;
         }
+
+        /// <summary>
+        /// Get the full configuration for logging purposes.
+        /// </summary>
+        /// <remarks>
+        /// Excludes any potentially sensitive information via </remarks>
+        /// <returns></returns>
+        public virtual IDictionary<TLookup, string> GetCurrentConfigurationForLogging() => ConfigStore
+                                                                                           .Where(kvp => !CheckLookupContainsPrivateInformation(kvp.Key))
+                                                                                           .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToString());
+
+        /// <summary>
+        /// Check whether a specific lookup may contain private user information.
+        /// </summary>
+        /// <param name="lookup">The lookup type to check.</param>
+        /// <returns>Whether private information is present.</returns>
+        protected virtual bool CheckLookupContainsPrivateInformation(TLookup lookup) => false;
 
         /// <summary>
         /// Set all required default values via Set() calls.


### PR DESCRIPTION
Implementation borrowed from [OsuConfigManager](https://github.com/ppy/osu/blob/3fb3a18e68e58bb016d3340a84c44517b3b520f7/osu.Game/Configuration/OsuConfigManager.cs#L175-L187).

Allows logging framework configuration to sentry, which can be quite useful in tracking down certain issues. The case I'm interested in which made me want to add this was knowing whether the game is running in single or multithreaded mode.