### PR TITLE
Do not apply hidden state to system drives in directory selector

### DIFF
--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -29,7 +29,8 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 bool isHidden = directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true;
 
-                // System drives show up as `System | Hidden | Directory` but shouldn't be shown in a hidden state.
+                // On Windows, system drives are returned with `System | Hidden | Directory` file attributes,
+                // but the expectation is that they shouldn't be shown in a hidden state.
                 bool isSystemDrive = directory?.Parent == null;
 
                 if (isHidden && !isSystemDrive)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -27,7 +27,8 @@ namespace osu.Framework.Graphics.UserInterface
 
             try
             {
-                if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
+                if (directory?.Attributes.HasFlagFast(FileAttributes.System) == true) { }
+                else if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
                     ApplyHiddenState();
             }
             catch (UnauthorizedAccessException)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -30,9 +30,9 @@ namespace osu.Framework.Graphics.UserInterface
                 bool isHidden = directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true;
 
                 // System drives show up as `System | Hidden | Directory` but shouldn't be shown in a hidden state.
-                bool isSystem = directory?.Attributes.HasFlagFast(FileAttributes.System) == true;
+                bool isSystemDrive = directory?.Parent == null;
 
-                if (isHidden && !isSystem)
+                if (isHidden && !isSystemDrive)
                     ApplyHiddenState();
             }
             catch (UnauthorizedAccessException)

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -27,8 +27,12 @@ namespace osu.Framework.Graphics.UserInterface
 
             try
             {
-                if (directory?.Attributes.HasFlagFast(FileAttributes.System) == true) { }
-                else if (directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true)
+                bool isHidden = directory?.Attributes.HasFlagFast(FileAttributes.Hidden) == true;
+
+                // System drives show up as `System | Hidden | Directory` but shouldn't be shown in a hidden state.
+                bool isSystem = directory?.Attributes.HasFlagFast(FileAttributes.System) == true;
+
+                if (isHidden && !isSystem)
                     ApplyHiddenState();
             }
             catch (UnauthorizedAccessException)


### PR DESCRIPTION
A small QoL commit to fix the DirectorySelectorDirectory applying hidden state to system drives, thus fixing a color discrepancy between local drives and network drives. Breadcrumbs are not affected by this issue.

**Seen on: osu-framework & osu-lazer**
**Tested on: Windows 10 21H2 (Build 19044.1826)**

Original behavior (master):
![master-Test](https://user-images.githubusercontent.com/23091058/185960808-915172d6-78de-47f3-95ac-66ec0add8a7c.png)

Additional Information (`directory` Attributes):
Local Drive:
![master-localDrive](https://user-images.githubusercontent.com/23091058/185961816-7e204d5b-2721-45d7-b6fa-f8ca7cdcb24e.png)
Network Drive:
![master-networkDrive](https://user-images.githubusercontent.com/23091058/185961829-7dbf310a-226e-4020-bd67-bcfa7ac84525.png)

Fixed:
![fix-Test](https://user-images.githubusercontent.com/23091058/185960957-e7ddb96f-08f2-42b4-a7f3-3ce789b7c89d.png)

P.S This is my first time contributing to an open-source project, feel free to point out anything that needs to be improved. Thank you.
 