### PR TITLE
Expose method to allow implementations to perform operations when drawable items change in `RearrangeableListContainer`

### DIFF
--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -75,6 +75,13 @@ namespace osu.Framework.Graphics.Containers
             Items.CollectionChanged += collectionChanged;
         }
 
+        /// <summary>
+        /// Fired whenever new drawable items are added or removed from <see cref="ListContainer"/>.
+        /// </summary>
+        protected virtual void OnItemsChanged()
+        {
+        }
+
         private void collectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             switch (e.Action)
@@ -120,7 +127,8 @@ namespace osu.Framework.Graphics.Containers
                 itemMap.Remove(item);
             }
 
-            reSort();
+            sortItems();
+            OnItemsChanged();
         }
 
         private void addItems(IList items)
@@ -160,11 +168,12 @@ namespace osu.Framework.Graphics.Containers
                         ListContainer.Add(d);
                 }
 
-                reSort();
+                sortItems();
+                OnItemsChanged();
             }
         }
 
-        private void reSort()
+        private void sortItems()
         {
             for (int i = 0; i < Items.Count; i++)
             {
@@ -271,7 +280,7 @@ namespace osu.Framework.Graphics.Containers
             Items.Move(srcIndex, dstIndex);
 
             // Todo: this could be optimised, but it's a very simple iteration over all the items
-            reSort();
+            sortItems();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -103,6 +103,7 @@ namespace osu.Framework.Graphics.Containers
                     currentlyDraggedItem = null;
                     ListContainer.Clear();
                     itemMap.Clear();
+                    OnItemsChanged();
                     break;
 
                 case NotifyCollectionChangedAction.Replace:


### PR DESCRIPTION
Without this it's basically impossible to perform post-change filtering.

Will be used to fix remaining test failures noticed in `TestScenePlaylistOverlay`.