### PR TITLE
Avoid performing `Seek` operations on a decoupled source when the source is not running

### DIFF
--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -304,7 +304,9 @@ namespace osu.Framework.Tests.Clocks
             decoupleable.IsCoupled = false;
             decoupleable.Seek(1000);
 
-            Assert.AreEqual(decoupleable.CurrentTime, source.CurrentTime, "Source time should match coupled time.");
+            Assert.AreEqual(decoupleable.CurrentTime, 1000, "Decoupled time should match seek target.");
+            // Seek on the source is not performed as the clock is stopped.
+            Assert.AreNotEqual(source.CurrentTime, decoupleable.CurrentTime, "Source time should not match coupled time.");
         }
 
         /// <summary>

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -181,11 +181,11 @@ namespace osu.Framework.Timing
 
                 Debug.Assert(adjustableSource != null);
 
-                // Begin by performing a seek on the source clock.
-                bool success = adjustableSource.Seek(position);
-
                 if (IsCoupled)
                 {
+                    // Begin by performing a seek on the source clock.
+                    bool success = adjustableSource.Seek(position);
+
                     // If coupled, regardless of the success of the seek on the source, use the updated
                     // source's current position. This is done because in the case of a seek failure, the
                     // source may update the value
@@ -198,8 +198,10 @@ namespace osu.Framework.Timing
                     // If decoupled, a seek operation should cause the decoupled clock to seek regardless
                     // of whether the source clock could handle the target location.
 
-                    // In the case of the source seek failing, ensure the source is stopped for safety..
-                    if (!success)
+                    // In the case the source is running, attempt a seek and stop it if that seek fails.
+                    // Note that we don't need to perform a seek if the source is not running.
+                    // This is important to improve performance in the decoupled case if the source clock's Seek call is not immediate.
+                    if (adjustableSource.IsRunning && !adjustableSource.Seek(position))
                         adjustableSource?.Stop();
 
                     // ..then perform the requested seek precisely on the decoupled clock.


### PR DESCRIPTION
With https://github.com/ppy/osu-framework/pull/5355, we are now always performing a source seek. On the surface this seemed like it would be fine, but it turns out there is a performance issue if `Seek` is called too often.

This reverts the non-`Coupled` case to not perform a source seek if not required.

~I'm still cross-testing this with my ongoing clock changes to make sure it works well.~ Seems fine.