### PR TITLE
Update `IContainer` interface to add explicit disposal argument on `Remove` methods

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkDrawableAudioWrapper.cs
+++ b/osu.Framework.Benchmarks/BenchmarkDrawableAudioWrapper.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Benchmarks
 
             private void transferTo(AudioContainer target)
             {
-                lastContainer?.Remove(Sample);
+                lastContainer?.Remove(Sample, false);
                 target.Add(Sample);
                 lastContainer = target;
             }

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Backdrop.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Backdrop.cs
@@ -104,7 +104,7 @@ namespace FlappyDon.Game.Elements
             {
                 // Update the number of sprites in the list to match the number we need to cover the whole container
                 while (InternalChildren.Count > spriteNum)
-                    RemoveInternal(InternalChildren.Last());
+                    RemoveInternal(InternalChildren.Last(), true);
 
                 while (InternalChildren.Count < spriteNum)
                     AddInternal(createSprite());

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Obstacles.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Obstacles.cs
@@ -141,7 +141,7 @@ namespace FlappyDon.Game.Elements
 
             while (obstaclesToRemove.TryPop(out var obstacle))
             {
-                RemoveInternal(obstacle);
+                RemoveInternal(obstacle, true);
 
                 // Increase the obstacle count, which will reset threshold detection
                 // for the pipe after this one.

--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Tests.Audio
 
             AddStep("move track a container with 0 volume", () =>
             {
-                Remove(track);
+                Remove(track, false);
                 Child = new AudioContainer
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Tests.Containers
             Assert.IsTrue(container.Contains(sprite));
 
             // Remove
-            Assert.DoesNotThrow(() => container.Remove(sprite));
+            Assert.DoesNotThrow(() => container.Remove(sprite, false));
             Assert.IsFalse(container.Contains(sprite));
 
             // Re-add
@@ -106,7 +106,7 @@ namespace osu.Framework.Tests.Containers
                 target.Schedule(() => { });
             });
 
-            AddStep("remove target", () => Remove(target));
+            AddStep("remove target", () => Remove(target, false));
             AddStep("add target to unloaded container", () => Add(new Container { Child = target }));
         }
 
@@ -132,8 +132,8 @@ namespace osu.Framework.Tests.Containers
             Assert.IsTrue(newContainer.First(c => c.Contains(drawableA)) == containerA);
             Assert.IsTrue(newContainer.First(c => c.Contains(drawableB)) == containerB);
 
-            Assert.DoesNotThrow(() => newContainer.First(c => c.Contains(drawableA)).Remove(drawableA));
-            Assert.DoesNotThrow(() => newContainer.First(c => c.Contains(drawableB)).Remove(drawableB));
+            Assert.DoesNotThrow(() => newContainer.First(c => c.Contains(drawableA)).Remove(drawableA, false));
+            Assert.DoesNotThrow(() => newContainer.First(c => c.Contains(drawableB)).Remove(drawableB, false));
         }
 
         [Test]
@@ -223,7 +223,7 @@ namespace osu.Framework.Tests.Containers
             AddStep("begin async load", () =>
             {
                 safeContainer.LoadComponentAsync(drawable = new DelayedLoadDrawable(), _ => { });
-                Remove(safeContainer);
+                Remove(safeContainer, false);
             });
 
             AddUntilStep("wait until loading", () => drawable.LoadState == LoadState.Loading);

--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -37,11 +37,35 @@ namespace osu.Framework.Tests.Containers
 
             // Remove
             Assert.DoesNotThrow(() => container.Remove(sprite, false));
+            Assert.IsFalse(sprite.IsDisposed);
             Assert.IsFalse(container.Contains(sprite));
 
             // Re-add
             Assert.DoesNotThrow(() => container.Add(sprite));
             Assert.IsTrue(container.Contains(sprite));
+        }
+
+        /// <summary>
+        /// Tests if a drawable is added then removed with disposal, it can't be added again.
+        /// </summary>
+        [Test]
+        public void TestAttemptAddAfterDisposal()
+        {
+            var container = new Container();
+            var sprite = new Sprite();
+
+            // Add
+            Assert.DoesNotThrow(() => container.Add(sprite));
+            Assert.IsTrue(container.Contains(sprite));
+
+            // Remove with disposal
+            Assert.DoesNotThrow(() => container.Remove(sprite, true));
+            Assert.IsTrue(sprite.IsDisposed);
+            Assert.IsFalse(container.Contains(sprite));
+
+            // Attempts re-add
+            Assert.Throws<ObjectDisposedException>(() => container.Add(sprite));
+            Assert.IsFalse(container.Contains(sprite));
         }
 
         /// <summary>

--- a/osu.Framework.Tests/Exceptions/TestAddRemoveExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestAddRemoveExceptions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -27,7 +25,7 @@ namespace osu.Framework.Tests.Exceptions
                     broken.Add(candidate);
                     broken.Add(candidate2);
 
-                    broken.Remove(candidate);
+                    broken.Remove(candidate, true);
                 }
             });
         }

--- a/osu.Framework.Tests/Input/KeyboardInputTest.cs
+++ b/osu.Framework.Tests/Input/KeyboardInputTest.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Tests.Input
 
             AddStep("remove receptor 0 & reset repeat", () =>
             {
-                Remove(receptors[0]);
+                Remove(receptors[0], true);
                 receptors[0].RepeatReceived = false;
                 receptors[1].RepeatReceived = false;
             });
@@ -112,7 +112,7 @@ namespace osu.Framework.Tests.Input
             AddStep("press key", () => InputManager.PressKey(Key.A));
             AddStep("remove receptor 0 & reset repeat", () =>
             {
-                Remove(receptors[0]);
+                Remove(receptors[0], false);
                 receptors[0].RepeatReceived = false;
                 receptors[1].RepeatReceived = false;
             });

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Tests.Input
             AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
             AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
 
-            AddStep("remove receptor 0", () => Remove(receptors[0]));
+            AddStep("remove receptor 0", () => Remove(receptors[0], true));
 
             AddStep("release button", () => InputManager.ReleaseButton(MouseButton.Left));
             AddAssert("receptor 0 did not receive click", () => !receptors[0].ClickReceived);
@@ -63,7 +63,7 @@ namespace osu.Framework.Tests.Input
             AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
             AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
 
-            AddStep("remove receptor 0", () => Remove(receptors[0]));
+            AddStep("remove receptor 0", () => Remove(receptors[0], false));
             AddStep("add back receptor 0", () => Add(receptors[0]));
 
             AddStep("release button", () => InputManager.ReleaseButton(MouseButton.Left));
@@ -92,7 +92,7 @@ namespace osu.Framework.Tests.Input
 
             AddStep("remove receptor and double click", () =>
             {
-                Remove(receptor); // Test correctness can be asserted by removing this line and ensuring the test fails
+                Remove(receptor, true); // Test correctness can be asserted by removing this line and ensuring the test fails
                 InputManager.Click(MouseButton.Left); // Done immediately after due to double clicks being frame-dependent (timing)
             });
 

--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.Tests.Visual.Audio
                 if (targetContainer == currentContainer)
                     return;
 
-                currentContainer.Remove(this);
+                currentContainer.Remove(this, false);
                 targetContainer.Add(this);
 
                 Position = Parent.ToLocalSpace(centre);

--- a/osu.Framework.Tests/Visual/Containers/TestSceneBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneBufferedContainer.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Tests.Visual.Containers
     {
         public TestSceneBufferedContainer()
         {
-            Remove(TestContainer);
+            Remove(TestContainer, false);
 
             BufferedContainer buffer;
             Add(buffer = new BufferedContainer

--- a/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Tests.Visual.Containers
         [Test]
         public void TestLifetimeMutatingChildren()
         {
-            AddStep("detach container", () => Remove(container));
+            AddStep("detach container", () => Remove(container, false));
 
             TestLifetimeMutatingChild first = null, second = null;
             AddStep("add children", () =>

--- a/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Tests.Visual.Containers
 
             AddStep("add child", () => container.AddInternal(child = new TestChild(0, 2)));
             skipTo(1);
-            AddStep("remove child", () => container.RemoveInternal(child));
+            AddStep("remove child", () => container.RemoveInternal(child, false));
             AddStep("add same child", () => container.AddInternal(child));
             validate(1);
         }
@@ -250,7 +250,7 @@ namespace osu.Framework.Tests.Visual.Containers
             {
                 var child = container.InternalChildren[rng.Next(container.InternalChildren.Count)];
                 Logger.Log($"removeChild: {child.ChildID}");
-                container.RemoveInternal(child);
+                container.RemoveInternal(child, true);
             }
 
             void changeLifetime()

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -281,7 +281,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("press page down and remove scroll container", () => InputManager.PressKey(Key.PageDown));
             AddStep("remove scroll container", () =>
             {
-                Remove(scrollContainer);
+                Remove(scrollContainer, false);
                 ((RepeatCountingScrollContainer)scrollContainer).RepeatCount = 0;
             });
 
@@ -540,7 +540,7 @@ namespace osu.Framework.Tests.Visual.Containers
 
             AddStep("Nest vertical scroll inside of horizontal", () =>
             {
-                Remove(scrollContainer);
+                Remove(scrollContainer, false);
 
                 Add(horizontalScrollContainer = new BasicScrollContainer(Direction.Horizontal)
                 {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
@@ -246,10 +246,10 @@ namespace osu.Framework.Tests.Visual.Drawables
 
         private void switchOffCustomBlending()
         {
-            settingsBox.Remove(blendingSrcContainer);
-            settingsBox.Remove(blendingDestContainer);
-            settingsBox.Remove(blendingAlphaSrcContainer);
-            settingsBox.Remove(blendingAlphaDestContainer);
+            settingsBox.Remove(blendingSrcContainer, false);
+            settingsBox.Remove(blendingDestContainer, false);
+            settingsBox.Remove(blendingAlphaSrcContainer, false);
+            settingsBox.Remove(blendingAlphaDestContainer, false);
         }
 
         private void updateBlending()

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -409,7 +409,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             });
 
             AddUntilStep("wait for load", () => wrapper.Content?.IsLoaded == true);
-            AddStep("remove parent", () => Remove(parent));
+            AddStep("remove parent", () => Remove(parent, false));
             AddUntilStep("wait for unload", () => wrapper.Content?.IsLoaded != true);
         }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawNodeDisposal.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawNodeDisposal.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddStep("clear + remove parent container", () =>
             {
                 parentContainer.Clear();
-                Remove(parentContainer);
+                Remove(parentContainer, false);
 
                 // Lose last hard-reference to the child
                 child = null;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -180,7 +180,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     RelativeSizeAxes = Axes.Both,
                 });
 
-                Remove(focusTopLeft);
+                Remove(focusTopLeft, false);
                 container.Add(focusTopLeft);
             });
             AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneStressGLDisposal.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneStressGLDisposal.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
                     if (fillFlow.Count > 100)
                     {
-                        fillFlow.Remove(fillFlow.First());
+                        fillFlow.Remove(fillFlow.First(), true);
                     }
                 }
             }, 100000);

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -183,8 +183,9 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private void refreshScreens()
         {
-            screenContainer.Remove(windowContainer);
+            screenContainer.Remove(windowContainer, false);
             screenContainer.Clear();
+
             var bounds = new RectangleI();
 
             foreach (var display in window.Displays)

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -703,8 +703,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 for (int i = 0; i < exit_count; i++)
                     stack.Exit();
 
-                Remove(stack);
-                stack.Dispose();
+                Remove(stack, true);
             });
 
             AddUntilStep("All screens unbound in correct order", () => screens.Count == 0);

--- a/osu.Framework/Graphics/Containers/AudioContainer.cs
+++ b/osu.Framework/Graphics/Containers/AudioContainer.cs
@@ -100,7 +100,8 @@ namespace osu.Framework.Graphics.Containers
             set => container.Children = value;
         }
 
-        public int RemoveAll(Predicate<T> match) => container.RemoveAll(match);
+        public int RemoveAll(Predicate<T> match, bool disposeImmediately) =>
+            container.RemoveAll(match, disposeImmediately);
 
         public T Child
         {
@@ -135,14 +136,17 @@ namespace osu.Framework.Graphics.Containers
             container.AddRange(collection);
         }
 
-        public bool Remove(T drawable) => container.Remove(drawable);
+        public bool Remove(T drawable, bool disposeImmediately) => container.Remove(drawable, disposeImmediately);
+
+        bool ICollection<T>.Remove(T item) => container.Remove(item, true);
+
         int ICollection<T>.Count => container.Count;
 
         public bool IsReadOnly => container.IsReadOnly;
 
-        public void RemoveRange(IEnumerable<T> range)
+        public void RemoveRange(IEnumerable<T> range, bool disposeImmediately)
         {
-            container.RemoveRange(range);
+            container.RemoveRange(range, disposeImmediately);
         }
 
         int IReadOnlyCollection<T>.Count => container.Count;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -3,15 +3,15 @@
 
 #nullable disable
 
-using osu.Framework.Lists;
-using System.Collections.Generic;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Colour;
-using osuTK;
-using System.Collections;
-using System.Diagnostics;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Lists;
+using osuTK;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -206,6 +206,12 @@ namespace osu.Framework.Graphics.Containers
         {
             if (drawable == Content)
                 throw new InvalidOperationException("Content may not be added to itself.");
+
+            if (drawable == null)
+                throw new ArgumentNullException(nameof(drawable));
+
+            if (drawable.IsDisposed)
+                throw new ObjectDisposedException(nameof(drawable));
 
             if (Content == this)
                 AddInternal(drawable);

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// The content of this container. <see cref="Children"/> and all methods that mutate
-        /// <see cref="Children"/> (e.g. <see cref="Add(T)"/> and <see cref="Remove(T)"/>) are
+        /// <see cref="Children"/> (e.g. <see cref="Add(T)"/> and <see cref="Remove(T, bool)"/>) are
         /// forwarded to the content. By default a container's content is itself, in which case
         /// <see cref="Children"/> refers to <see cref="CompositeDrawable.InternalChildren"/>.
         /// This property is useful for containers that require internal children that should
@@ -124,6 +124,8 @@ namespace osu.Framework.Graphics.Containers
             foreach (var c in Children)
                 array[arrayIndex++] = c;
         }
+
+        bool ICollection<T>.Remove(T item) => Remove(item, true);
 
         public Enumerator GetEnumerator() => new Enumerator(this);
 
@@ -230,7 +232,10 @@ namespace osu.Framework.Graphics.Containers
         protected internal override void AddInternal(Drawable drawable)
         {
             if (Content == this && drawable != null && !(drawable is T))
-                throw new InvalidOperationException($"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {GetType().ReadableName()} which does not redirect {nameof(Content)}.");
+            {
+                throw new InvalidOperationException(
+                    $"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {GetType().ReadableName()} which does not redirect {nameof(Content)}.");
+            }
 
             base.AddInternal(drawable);
         }
@@ -238,18 +243,29 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Removes a given child from this container.
         /// </summary>
-        public virtual bool Remove(T drawable) => Content != this ? Content.Remove(drawable) : RemoveInternal(drawable);
+        public virtual bool Remove(T drawable, bool disposeImmediately)
+        {
+            if (Content != this)
+                return Content.Remove(drawable, disposeImmediately);
+
+            bool wasRemoved = RemoveInternal(drawable);
+
+            if (disposeImmediately)
+                drawable.Dispose();
+
+            return wasRemoved;
+        }
 
         /// <summary>
         /// Removes all children which match the given predicate.
-        /// This is equivalent to calling <see cref="Remove(T)"/> for each child that
+        /// This is equivalent to calling <see cref="Remove(T, bool)"/> for each child that
         /// matches the given predicate.
         /// </summary>
         /// <returns>The amount of removed children.</returns>
-        public int RemoveAll(Predicate<T> pred)
+        public int RemoveAll(Predicate<T> pred, bool disposeImmediately)
         {
             if (Content != this)
-                return Content.RemoveAll(pred);
+                return Content.RemoveAll(pred, disposeImmediately);
 
             int removedCount = 0;
 
@@ -260,6 +276,8 @@ namespace osu.Framework.Graphics.Containers
                 if (pred.Invoke(tChild))
                 {
                     RemoveInternal(tChild);
+                    if (disposeImmediately)
+                        tChild.Dispose();
                     removedCount++;
                     i--;
                 }
@@ -269,16 +287,16 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Removes a range of children. This is equivalent to calling <see cref="Remove(T)"/> on
+        /// Removes a range of children. This is equivalent to calling <see cref="Remove(T, bool)"/> on
         /// each element of the range in order.
         /// </summary>
-        public void RemoveRange(IEnumerable<T> range)
+        public void RemoveRange(IEnumerable<T> range, bool disposeImmediately)
         {
             if (range == null)
                 return;
 
             foreach (T p in range)
-                Remove(p);
+                Remove(p, disposeImmediately);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -254,12 +254,7 @@ namespace osu.Framework.Graphics.Containers
             if (Content != this)
                 return Content.Remove(drawable, disposeImmediately);
 
-            bool wasRemoved = RemoveInternal(drawable);
-
-            if (disposeImmediately)
-                drawable.Dispose();
-
-            return wasRemoved;
+            return RemoveInternal(drawable, disposeImmediately);
         }
 
         /// <summary>
@@ -281,9 +276,7 @@ namespace osu.Framework.Graphics.Containers
 
                 if (pred.Invoke(tChild))
                 {
-                    RemoveInternal(tChild);
-                    if (disposeImmediately)
-                        tChild.Dispose();
+                    RemoveInternal(tChild, disposeImmediately);
                     removedCount++;
                     i--;
                 }

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Containers
             // placeholders via AddPlaceholder() are similar to manual text parts
             // in that they were added/registered externally and cannot be recreated.
             // remove them before proceeding with part recreation to avoid accidentally disposing them in the process.
-            RemoveRange(Placeholders);
+            RemoveRange(Placeholders, false);
 
             base.RecreateAllParts();
         }

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -84,13 +84,14 @@ namespace osu.Framework.Graphics.Containers
             base.AddInternal(drawable);
         }
 
-        protected internal override bool RemoveInternal(Drawable drawable)
+        protected internal override bool RemoveInternal(Drawable drawable, bool disposeImmediately)
         {
             layoutChildren.Remove(drawable);
             // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
             // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
             InvalidateLayout();
-            return base.RemoveInternal(drawable);
+
+            return base.RemoveInternal(drawable, disposeImmediately);
         }
 
         protected internal override void ClearInternal(bool disposeChildren = true)

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -24,7 +24,17 @@ namespace osu.Framework.Graphics.Containers
     {
         IReadOnlyList<T> Children { get; }
 
-        int RemoveAll(Predicate<T> match);
+        /// <summary>
+        /// Remove all matching children from this container.
+        /// </summary>
+        /// <param name="match">A predicate used to find matching items.</param>
+        /// <param name="disposeImmediately">Whether removed items should be immediately disposed.</param>
+        /// <remarks>
+        /// <paramref name="disposeImmediately"/> should be <c>true</c> unless the removed items are to be re-used in the future.
+        /// If <c>false</c>, ensure removed items are manually disposed else object leakage may occur.
+        /// </remarks>
+        /// <returns>The number of matching items removed.</returns>
+        int RemoveAll(Predicate<T> match, bool disposeImmediately);
     }
 
     public interface IContainerCollection<in T> : IContainer
@@ -39,7 +49,28 @@ namespace osu.Framework.Graphics.Containers
         void Add(T drawable);
         void AddRange(IEnumerable<T> collection);
 
-        bool Remove(T drawable);
-        void RemoveRange(IEnumerable<T> range);
+        /// <summary>
+        /// Remove the provided drawable from this container's children.
+        /// </summary>
+        /// <param name="drawable">The drawable to be removed.</param>
+        /// <param name="disposeImmediately">Whether removed item should be immediately disposed.</param>
+        /// <remarks>
+        /// <paramref name="disposeImmediately"/> should be <c>true</c> unless the removed item is to be re-used in the future.
+        /// If <c>false</c>, ensure the removed item is manually disposed (or added back to another part of the hierarchy) else
+        /// object leakage may occur.
+        /// </remarks>
+        /// <returns>Whether the drawable was removed.</returns>
+        bool Remove(T drawable, bool disposeImmediately);
+
+        /// <summary>
+        /// Remove all matching children from this container.
+        /// </summary>
+        /// <param name="range">The drawables to be removed.</param>
+        /// <param name="disposeImmediately">Whether removed items should be immediately disposed.</param>
+        /// <remarks>
+        /// <paramref name="disposeImmediately"/> should be <c>true</c> unless the removed items are to be re-used in the future.
+        /// If <c>false</c>, ensure removed items are manually disposed else object leakage may occur.
+        /// </remarks>
+        void RemoveRange(IEnumerable<T> range, bool disposeImmediately);
     }
 }

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -58,19 +58,19 @@ namespace osu.Framework.Graphics.Containers
                 unmanagedDrawablesToProcess.Add(drawable);
         }
 
-        protected internal override bool RemoveInternal(Drawable drawable)
+        protected internal override bool RemoveInternal(Drawable drawable, bool disposeImmediately)
         {
             unmanagedDrawablesToProcess.Remove(drawable);
 
             if (!drawableMap.TryGetValue(drawable, out var entry))
-                return base.RemoveInternal(drawable);
+                return base.RemoveInternal(drawable, disposeImmediately);
 
             manager.RemoveEntry(entry);
             drawableMap.Remove(drawable);
 
             entry.Dispose();
 
-            return base.RemoveInternal(drawable);
+            return base.RemoveInternal(drawable, disposeImmediately);
         }
 
         protected internal override void ClearInternal(bool disposeChildren = true)

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.Containers
             // Remove the previous wrapper if the inner drawable hasn't finished loading.
             if (currentWrapper?.DelayedLoadCompleted == false)
             {
-                RemoveInternal(currentWrapper);
+                RemoveInternal(currentWrapper, false);
                 DisposeChildAsync(currentWrapper);
             }
 

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -122,7 +122,7 @@ namespace osu.Framework.Graphics.Containers
 
                 var drawableItem = itemMap[item];
 
-                ListContainer.Remove(drawableItem);
+                ListContainer.Remove(drawableItem, false);
                 DisposeChildAsync(drawableItem);
 
                 itemMap.Remove(item);

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -322,7 +322,7 @@ namespace osu.Framework.Graphics.Containers
             // manual parts need to be manually removed before clearing contents,
             // to avoid accidentally disposing of them in the process.
             foreach (var manualPart in parts.OfType<TextPartManual>())
-                RemoveRange(manualPart.Drawables);
+                RemoveRange(manualPart.Drawables, false);
 
             // make sure not to clear the list of parts by accident.
             base.Clear(true);

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -154,7 +154,7 @@ namespace osu.Framework.Graphics.Cursor
                     CurrentTooltip.SetContent(getTargetContent(target));
                 else
                 {
-                    RemoveInternal((Drawable)CurrentTooltip);
+                    RemoveInternal((Drawable)CurrentTooltip, false);
                     CurrentTooltip = proposedTooltip;
                     AddInternal((Drawable)proposedTooltip);
                 }

--- a/osu.Framework/Graphics/DrawableExtensions.cs
+++ b/osu.Framework/Graphics/DrawableExtensions.cs
@@ -59,8 +59,10 @@ namespace osu.Framework.Graphics
         {
             ThreadSafety.EnsureUpdateThread();
 
-            drawable.Parent?.RemoveInternal(drawable);
-            drawable.Dispose();
+            if (drawable.Parent != null)
+                drawable.Parent.RemoveInternal(drawable, true);
+            else
+                drawable.Dispose();
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -306,7 +306,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <returns>Whether <paramref name="item"/> was successfully removed.</returns>
         public bool Remove(MenuItem item)
         {
-            bool result = ItemsContainer.RemoveAll(d => d.Item == item) > 0;
+            bool result = ItemsContainer.RemoveAll(d => d.Item == item, true) > 0;
             itemsFlow.SizeCache.Invalidate();
 
             return result;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -333,7 +333,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (removeFromDropdown)
                 Dropdown?.RemoveDropdownItem(tab.Value);
 
-            TabContainer.Remove(tab);
+            TabContainer.Remove(tab, true);
         }
 
         /// <summary>
@@ -538,10 +538,10 @@ namespace osu.Framework.Graphics.UserInterface
                 base.Clear(disposeChildren);
             }
 
-            public override bool Remove(TabItem<T> drawable)
+            public override bool Remove(TabItem<T> drawable, bool disposeImmediately)
             {
                 tabVisibility.Remove(drawable);
-                return base.Remove(drawable);
+                return base.Remove(drawable, disposeImmediately);
             }
         }
     }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -692,7 +692,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             foreach (var d in TextFlow.Children.Skip(removeStart).Take(removeCount).ToArray()) //ToArray since we are removing items from the children in this block.
             {
-                TextFlow.Remove(d);
+                TextFlow.Remove(d, false);
 
                 TextContainer.Add(d);
 
@@ -733,7 +733,7 @@ namespace osu.Framework.Graphics.UserInterface
             List<Drawable> charsRight = new List<Drawable>();
             foreach (Drawable d in TextFlow.Children.Skip(selectionLeft))
                 charsRight.Add(d);
-            TextFlow.RemoveRange(charsRight);
+            TextFlow.RemoveRange(charsRight, false);
 
             // Update their depth to make room for the to-be inserted character.
             int i = selectionLeft;

--- a/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
 
                 case NotifyCollectionChangedAction.Remove:
                     Debug.Assert(e.OldItems != null);
-                    mixerFlow.RemoveAll(m => e.OldItems.OfType<AudioMixer>().Contains(m.Mixer));
+                    mixerFlow.RemoveAll(m => e.OldItems.OfType<AudioMixer>().Contains(m.Mixer), true);
                     break;
             }
         });

--- a/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
                     mixerChannelsContainer.Add(new AudioChannelDisplay(channel));
             }
 
-            mixerChannelsContainer.RemoveAll(ch => !channels.Contains(ch.ChannelHandle));
+            mixerChannelsContainer.RemoveAll(ch => !channels.Contains(ch.ChannelHandle), true);
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -298,7 +298,7 @@ namespace osu.Framework.Graphics.Visualisation
             flow.Add(visualiser);
         }
 
-        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser) => flow.Remove(visualiser, true);
+        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser) => flow.Remove(visualiser, false);
 
         public VisualisedDrawable FindVisualisedDrawable(Drawable drawable)
         {

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -298,7 +298,7 @@ namespace osu.Framework.Graphics.Visualisation
             flow.Add(visualiser);
         }
 
-        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser) => flow.Remove(visualiser);
+        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser) => flow.Remove(visualiser, true);
 
         public VisualisedDrawable FindVisualisedDrawable(Drawable drawable)
         {

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -383,7 +383,7 @@ namespace osu.Framework.Screens
             {
                 foreach (var s in exited)
                 {
-                    RemoveInternal(s);
+                    RemoveInternal(s, false);
                     DisposeChildAsync(s);
                 }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -636,7 +636,7 @@ namespace osu.Framework.Testing
                     hasCaught = true;
 
                     OnCaughtError?.Invoke(e);
-                    RemoveInternal(Content);
+                    RemoveInternal(Content, true);
                 }
 
                 return false;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -353,8 +353,7 @@ namespace osu.Framework.Testing
         {
             if (CurrentTest?.Parent != null)
             {
-                testContentContainer.Remove(CurrentTest.Parent);
-                CurrentTest.Dispose();
+                testContentContainer.Remove(CurrentTest.Parent, true);
             }
 
             CurrentTest = null;
@@ -399,7 +398,7 @@ namespace osu.Framework.Testing
                 if (newTest.Parent != null)
                 {
                     // There could have been multiple loads fired after us. In such a case we want to silently remove ourselves.
-                    testContentContainer.Remove(newTest.Parent);
+                    testContentContainer.Remove(newTest.Parent, true);
                 }
 
                 return;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Testing
         protected internal override void ClearInternal(bool disposeChildren = true) =>
             throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Clear)} instead.");
 
-        protected internal override bool RemoveInternal(Drawable drawable) =>
+        protected internal override bool RemoveInternal(Drawable drawable, bool disposeImmediately) =>
             throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Remove)} instead.");
 
         /// <summary>
@@ -406,12 +406,9 @@ namespace osu.Framework.Testing
 
         private void exitNestedGame()
         {
-            if (nestedGame?.Parent == null) return;
-
             // important that we do a synchronous disposal.
             // using Expire() will cause a deadlock in AsyncDisposalQueue.
-            nestedGame.Parent.RemoveInternal(nestedGame);
-            nestedGame.Dispose();
+            nestedGame?.Parent?.RemoveInternal(nestedGame, true);
         }
 
         #region NUnit execution setup

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Testing
                     // We want to remove the TestScene from the hierarchy on completion as under nUnit, it may have operations run on it from a different thread.
                     // This is because nUnit will reuse the same class multiple times, running a different [Test] method each time, while the GameHost
                     // is run from its own asynchronous thread.
-                    RemoveInternal(test);
+                    RemoveInternal(test, false);
                     completed = true;
                 }
 


### PR DESCRIPTION
Closes #5378.

## Breaking Changes

### `CompositeDrawable.RemoveInternal`, `IContainer.Remove`, `IContainer.RemoveRange` and `IContainer.RemoveAll` now require a `bool` parameter

A common mistake we've seen made osu!-side is where drawables are `Remove`d from the hierarchy with the intention of never using them again. In such cases, disposal is not guaranteed – nor is unbinding of `Bindable` fields/properties – which can lead to event and object leakage.

To prevent this from happening, a new `disposeImmediately` parameter has been added.

Generally this should be set to `true` unless you intend to reuse the removed drawable (ie. by adding back to the hierarchy at a different location).