### PR TITLE
Fix nested storage lookup check not accounting for case insensitive filesystems

### DIFF
--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -70,5 +70,40 @@ namespace osu.Framework.Tests.IO
                 Assert.That(storage.GetStorageForDirectory(string.Empty).GetFullPath(string.Empty), Is.EqualTo(storage.GetFullPath(string.Empty)));
             }
         }
+
+        [Test]
+        public void TestCaseSensitivity()
+        {
+            // First test if this unit test is running on a filesystem which is case sensitive.
+            File.WriteAllText(Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "case-sensitivity-test"), "test");
+            bool isCaseSensitive = !File.Exists(Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "CASE-SENSITIVITY-TEST"));
+            File.Delete("case-sensitivity-test");
+
+            // Then check our methods match this.
+            using (var storage = new TemporaryNativeStorage("test"))
+            {
+                using (var stream = storage.CreateFileSafely("test-file"))
+                    stream.WriteByte(0);
+
+                Assert.That(storage.Exists("test-file"), Is.True);
+                Assert.That(storage.Exists("TEST-FILE"), Is.EqualTo(!isCaseSensitive));
+
+                using (var storage2 = new TemporaryNativeStorage("TEST"))
+                {
+                    Assert.That(storage2.Exists("test-file"), Is.EqualTo(!isCaseSensitive));
+                    Assert.That(storage2.Exists("TEST-FILE"), Is.EqualTo(!isCaseSensitive));
+
+                    // Test that base path lookup checks don't incorrectly fail.
+                    // This should pass regardless of case sensitivity of the underlying partition.
+                    var nested = storage2.GetStorageForDirectory("subdir");
+
+                    using (var stream = nested.CreateFileSafely("test-file"))
+                        stream.WriteByte(0);
+
+                    Assert.That(nested.GetDirectories(string.Empty), Is.Empty);
+                    Assert.That(nested.GetFiles(string.Empty), Has.One.Items);
+                }
+            }
+        }
     }
 }

--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -74,10 +74,7 @@ namespace osu.Framework.Tests.IO
         [Test]
         public void TestCaseSensitivity()
         {
-            // First test if this unit test is running on a filesystem which is case sensitive.
-            File.WriteAllText(Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "case-sensitivity-test"), "test");
-            bool isCaseSensitive = !File.Exists(Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "CASE-SENSITIVITY-TEST"));
-            File.Delete("case-sensitivity-test");
+            bool isCaseSensitive = isCaseSensitiveFilesystem();
 
             // Then check our methods match this.
             using (var storage = new TemporaryNativeStorage("test"))
@@ -104,6 +101,16 @@ namespace osu.Framework.Tests.IO
                     Assert.That(nested.GetFiles(string.Empty), Has.One.Items);
                 }
             }
+        }
+
+        private static bool isCaseSensitiveFilesystem()
+        {
+            // First test if this unit test is running on a filesystem which is case sensitive.
+            string testFile = Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "case-sensitivity-test");
+            File.WriteAllText(testFile, "test");
+            bool isCaseSensitive = !File.Exists(testFile.ToUpperInvariant());
+            File.Delete(testFile);
+            return isCaseSensitive;
         }
     }
 }

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Platform
             string basePath = Path.GetFullPath(GetFullPath(string.Empty));
             return paths.Select(Path.GetFullPath).Select(path =>
             {
-                if (!path.StartsWith(basePath, StringComparison.Ordinal)) throw new ArgumentException($"\"{path}\" does not start with \"{basePath}\" and is probably malformed");
+                if (!path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException($"\"{path}\" does not start with \"{basePath}\" and is probably malformed");
 
                 return path.AsSpan(basePath.Length).TrimStart(Path.DirectorySeparatorChar).ToString();
             });
@@ -72,7 +72,7 @@ namespace osu.Framework.Platform
             string basePath = Path.GetFullPath(BasePath).TrimEnd(Path.DirectorySeparatorChar);
             string resolvedPath = Path.GetFullPath(Path.Combine(basePath, path));
 
-            if (!resolvedPath.StartsWith(basePath, StringComparison.Ordinal)) throw new ArgumentException($"\"{resolvedPath}\" traverses outside of \"{basePath}\" and is probably malformed");
+            if (!resolvedPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException($"\"{resolvedPath}\" traverses outside of \"{basePath}\" and is probably malformed");
 
             if (createIfNotExisting) Directory.CreateDirectory(Path.GetDirectoryName(resolvedPath));
             return resolvedPath;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/19996#issuecomment-1229428045.

Tests do not fail as it stands. I can't figure out the correct call to reproduce what the user was seeing. Help.