### PR TITLE
Add `Name` to samples and channels

### DIFF
--- a/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Tests.Audio
         [SetUp]
         public void Setup()
         {
-            sample = new SampleVirtual();
+            sample = new SampleVirtual("virtual");
             updateSample();
         }
 

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Tests.Audio
         [SetUp]
         public void Setup()
         {
-            track = new TrackVirtual(60000);
+            track = new TrackVirtual(60000, "virtual");
             updateTrack();
         }
 
@@ -45,7 +45,7 @@ namespace osu.Framework.Tests.Audio
         public void TestStartZeroLength()
         {
             // override default with custom length
-            track = new TrackVirtual(0);
+            track = new TrackVirtual(0, "virtual");
 
             track.Start();
             updateTrack();

--- a/osu.Framework/Audio/Mixing/IAudioChannel.cs
+++ b/osu.Framework/Audio/Mixing/IAudioChannel.cs
@@ -12,6 +12,11 @@ namespace osu.Framework.Audio.Mixing
     public interface IAudioChannel
     {
         /// <summary>
+        /// A name identifying this sample internally.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// The mixer in which all audio produced by this channel should be routed into.
         /// </summary>
         internal AudioMixer? Mixer { get; set; }

--- a/osu.Framework/Audio/Sample/ISample.cs
+++ b/osu.Framework/Audio/Sample/ISample.cs
@@ -13,6 +13,11 @@ namespace osu.Framework.Audio.Sample
     public interface ISample : IAdjustableAudioComponent
     {
         /// <summary>
+        /// A name identifying this sample internally.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// The length in milliseconds of this <see cref="ISample"/>.
         /// </summary>
         double Length { get; }

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -11,6 +11,11 @@ namespace osu.Framework.Audio.Sample
     public interface ISampleChannel : IHasAmplitudes
     {
         /// <summary>
+        /// A name identifying this sample internally.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Starts or resumes playback. Has no effect if this <see cref="ISampleChannel"/> is already playing.
         /// </summary>
         void Play();

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -12,8 +12,14 @@ namespace osu.Framework.Audio.Sample
     {
         public const int DEFAULT_CONCURRENCY = 2;
 
-        public double Length { get; protected set; }
+        public string Name { get; }
 
+        protected Sample(string name)
+        {
+            Name = name;
+        }
+
+        public double Length { get; protected set; }
         public Bindable<int> PlaybackConcurrency { get; } = new Bindable<int>(DEFAULT_CONCURRENCY);
 
         internal Action<Sample> OnPlay;

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -15,6 +15,7 @@ namespace osu.Framework.Audio.Sample
         private readonly BassAudioMixer mixer;
 
         internal SampleBass(SampleBassFactory factory, BassAudioMixer mixer)
+            : base(factory.Name)
         {
             this.factory = factory;
             this.mixer = mixer;

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -16,6 +16,11 @@ namespace osu.Framework.Audio.Sample
     /// </summary>
     internal class SampleBassFactory : AudioCollectionManager<AdjustableAudioComponent>
     {
+        /// <summary>
+        /// A name identifying the sample to be created by this factory.
+        /// </summary>
+        public string Name { get; }
+
         public int SampleId { get; private set; }
 
         public override bool IsLoaded => SampleId != 0;
@@ -32,10 +37,12 @@ namespace osu.Framework.Audio.Sample
         private NativeMemoryTracker.NativeMemoryLease? memoryLease;
         private byte[]? data;
 
-        public SampleBassFactory(byte[] data, BassAudioMixer mixer)
+        public SampleBassFactory(byte[] data, string name, BassAudioMixer mixer)
         {
             this.data = data;
             this.mixer = mixer;
+
+            Name = name;
 
             EnqueueAction(loadSample);
 

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -13,6 +13,13 @@ namespace osu.Framework.Audio.Sample
     {
         internal Action<SampleChannel>? OnPlay;
 
+        public string Name { get; }
+
+        protected SampleChannel(string name)
+        {
+            Name = name;
+        }
+
         public virtual void Play()
         {
             if (IsDisposed)

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -56,6 +56,7 @@ namespace osu.Framework.Audio.Sample
         /// </summary>
         /// <param name="sample">The <see cref="SampleBass"/> to create the channel from.</param>
         public SampleChannelBass(SampleBass sample)
+            : base(sample.Name)
         {
             this.sample = sample;
 

--- a/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
@@ -15,6 +15,11 @@ namespace osu.Framework.Audio.Sample
 
         public override bool Playing => playing;
 
+        public SampleChannelVirtual(string name)
+            : base(name)
+        {
+        }
+
         protected override void UpdateState()
         {
             base.UpdateState();

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Audio.Sample
                     this.LogIfNonBackgroundThread(name);
 
                     byte[] data = store.Get(name);
-                    factory = factories[name] = data == null ? null : new SampleBassFactory(data, (BassAudioMixer)mixer) { PlaybackConcurrency = { Value = PlaybackConcurrency } };
+                    factory = factories[name] = data == null ? null : new SampleBassFactory(data, name, (BassAudioMixer)mixer) { PlaybackConcurrency = { Value = PlaybackConcurrency } };
 
                     if (factory != null)
                         AddItem(factory);

--- a/osu.Framework/Audio/Sample/SampleVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleVirtual.cs
@@ -11,6 +11,11 @@ namespace osu.Framework.Audio.Sample
     /// </summary>
     public sealed class SampleVirtual : Sample
     {
-        protected override SampleChannel CreateChannel() => new SampleChannelVirtual();
+        protected override SampleChannel CreateChannel() => new SampleChannelVirtual(Name);
+
+        public SampleVirtual(string name = "virtual")
+            : base(name)
+        {
+        }
     }
 }

--- a/osu.Framework/Audio/Track/ITrackStore.cs
+++ b/osu.Framework/Audio/Track/ITrackStore.cs
@@ -11,7 +11,8 @@ namespace osu.Framework.Audio.Track
         /// Retrieve a <see cref="TrackVirtual"/> with no audio device backing.
         /// </summary>
         /// <param name="length">The length of the virtual track.</param>
+        /// <param name="name">A name to identify the virtual track internally.</param>
         /// <returns>A new virtual track.</returns>
-        Track GetVirtual(double length = double.PositiveInfinity);
+        Track GetVirtual(double length = double.PositiveInfinity, string name = "virtual");
     }
 }

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -23,6 +23,13 @@ namespace osu.Framework.Audio.Track
 
         public virtual bool Looping { get; set; }
 
+        public string Name { get; }
+
+        protected Track(string name)
+        {
+            Name = name;
+        }
+
         /// <summary>
         /// Reset this track to a logical default state.
         /// </summary>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -67,8 +67,10 @@ namespace osu.Framework.Audio.Track
         /// Constructs a new <see cref="TrackBass"/> from provided audio data.
         /// </summary>
         /// <param name="data">The sample data stream.</param>
+        /// <param name="name">A name identifying the track internally.</param>
         /// <param name="quick">If true, the track will not be fully loaded, and should only be used for preview purposes.  Defaults to false.</param>
-        internal TrackBass(Stream data, bool quick = false)
+        internal TrackBass(Stream data, string name, bool quick = false)
+            : base(name)
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -27,11 +27,11 @@ namespace osu.Framework.Audio.Track
             (store as ResourceStore<byte[]>)?.AddExtension(@"mp3");
         }
 
-        public Track GetVirtual(double length = double.PositiveInfinity)
+        public Track GetVirtual(double length = double.PositiveInfinity, string name = "virtual")
         {
             if (IsDisposed) throw new ObjectDisposedException($"Cannot retrieve items for an already disposed {nameof(TrackStore)}");
 
-            var track = new TrackVirtual(length);
+            var track = new TrackVirtual(length, name);
             AddItem(track);
             return track;
         }
@@ -47,7 +47,7 @@ namespace osu.Framework.Audio.Track
             if (dataStream == null)
                 return null;
 
-            TrackBass trackBass = new TrackBass(dataStream);
+            TrackBass trackBass = new TrackBass(dataStream, name);
 
             mixer.Add(trackBass);
             AddItem(trackBass);

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -15,7 +15,8 @@ namespace osu.Framework.Audio.Track
 
         private double seekOffset;
 
-        public TrackVirtual(double length)
+        public TrackVirtual(double length, string name = "virtual")
+            : base(name)
         {
             Length = length;
         }

--- a/osu.Framework/Graphics/Audio/DrawableSample.cs
+++ b/osu.Framework/Graphics/Audio/DrawableSample.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.Graphics.Audio
         {
             this.sample = sample;
 
+            Name = sample.Name;
+
             PlaybackConcurrency.BindTo(sample.PlaybackConcurrency);
         }
 
@@ -46,6 +48,8 @@ namespace osu.Framework.Graphics.Audio
 
             return channel;
         }
+
+        string ISample.Name => sample.Name;
 
         public double Length => sample.Length;
 


### PR DESCRIPTION
Not displayed anywhere yet. I was hoping to display this in the audio mixer overlay (`Ctrl+F9`) but it turns out to be a bit harder than expected - that overlay is retrieving raw handle IDs from bass.

This is still useful in debug scenarios, where you want to know which samples are playing. ie.

```csharp
Logger.Log($"Playing sample {Name} with volume {AggregateVolume.Value}");
```

can now be done in a `Play()` call, whereas previously it was nigh impossible to know the name of the sample that was firing the call.