### PR TITLE
Remove "GL" prefix from performance collection type enum

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -439,7 +439,7 @@ namespace osu.Framework.Graphics.Performance
                 case PerformanceCollectionType.WndProc:
                     return Color4.GhostWhite;
 
-                case PerformanceCollectionType.Reset:
+                case PerformanceCollectionType.DrawReset:
                     return Color4.Cyan;
             }
         }

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -439,7 +439,7 @@ namespace osu.Framework.Graphics.Performance
                 case PerformanceCollectionType.WndProc:
                     return Color4.GhostWhite;
 
-                case PerformanceCollectionType.GLReset:
+                case PerformanceCollectionType.Reset:
                     return Color4.Cyan;
             }
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -479,7 +479,7 @@ namespace osu.Framework.Platform
 
             try
             {
-                using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
+                using (drawMonitor.BeginCollecting(PerformanceCollectionType.Reset))
                     Renderer.BeginFrame(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
 
                 if (!bypassFrontToBackPass.Value)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -479,7 +479,7 @@ namespace osu.Framework.Platform
 
             try
             {
-                using (drawMonitor.BeginCollecting(PerformanceCollectionType.Reset))
+                using (drawMonitor.BeginCollecting(PerformanceCollectionType.DrawReset))
                     Renderer.BeginFrame(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
 
                 if (!bypassFrontToBackPass.Value)

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Statistics
         Sleep,
         Scheduler,
         IPC,
-        Reset,
+        DrawReset,
     }
 
     internal enum StatisticsCounterType

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Statistics
         Sleep,
         Scheduler,
         IPC,
-        GLReset,
+        Reset,
     }
 
     internal enum StatisticsCounterType


### PR DESCRIPTION
Still kept the name `Reset` as it makes sense for what the underlying operation is doing, despite the fact that it's called `BeginFrame` now.