### PR TITLE
Update `GlobalPropertyManager` to support registering `IShader`s

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -25,6 +25,8 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
         internal readonly Dictionary<string, IUniform> Uniforms = new Dictionary<string, IUniform>();
 
+        IReadOnlyDictionary<string, IUniform> IShader.Uniforms => Uniforms;
+
         /// <summary>
         /// Holds all the <see cref="Uniforms"/> values for faster access than iterating on <see cref="Dictionary{TKey,TValue}.Values"/>.
         /// </summary>
@@ -105,11 +107,6 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
             IsBound = false;
         }
 
-        /// <summary>
-        /// Returns a uniform from the shader.
-        /// </summary>
-        /// <param name="name">The name of the uniform.</param>
-        /// <returns>Returns a base uniform.</returns>
         public Uniform<T> GetUniform<T>(string name)
             where T : struct, IEquatable<T>
         {

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyShader.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyShader.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Shaders;
 
 namespace osu.Framework.Graphics.Rendering.Dummy
@@ -12,6 +13,8 @@ namespace osu.Framework.Graphics.Rendering.Dummy
     internal class DummyShader : IShader
     {
         private readonly IRenderer renderer;
+
+        IReadOnlyDictionary<string, IUniform> IShader.Uniforms { get; } = new Dictionary<string, IUniform>();
 
         public DummyShader(IRenderer renderer)
         {

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -6,14 +6,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics.OpenGL.Shaders;
 using osuTK;
 
 namespace osu.Framework.Graphics.Shaders
 {
     internal static class GlobalPropertyManager
     {
-        private static readonly HashSet<GLShader> all_shaders = new HashSet<GLShader>();
+        private static readonly HashSet<IShader> all_shaders = new HashSet<IShader>();
         private static readonly IUniformMapping[] global_properties;
 
         static GlobalPropertyManager()
@@ -54,7 +53,7 @@ namespace osu.Framework.Graphics.Shaders
             ((UniformMapping<T>)global_properties[(int)property]).UpdateValue(ref value);
         }
 
-        public static void Register(GLShader shader)
+        public static void Register(IShader shader)
         {
             if (!all_shaders.Add(shader)) return;
 
@@ -68,7 +67,7 @@ namespace osu.Framework.Graphics.Shaders
             }
         }
 
-        public static void Unregister(GLShader shader)
+        public static void Unregister(IShader shader)
         {
             if (!all_shaders.Remove(shader)) return;
 

--- a/osu.Framework/Graphics/Shaders/IShader.cs
+++ b/osu.Framework/Graphics/Shaders/IShader.cs
@@ -2,11 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 
 namespace osu.Framework.Graphics.Shaders
 {
     public interface IShader : IDisposable
     {
+        /// <summary>
+        /// All uniforms declared by this shader.
+        /// </summary>
+        internal IReadOnlyDictionary<string, IUniform> Uniforms { get; }
+
         /// <summary>
         /// Binds this shader to be used for rendering.
         /// </summary>

--- a/osu.Framework/Graphics/Shaders/IUniform.cs
+++ b/osu.Framework/Graphics/Shaders/IUniform.cs
@@ -8,12 +8,29 @@ namespace osu.Framework.Graphics.Shaders
     /// <summary>
     /// Represents an updateable shader uniform.
     /// </summary>
-    internal interface IUniform
+    public interface IUniform
     {
-        void Update();
-
+        /// <summary>
+        /// The shader which this uniform was declared in.
+        /// </summary>
         IShader Owner { get; }
-        int Location { get; }
+
+        /// <summary>
+        /// The name of this uniform as declared by the shader, or <see cref="GlobalPropertyManager"/> for global uniforms.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// The location of this uniform in relation to all other uniforms in the shader.
+        /// </summary>
+        /// <remarks>
+        /// Depending on the renderer used, this could either be zero-based index number or location in bytes.
+        /// </remarks>
+        int Location { get; }
+
+        /// <summary>
+        /// Updates the renderer with the current value of this uniform.
+        /// </summary>
+        void Update();
     }
 }

--- a/osu.Framework/Graphics/Shaders/IUniform.cs
+++ b/osu.Framework/Graphics/Shaders/IUniform.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Graphics.Shaders
     /// <summary>
     /// Represents an updateable shader uniform.
     /// </summary>
-    public interface IUniform
+    internal interface IUniform
     {
         /// <summary>
         /// The shader which this uniform was declared in.


### PR DESCRIPTION
Was initially going to define a generic-less `GetUniform` method and move the generic variant to an extensions or seal it, but `GlobalPropertyManager` isn't aware whether the global uniform is defined by the shader or not, and `GetUniform` throws if the uniform could not be found.

Therefore I've went with an internal uniforms dictionary and called it a day.