### PR TITLE
Add `unmanaged` constraint to vertex/uniform generic types

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Batches/GLLinearBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLLinearBatch.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics.ES30;
 namespace osu.Framework.Graphics.OpenGL.Batches
 {
     internal class GLLinearBatch<T> : GLVertexBatch<T>
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         private readonly PrimitiveType type;
 

--- a/osu.Framework/Graphics/OpenGL/Batches/GLQuadBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLQuadBatch.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics.ES30;
 namespace osu.Framework.Graphics.OpenGL.Batches
 {
     internal class GLQuadBatch<T> : GLVertexBatch<T>
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         public GLQuadBatch(GLRenderer renderer, int size, int maxBuffers)
             : base(renderer, size, maxBuffers)

--- a/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
@@ -13,7 +13,7 @@ using osu.Framework.Statistics;
 namespace osu.Framework.Graphics.OpenGL.Batches
 {
     internal abstract class GLVertexBatch<T> : IVertexBatch<T>
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         public List<GLVertexBuffer<T>> VertexBuffers = new List<GLVertexBuffer<T>>();
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLLinearBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLLinearBuffer.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     /// This type of vertex buffer lets the ith vertex be referenced by the ith index.
     /// </summary>
     internal class GLLinearBuffer<T> : GLVertexBuffer<T>
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         private readonly int amountVertices;
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLQuadBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLQuadBuffer.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     }
 
     internal class GLQuadBuffer<T> : GLVertexBuffer<T>
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         private readonly int amountIndices;
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
@@ -14,7 +14,7 @@ using SixLabors.ImageSharp.Memory;
 namespace osu.Framework.Graphics.OpenGL.Buffers
 {
     internal abstract class GLVertexBuffer<T> : IGLVertexBuffer, IDisposable
-        where T : struct, IEquatable<T>, IVertex
+        where T : unmanaged, IEquatable<T>, IVertex
     {
         /// <summary>
         /// The maximum number of vertices supported by this buffer.

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexUtils.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     /// Helper method that provides functionality to enable and bind GL vertex attributes.
     /// </summary>
     internal static class GLVertexUtils<T>
-        where T : struct, IVertex
+        where T : unmanaged, IVertex
     {
         /// <summary>
         /// The stride of the vertex of type <typeparamref name="T"/>.

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
         /// <param name="name">The name of the uniform.</param>
         /// <returns>Returns a base uniform.</returns>
         public Uniform<T> GetUniform<T>(string name)
-            where T : struct, IEquatable<T>
+            where T : unmanaged, IEquatable<T>
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not retrieve uniforms from a disposed shader.");
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
             }
 
             IUniform createUniform<T>(string name)
-                where T : struct, IEquatable<T>
+                where T : unmanaged, IEquatable<T>
             {
                 int location = GL.GetUniformLocation(this, name);
 

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyShader.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyShader.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public bool IsBound { get; private set; }
 
         public Uniform<T> GetUniform<T>(string name)
-            where T : struct, IEquatable<T>
+            where T : unmanaged, IEquatable<T>
         {
             return new Uniform<T>(renderer, this, name, 0);
         }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -300,7 +300,7 @@ namespace osu.Framework.Graphics.Rendering
         /// Sets the value of a uniform.
         /// </summary>
         /// <param name="uniform">The uniform to set.</param>
-        internal void SetUniform<T>(IUniformWithValue<T> uniform) where T : struct, IEquatable<T>;
+        internal void SetUniform<T>(IUniformWithValue<T> uniform) where T : unmanaged, IEquatable<T>;
 
         /// <summary>
         /// Sets the current draw depth.

--- a/osu.Framework/Graphics/Rendering/IVertexBatch.cs
+++ b/osu.Framework/Graphics/Rendering/IVertexBatch.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Rendering
     }
 
     public interface IVertexBatch<in TVertex> : IVertexBatch
-        where TVertex : struct, IEquatable<TVertex>, IVertex
+        where TVertex : unmanaged, IEquatable<TVertex>, IVertex
     {
         /// <summary>
         /// Adds a vertex to this <see cref="IVertexBatch{T}"/>.

--- a/osu.Framework/Graphics/Rendering/Vertices/DepthWrappingVertex.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/DepthWrappingVertex.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
 {
     [StructLayout(LayoutKind.Sequential)]
     internal struct DepthWrappingVertex<TVertex> : IVertex, IEquatable<DepthWrappingVertex<TVertex>>
-        where TVertex : struct, IVertex, IEquatable<TVertex>
+        where TVertex : unmanaged, IVertex, IEquatable<TVertex>
     {
         public TVertex Vertex;
 

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.Shaders
         /// <param name="property">The uniform.</param>
         /// <param name="value">The uniform value.</param>
         public static void Set<T>(GlobalProperty property, T value)
-            where T : struct, IEquatable<T>
+            where T : unmanaged, IEquatable<T>
         {
             ((UniformMapping<T>)global_properties[(int)property]).UpdateValue(ref value);
         }

--- a/osu.Framework/Graphics/Shaders/GlobalUniform.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalUniform.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Rendering;
 namespace osu.Framework.Graphics.Shaders
 {
     internal class GlobalUniform<T> : IUniformWithValue<T>
-        where T : struct, IEquatable<T>
+        where T : unmanaged, IEquatable<T>
     {
         public IShader Owner { get; }
         public int Location { get; }

--- a/osu.Framework/Graphics/Shaders/IShader.cs
+++ b/osu.Framework/Graphics/Shaders/IShader.cs
@@ -33,6 +33,6 @@ namespace osu.Framework.Graphics.Shaders
         /// <param name="name">The name of the uniform.</param>
         /// <returns>The retrieved uniform.</returns>
         Uniform<T> GetUniform<T>(string name)
-            where T : struct, IEquatable<T>;
+            where T : unmanaged, IEquatable<T>;
     }
 }

--- a/osu.Framework/Graphics/Shaders/IUniformWithValue.cs
+++ b/osu.Framework/Graphics/Shaders/IUniformWithValue.cs
@@ -8,7 +8,7 @@ using System;
 namespace osu.Framework.Graphics.Shaders
 {
     internal interface IUniformWithValue<T> : IUniform
-        where T : struct, IEquatable<T>
+        where T : unmanaged, IEquatable<T>
     {
         ref T GetValueByRef();
         T GetValue();

--- a/osu.Framework/Graphics/Shaders/Uniform.cs
+++ b/osu.Framework/Graphics/Shaders/Uniform.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Rendering;
 namespace osu.Framework.Graphics.Shaders
 {
     public class Uniform<T> : IUniformWithValue<T>
-        where T : struct, IEquatable<T>
+        where T : unmanaged, IEquatable<T>
     {
         public IShader Owner { get; }
         public string Name { get; }

--- a/osu.Framework/Graphics/Shaders/UniformMapping.cs
+++ b/osu.Framework/Graphics/Shaders/UniformMapping.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Shaders
     /// A mapping of a global uniform to many shaders which need to receive updates on a change.
     /// </summary>
     internal class UniformMapping<T> : IUniformMapping
-        where T : struct, IEquatable<T>
+        where T : unmanaged, IEquatable<T>
     {
         private T val;
 


### PR DESCRIPTION
Required for Veldrid as it disallows updating vertex/uniform buffers with values that do not use the `unmanaged` constraint (see [`UpdateBuffer`](https://github.com/mellinoe/veldrid/blob/b881f7dcb444c4856e29464435b10d4be0ff38e0/src/Veldrid/CommandList.cs#L799-L803)). I've also updated non-required GL variants for consistency.