### PR TITLE
Rename `DepthStencilFunction` to `BufferTestFunction`

### DIFF
--- a/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                 // Populate the stencil buffer with 255 in places defined by the draw node.
                 renderer.PushStencilInfo(new StencilInfo(
                     stencilTest: true,
-                    testFunction: DepthStencilFunction.Always,
+                    testFunction: BufferTestFunction.Always,
                     255,
                     passed: StencilOperation.Replace));
 
@@ -129,7 +129,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                 // Only pass the stencil test where the stencil buffer value is 255.
                 renderer.PushStencilInfo(new StencilInfo(
                     stencilTest: true,
-                    testFunction: DepthStencilFunction.Equal,
+                    testFunction: BufferTestFunction.Equal,
                     mask: 255,
                     testValue: 255,
                     stencilFailed: StencilOperation.Keep,

--- a/osu.Framework/Graphics/OpenGL/GLUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/GLUtils.cs
@@ -33,32 +33,32 @@ namespace osu.Framework.Graphics.OpenGL
             }
         }
 
-        public static DepthFunction ToDepthFunction(DepthStencilFunction testFunction)
+        public static DepthFunction ToDepthFunction(BufferTestFunction testFunction)
         {
             switch (testFunction)
             {
-                case DepthStencilFunction.Never:
+                case BufferTestFunction.Never:
                     return DepthFunction.Never;
 
-                case DepthStencilFunction.LessThan:
+                case BufferTestFunction.LessThan:
                     return DepthFunction.Less;
 
-                case DepthStencilFunction.LessThanOrEqual:
+                case BufferTestFunction.LessThanOrEqual:
                     return DepthFunction.Lequal;
 
-                case DepthStencilFunction.Equal:
+                case BufferTestFunction.Equal:
                     return DepthFunction.Equal;
 
-                case DepthStencilFunction.GreaterThanOrEqual:
+                case BufferTestFunction.GreaterThanOrEqual:
                     return DepthFunction.Gequal;
 
-                case DepthStencilFunction.GreaterThan:
+                case BufferTestFunction.GreaterThan:
                     return DepthFunction.Greater;
 
-                case DepthStencilFunction.NotEqual:
+                case BufferTestFunction.NotEqual:
                     return DepthFunction.Notequal;
 
-                case DepthStencilFunction.Always:
+                case BufferTestFunction.Always:
                     return DepthFunction.Always;
 
                 default:
@@ -66,32 +66,32 @@ namespace osu.Framework.Graphics.OpenGL
             }
         }
 
-        public static StencilFunction ToStencilFunction(DepthStencilFunction testFunction)
+        public static StencilFunction ToStencilFunction(BufferTestFunction testFunction)
         {
             switch (testFunction)
             {
-                case DepthStencilFunction.Never:
+                case BufferTestFunction.Never:
                     return StencilFunction.Never;
 
-                case DepthStencilFunction.LessThan:
+                case BufferTestFunction.LessThan:
                     return StencilFunction.Less;
 
-                case DepthStencilFunction.LessThanOrEqual:
+                case BufferTestFunction.LessThanOrEqual:
                     return StencilFunction.Lequal;
 
-                case DepthStencilFunction.Equal:
+                case BufferTestFunction.Equal:
                     return StencilFunction.Equal;
 
-                case DepthStencilFunction.GreaterThanOrEqual:
+                case BufferTestFunction.GreaterThanOrEqual:
                     return StencilFunction.Gequal;
 
-                case DepthStencilFunction.GreaterThan:
+                case BufferTestFunction.GreaterThan:
                     return StencilFunction.Greater;
 
-                case DepthStencilFunction.NotEqual:
+                case BufferTestFunction.NotEqual:
                     return StencilFunction.Notequal;
 
-                case DepthStencilFunction.Always:
+                case BufferTestFunction.Always:
                     return StencilFunction.Always;
 
                 default:

--- a/osu.Framework/Graphics/Rendering/BufferTestFunction.cs
+++ b/osu.Framework/Graphics/Rendering/BufferTestFunction.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Rendering
 {
-    public enum DepthStencilFunction
+    public enum BufferTestFunction
     {
         /// <summary>
         /// The test always fails.

--- a/osu.Framework/Graphics/Rendering/DepthInfo.cs
+++ b/osu.Framework/Graphics/Rendering/DepthInfo.cs
@@ -28,9 +28,9 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The depth test function.
         /// </summary>
-        public readonly DepthStencilFunction Function;
+        public readonly BufferTestFunction Function;
 
-        public DepthInfo(bool depthTest = true, bool writeDepth = true, DepthStencilFunction function = DepthStencilFunction.LessThan)
+        public DepthInfo(bool depthTest = true, bool writeDepth = true, BufferTestFunction function = BufferTestFunction.LessThan)
         {
             DepthTest = depthTest;
             WriteDepth = writeDepth;

--- a/osu.Framework/Graphics/Rendering/StencilInfo.cs
+++ b/osu.Framework/Graphics/Rendering/StencilInfo.cs
@@ -14,14 +14,14 @@ namespace osu.Framework.Graphics.Rendering
 
         /// <summary>
         /// Whether stencil testing should occur.
-        /// If this is false, no <see cref="StencilOperation"/> will occur (use <see cref="DepthStencilFunction.Always"/> instead).
+        /// If this is false, no <see cref="StencilOperation"/> will occur (use <see cref="BufferTestFunction.Always"/> instead).
         /// </summary>
         public readonly bool StencilTest;
 
         /// <summary>
         /// The stencil test function.
         /// </summary>
-        public readonly DepthStencilFunction TestFunction;
+        public readonly BufferTestFunction TestFunction;
 
         /// <summary>
         /// The stencil test value to compare against.
@@ -48,7 +48,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         public readonly StencilOperation TestPassedOperation;
 
-        public StencilInfo(bool stencilTest = true, DepthStencilFunction testFunction = DepthStencilFunction.Always, int testValue = 1, int mask = 0xff,
+        public StencilInfo(bool stencilTest = true, BufferTestFunction testFunction = BufferTestFunction.Always, int testValue = 1, int mask = 0xff,
                            StencilOperation stencilFailed = StencilOperation.Keep, StencilOperation depthFailed = StencilOperation.Keep, StencilOperation passed = StencilOperation.Replace)
         {
             StencilTest = stencilTest;


### PR DESCRIPTION
Around the time #5351 was merged, `DepthTestFunction` was renamed to `DepthStencilFunction` (#5352) to allow the enum to be reused.
At the time I didn't pay too much attention to it, but I believe the name `BufferTestFunction` works better as a generalisation of the `{Depth,Stencil}TestFunction` concept.