### PR TITLE
Improve invalidation/validation performance

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkInvalidationList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkInvalidationList.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics;
+using osu.Framework.Layout;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkInvalidationList
+    {
+        private InvalidationList list;
+
+        [Benchmark]
+        public void Invalidate() => list.Invalidate(InvalidationSource.Self, Invalidation.All);
+
+        [Benchmark]
+        public void Validate() => list.Validate(Invalidation.All);
+    }
+}

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -1,9 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using osu.Framework.Layout;
 
@@ -53,8 +52,11 @@ namespace osu.Framework.Graphics
                     return invalidate(ref childInvalidation, flags);
 
                 default:
-                    throw new ArgumentException("Unexpected invalidation source.", nameof(source));
+                    return throwInvalidSourceException();
             }
+
+            [DoesNotReturn]
+            static bool throwInvalidSourceException() => throw new ArgumentException("Unexpected invalidation source.", nameof(source));
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -51,11 +51,8 @@ namespace osu.Framework.Graphics
                 case InvalidationSource.Parent:
                     return invalidate(parentInvalidation, flags, out parentInvalidation);
 
-                case InvalidationSource.Child:
-                    return invalidate(childInvalidation, flags, out childInvalidation);
-
                 default:
-                    return false;
+                    return invalidate(childInvalidation, flags, out childInvalidation);
             }
         }
 

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -25,9 +25,9 @@ namespace osu.Framework.Graphics
         {
             this = default;
 
-            invalidate(ref selfInvalidation, initialState);
-            invalidate(ref parentInvalidation, initialState);
-            invalidate(ref childInvalidation, initialState);
+            invalidate(selfInvalidation, initialState, out selfInvalidation);
+            invalidate(parentInvalidation, initialState, out parentInvalidation);
+            invalidate(childInvalidation, initialState, out childInvalidation);
         }
 
         /// <summary>
@@ -43,13 +43,13 @@ namespace osu.Framework.Graphics
             switch (source)
             {
                 case InvalidationSource.Self:
-                    return invalidate(ref selfInvalidation, flags);
+                    return invalidate(selfInvalidation, flags, out selfInvalidation);
 
                 case InvalidationSource.Parent:
-                    return invalidate(ref parentInvalidation, flags);
+                    return invalidate(parentInvalidation, flags, out parentInvalidation);
 
                 case InvalidationSource.Child:
-                    return invalidate(ref childInvalidation, flags);
+                    return invalidate(childInvalidation, flags, out childInvalidation);
 
                 default:
                     return throwInvalidSourceException();
@@ -67,30 +67,24 @@ namespace osu.Framework.Graphics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Validate(Invalidation validation)
         {
-            return validate(ref selfInvalidation, validation)
-                   | validate(ref parentInvalidation, validation)
-                   | validate(ref childInvalidation, validation);
+            return validate(selfInvalidation, validation, out selfInvalidation)
+                   | validate(parentInvalidation, validation, out parentInvalidation)
+                   | validate(childInvalidation, validation, out childInvalidation);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool invalidate(ref Invalidation target, Invalidation flags)
+        private bool invalidate(Invalidation target, Invalidation flags, out Invalidation result)
         {
-            if ((target & flags) == flags)
-                return false;
-
             // Remove all non-layout flags, as they should always propagate and are thus not to be stored.
-            target |= flags & Invalidation.Layout;
-            return true;
+            result = target | (flags & Invalidation.Layout);
+            return (target & flags) != flags;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool validate(ref Invalidation target, Invalidation flags)
+        private bool validate(Invalidation target, Invalidation flags, out Invalidation result)
         {
-            if ((target & flags) == 0)
-                return false;
-
-            target &= ~flags;
-            return true;
+            result = target & ~flags;
+            return (target & flags) != 0;
         }
     }
 }

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -33,14 +33,16 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Invalidates a <see cref="InvalidationSource"/> with given <see cref="Invalidation"/> flags.
         /// </summary>
+        /// <remarks>
+        /// Call sites must ensure that on a <see cref="InvalidationSource.Self"/>, <see cref="InvalidationSource.Parent"/> or <see cref="InvalidationSource.Child"/> source is provided.
+        /// </remarks>
         /// <param name="source">The <see cref="InvalidationSource"/> to invalidate.</param>
         /// <param name="flags">The <see cref="Invalidation"/> flags to invalidate with.</param>
         /// <returns>Whether an invalidation was performed.</returns>
-        /// <exception cref="ArgumentException">If <see cref="InvalidationSource"/> was not a valid source.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Invalidate(InvalidationSource source, Invalidation flags)
         {
-            // Guaranteed by preconditions at the callsite.
+            // Guaranteed by preconditions at the call site.
             Debug.Assert(source is InvalidationSource.Self or InvalidationSource.Parent or InvalidationSource.Child);
 
             switch (source)
@@ -51,6 +53,7 @@ namespace osu.Framework.Graphics
                 case InvalidationSource.Parent:
                     return invalidate(parentInvalidation, flags, out parentInvalidation);
 
+                // Guaranteed to be InvalidationSource.Child by the call site of this method.
                 default:
                     return invalidate(childInvalidation, flags, out childInvalidation);
             }

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Layout;
 
@@ -40,6 +40,9 @@ namespace osu.Framework.Graphics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Invalidate(InvalidationSource source, Invalidation flags)
         {
+            // Guaranteed by preconditions at the callsite.
+            Debug.Assert(source is InvalidationSource.Self or InvalidationSource.Parent or InvalidationSource.Child);
+
             switch (source)
             {
                 case InvalidationSource.Self:
@@ -52,11 +55,8 @@ namespace osu.Framework.Graphics
                     return invalidate(childInvalidation, flags, out childInvalidation);
 
                 default:
-                    return throwInvalidSourceException();
+                    return false;
             }
-
-            [DoesNotReturn]
-            static bool throwInvalidSourceException() => throw new ArgumentException("Unexpected invalidation source.", nameof(source));
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Layout;


### PR DESCRIPTION
Initial:

|     Method |      Mean |     Error |    StdDev |
|----------- |----------:|----------:|----------:|
| Invalidate | 2.4286 ns | 0.0092 ns | 0.0072 ns |
|   Validate | 0.8363 ns | 0.0022 ns | 0.0020 ns |

Removing exception:

|     Method |      Mean |     Error |    StdDev |
|----------- |----------:|----------:|----------:|
| Invalidate | 0.5200 ns | 0.0233 ns | 0.0218 ns |
|   Validate | 0.8370 ns | 0.0063 ns | 0.0056 ns |

Removing branching:

|     Method |      Mean |     Error |    StdDev |
|----------- |----------:|----------:|----------:|
| Invalidate | 0.5070 ns | 0.0161 ns | 0.0143 ns |
|   Validate | 0.5107 ns | 0.0126 ns | 0.0098 ns |

I suspect the branching is different on different CPUs and different workloads, but will now be consistent across the board.

I expect this can be further vectorised as future work, but probably won't lead to much improvement in this case.