### PR TITLE
Allow Drawable `Scale` to be exactly zero

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableScale.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableScale.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneDrawableScale : FrameworkTestScene
+    {
+        [TestCase(1, true)]
+        [TestCase(2, true)]
+        [TestCase(-1, true)]
+        [TestCase(-2, true)]
+        [TestCase(0, false)]
+        public void TestDrawablePresence(float scale, bool shouldBePresent)
+        {
+            Box box = null!;
+
+            AddStep("set child", () => Child = box = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(100),
+                Scale = new Vector2(scale)
+            });
+
+            AddAssert("box is present", () => box.IsPresent, () => Is.EqualTo(shouldBePresent));
+        }
+
+        [TestCase(1, 100)]
+        [TestCase(2, 200)]
+        [TestCase(-1, 100)]
+        [TestCase(-2, 200)]
+        [TestCase(0, 0)]
+        public void TestAutoSize(float scale, float expectedSize)
+        {
+            Container container = null!;
+
+            AddStep("set container", () => Child = container = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Child = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(100),
+                    Scale = new Vector2(scale)
+                }
+            });
+
+            AddAssert("width is correct", () => container.DrawSize.X, () => Is.EqualTo(expectedSize).Within(1));
+            AddAssert("height is correct", () => container.DrawSize.Y, () => Is.EqualTo(expectedSize).Within(1));
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(-1)]
+        [TestCase(-2)]
+        [TestCase(0)]
+        public void TestInput(float scale)
+        {
+            Box box = null!;
+
+            AddStep("set child", () => Child = box = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(100),
+                Scale = new Vector2(scale)
+            });
+
+            AddAssert("passed through input X position is correct",
+                () => box.ToParentSpace(box.ToLocalSpace(box.Parent.ToScreenSpace(Vector2.Zero))).X,
+                () => Is.Zero.Within(1));
+
+            AddAssert("passed through input Y position is correct",
+                () => box.ToParentSpace(box.ToLocalSpace(box.Parent.ToScreenSpace(Vector2.Zero))).Y,
+                () => Is.Zero.Within(1));
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -67,7 +67,9 @@ namespace osu.Framework.Graphics.Containers
                     break;
             }
 
-            content.Size = Vector2.Divide(Vector2.One, content.Scale);
+            content.Size = new Vector2(
+                content.Scale.X == 0 ? 0 : 1 / content.Scale.X,
+                content.Scale.Y == 0 ? 0 : 1 / content.Scale.Y);
         }
     }
 

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -53,9 +53,12 @@ namespace osu.Framework.Graphics
 
             if (scale != Vector2.One)
             {
-                Vector2 inverseScale = new Vector2(1.0f / scale.X, 1.0f / scale.Y);
+                // Zero scale leads to unexpected input and autosize calculations, so it's clamped to a sane value.
+                if (scale.X == 0) scale.X = Precision.FLOAT_EPSILON;
+                if (scale.Y == 0) scale.Y = Precision.FLOAT_EPSILON;
+
                 MatrixExtensions.ScaleFromLeft(ref Matrix, scale);
-                MatrixExtensions.ScaleFromRight(ref MatrixInverse, inverseScale);
+                MatrixExtensions.ScaleFromRight(ref MatrixInverse, Vector2.Divide(Vector2.One, scale));
             }
 
             if (origin != Vector2.Zero)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -970,11 +970,6 @@ namespace osu.Framework.Graphics
             get => scale;
             set
             {
-                if (Math.Abs(value.X) < Precision.FLOAT_EPSILON)
-                    value.X = Precision.FLOAT_EPSILON;
-                if (Math.Abs(value.Y) < Precision.FLOAT_EPSILON)
-                    value.Y = Precision.FLOAT_EPSILON;
-
                 if (scale == value)
                     return;
 
@@ -1321,7 +1316,7 @@ namespace osu.Framework.Graphics
         /// Determines whether this Drawable is present based on its <see cref="Alpha"/> value.
         /// Can be forced always on with <see cref="AlwaysPresent"/>.
         /// </summary>
-        public virtual bool IsPresent => AlwaysPresent || (Alpha > visibility_cutoff && Math.Abs(Scale.X) > Precision.FLOAT_EPSILON && Math.Abs(Scale.Y) > Precision.FLOAT_EPSILON);
+        public virtual bool IsPresent => AlwaysPresent || (Alpha > visibility_cutoff && Scale.X != 0 && Scale.Y != 0);
 
         private bool alwaysPresent;
 


### PR DESCRIPTION
I don't know the original issue with storyboards so @peppy please test if this works for you.

`DrawInfo` still needs to handle zero scale. As it turns out, this value cannot be 0 for either the scale or the inverse scale, as input breaks either way. Tests have been added for this case.