### PR TITLE
Attempt to fix AppVeyor not publishing .snupkgs

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -230,7 +230,7 @@ Task("Publish")
     .WithCriteria(AppVeyor.IsRunningOnAppVeyor)
     .Does(() => {
         foreach (var artifact in GetFiles(artifactsDirectory.CombineWithFilePath("*").FullPath))
-            AppVeyor.UploadArtifact(artifact);
+            AppVeyor.UploadArtifact(artifact, settings => settings.SetArtifactType(AppVeyorUploadArtifactType.NuGetPackage));
     });
 
 Task("Build")


### PR DESCRIPTION
I'm seeing callbacks to this in various places like https://help.appveyor.com/discussions/questions/44202-how-to-publish-symbol-packages-snupkg-on-nuget and https://help.appveyor.com/discussions/questions/49442-snupkg-symbols-are-not-uploaded-to-nugetorg where they specifically mention adding `-Type NuGetPackage`. By default it seems that cake uses `-Type Auto`