### PR TITLE
Throw exception when modifying contents of Container<T> while iterating through it

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
+++ b/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Containers
         {
             AddStep("iterate through parent doing nothing", () => Assert.DoesNotThrow(() =>
             {
-                foreach (var child in parent)
+                foreach (var _ in parent)
                 {
                 }
             }));
@@ -39,7 +39,7 @@ namespace osu.Framework.Tests.Containers
         {
             AddStep("adding child during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
             {
-                foreach (var child in parent)
+                foreach (var _ in parent)
                 {
                     parent.Add(new Container());
                 }
@@ -63,7 +63,7 @@ namespace osu.Framework.Tests.Containers
         {
             AddStep("clearing children during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
             {
-                foreach (var child in parent)
+                foreach (var _ in parent)
                 {
                     parent.Clear();
                 }

--- a/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
+++ b/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
@@ -6,23 +6,22 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Tests.Visual;
 
-namespace osu.Framework.Tests.Visual.Containers
+namespace osu.Framework.Tests.Containers
 {
-    public class TestSceneEnumerator : FrameworkTestScene
+    public class TestSceneEnumeratorVersion : FrameworkTestScene
     {
         private Container parent;
 
         [SetUp]
-        public void SetUp()
+        public void SetUp() => Schedule(() =>
         {
             Child = parent = new Container
             {
-                Child = new Container
-                {
-                }
+                Child = new Container()
             };
-        }
+        });
 
         [Test]
         public void TestEnumeratingNormally()

--- a/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
+++ b/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
@@ -12,7 +10,7 @@ namespace osu.Framework.Tests.Containers
 {
     public class TestSceneEnumeratorVersion : FrameworkTestScene
     {
-        private Container parent;
+        private Container parent = null!;
 
         [SetUp]
         public void SetUp() => Schedule(() =>

--- a/osu.Framework.Tests/Visual/Containers/TestSceneEnumerator.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneEnumerator.cs
@@ -13,23 +13,31 @@ namespace osu.Framework.Tests.Visual.Containers
     {
         private Container parent;
 
-        [Test]
-        public void TestAddChildDuringEnumerationFails()
+        [SetUp]
+        public void SetUp()
         {
-            AddStep("create hierarchy", () => Child = parent = new Container
+            Child = parent = new Container
             {
                 Child = new Container
                 {
                 }
-            });
+            };
+        }
 
+        [Test]
+        public void TestEnumeratingNormally()
+        {
             AddStep("iterate through parent doing nothing", () => Assert.DoesNotThrow(() =>
             {
                 foreach (var child in parent)
                 {
                 }
             }));
+        }
 
+        [Test]
+        public void TestAddChildDuringEnumerationFails()
+        {
             AddStep("adding child during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
             {
                 foreach (var child in parent)
@@ -42,25 +50,23 @@ namespace osu.Framework.Tests.Visual.Containers
         [Test]
         public void TestRemoveChildDuringEnumerationFails()
         {
-            AddStep("create hierarchy", () => Child = parent = new Container
-            {
-                Child = new Container
-                {
-                }
-            });
-
-            AddStep("iterate through parent doing nothing", () => Assert.DoesNotThrow(() =>
-            {
-                foreach (var child in parent)
-                {
-                }
-            }));
-
             AddStep("removing child during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
             {
                 foreach (var child in parent)
                 {
                     parent.Remove(child, true);
+                }
+            }));
+        }
+
+        [Test]
+        public void TestClearDuringEnumerationFails()
+        {
+            AddStep("clearing children during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var child in parent)
+                {
+                    parent.Clear();
                 }
             }));
         }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneEnumerator.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneEnumerator.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestSceneEnumerator : FrameworkTestScene
+    {
+        private Container parent;
+
+        [Test]
+        public void TestAddChildDuringEnumerationFails()
+        {
+            AddStep("create hierarchy", () => Child = parent = new Container
+            {
+                Child = new Container
+                {
+                }
+            });
+
+            AddStep("iterate through parent doing nothing", () => Assert.DoesNotThrow(() =>
+            {
+                foreach (var child in parent)
+                {
+                }
+            }));
+
+            AddStep("adding child during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var child in parent)
+                {
+                    parent.Add(new Container());
+                }
+            }));
+        }
+
+        [Test]
+        public void TestRemoveChildDuringEnumerationFails()
+        {
+            AddStep("create hierarchy", () => Child = parent = new Container
+            {
+                Child = new Container
+                {
+                }
+            });
+
+            AddStep("iterate through parent doing nothing", () => Assert.DoesNotThrow(() =>
+            {
+                foreach (var child in parent)
+                {
+                }
+            }));
+
+            AddStep("removing child during enumeration fails", () => Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var child in parent)
+                {
+                    parent.Remove(child, true);
+                }
+            }));
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -39,9 +39,9 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// This is checked when enumerating through this <see cref="Container"/> to throw when
         /// <see cref="Children"/> was mutated while enumerating (in <see cref="Enumerator"/>).
-        /// This is incremented whenever <see cref="Children"/> is mutated (e.g. with <see cref="Add(T)"/>). 
+        /// This is incremented whenever <see cref="Children"/> is mutated (e.g. with <see cref="Add(T)"/>).
         /// </summary>
-        private int version = 0;
+        private int enumeratorVersion;
 
         /// <summary>
         /// Constructs a <see cref="Container"/> that stores children.
@@ -250,7 +250,7 @@ namespace osu.Framework.Graphics.Containers
                     $"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {GetType().ReadableName()} which does not redirect {nameof(Content)}.");
             }
 
-            version++;
+            enumeratorVersion++;
 
             base.AddInternal(drawable);
         }
@@ -309,7 +309,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected internal override bool RemoveInternal(Drawable drawable, bool disposeImmediately)
         {
-            version++;
+            enumeratorVersion++;
 
             return base.RemoveInternal(drawable, disposeImmediately);
         }
@@ -336,7 +336,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected internal override void ClearInternal(bool disposeChildren = true)
         {
-            version++;
+            enumeratorVersion++;
 
             base.ClearInternal(disposeChildren);
         }
@@ -513,18 +513,18 @@ namespace osu.Framework.Graphics.Containers
         {
             private Container<T> container;
             private int currentIndex;
-            private int version;
+            private readonly int version;
 
             internal Enumerator(Container<T> container)
             {
                 this.container = container;
                 currentIndex = -1; // The first MoveNext() should bring the iterator to 0
-                version = container.version;
+                version = container.enumeratorVersion;
             }
 
             public bool MoveNext()
             {
-                if (version != container.version)
+                if (version != container.enumeratorVersion)
                     throw new InvalidOperationException($"May not add or remove {nameof(Children)} from this {nameof(Container)} during enumeration.");
 
                 return ++currentIndex < container.Count;


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/5379

I believe I've covered all the methods that can mutate `Children`?

Also not sure if I should also check the version in `Reset()` of the enumerator. `List<T>` does it but I can't think of the case where that would throw