### PR TITLE
Make `IsPresent` consider `DrawScale` instead of `Scale`

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1316,7 +1316,7 @@ namespace osu.Framework.Graphics
         /// Determines whether this Drawable is present based on its <see cref="Alpha"/> value.
         /// Can be forced always on with <see cref="AlwaysPresent"/>.
         /// </summary>
-        public virtual bool IsPresent => AlwaysPresent || (Alpha > visibility_cutoff && Scale.X != 0 && Scale.Y != 0);
+        public virtual bool IsPresent => AlwaysPresent || (Alpha > visibility_cutoff && DrawScale.X != 0 && DrawScale.Y != 0);
 
         private bool alwaysPresent;
 


### PR DESCRIPTION
This is stupid and I hope we will remove `DrawScale` at some point, but I'm not entirely sure how to handle storyboard just yet. It (storyboard) is the only consumer of `DrawScale`.

No consumer should be overriding `DrawScale` for the simple reason that it bypasses invalidation.