### PR TITLE
Mark `TestSceneEnumeratorVersion` as headless

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
+++ b/osu.Framework.Tests/Containers/TestSceneEnumeratorVersion.cs
@@ -4,10 +4,12 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 using osu.Framework.Tests.Visual;
 
 namespace osu.Framework.Tests.Containers
 {
+    [HeadlessTest]
     public class TestSceneEnumeratorVersion : FrameworkTestScene
     {
         private Container parent = null!;


### PR DESCRIPTION
Shouldn't display in visual test browser. Caused all tests to be prefixed with `Visuals.`.