### PR TITLE
Add option to neglect non-space characters such as diacritics to SearchContainer

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -139,6 +139,26 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(count);
         }
 
+        [TestCase("sUbSeCtIoN 1", 6)]
+        [TestCase("èê", 1)]
+        [TestCase("ouaeeeaaa", 0)]
+        public void TestMatchingNonSpace(string term, int count)
+        {
+            AddStep("set matching non-space characters on", () => search.NonSpaceCharactersMatching = true);
+            setTerm(term);
+            checkCount(count);
+        }
+
+        [TestCase("sUbSeCtIoN 1", 6)]
+        [TestCase("èê", 1)]
+        [TestCase("ouaeeeaaa", 1)]
+        public void TestIgnoreNonSpace(string term, int count)
+        {
+            AddStep("set matching non-space characters off", () => search.NonSpaceCharactersMatching = false);
+            setTerm(term);
+            checkCount(count);
+        }
+
         [TestCase("tst", 2)]
         [TestCase("ssn 1", 6)]
         [TestCase("sns 1", 0)]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -185,6 +185,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Change locale to es", () => configManager.SetValue(FrameworkSetting.Locale, "es"));
             setTerm("Adiós");
             checkCount(1);
+            setTerm("Adios");
+            checkCount(1);
             setTerm("Goodbye");
             checkCount(1);
         }

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -126,14 +126,14 @@ namespace osu.Framework.Graphics.Containers
         private static bool checkTerm(string haystack, string needle, bool nonContiguous)
         {
             if (!nonContiguous)
-                return haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+                return CultureInfo.InvariantCulture.CompareInfo.IndexOf(haystack, needle, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase) >= 0;
 
             int index = 0;
 
             for (int i = 0; i < needle.Length; i++)
             {
                 // string.IndexOf doesn't have an overload which takes both a `startIndex` and `StringComparison` mode.
-                int found = CultureInfo.InvariantCulture.CompareInfo.IndexOf(haystack, needle[i], index, CompareOptions.OrdinalIgnoreCase);
+                int found = CultureInfo.InvariantCulture.CompareInfo.IndexOf(haystack, needle[i], index, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase);
                 if (found < 0)
                     return false;
 

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -52,6 +52,10 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        /// <summary>
+        /// Whether the matching algorithm should consider non-space characters like Diacritics.
+        /// If <c>false</c>, searching for "Adios" will match "Adiós".
+        /// </summary>
         public bool NonSpaceCharactersMatching
         {
             get => nonSpaceCharactersMatching;


### PR DESCRIPTION
This pull request addresses issue https://github.com/ppy/osu/issues/19591.

With this implementation diacritics are neglected altogether if NonSpaceCharacterMatching is set to false.

I think almost always diacritics should be neglected but maybe there are cases when it matters.