### PR TITLE
Fix `PoolableDrawable` prepare call schedules potentially creating overhead if drawable never updated

### DIFF
--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -101,8 +101,7 @@ namespace osu.Framework.Graphics.Pooling
 
             IsInUse = true;
 
-            // prepare call is scheduled as it may contain user code dependent on the clock being updated.
-            // must use Scheduler.Add, not Schedule as we may have the wrong clock at this point in load.
+            // prepare call is performed on Update() as it may contain user code dependent on the clock being updated.
             waitingForPrepare = true;
         }
 


### PR DESCRIPTION
If a drawable is taken from a pool but never `IsPresent` before being returned, the schduled `PrepareForUse` operation may never run. This can cause a single pooled drawable to end up with thousands of schduled delegates.

In this version, I removed usage of `Scheduler` completely. Rationale is that there was already a flag tracking whether prepare has been run (`waitingForPrepare`) and it may avoid creating a `Scheduler` in the case it is not used elsewhere (as these are lazily created in `Drawable`).

If preferred, [see this branch](https://github.com/ppy/osu-framework/compare/master...peppy:osu-framework:fix-pooling-shit-v1?expand=1) for a version which switches to using `AddOnce`.

This fixes one portion of editor performance during slider rotation eventually degrading (https://github.com/ppy/osu/issues/20208).