### PR TITLE
Remove `EnumerateBaseTypes` overhead in `UnbindAllBindables`

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkUnbindAllBindables.cs
+++ b/osu.Framework.Benchmarks/BenchmarkUnbindAllBindables.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkUnbindAllBindables
+    {
+        private readonly IFrameBasedClock clock = new FramedClock();
+        private readonly IReadOnlyDependencyContainer dependencies = new DependencyContainer();
+
+        [Test]
+        [Benchmark]
+        public void TestBaseline()
+        {
+            object _ = new object();
+        }
+
+        [Test]
+        [Benchmark]
+        public void TestCompositeDrawable()
+        {
+            var _ = new SimpleComposite();
+            _.Load(clock, dependencies);
+            _.UnbindAllBindables();
+        }
+
+        [Test]
+        [Benchmark]
+        public void TestContainer()
+        {
+            var _ = new Container();
+            _.Load(clock, dependencies);
+            _.UnbindAllBindables();
+        }
+
+        [Test]
+        [Benchmark]
+        public void TestTypeNestedComposite()
+        {
+            var _ = new SimpleComposite3();
+            _.Load(clock, dependencies);
+            _.UnbindAllBindables();
+        }
+
+        public class SimpleComposite3 : SimpleComposite2
+        {
+        }
+
+        public class SimpleComposite2 : SimpleComposite1
+        {
+        }
+
+        public class SimpleComposite1 : SimpleComposite
+        {
+        }
+
+        public class SimpleComposite : CompositeDrawable
+        {
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -59,9 +59,6 @@ namespace osu.Framework.Graphics.Containers
             AddLayout(childrenSizeDependencies);
         }
 
-        [Resolved]
-        private Game game { get; set; }
-
         /// <summary>
         /// Create a local dependency container which will be used by our nested children.
         /// If not overridden, the load-time parent's dependency tree will be used.
@@ -142,7 +139,7 @@ namespace osu.Framework.Graphics.Containers
                                                                Scheduler scheduler = null)
             where TLoadable : Drawable
         {
-            if (game == null)
+            if (LoadState < LoadState.Loading)
                 throw new InvalidOperationException($"May not invoke {nameof(LoadComponentAsync)} prior to this {nameof(CompositeDrawable)} being loaded.");
 
             EnsureMutationAllowed($"load components via {nameof(LoadComponentsAsync)}");
@@ -221,7 +218,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="components">The children or grand-children to be loaded.</param>
         protected void LoadComponents<TLoadable>(IEnumerable<TLoadable> components) where TLoadable : Drawable
         {
-            if (game == null)
+            if (LoadState < LoadState.Loading)
                 throw new InvalidOperationException($"May not invoke {nameof(LoadComponent)} prior to this {nameof(CompositeDrawable)} being loaded.");
 
             if (IsDisposed)


### PR DESCRIPTION
At a small memory footprint cost (in the `static` cache), we can improve throughput of `UnbindAllBindables` significantly. I believe this is worth it because we are usually running `UnbindAllBindables` synchronously and every bit helps there, especially in edge case scenarios where many drawables are involved.

This also reduces allocs in construction of the drawable due to not checking the caching at each base type anymore.

For what it's worth, this came up in editor profiling:

<img width="468" alt="Parallels Desktop 2022-09-14 at 20 33 54@2x" src="https://user-images.githubusercontent.com/191335/190256823-e115e05e-b2d7-4902-a577-7ea7ecf36e8c.png">
<img width="469" alt="Parallels Desktop 2022-09-14 at 20 34 56@2x" src="https://user-images.githubusercontent.com/191335/190257021-e7901afd-7c01-471d-ba6e-80b0cdb5c52d.png">

---

master

|                  Method |          Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------ |--------------:|-----------:|-----------:|-------:|----------:|
|            TestBaseline |     0.0000 ns |  0.0000 ns |  0.0000 ns |      - |         - |
|   TestCompositeDrawable | 2,566.2274 ns | 50.6315 ns | 47.3607 ns | 0.1678 |   1,936 B |
|           TestContainer | 2,837.5013 ns | 41.0672 ns | 38.4143 ns | 0.1717 |   2,008 B |
| TestTypeNestedComposite | 3,006.6396 ns | 55.4453 ns | 51.8635 ns | 0.1678 |   1,936 B |

this PR

|                  Method |          Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------ |--------------:|-----------:|-----------:|-------:|----------:|
|            TestBaseline |     0.0000 ns |  0.0000 ns |  0.0000 ns |      - |         - |
|   TestCompositeDrawable | 2,398.8362 ns | 46.4871 ns | 49.7407 ns | 0.1564 |   1,808 B |
|           TestContainer | 2,718.9215 ns | 49.2533 ns | 46.0716 ns | 0.1602 |   1,880 B |
| TestTypeNestedComposite | 2,768.1898 ns | 52.0354 ns | 51.1058 ns | 0.1564 |   1,808 B |

