### PR TITLE
Reduce overhead of `Waveform`

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkWaveform.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWaveform.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using ManagedBass;
+using NUnit.Framework;
+using osu.Framework.Audio.Track;
+using osu.Framework.IO.Stores;
+using osu.Framework.Tests.Visual;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkWaveform : BenchmarkTest
+    {
+        private Stream data = null!;
+        private Waveform preloadedWaveform = null!;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            Bass.Init();
+
+            var store = new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(FrameworkTestScene).Assembly), "Resources");
+
+            data = store.GetStream("Tracks/sample-track.mp3");
+
+            Debug.Assert(data != null);
+
+            preloadedWaveform = new Waveform(data);
+            // wait for load
+            preloadedWaveform.GetPoints();
+        }
+
+        [Benchmark]
+        [Test]
+        public async Task TestCreate()
+        {
+            var waveform = new Waveform(data);
+
+            var originalPoints = await waveform.GetPointsAsync().ConfigureAwait(false);
+            Debug.Assert(originalPoints.Length > 0);
+        }
+
+        [Arguments(1024)]
+        [TestCase(1024)]
+        [Arguments(32768)]
+        [TestCase(32768)]
+        [Benchmark]
+        public async Task TestResample(int size)
+        {
+            var resampled = await preloadedWaveform.GenerateResampledAsync(size).ConfigureAwait(false);
+            var resampledPoints = await resampled.GetPointsAsync().ConfigureAwait(false);
+
+            Debug.Assert(resampledPoints.Length > 0);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddUntilStep("wait for load", () => graph.Regenerated);
 
-            AddUntilStep("wait for sampling", () => graph.Waveform.GetPoints().Count > 0);
+            AddUntilStep("wait for sampling", () => graph.Waveform.GetPoints().Length > 0);
         }
 
         private void startStop()

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -140,7 +140,7 @@ namespace osu.Framework.Audio.Track
                             {
                                 // Find the maximum amplitude for each channel in the point
                                 point.AmplitudeLeft = Math.Max(point.AmplitudeLeft, Math.Abs(sampleBuffer[j]));
-                                point.AmplitudeRight = Math.Max(point.AmplitudeLeft, Math.Abs(sampleBuffer[j + secondChannelIndex]));
+                                point.AmplitudeRight = Math.Max(point.AmplitudeRight, Math.Abs(sampleBuffer[j + secondChannelIndex]));
                             }
 
                             // BASS may provide unclipped samples, so clip them ourselves

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// The data stream is iteratively decoded to provide this many points per iteration so as to not exceed BASS's internal buffer size.
         /// </summary>
-        private const int points_per_iteration = 100000;
+        private const int points_per_iteration = 1000;
 
         /// <summary>
         /// FFT1024 gives ~40hz accuracy.

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -45,22 +45,22 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Minimum frequency for low-range (bass) frequencies. Based on lower range of bass drum fallout.
         /// </summary>
-        private const double low_min = 20;
+        private const float low_min = 20;
 
         /// <summary>
         /// Minimum frequency for mid-range frequencies. Based on higher range of bass drum fallout.
         /// </summary>
-        private const double mid_min = 100;
+        private const float mid_min = 100;
 
         /// <summary>
         /// Minimum frequency for high-range (treble) frequencies.
         /// </summary>
-        private const double high_min = 2000;
+        private const float high_min = 2000;
 
         /// <summary>
         /// Maximum frequency for high-range (treble) frequencies. A sane value.
         /// </summary>
-        private const double high_max = 12000;
+        private const float high_max = 12000;
 
         private int channels;
         private List<Point> points = new List<Point>();
@@ -150,9 +150,9 @@ namespace osu.Framework.Audio.Track
                         length = Bass.ChannelGetData(decodeStream, bins, (int)fft_samples);
                         currentByte += length;
 
-                        double lowIntensity = computeIntensity(info, bins, low_min, mid_min);
-                        double midIntensity = computeIntensity(info, bins, mid_min, high_min);
-                        double highIntensity = computeIntensity(info, bins, high_min, high_max);
+                        float lowIntensity = computeIntensity(info, bins, low_min, mid_min);
+                        float midIntensity = computeIntensity(info, bins, mid_min, high_min);
+                        float highIntensity = computeIntensity(info, bins, high_min, high_max);
 
                         // In general, the FFT function will read more data than the amount of data we have in one point
                         // so we'll be setting intensities for all points whose data fits into the amount read by the FFT
@@ -174,7 +174,7 @@ namespace osu.Framework.Audio.Track
             }, cancelSource.Token);
         }
 
-        private double computeIntensity(ChannelInfo info, float[] bins, double startFrequency, double endFrequency)
+        private float computeIntensity(ChannelInfo info, float[] bins, float startFrequency, float endFrequency)
         {
             int startBin = (int)(fft_bins * 2 * startFrequency / info.Frequency);
             int endBin = (int)(fft_bins * 2 * endFrequency / info.Frequency);
@@ -182,7 +182,7 @@ namespace osu.Framework.Audio.Track
             startBin = Math.Clamp(startBin, 0, bins.Length);
             endBin = Math.Clamp(endBin, 0, bins.Length);
 
-            double value = 0;
+            float value = 0;
             for (int i = startBin; i < endBin; i++)
                 value += bins[i];
             return value;
@@ -351,17 +351,17 @@ namespace osu.Framework.Audio.Track
             /// <summary>
             /// Unnormalised total intensity of the low-range (bass) frequencies.
             /// </summary>
-            public double LowIntensity;
+            public float LowIntensity;
 
             /// <summary>
             /// Unnormalised total intensity of the mid-range frequencies.
             /// </summary>
-            public double MidIntensity;
+            public float MidIntensity;
 
             /// <summary>
             /// Unnormalised total intensity of the high-range (treble) frequencies.
             /// </summary>
-            public double HighIntensity;
+            public float HighIntensity;
 
             /// <summary>
             /// Constructs a <see cref="Point"/>.

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -159,9 +159,11 @@ namespace osu.Framework.Audio.Track
                         // We know that each data point required sampleDataPerPoint amount of data
                         for (; currentPoint < points.Count && currentPoint * bytesPerPoint < currentByte; currentPoint++)
                         {
-                            points[currentPoint].LowIntensity = lowIntensity;
-                            points[currentPoint].MidIntensity = midIntensity;
-                            points[currentPoint].HighIntensity = highIntensity;
+                            var point = points[currentPoint];
+                            point.LowIntensity = lowIntensity;
+                            point.MidIntensity = midIntensity;
+                            point.HighIntensity = highIntensity;
+                            points[currentPoint] = point;
                         }
                     }
 
@@ -341,7 +343,7 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Represents a singular point of data in a <see cref="Waveform"/>.
         /// </summary>
-        public class Point
+        public struct Point
         {
             /// <summary>
             /// An array of amplitudes, one for each channel.
@@ -370,6 +372,10 @@ namespace osu.Framework.Audio.Track
             public Point(int channels)
             {
                 Amplitude = new float[channels];
+
+                LowIntensity = 0;
+                MidIntensity = 0;
+                HighIntensity = 0;
             }
         }
     }

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -380,10 +380,10 @@ namespace osu.Framework.Graphics.Audio
                         {
                             float height = drawSize.Y / 2;
                             quadToDraw = new Quad(
-                                new Vector2(leftX, height - points[i].Amplitude[0] * height),
-                                new Vector2(rightX, height - points[i + 1].Amplitude[0] * height),
-                                new Vector2(leftX, height + points[i].Amplitude[1] * height),
-                                new Vector2(rightX, height + points[i + 1].Amplitude[1] * height)
+                                new Vector2(leftX, height - points[i].AmplitudeLeft * height),
+                                new Vector2(rightX, height - points[i + 1].AmplitudeLeft * height),
+                                new Vector2(leftX, height + points[i].AmplitudeRight * height),
+                                new Vector2(rightX, height + points[i + 1].AmplitudeRight * height)
                             );
                             break;
                         }
@@ -391,8 +391,8 @@ namespace osu.Framework.Graphics.Audio
                         case 1:
                         {
                             quadToDraw = new Quad(
-                                new Vector2(leftX, drawSize.Y - points[i].Amplitude[0] * drawSize.Y),
-                                new Vector2(rightX, drawSize.Y - points[i + 1].Amplitude[0] * drawSize.Y),
+                                new Vector2(leftX, drawSize.Y - points[i].AmplitudeLeft * drawSize.Y),
+                                new Vector2(rightX, drawSize.Y - points[i + 1].AmplitudeLeft * drawSize.Y),
                                 new Vector2(leftX, drawSize.Y),
                                 new Vector2(rightX, drawSize.Y)
                             );

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -265,7 +265,7 @@ namespace osu.Framework.Graphics.Audio
             private IShader shader;
             private Texture texture;
 
-            private readonly List<Waveform.Point> points = new List<Waveform.Point>();
+            private List<Waveform.Point> points;
 
             private Vector2 drawSize;
             private int channels;
@@ -304,10 +304,16 @@ namespace osu.Framework.Graphics.Audio
 
                 if (Source.resampledVersion != version)
                 {
-                    points.Clear();
+                    // Late initialise list to use a sane initial capacity.
+                    if (points == null)
+                        points = new List<Waveform.Point>(Source.resampledPoints ?? Enumerable.Empty<Waveform.Point>());
+                    else
+                    {
+                        points.Clear();
 
-                    if (Source.resampledPoints != null)
-                        points.AddRange(Source.resampledPoints);
+                        if (Source.resampledPoints != null)
+                            points.AddRange(Source.resampledPoints);
+                    }
 
                     channels = Source.resampledChannels;
 

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -177,7 +177,7 @@ namespace osu.Framework.Graphics.Audio
         private CancellationTokenSource cancelSource = new CancellationTokenSource();
 
         private long resampledVersion;
-        private List<Waveform.Point> resampledPoints;
+        private Waveform.Point[] resampledPoints;
         private int? resampledPointCount;
         private int resampledChannels;
         private double resampledMaxHighIntensity;
@@ -208,16 +208,16 @@ namespace osu.Framework.Graphics.Audio
             {
                 var resampled = await originalWaveform.GenerateResampledAsync(requiredPointCount, token).ConfigureAwait(false);
 
-                int originalPointCount = (await originalWaveform.GetPointsAsync().ConfigureAwait(false)).Count;
+                int originalPointCount = (await originalWaveform.GetPointsAsync().ConfigureAwait(false)).Length;
 
                 Logger.Log($"Waveform resampled with {requiredPointCount:N0} points (original {originalPointCount:N0})...");
 
                 var points = await resampled.GetPointsAsync().ConfigureAwait(false);
                 int channels = await resampled.GetChannelsAsync().ConfigureAwait(false);
 
-                double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
-                double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
-                double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
+                double maxHighIntensity = points.Length > 0 ? points.Max(p => p.HighIntensity) : 0;
+                double maxMidIntensity = points.Length > 0 ? points.Max(p => p.MidIntensity) : 0;
+                double maxLowIntensity = points.Length > 0 ? points.Max(p => p.LowIntensity) : 0;
 
                 Schedule(() =>
                 {


### PR DESCRIPTION
Noticed that waveform points are up in the top 5 memory usages in editor (*game*-wide) so did a bit of refactoring. There's likely much more that can be improved here, but this was the low-hanging pass.

Before:

![Parallels Desktop 2022-09-15 at 05 10 27](https://user-images.githubusercontent.com/191335/190319635-8d97a37d-a2de-485c-907b-4202c577cff4.png)

![Parallels Desktop 2022-09-15 at 05 11 14](https://user-images.githubusercontent.com/191335/190319745-b2bbb8c5-01e1-4cab-bb9f-e2e4186699d1.png)

After:

![Parallels Desktop 2022-09-15 at 05 07 45](https://user-images.githubusercontent.com/191335/190319393-dc443d7a-8d53-4bf1-95af-da20a875c42d.png)

Note that the counts here are a bit off (one more retained array in the "after" run) so savings are probably a touch better than displayed. Also the main goal was to switch away from `Point` being a `class`.

I also looked into reducing overall allocations during construction and resampling. The main fix for this was to reduce the `points_per_iteration` to a more sane number (it was previously allocating a very large buffer with no real benefit performance-wise). And then using `ArrayPool` for it (now that the size is beneath the `ArrayPool` allowance).

These results are probably more telling:

Before:

|       Method |  size |      Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------- |------ |----------:|----------:|----------:|---------:|---------:|---------:|----------:|
|   TestCreate |     ? | 99.921 ms | 1.2161 ms | 1.1375 ms | 800.0000 | 600.0000 | 400.0000 | 23,815 KB |
| TestResample |  1024 |  3.468 ms | 0.0175 ms | 0.0164 ms |   7.8125 |        - |        - |     98 KB |
| TestResample | 32768 |  6.994 ms | 0.1383 ms | 0.1480 ms | 257.8125 | 140.6250 | 109.3750 |  3,074 KB |

After:


|       Method |  size |      Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------- |------ |----------:|----------:|----------:|---------:|---------:|---------:|----------:|
|   TestCreate |     ? | 91.525 ms | 0.8581 ms | 0.8026 ms | 333.3333 | 166.6667 | 166.6667 |  3,614 KB |
| TestResample |  1024 |  2.323 ms | 0.0098 ms | 0.0082 ms |   3.9063 |        - |        - |     58 KB |
| TestResample | 32768 |  3.421 ms | 0.0214 ms | 0.0200 ms | 285.1563 | 257.8125 | 195.3125 |  1,795 KB |
