### PR TITLE
Fix unbind action caching occurring too late

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -271,12 +271,12 @@ namespace osu.Framework.Graphics
             RequestsNonPositionalInputSubTree = RequestsNonPositionalInput;
             RequestsPositionalInputSubTree = RequestsPositionalInput;
 
-            InjectDependencies(dependencies);
-
             var type = GetType();
 
             if (!unbind_action_cache.ContainsKey(type))
                 cacheUnbindAction(type);
+
+            InjectDependencies(dependencies);
 
             LoadAsyncComplete();
 


### PR DESCRIPTION
This was causing osu! side failures. It "regressed" with #5411, but was only "working" previously due to the relevant base types being cached elsewhere. So a bit of luck that things have been working until now.

I'm not sure how to write test coverage for this (or if it's required), but I've run osu! side tests and confirmed they now pass (see failure on [update attempt](https://github.com/ppy/osu/pull/20328)).