### PR TITLE
Ensure unbind action is always available on request

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -253,9 +253,6 @@ namespace osu.Framework.Graphics
                 {
                     Trace.Assert(loadState == LoadState.NotLoaded);
 
-                    if (!unbind_action_cache.ContainsKey(GetType()))
-                        getUnbindAction();
-
                     loadState = LoadState.Loading;
 
                     load(clock, dependencies);
@@ -268,6 +265,9 @@ namespace osu.Framework.Graphics
         private void load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
         {
             LoadThread = Thread.CurrentThread;
+
+            // Cache eagerly during load to hopefully defer the reflection overhead to an async pathway.
+            getUnbindAction();
 
             UpdateClock(clock);
 


### PR DESCRIPTION
Caching is still left in place to defer the overhead to a potentially asynchronous load operation. But as we've found, there's a chance `UnbindAllBindables` can be called while a load is also running, and in such cases we want to be assured that the unbind action still runs.

master:

|                  Method |          Mean |      Error |     StdDev |        Median |  Gen 0 | Allocated |
|------------------------ |--------------:|-----------:|-----------:|--------------:|-------:|----------:|
|            TestBaseline |     0.0018 ns |  0.0073 ns |  0.0061 ns |     0.0000 ns |      - |         - |
|   TestCompositeDrawable | 2,075.5773 ns | 21.8103 ns | 17.0280 ns | 2,075.6587 ns | 0.1450 |   1,680 B |
|           TestContainer | 2,243.6053 ns | 23.6792 ns | 20.9910 ns | 2,245.7282 ns | 0.1488 |   1,752 B |
| TestTypeNestedComposite | 2,412.0879 ns | 20.9093 ns | 19.5586 ns | 2,417.2321 ns | 0.1450 |   1,680 B |


this PR:

|                  Method |          Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------ |--------------:|-----------:|-----------:|-------:|----------:|
|            TestBaseline |     0.0000 ns |  0.0000 ns |  0.0000 ns |      - |         - |
|   TestCompositeDrawable | 2,107.0397 ns | 30.1856 ns | 28.2356 ns | 0.1488 |   1,712 B |
|           TestContainer | 2,320.3007 ns | 16.9093 ns | 13.2017 ns | 0.1526 |   1,784 B |
| TestTypeNestedComposite | 2,422.2889 ns | 12.8755 ns | 10.7516 ns | 0.1488 |   1,712 B |

The extra allocation overhead comes from the `Action<object>` inside the `getUnbindAction` implementation, but I don't think it's too important. Performance different is small enough to be within error margins.