### PR TITLE
Forward tablet driver output to custom logging target

### DIFF
--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -227,7 +227,7 @@ namespace osu.Framework.Android.Input
 
         private void logUnhandledEvent(string methodName, InputEvent inputEvent)
         {
-            Logger.Log($"Unknown {GetType().ReadableName()}.{methodName} event: {inputEvent}");
+            Log($"Unknown {GetType().ReadableName()}.{methodName} event: {inputEvent}");
         }
     }
 }

--- a/osu.Framework.Android/Input/AndroidJoystickHandler.cs
+++ b/osu.Framework.Android/Input/AndroidJoystickHandler.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Android.Input
                 if (axis.TryGetJoystickAxisSource(out _))
                     return true;
 
-                Logger.Log($"Unknown joystick axis: {axis}");
+                Log($"Unknown joystick axis: {axis}");
                 return false;
             }
         }

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -8,12 +8,15 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Input.Handlers
 {
     public abstract class InputHandler : IDisposable, IHasDescription
     {
+        private static readonly Logger logger = Logger.GetLogger(LoggingTarget.Input);
+
         private bool isInitialized;
 
         /// <summary>
@@ -63,7 +66,7 @@ namespace osu.Framework.Input.Handlers
         public abstract bool IsActive { get; }
 
         /// <summary>
-        /// A user-readable description of this input handler, for display in settings.
+        /// A user-readable description of this input handler, for display in settings and logs.
         /// </summary>
         public virtual string Description => ToString().Replace("Handler", string.Empty);
 
@@ -71,6 +74,14 @@ namespace osu.Framework.Input.Handlers
         /// Whether this InputHandler should be collecting <see cref="IInput"/>s to return on the next <see cref="CollectPendingInputs"/> call
         /// </summary>
         public BindableBool Enabled { get; } = new BindableBool(true);
+
+        /// <summary>
+        /// Logs an arbitrary string prefixed by the name of this input handler.
+        /// </summary>
+        /// <param name="message">The message to log. Can include newline (\n) characters to split into multiple lines.</param>
+        /// <param name="level">The verbosity level.</param>
+        /// <param name="exception">An optional related exception.</param>
+        protected void Log(string message, LogLevel level = LogLevel.Verbose, Exception exception = null) => logger.Add($"[{Description}] {message}", level);
 
         public override string ToString() => GetType().Name;
 

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Input.Handlers.Midi
                             closeDevice(device);
                             openedDevices.Remove(key);
 
-                            Logger.Log($"Disconnected MIDI device: {device.Details.Name}");
+                            Log($"Disconnected MIDI device: {device.Details.Name}");
                         }
                     }
 
@@ -96,7 +96,7 @@ namespace osu.Framework.Input.Handlers.Midi
                             newInput.MessageReceived += onMidiMessageReceived;
                             openedDevices[input.Id] = newInput;
 
-                            Logger.Log($"Connected MIDI device: {newInput.Details.Name}");
+                            Log($"Connected MIDI device: {newInput.Details.Name}");
                         }
                     }
                 }
@@ -109,7 +109,7 @@ namespace osu.Framework.Input.Handlers.Midi
                     ? "Is libasound2-dev installed?"
                     : "There may be another application already using MIDI.";
 
-                Logger.Log($"MIDI devices could not be enumerated. {message} ({e.Message})");
+                Log($"MIDI devices could not be enumerated. {message} ({e.Message})");
 
                 // stop attempting to refresh devices until next startup.
                 inGoodState = false;
@@ -143,7 +143,7 @@ namespace osu.Framework.Input.Handlers.Midi
             catch (Exception exception)
             {
                 string dataString = string.Join("-", e.Data.Select(b => b.ToString("X2")));
-                Logger.Error(exception, $"An exception occurred while reading MIDI data from sender {senderId}: {dataString}");
+                Log($"An exception occurred while reading MIDI data from sender {senderId}: {dataString}", LogLevel.Error, exception);
             }
         }
 

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -14,8 +14,6 @@ namespace osu.Framework.Input.Handlers.Tablet
     /// </summary>
     public interface ITabletHandler
     {
-        const string LOGGER_NAME = "Tablet";
-
         /// <summary>
         /// The offset of the area which should be mapped to the game window.
         /// </summary>

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -14,6 +14,8 @@ namespace osu.Framework.Input.Handlers.Tablet
     /// </summary>
     public interface ITabletHandler
     {
+        const string LOGGER_NAME = "Tablet";
+
         /// <summary>
         /// The offset of the area which should be mapped to the game window.
         /// </summary>

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -74,6 +74,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                                 updateOutputArea(host.Window);
                             }
                         };
+                        tabletDriver.PostLog = Log;
                         tabletDriver.DeviceReported += handleDeviceReported;
                         tabletDriver.Detect();
                     });

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -30,6 +30,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private AbsoluteOutputMode outputMode;
 
+        public override string Description => "Tablet";
+
         public override bool IsActive => tabletDriver != null;
 
         public Bindable<Vector2> AreaOffset { get; } = new Bindable<Vector2>();

--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -22,6 +22,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 {
     public sealed class TabletDriver : Driver
     {
+        private static readonly Logger tablet_logger = Logger.GetLogger(ITabletHandler.LOGGER_NAME);
+
         private static readonly IEnumerable<int> known_vendors = Enum.GetValues<DeviceVendor>().Cast<int>();
 
         private CancellationTokenSource cancellationSource;
@@ -31,7 +33,11 @@ namespace osu.Framework.Input.Handlers.Tablet
         public TabletDriver([NotNull] ICompositeDeviceHub deviceHub, [NotNull] IReportParserProvider reportParserProvider, [NotNull] IDeviceConfigurationProvider configurationProvider)
             : base(deviceHub, reportParserProvider, configurationProvider)
         {
-            Log.Output += (_, logMessage) => Logger.Log($"{logMessage.Group}: {logMessage.Message}", level: (LogLevel)logMessage.Level);
+            Log.Output += (_, logMessage) =>
+            {
+                LogLevel level = (int)logMessage.Level > (int)LogLevel.Error ? LogLevel.Error : (LogLevel)logMessage.Level;
+                tablet_logger.Add($"{logMessage.Group}: {logMessage.Message}", level: level);
+            };
 
             deviceHub.DevicesChanged += (_, args) =>
             {

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -568,6 +568,11 @@ namespace osu.Framework.Logging
         /// <summary>
         /// Logging target for database-related events.
         /// </summary>
-        Database
+        Database,
+
+        /// <summary>
+        /// Logging target for input-related information.
+        /// </summary>
+        Input
     }
 }


### PR DESCRIPTION
One step towards better tablet notifications for osu!, see https://github.com/ppy/osu/issues/20324.

This stops them from being posted as notifications with raw messages ([notice `entry.Target == null`](https://github.com/ppy/osu/blob/a2492a4ff5e4b07bc24bca171e9c73efa25b3f8f/osu.Game/OsuGame.cs#L1003)). Instead, it allows the game to treat them differently by checking against `entry.LoggerName == ITabletHandler.LOGGER_NAME` when subscribed to logger events.

Also improves console log output in general:
```
[runtime] 2022-09-16 12:39:24 [verbose]: Starting legacy IPC provider...
[runtime] 2022-09-16 12:39:25 [verbose]: Attempting to use custom storage location /Users/salman/osu-lazer-development/
[runtime] 2022-09-16 12:39:25 [verbose]: Storage successfully changed to /Users/salman/osu-lazer-development/.
[tablet] 2022-09-16 12:39:25 [verbose]: Detect: Searching for tablets...
[tablet] 2022-09-16 12:39:25 [debug]: Detect: Searching for tablet '10moon 1060N'
[tablet] 2022-09-16 12:39:25 [debug]: Detect: Searching for tablet 'Acepen AP 1060'
[tablet] 2022-09-16 12:39:25 [debug]: Detect: Searching for tablet 'Artisul A1201'
[tablet] 2022-09-16 12:39:25 [debug]: Detect: Searching for tablet 'Artisul AP604'
...
Console output is being limited. Please check tablet.log for full logs.
[tablet] 2022-09-16 12:39:25 [verbose]: Detect: No tablets were detected.
[runtime] 2022-09-16 12:39:26 [verbose]: SDL error log [debug]: Window data not set
[runtime] 2022-09-16 12:39:26 [verbose]: SDL error log [debug]: Window data not set
[runtime] 2022-09-16 12:39:26 [verbose]: GL Initialized
[runtime] 2022-09-16 12:39:26 [verbose]: GL Version:                 2.1 Metal - 76.3
[runtime] 2022-09-16 12:39:26 [verbose]: GL Renderer:                Apple M1 Pro
[runtime] 2022-09-16 12:39:26 [verbose]: GL Shader Language version: 1.20
[runtime] 2022-09-16 12:39:26 [verbose]: GL Vendor:                  Apple
```

Not 100% sure about the addition of a new log file though, alternatives would be:
 - keep all tablet logs as "verbose" regardless of the level (similar to SDL) and prefix them to identify on logger event callback (+ some regex osu!-side to decode level and message from `entry.Message`, very ugly)
 - keep all tablet logs as "verbose" but add an event from `ITabletHandler` to listen to tablet logs (requires cloning classes because of net6.0-netstandard2.1 dual targetting shit)
 - add a whole other special path in `Logger` for notifications that "shouldn't be shown to user but remain logged in file and in console"
 
Need further thoughts on this, one upside about separate file may be allowing to easily attach tablet logs when directing users to report their issues over at OpenTabletDriver's repo (which is a good idea but may need an agreement with the folks there beforehand, so I'm not doing it just yet).