### PR TITLE
Add support for blending "write mask" in `IRenderer`

### DIFF
--- a/osu.Framework/Graphics/BlendingMask.cs
+++ b/osu.Framework/Graphics/BlendingMask.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using System;
+
+namespace osu.Framework.Graphics
+{
+    /// <summary>
+    /// Represents colour component flags used for colour write mask during blending.
+    /// </summary>
+    [Flags]
+    public enum BlendingMask
+    {
+        /// <summary>
+        /// No colour component will be written to the framebuffer.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The red component will be written to the framebuffer.
+        /// </summary>
+        Red = 1,
+
+        /// <summary>
+        /// The green component will be written to the framebuffer.
+        /// </summary>
+        Green = 1 << 1,
+
+        /// <summary>
+        /// The blue component will be written to the framebuffer.
+        /// </summary>
+        Blue = 1 << 2,
+
+        /// <summary>
+        /// The alpha component will be written to the framebuffer.
+        /// </summary>
+        Alpha = 1 << 3,
+
+        /// <summary>
+        /// All colour components will be written to the framebuffer.
+        /// </summary>
+        All = Red | Green | Blue | Alpha,
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Batches;
@@ -219,6 +220,14 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.BlendFuncSeparate(blendingParameters.SourceBlendingFactor, blendingParameters.DestinationBlendingFactor,
                     blendingParameters.SourceAlphaBlendingFactor, blendingParameters.DestinationAlphaBlendingFactor);
             }
+        }
+
+        protected override void SetBlendMaskImplementation(BlendingMask blendingMask)
+        {
+            GL.ColorMask(blendingMask.HasFlagFast(BlendingMask.Red),
+                blendingMask.HasFlagFast(BlendingMask.Green),
+                blendingMask.HasFlagFast(BlendingMask.Blue),
+                blendingMask.HasFlagFast(BlendingMask.Alpha));
         }
 
         protected override void SetViewportImplementation(RectangleI viewport) => GL.Viewport(viewport.Left, viewport.Top, viewport.Width, viewport.Height);

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -79,6 +79,10 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         {
         }
 
+        public void SetBlendMask(BlendingMask blendingMask)
+        {
+        }
+
         public void PushViewport(RectangleI viewport)
         {
         }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -173,6 +173,12 @@ namespace osu.Framework.Graphics.Rendering
         void SetBlend(BlendingParameters blendingParameters);
 
         /// <summary>
+        /// Sets a mask deciding which colour components are affected during blending.
+        /// </summary>
+        /// <param name="blendingMask">The blending mask.</param>
+        void SetBlendMask(BlendingMask blendingMask);
+
+        /// <summary>
         /// Applies a new viewport rectangle.
         /// </summary>
         /// <param name="viewport">The viewport rectangle.</param>

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -59,6 +59,7 @@ namespace osu.Framework.Graphics.Rendering
 
         protected ClearInfo CurrentClearInfo { get; private set; }
         protected BlendingParameters CurrentBlendingParameters { get; private set; }
+        protected BlendingMask CurrentBlendingMask { get; private set; }
 
         /// <summary>
         /// Whether scissor is currently enabled.
@@ -314,11 +315,28 @@ namespace osu.Framework.Graphics.Rendering
             CurrentBlendingParameters = blendingParameters;
         }
 
+        public void SetBlendMask(BlendingMask blendingMask)
+        {
+            if (CurrentBlendingMask == blendingMask)
+                return;
+
+            FlushCurrentBatch();
+            SetBlendMaskImplementation(blendingMask);
+
+            CurrentBlendingMask = blendingMask;
+        }
+
         /// <summary>
         /// Updates the graphics device with the new blending parameters.
         /// </summary>
         /// <param name="blendingParameters">The blending parameters.</param>
         protected abstract void SetBlendImplementation(BlendingParameters blendingParameters);
+
+        /// <summary>
+        /// Updates the graphics device with the new blending mask.
+        /// </summary>
+        /// <param name="blendingMask">The blending mask.</param>
+        protected abstract void SetBlendMaskImplementation(BlendingMask blendingMask);
 
         #endregion
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -486,15 +486,16 @@ namespace osu.Framework.Platform
                 {
                     depthValue.Reset();
 
-                    GL.ColorMask(false, false, false, false);
                     Renderer.SetBlend(BlendingParameters.None);
+
+                    Renderer.SetBlendMask(BlendingMask.None);
                     Renderer.PushDepthInfo(DepthInfo.Default);
 
                     // Front pass
                     buffer.Object.DrawOpaqueInteriorSubTree(Renderer, depthValue);
 
                     Renderer.PopDepthInfo();
-                    GL.ColorMask(true, true, true, true);
+                    Renderer.SetBlendMask(BlendingMask.All);
 
                     // The back pass doesn't write depth, but needs to depth test properly
                     Renderer.PushDepthInfo(new DepthInfo(true, false));


### PR DESCRIPTION
Dependency for supporting front-to-back passes in non-OpenGL renderers.