### PR TITLE
Fix unsubscription logic not handling null tablet drivers

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -75,10 +75,13 @@ namespace osu.Framework.Input.Handlers.Tablet
                 {
                     lastInitTask?.WaitSafely();
 
-                    tabletDriver.DeviceReported -= handleDeviceReported;
-                    tabletDriver.TabletsChanged -= handleTabletsChanged;
-                    tabletDriver?.Dispose();
-                    tabletDriver = null;
+                    if (tabletDriver != null)
+                    {
+                        tabletDriver.DeviceReported -= handleDeviceReported;
+                        tabletDriver.TabletsChanged -= handleTabletsChanged;
+                        tabletDriver.Dispose();
+                        tabletDriver = null;
+                    }
                 }
             }, true);
 

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -1,13 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 #if NET6_0_OR_GREATER
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using OpenTabletDriver;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
@@ -24,14 +21,13 @@ namespace osu.Framework.Input.Handlers.Tablet
 {
     public class OpenTabletDriverHandler : InputHandler, IAbsolutePointer, IRelativePointer, IPressureHandler, ITabletHandler
     {
-        private TabletDriver tabletDriver;
+        private TabletDriver? tabletDriver;
 
-        [CanBeNull]
-        private InputDeviceTree device;
+        private InputDeviceTree? device;
 
-        private AbsoluteOutputMode outputMode;
+        private AbsoluteOutputMode outputMode = null!;
 
-        private GameHost host;
+        private GameHost host = null!;
 
         public override bool IsActive => tabletDriver != null;
 
@@ -45,7 +41,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private readonly Bindable<TabletInfo> tablet = new Bindable<TabletInfo>();
 
-        private Task lastInitTask;
+        private Task? lastInitTask;
 
         public override bool Initialize(GameHost host)
         {
@@ -94,9 +90,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         void IPressureHandler.SetPressure(float percentage) => enqueueInput(new MouseButtonInput(osuTK.Input.MouseButton.Left, percentage > 0));
 
-        private void handleTabletsChanged(object _, IEnumerable<TabletReference> tablets)
+        private void handleTabletsChanged(object? sender, IEnumerable<TabletReference> tablets)
         {
-            device = tablets.Any() ? tabletDriver.InputDevices.First() : null;
+            device = tablets.Any() ? tabletDriver?.InputDevices.First() : null;
 
             if (device != null)
             {
@@ -108,7 +104,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             }
         }
 
-        private void handleDeviceReported(object sender, IDeviceReport report)
+        private void handleDeviceReported(object? sender, IDeviceReport report)
         {
             switch (report)
             {
@@ -145,7 +141,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             }
         }
 
-        private void updateInputArea([CanBeNull] InputDeviceTree inputDevice)
+        private void updateInputArea(InputDeviceTree? inputDevice)
         {
             if (inputDevice == null)
                 return;

--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -1,15 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 #if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver;
 using OpenTabletDriver.Plugin;
@@ -24,11 +21,11 @@ namespace osu.Framework.Input.Handlers.Tablet
     {
         private static readonly IEnumerable<int> known_vendors = Enum.GetValues<DeviceVendor>().Cast<int>();
 
-        private CancellationTokenSource cancellationSource;
+        private CancellationTokenSource? cancellationSource;
 
-        public event EventHandler<IDeviceReport> DeviceReported;
+        public event EventHandler<IDeviceReport>? DeviceReported;
 
-        public TabletDriver([NotNull] ICompositeDeviceHub deviceHub, [NotNull] IReportParserProvider reportParserProvider, [NotNull] IDeviceConfigurationProvider configurationProvider)
+        public TabletDriver(ICompositeDeviceHub deviceHub, IReportParserProvider reportParserProvider, IDeviceConfigurationProvider configurationProvider)
             : base(deviceHub, reportParserProvider, configurationProvider)
         {
             Log.Output += (_, logMessage) => Logger.Log($"{logMessage.Group}: {logMessage.Message}", level: (LogLevel)logMessage.Level);


### PR DESCRIPTION
Oversight from https://github.com/ppy/osu-framework/pull/5424. Apparently CI does not catch any critical failures on the input handler classes. That's spooky.