### PR TITLE
Add new rider metadata changes for preferring project settings

### DIFF
--- a/.idea/.idea.osu-framework.Android/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.osu-framework.Android/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/.idea.osu-framework.Desktop/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/.idea.osu-framework.iOS/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.osu-framework.iOS/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/.idea.osu-framework/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.osu-framework/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/.idea.osu-framework/.idea/vcs.xml
+++ b/.idea/.idea.osu-framework/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Without this change, Rider would use different codestyle settings and start complaining about it in code analysis. This only started happening on Rider 2022.2.3, but it may have been something that got reset on my machine. @peppy confirm you get that as well?