### PR TITLE
Fix VBO incorrectly flushing on no-op shader bind

### DIFF
--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -932,15 +932,18 @@ namespace osu.Framework.Graphics.Rendering
         {
             ThreadSafety.EnsureDrawThread();
 
+            if (shader == Shader)
+                return;
+
             if (shader != null)
             {
                 FrameStatistics.Increment(StatisticsCounterType.ShaderBinds);
 
                 FlushCurrentBatch();
                 SetShaderImplementation(shader);
-            }
 
-            Shader = shader;
+                Shader = shader;
+            }
         }
 
         internal void SetUniform<T>(IUniformWithValue<T> uniform)


### PR DESCRIPTION
Previously, we were maintaining a variable pointing to the current shader such that if a `Pop` then `Push` happened resulting in the same shader being bound, it would not trigger a buffer flush or any draw call overhead.

This check was removed incorrectly.

Regressed in https://github.com/ppy/osu-framework/pull/5404.

Closes ppy/osu#20421.