### PR TITLE
Always show exclusive fullscreen as enabled on Intel platforms

### DIFF
--- a/osu.Framework/Platform/Windows/IWindowsRenderer.cs
+++ b/osu.Framework/Platform/Windows/IWindowsRenderer.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Platform.Windows
+{
+    public interface IWindowsRenderer
+    {
+        IBindable<FullscreenCapability> FullscreenCapability { get; }
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
+++ b/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
@@ -1,0 +1,102 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Platform.Windows
+{
+    internal class WindowsGLRenderer : GLRenderer, IWindowsRenderer
+    {
+        public IBindable<FullscreenCapability> FullscreenCapability => fullscreenCapability;
+        private readonly Bindable<FullscreenCapability> fullscreenCapability = new Bindable<FullscreenCapability>();
+
+        private readonly WindowsGameHost host;
+
+        public WindowsGLRenderer(WindowsGameHost host)
+        {
+            this.host = host;
+        }
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+
+            WindowsWindow window = (WindowsWindow)host.Window;
+
+            window.IsActive.BindValueChanged(_ => detectFullscreenCapability(window));
+            window.WindowStateChanged += _ => detectFullscreenCapability(window);
+            detectFullscreenCapability(window);
+        }
+
+        private CancellationTokenSource? fullscreenCapabilityDetectionCancellationSource;
+
+        private void detectFullscreenCapability(IWindow window)
+        {
+            fullscreenCapabilityDetectionCancellationSource?.Cancel();
+            fullscreenCapabilityDetectionCancellationSource?.Dispose();
+            fullscreenCapabilityDetectionCancellationSource = null;
+
+            if (window.WindowState != WindowState.Fullscreen || !window.IsActive.Value || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
+                return;
+
+            var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();
+
+            // 50 attempts, 100ms apart = run the detection for a total of 5 seconds before yielding an incapable state.
+            const int max_attempts = 50;
+            const int time_per_attempt = 100;
+            int attempts = 0;
+
+            queueNextAttempt();
+
+            void queueNextAttempt() => Task.Delay(time_per_attempt, cancellationSource.Token).ContinueWith(_ =>
+            {
+                if (cancellationSource.IsCancellationRequested || window.WindowState != WindowState.Fullscreen || !window.IsActive.Value)
+                    return;
+
+                attempts++;
+
+                try
+                {
+                    SHQueryUserNotificationState(out var notificationState);
+
+                    var capability = notificationState == QueryUserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN
+                        ? Windows.FullscreenCapability.Capable
+                        : Windows.FullscreenCapability.Incapable;
+
+                    if (capability == Windows.FullscreenCapability.Incapable && attempts < max_attempts)
+                    {
+                        queueNextAttempt();
+                        return;
+                    }
+
+                    fullscreenCapability.Value = capability;
+                    Logger.Log($"Exclusive fullscreen capability: {fullscreenCapability.Value} ({notificationState})");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to detect fullscreen capabilities.");
+                    fullscreenCapability.Value = Windows.FullscreenCapability.Capable;
+                }
+            }, cancellationSource.Token);
+        }
+
+        [DllImport("shell32.dll")]
+        private static extern int SHQueryUserNotificationState(out QueryUserNotificationState state);
+
+        private enum QueryUserNotificationState
+        {
+            QUNS_NOT_PRESENT = 1,
+            QUNS_BUSY = 2,
+            QUNS_RUNNING_D3D_FULL_SCREEN = 3,
+            QUNS_PRESENTATION_MODE = 4,
+            QUNS_ACCEPTS_NOTIFICATIONS = 5,
+            QUNS_QUIET_TIME = 6
+        }
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
+++ b/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
@@ -58,6 +58,7 @@ namespace osu.Framework.Platform.Windows
                 return;
 
             var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();
+            var cancellationToken = cancellationSource.Token;
 
             // 50 attempts, 100ms apart = run the detection for a total of 5 seconds before yielding an incapable state.
             const int max_attempts = 50;
@@ -66,9 +67,9 @@ namespace osu.Framework.Platform.Windows
 
             queueNextAttempt();
 
-            void queueNextAttempt() => Task.Delay(time_per_attempt, cancellationSource.Token).ContinueWith(_ =>
+            void queueNextAttempt() => Task.Delay(time_per_attempt, cancellationToken).ContinueWith(_ =>
             {
-                if (cancellationSource.IsCancellationRequested || window.WindowState != WindowState.Fullscreen || !window.IsActive.Value)
+                if (cancellationToken.IsCancellationRequested || window.WindowState != WindowState.Fullscreen || !window.IsActive.Value)
                     return;
 
                 attempts++;
@@ -95,7 +96,7 @@ namespace osu.Framework.Platform.Windows
                     Logger.Error(ex, "Failed to detect fullscreen capabilities.");
                     fullscreenCapability.Value = Windows.FullscreenCapability.Capable;
                 }
-            }, cancellationSource.Token);
+            }, cancellationToken);
         }
 
         [DllImport("shell32.dll")]

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
@@ -66,6 +67,8 @@ namespace osu.Framework.Platform.Windows
                        .Where(t => !(t is MouseHandler))
                        .Concat(new InputHandler[] { new WindowsMouseHandler() });
         }
+
+        protected override IRenderer CreateRenderer() => new WindowsGLRenderer(this);
 
         protected override void SetupForRun()
         {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -6,12 +6,8 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
-using osu.Framework.Bindables;
 using osu.Framework.Input.Handlers.Mouse;
-using osu.Framework.Logging;
 using osu.Framework.Platform.SDL2;
 using osu.Framework.Platform.Windows.Native;
 using osuTK;
@@ -29,9 +25,6 @@ namespace osu.Framework.Platform.Windows
         private const int large_icon_size = 256;
         private const int small_icon_size = 16;
 
-        public IBindable<FullscreenCapability> FullscreenCapability => fullscreenCapability;
-        private readonly Bindable<FullscreenCapability> fullscreenCapability = new Bindable<FullscreenCapability>();
-
         private Icon smallIcon;
         private Icon largeIcon;
 
@@ -48,62 +41,6 @@ namespace osu.Framework.Platform.Windows
             {
                 // API doesn't exist on Windows 7 so it needs to be allowed to fail silently.
             }
-
-            IsActive.BindValueChanged(_ => detectFullscreenCapability(WindowState));
-            WindowStateChanged += detectFullscreenCapability;
-            detectFullscreenCapability(WindowState);
-        }
-
-        private CancellationTokenSource fullscreenCapabilityDetectionCancellationSource;
-
-        private void detectFullscreenCapability(WindowState state)
-        {
-            fullscreenCapabilityDetectionCancellationSource?.Cancel();
-            fullscreenCapabilityDetectionCancellationSource?.Dispose();
-            fullscreenCapabilityDetectionCancellationSource = null;
-
-            if (state != WindowState.Fullscreen || !IsActive.Value || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
-                return;
-
-            var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();
-
-            // 50 attempts, 100ms apart = run the detection for a total of 5 seconds before yielding an incapable state.
-            const int max_attempts = 50;
-            const int time_per_attempt = 100;
-            int attempts = 0;
-
-            queueNextAttempt();
-
-            void queueNextAttempt() => Task.Delay(time_per_attempt, cancellationSource.Token).ContinueWith(_ => ScheduleEvent(() =>
-            {
-                if (cancellationSource.IsCancellationRequested || WindowState != WindowState.Fullscreen || !IsActive.Value)
-                    return;
-
-                attempts++;
-
-                try
-                {
-                    SHQueryUserNotificationState(out var notificationState);
-
-                    var capability = notificationState == QueryUserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN
-                        ? Windows.FullscreenCapability.Capable
-                        : Windows.FullscreenCapability.Incapable;
-
-                    if (capability == Windows.FullscreenCapability.Incapable && attempts < max_attempts)
-                    {
-                        queueNextAttempt();
-                        return;
-                    }
-
-                    fullscreenCapability.Value = capability;
-                    Logger.Log($"Exclusive fullscreen capability: {fullscreenCapability.Value} ({notificationState})");
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, "Failed to detect fullscreen capabilities.");
-                    fullscreenCapability.Value = Windows.FullscreenCapability.Capable;
-                }
-            }), cancellationSource.Token);
         }
 
         public override void Create()
@@ -334,18 +271,5 @@ namespace osu.Framework.Platform.Windows
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
-
-        [DllImport("shell32.dll")]
-        private static extern int SHQueryUserNotificationState(out QueryUserNotificationState state);
-
-        private enum QueryUserNotificationState
-        {
-            QUNS_NOT_PRESENT = 1,
-            QUNS_BUSY = 2,
-            QUNS_RUNNING_D3D_FULL_SCREEN = 3,
-            QUNS_PRESENTATION_MODE = 4,
-            QUNS_ACCEPTS_NOTIFICATIONS = 5,
-            QUNS_QUIET_TIME = 6
-        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/19961

I've moved the code to `WindowsGLRenderer` since it now queries the GL vendor to check if it's `Intel`. I've tested this to work as expected on a PC with only an Intel iGPU and a laptop with both iGPU and dGPU (Optimus).

Hopefully this won't interfere with @frenzibyte 's changes.