### PR TITLE
Expose `ScrollContainer.Target`

### DIFF
--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -228,7 +228,7 @@ namespace osu.Framework.Graphics.Containers
                 scrollSpeed = (float)(MathF.Pow(exp_base, power) * Clock.ElapsedFrameTime * 0.1);
             }
 
-            if ((scrollSpeed < 0 && ScrollContainer.Current > 0) || (scrollSpeed > 0 && !ScrollContainer.IsScrolledToEnd()))
+            if ((scrollSpeed < 0 && !ScrollContainer.IsScrolledToStart()) || (scrollSpeed > 0 && !ScrollContainer.IsScrolledToEnd()))
                 ScrollContainer.ScrollBy(scrollSpeed);
         }
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -119,9 +119,12 @@ namespace osu.Framework.Graphics.Containers
         public float Current { get; private set; }
 
         /// <summary>
-        /// The target scroll position which is exponentially approached by current via a rate of distanceDecay.
+        /// The target scroll position which is exponentially approached by current via a rate of distance decay.
         /// </summary>
-        protected float Target { get; private set; }
+        /// <remarks>
+        /// When not animating scroll position, this will always be equal to <see cref="Current"/>.
+        /// </remarks>
+        public float Target { get; private set; }
 
         /// <summary>
         /// The maximum distance that can be scrolled in the scroll direction.
@@ -141,6 +144,12 @@ namespace osu.Framework.Graphics.Containers
         protected float Clamp(float position, float extension = 0) => Math.Max(Math.Min(position, ScrollableExtent + extension), -extension);
 
         protected override Container<T> Content => ScrollContent;
+
+        /// <summary>
+        /// Whether we are currently scrolled to the beginning of content.
+        /// </summary>
+        /// <param name="lenience">How close to the extent we need to be.</param>
+        public bool IsScrolledToStart(float lenience = Precision.FLOAT_EPSILON) => Precision.AlmostBigger(0, Target, lenience);
 
         /// <summary>
         /// Whether we are currently scrolled as far as possible into the scroll direction.


### PR DESCRIPTION
No reason not to have these methods exposed, quite useful.