### PR TITLE
Fix `Shader` not reset to null when completely unbound

### DIFF
--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -941,9 +941,9 @@ namespace osu.Framework.Graphics.Rendering
 
                 FlushCurrentBatch();
                 SetShaderImplementation(shader);
-
-                Shader = shader;
             }
+
+            Shader = shader;
         }
 
         internal void SetUniform<T>(IUniformWithValue<T> uniform)


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu-framework/pull/5431#discussion_r979790479.