### PR TITLE
Avoid flushing VBO when the renderer state is not affected

### DIFF
--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -167,9 +167,6 @@ namespace osu.Framework.Graphics.Rendering
                 b.ResetCounters();
             batchResetList.Clear();
 
-            FrameBuffer?.Unbind();
-            FrameBuffer = null;
-
             Shader?.Unbind();
             Shader = null;
 
@@ -187,7 +184,7 @@ namespace osu.Framework.Graphics.Rendering
             quadBatches.Clear();
             quadBatches.Push(defaultQuadBatch);
 
-            setFrameBuffer(null);
+            setFrameBuffer(null, true);
 
             Scissor = RectangleI.Empty;
             ScissorOffset = Vector2I.Zero;
@@ -462,6 +459,7 @@ namespace osu.Framework.Graphics.Rendering
             if (enabled == ScissorState)
                 return;
 
+            FlushCurrentBatch();
             SetScissorStateImplementation(enabled);
             ScissorState = enabled;
         }
@@ -855,9 +853,9 @@ namespace osu.Framework.Graphics.Rendering
             setFrameBuffer(frameBufferStack.TryPeek(out var lastFramebuffer) ? lastFramebuffer : null);
         }
 
-        private void setFrameBuffer(IFrameBuffer? frameBuffer)
+        private void setFrameBuffer(IFrameBuffer? frameBuffer, bool force = false)
         {
-            if (frameBuffer == FrameBuffer)
+            if (frameBuffer == FrameBuffer && !force)
                 return;
 
             FlushCurrentBatch();


### PR DESCRIPTION
Haven't profiled this yet, but I've noticed certain cases where VBO could be flushed while no actual changes occur. Most of these cases may come from a path where flushing VBO wouldn't add any overhead, but still worth having it to define the real purpose of this method for any future renderer states (we could also consider encapsulating these methods into a `RendererState` class, but that's for a rainy day).

Everything seems to still work fine, but double-checking would be appreciated.