### PR TITLE
Fix `Displays` querying on every access and add `DisplaysChanged`

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -149,9 +150,8 @@ namespace osu.Framework.Tests.Visual.Platform
                 return;
             }
 
-            refreshScreens();
-
-            AddStep("set up screens", refreshScreens);
+            window.DisplaysChanged += onDisplaysChanged;
+            refreshScreens(window.Displays);
 
             const string desc2 = "Check whether the window size is one pixel wider than the screen in each direction";
 
@@ -181,14 +181,19 @@ namespace osu.Framework.Tests.Visual.Platform
             }
         }
 
-        private void refreshScreens()
+        private void onDisplaysChanged(IEnumerable<Display> displays)
+        {
+            Scheduler.AddOnce(refreshScreens, displays);
+        }
+
+        private void refreshScreens(IEnumerable<Display> displays)
         {
             screenContainer.Remove(windowContainer, false);
             screenContainer.Clear();
 
             var bounds = new RectangleI();
 
-            foreach (var display in window.Displays)
+            foreach (var display in displays)
             {
                 screenContainer.Add(createScreen(display, display.Name));
                 bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
@@ -237,6 +242,14 @@ namespace osu.Framework.Tests.Visual.Platform
             currentActualSize.Text = $"Window size: {window?.Size}";
             currentClientSize.Text = $"Client size: {window?.ClientSize}";
             currentDisplay.Text = $"Current Display: {window?.CurrentDisplayBindable.Value.Name}";
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (window != null)
+                window.DisplaysChanged -= onDisplaysChanged;
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using NUnit.Framework;
@@ -72,11 +73,20 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window == null)
                 return;
 
-            displaysDropdown.Items = window.Displays;
+            window.DisplaysChanged += onDisplaysChanged;
+            updateDisplays(window.Displays);
+
             displaysDropdown.Current.BindTo(window.CurrentDisplayBindable);
 
             supportedWindowModes.Text = $"Supported Window Modes: {string.Join(", ", window.SupportedWindowModes)}";
         }
+
+        private void onDisplaysChanged(IEnumerable<Display> displays)
+        {
+            Scheduler.AddOnce(updateDisplays, displays);
+        }
+
+        private void updateDisplays(IEnumerable<Display> displays) => displaysDropdown.Items = displays;
 
         [Test]
         public void TestScreenModeSwitch()
@@ -155,6 +165,14 @@ namespace osu.Framework.Tests.Visual.Platform
         private void testResolution(int w, int h)
         {
             AddStep($"set to {w}x{h}", () => sizeFullscreen.Value = new Size(w, h));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (window != null)
+                window.DisplaysChanged -= onDisplaysChanged;
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework/Platform/Display.cs
+++ b/osu.Framework/Platform/Display.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Drawing;
 using System.Linq;
@@ -17,7 +15,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// The name of the display, if available. Usually the manufacturer.
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// The current rectangle of the display in screen space.
@@ -36,7 +34,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public int Index { get; }
 
-        public Display(int index, string name, Rectangle bounds, DisplayMode[] displayModes)
+        public Display(int index, string? name, Rectangle bounds, DisplayMode[] displayModes)
         {
             Index = index;
             Name = name;
@@ -46,12 +44,15 @@ namespace osu.Framework.Platform
 
         public override string ToString() => $"Name: {Name ?? "Unknown"}, Bounds: {Bounds}, DisplayModes: {DisplayModes.Length}, Index: {Index}";
 
-        public bool Equals(Display other)
+        public bool Equals(Display? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Index == other.Index;
+            return Index == other.Index
+                   && Name == other.Name
+                   && Bounds == other.Bounds
+                   && DisplayModes.SequenceEqual(other.DisplayModes);
         }
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -121,6 +121,12 @@ namespace osu.Framework.Platform
         IEnumerable<Display> Displays { get; }
 
         /// <summary>
+        /// Invoked when <see cref="Displays"/> has changed.
+        /// </summary>
+        [CanBeNull]
+        event Action<IEnumerable<Display>> DisplaysChanged;
+
+        /// <summary>
         /// Gets the <see cref="Display"/> that has been set as "primary" or "default" in the operating system.
         /// </summary>
         Display PrimaryDisplay { get; }

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -82,6 +82,10 @@ namespace osu.Framework.Platform
 
         public virtual IEnumerable<Display> Displays => new[] { DisplayDevice.GetDisplay(DisplayIndex.Primary).ToDisplay() };
 
+#pragma warning disable CS0067
+        public event Action<IEnumerable<Display>> DisplaysChanged;
+#pragma warning restore CS0067
+
         public virtual Display PrimaryDisplay => Displays.FirstOrDefault(d => d.Index == (int)DisplayDevice.Default.GetIndex());
 
         public Bindable<Display> CurrentDisplayBindable { get; } = new Bindable<Display>();
@@ -176,7 +180,8 @@ namespace osu.Framework.Platform
         /// <para>Note that this will use the default <see cref="GameWindow"/> implementation, which is not compatible with every platform.</para>
         /// </summary>
         protected OsuTKWindow(int width, int height)
-            : this(new GameWindow(width, height, new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3)))
+            : this(new GameWindow(width, height,
+                new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3)))
         {
         }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -351,6 +351,10 @@ namespace osu.Framework.Platform
                     handleQuitEvent(e.quit);
                     break;
 
+                case SDL.SDL_EventType.SDL_DISPLAYEVENT:
+                    handleDisplayEvent(e.display);
+                    break;
+
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:
                     handleWindowEvent(e.window);
                     break;

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Platform
         {
             updateDisplays();
 
+            DisplaysChanged += _ => CurrentDisplayBindable.Default = PrimaryDisplay;
             CurrentDisplayBindable.Default = PrimaryDisplay;
             CurrentDisplayBindable.ValueChanged += evt =>
             {
@@ -268,6 +269,8 @@ namespace osu.Framework.Platform
         /// </summary>
         public IEnumerable<Display> Displays { get; private set; } = null!;
 
+        public event Action<IEnumerable<Display>>? DisplaysChanged;
+
         // ReSharper disable once UnusedParameter.Local
         private void handleDisplayEvent(SDL.SDL_DisplayEvent evtDisplay) => updateDisplays();
 
@@ -283,6 +286,7 @@ namespace osu.Framework.Platform
         private void updateDisplays()
         {
             Displays = getSDLDisplays();
+            DisplaysChanged?.Invoke(Displays);
         }
 
         private IEnumerable<Display> getSDLDisplays()

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using osu.Framework.Bindables;
@@ -289,6 +290,21 @@ namespace osu.Framework.Platform
             DisplaysChanged?.Invoke(Displays);
         }
 
+        /// <summary>
+        /// Asserts that the current <see cref="Displays"/> match the actual displays as reported by SDL.
+        /// </summary>
+        /// <remarks>
+        /// This assert is not fatal, as the <see cref="Displays"/> will get updated sooner or later
+        /// in <see cref="handleDisplayEvent"/> or <see cref="handleWindowEvent"/>.
+        /// </remarks>
+        [Conditional("DEBUG")]
+        private void assertDisplaysMatchSDL()
+        {
+            var actualDisplays = getSDLDisplays();
+            Debug.Assert(actualDisplays.SequenceEqual(Displays), $"Stored {nameof(Displays)} don't match actual displays",
+                $"Stored displays:\n  {string.Join("\n  ", Displays)}\n\nActual displays:\n  {string.Join("\n  ", actualDisplays)}");
+        }
+
         private IEnumerable<Display> getSDLDisplays()
         {
             return Enumerable.Range(0, SDL.SDL_GetNumVideoDisplays()).Select(displayFromSDL).ToArray();
@@ -424,6 +440,8 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
                     break;
             }
+
+            assertDisplaysMatchSDL();
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -288,6 +288,20 @@ namespace osu.Framework.Platform
         private IEnumerable<Display> getSDLDisplays()
         {
             return Enumerable.Range(0, SDL.SDL_GetNumVideoDisplays()).Select(displayFromSDL).ToArray();
+
+            static Display displayFromSDL(int displayIndex)
+            {
+                var displayModes = Enumerable.Range(0, SDL.SDL_GetNumDisplayModes(displayIndex))
+                                             .Select(modeIndex =>
+                                             {
+                                                 SDL.SDL_GetDisplayMode(displayIndex, modeIndex, out var mode);
+                                                 return mode.ToDisplayMode(displayIndex);
+                                             })
+                                             .ToArray();
+
+                SDL.SDL_GetDisplayBounds(displayIndex, out var rect);
+                return new Display(displayIndex, SDL.SDL_GetDisplayName(displayIndex), new Rectangle(rect.x, rect.y, rect.w, rect.h), displayModes);
+            }
         }
 
         #endregion
@@ -665,20 +679,6 @@ namespace osu.Framework.Platform
                 return mode;
 
             throw new InvalidOperationException("couldn't retrieve valid display mode");
-        }
-
-        private static Display displayFromSDL(int displayIndex)
-        {
-            var displayModes = Enumerable.Range(0, SDL.SDL_GetNumDisplayModes(displayIndex))
-                                         .Select(modeIndex =>
-                                         {
-                                             SDL.SDL_GetDisplayMode(displayIndex, modeIndex, out var mode);
-                                             return mode.ToDisplayMode(displayIndex);
-                                         })
-                                         .ToArray();
-
-            SDL.SDL_GetDisplayBounds(displayIndex, out var rect);
-            return new Display(displayIndex, SDL.SDL_GetDisplayName(displayIndex), new Rectangle(rect.x, rect.y, rect.w, rect.h), displayModes);
         }
 
         #endregion


### PR DESCRIPTION
peppy reported it [on discord](https://discord.com/channels/188630481301012481/589331078574112768/1019675813953683568): `Displays` were queried in a hot path (every frame).

Adds `DisplaysChanged` event to `IWindow` so consumers can watch for display changes. For now, this doesn't check if the displays actually changed, and will be invoked every time the displays are queried.