### PR TITLE
Fix `SpriteText` size not immediately responding to changes in text

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextSizing.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextSizing.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public class TestSceneSpriteTextSizing : FrameworkTestScene
+    {
+        [Test]
+        public void TestNewSizeImmediatelyAvailableAfterTextChange()
+        {
+            SpriteText text = null!;
+            float initialSize = 0;
+
+            AddStep("add initial text and get size", () =>
+            {
+                Child = text = new SpriteText { Text = "First" };
+                initialSize = text.DrawWidth;
+            });
+
+            float updatedSize = 0;
+            AddStep("set new text and grab size", () =>
+            {
+                text.Text = "Second";
+                updatedSize = text.DrawWidth;
+            });
+
+            AddAssert("updated size is not equal to the initial size", () => updatedSize, () => Is.Not.EqualTo(initialSize));
+        }
+    }
+}

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -557,7 +557,7 @@ namespace osu.Framework.Graphics.Sprites
             parentScreenSpaceCache.Invalidate();
             localScreenSpaceCache.Invalidate();
 
-            Invalidate(Invalidation.DrawNode);
+            Invalidate(Invalidation.RequiredParentSizeToFit);
         }
 
         #endregion


### PR DESCRIPTION
Previously, it would wait until the end of the current frame for the `DrawNode` to be created and the `charactersCache` invalidation to cause the `Width`/`Height` to change. Only then would `Drawable.drawSizeBacking` be invalidated and queries to `DrawWidth` return the correct value.