### PR TITLE
Refactor borderless test for component reuse and to show more info

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -154,6 +154,7 @@ namespace osu.Framework.Tests.Visual.Platform
                             BorderThickness = 20,
                             Masking = true,
                             Depth = -10,
+                            Alpha = 0.7f,
                             Children = new Drawable[]
                             {
                                 new Box
@@ -167,7 +168,10 @@ namespace osu.Framework.Tests.Visual.Platform
                                     sprite.Colour = Color4.White;
                                 })
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
                                     Padding = new MarginPadding(50),
                                     Colour = Color4.White
                                 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -1,23 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
@@ -115,189 +108,6 @@ namespace osu.Framework.Tests.Visual.Platform
             currentActualSize.Text = $"Window size: {window?.Size}";
             currentClientSize.Text = $"Client size: {window?.ClientSize}";
             currentDisplay.Text = $"Current Display: {window?.CurrentDisplayBindable.Value.Name}";
-        }
-    }
-
-    public class WindowDisplaysPreview : Container
-    {
-        public const float FONT_SIZE = 120f;
-
-        private readonly TextFlowContainer windowCaption;
-        private readonly Container paddedContainer;
-        private readonly Container screenContainer;
-        private readonly Container windowContainer;
-        private Vector2 screenContainerOffset;
-
-        private static readonly Color4 active_fill = new Color4(255, 138, 104, 255);
-        private static readonly Color4 active_stroke = new Color4(244, 74, 25, 255);
-        private static readonly Color4 screen_fill = new Color4(255, 181, 104, 255);
-        private static readonly Color4 screen_stroke = new Color4(244, 137, 25, 255);
-        private static readonly Color4 window_fill = new Color4(95, 113, 197, 255);
-        private static readonly Color4 window_stroke = new Color4(36, 59, 166, 255);
-
-        private SDL2DesktopWindow? window;
-        private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
-
-        public WindowDisplaysPreview()
-        {
-            Child = new Container
-            {
-                RelativeSizeAxes = Axes.Both,
-                Padding = new MarginPadding(70),
-                Child = paddedContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = screenContainer = new Container
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Child = windowContainer = new Container
-                        {
-                            BorderColour = window_stroke,
-                            BorderThickness = 20,
-                            Masking = true,
-                            Depth = -10,
-                            Alpha = 0.7f,
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = window_fill
-                                },
-                                windowCaption = new TextFlowContainer(sprite =>
-                                {
-                                    sprite.Font = sprite.Font.With(size: FONT_SIZE);
-                                    sprite.Colour = Color4.White;
-                                })
-                                {
-                                    Anchor = Anchor.BottomLeft,
-                                    Origin = Anchor.BottomLeft,
-                                    RelativeSizeAxes = Axes.X,
-                                    AutoSizeAxes = Axes.Y,
-                                    Padding = new MarginPadding(50),
-                                    Colour = Color4.White
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config, GameHost host)
-        {
-            window = host.Window as SDL2DesktopWindow;
-            config.BindWith(FrameworkSetting.WindowMode, windowMode);
-
-            if (window != null)
-            {
-                window.DisplaysChanged += onDisplaysChanged;
-                refreshScreens(window.Displays);
-            }
-        }
-
-        private void onDisplaysChanged(IEnumerable<Display> displays)
-        {
-            Scheduler.AddOnce(refreshScreens, displays);
-        }
-
-        private void refreshScreens(IEnumerable<Display> displays)
-        {
-            screenContainer.RemoveAll(d => d != windowContainer, false);
-
-            var bounds = new RectangleI();
-
-            foreach (var display in displays)
-            {
-                screenContainer.Add(createScreen(display, window.AsNonNull().CurrentDisplay.Index));
-                bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
-            }
-
-            screenContainerOffset = bounds.Location;
-
-            foreach (var box in screenContainer.Children)
-            {
-                box.Position -= bounds.Location;
-            }
-
-            screenContainer.Size = bounds.Size;
-        }
-
-        private Container createScreen(Display display, int activeDisplayIndex)
-        {
-            bool isActive = display.Index == activeDisplayIndex;
-
-            return new Container
-            {
-                X = display.Bounds.X,
-                Y = display.Bounds.Y,
-                Width = display.Bounds.Width,
-                Height = display.Bounds.Height,
-
-                BorderColour = isActive ? active_stroke : screen_stroke,
-                BorderThickness = 20,
-                Masking = true,
-
-                Children = new Drawable[]
-                {
-                    new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Colour = isActive ? active_fill : screen_fill
-                    },
-                    new TextFlowContainer(sprite =>
-                    {
-                        sprite.Font = new FontUsage(size: FONT_SIZE);
-                        sprite.Colour = Color4.Black;
-                    })
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Text = $"{display.Name}\n"
-                               + $"{display.Bounds.Width}x{display.Bounds.Height}\n"
-                               + $"Mode: {modeName(display.DisplayModes.First())}",
-                        Padding = new MarginPadding(50),
-                    }
-                }
-            };
-        }
-
-        private string modeName(DisplayMode mode) => $"{mode.Size.Width}x{mode.Size.Height}@{mode.RefreshRate}";
-
-        private void updateWindowContainer()
-        {
-            if (window == null) return;
-
-            bool fullscreen = window.WindowMode.Value == WindowMode.Fullscreen;
-            var currentBounds = window.CurrentDisplayBindable.Value.Bounds;
-
-            windowContainer.X = window.Position.X;
-            windowContainer.Y = window.Position.Y;
-            windowContainer.Width = fullscreen ? currentBounds.Width : window.Size.Width;
-            windowContainer.Height = fullscreen ? currentBounds.Height : window.Size.Height;
-            windowContainer.Position -= screenContainerOffset;
-            windowCaption.Text = $"{windowMode}\nSize: {window.Size.Width}x{window.Size.Height}\nClient: {window.ClientSize.Width}x{window.ClientSize.Height}";
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (window == null)
-                return;
-
-            updateWindowContainer();
-            var scale = Vector2.Divide(paddedContainer.DrawSize, screenContainer.Size);
-            screenContainer.Scale = new Vector2(Math.Min(scale.X, scale.Y));
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            if (window != null)
-                window.DisplaysChanged -= onDisplaysChanged;
-
-            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -119,6 +119,8 @@ namespace osu.Framework.Tests.Visual.Platform
 
     public class WindowDisplaysPreview : Container
     {
+        public const float FONT_SIZE = 120f;
+
         private readonly TextFlowContainer windowCaption;
         private readonly Container paddedContainer;
         private readonly Container screenContainer;
@@ -164,7 +166,7 @@ namespace osu.Framework.Tests.Visual.Platform
                                 },
                                 windowCaption = new TextFlowContainer(sprite =>
                                 {
-                                    sprite.Font = sprite.Font.With(size: 150);
+                                    sprite.Font = sprite.Font.With(size: FONT_SIZE);
                                     sprite.Colour = Color4.White;
                                 })
                                 {
@@ -241,15 +243,22 @@ namespace osu.Framework.Tests.Visual.Platform
                         RelativeSizeAxes = Axes.Both,
                         Colour = display.Index == 0 ? active_fill : screen_fill
                     },
-                    new SpriteText
+                    new TextFlowContainer(sprite =>
                     {
+                        sprite.Font = new FontUsage(size: FONT_SIZE);
+                        sprite.Colour = Color4.Black;
+                    })
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Text = $"{display.Name}\n"
+                               + $"{display.Bounds.Width}x{display.Bounds.Height}\n"
+                               + $"Mode: {modeName(display.DisplayModes.First())}",
                         Padding = new MarginPadding(50),
-                        Text = display.Name ?? "unknown",
-                        Font = new FontUsage(size: 200),
-                        Colour = Color4.Black
                     }
                 }
             };
+
+        private string modeName(DisplayMode mode) => $"{mode.Size.Width}x{mode.Size.Height}@{mode.RefreshRate}";
 
         private void updateWindowContainer()
         {

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -69,6 +69,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             Point originalWindowPosition = Point.Empty;
 
+            // so the test doesn't switch to windowed on startup.
             AddStep("nothing", () => { });
 
             foreach (var display in window.Displays)

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
@@ -210,7 +211,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             foreach (var display in displays)
             {
-                screenContainer.Add(createScreen(display));
+                screenContainer.Add(createScreen(display, window.AsNonNull().CurrentDisplay.Index));
                 bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
             }
 
@@ -224,15 +225,18 @@ namespace osu.Framework.Tests.Visual.Platform
             screenContainer.Size = bounds.Size;
         }
 
-        private Container createScreen(Display display) =>
-            new Container
+        private Container createScreen(Display display, int activeDisplayIndex)
+        {
+            bool isActive = display.Index == activeDisplayIndex;
+
+            return new Container
             {
                 X = display.Bounds.X,
                 Y = display.Bounds.Y,
                 Width = display.Bounds.Width,
                 Height = display.Bounds.Height,
 
-                BorderColour = display.Index == 0 ? active_stroke : screen_stroke,
+                BorderColour = isActive ? active_stroke : screen_stroke,
                 BorderThickness = 20,
                 Masking = true,
 
@@ -241,7 +245,7 @@ namespace osu.Framework.Tests.Visual.Platform
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = display.Index == 0 ? active_fill : screen_fill
+                        Colour = isActive ? active_fill : screen_fill
                     },
                     new TextFlowContainer(sprite =>
                     {
@@ -257,6 +261,7 @@ namespace osu.Framework.Tests.Visual.Platform
                     }
                 }
             };
+        }
 
         private string modeName(DisplayMode mode) => $"{mode.Size.Width}x{mode.Size.Height}@{mode.RefreshRate}";
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -42,7 +40,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private static readonly Color4 window_fill = new Color4(95, 113, 197, 255);
         private static readonly Color4 window_stroke = new Color4(36, 59, 166, 255);
 
-        private SDL2DesktopWindow window;
+        private SDL2DesktopWindow? window;
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
         public TestSceneBorderless()
@@ -109,7 +107,7 @@ namespace osu.Framework.Tests.Visual.Platform
             windowMode.TriggerChange();
         }
 
-        private Container createScreen(Display display, string name) =>
+        private Container createScreen(Display display) =>
             new Container
             {
                 X = display.Bounds.X,
@@ -131,7 +129,7 @@ namespace osu.Framework.Tests.Visual.Platform
                     new SpriteText
                     {
                         Padding = new MarginPadding(50),
-                        Text = name,
+                        Text = display.Name ?? "unknown",
                         Font = new FontUsage(size: 200),
                         Colour = Color4.Black
                     }
@@ -195,7 +193,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             foreach (var display in displays)
             {
-                screenContainer.Add(createScreen(display, display.Name));
+                screenContainer.Add(createScreen(display));
                 bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
             }
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -39,20 +39,31 @@ namespace osu.Framework.Tests.Visual.Platform
         {
             var currentBindableSize = new SpriteText();
 
-            Child = new FillFlowContainer
+            Children = new Drawable[]
             {
-                Padding = new MarginPadding(10),
-                Spacing = new Vector2(10),
-                Children = new Drawable[]
+                new FillFlowContainer
                 {
-                    currentBindableSize,
-                    currentActualSize,
-                    currentDisplayMode,
-                    currentWindowMode,
-                    currentWindowState,
-                    supportedWindowModes,
-                    displaysDropdown = new BasicDropdown<Display> { Width = 600 }
+                    Padding = new MarginPadding(10),
+                    Spacing = new Vector2(10),
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        currentBindableSize,
+                        currentActualSize,
+                        currentDisplayMode,
+                        currentWindowMode,
+                        currentWindowState,
+                        supportedWindowModes,
+                        displaysDropdown = new BasicDropdown<Display> { Width = 800 }
+                    }
                 },
+                new WindowDisplaysPreview
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = 230 }
+                }
             };
 
             sizeFullscreen.ValueChanged += newSize => currentBindableSize.Text = $"Fullscreen size: {newSize.NewValue}";

--- a/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
+++ b/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
@@ -1,0 +1,204 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Platform
+{
+    public class WindowDisplaysPreview : Container
+    {
+        public const float FONT_SIZE = 120f;
+
+        private readonly TextFlowContainer windowCaption;
+        private readonly Container paddedContainer;
+        private readonly Container screenContainer;
+        private readonly Container windowContainer;
+        private Vector2 screenContainerOffset;
+
+        private static readonly Color4 active_fill = new Color4(255, 138, 104, 255);
+        private static readonly Color4 active_stroke = new Color4(244, 74, 25, 255);
+        private static readonly Color4 screen_fill = new Color4(255, 181, 104, 255);
+        private static readonly Color4 screen_stroke = new Color4(244, 137, 25, 255);
+        private static readonly Color4 window_fill = new Color4(95, 113, 197, 255);
+        private static readonly Color4 window_stroke = new Color4(36, 59, 166, 255);
+
+        private SDL2DesktopWindow? window;
+        private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
+
+        public WindowDisplaysPreview()
+        {
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Padding = new MarginPadding(70),
+                Child = paddedContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = screenContainer = new Container
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Child = windowContainer = new Container
+                        {
+                            BorderColour = window_stroke,
+                            BorderThickness = 20,
+                            Masking = true,
+                            Depth = -10,
+                            Alpha = 0.7f,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = window_fill
+                                },
+                                windowCaption = new TextFlowContainer(sprite =>
+                                {
+                                    sprite.Font = sprite.Font.With(size: FONT_SIZE);
+                                    sprite.Colour = Color4.White;
+                                })
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Padding = new MarginPadding(50),
+                                    Colour = Color4.White
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(FrameworkConfigManager config, GameHost host)
+        {
+            window = host.Window as SDL2DesktopWindow;
+            config.BindWith(FrameworkSetting.WindowMode, windowMode);
+
+            if (window != null)
+            {
+                window.DisplaysChanged += onDisplaysChanged;
+                refreshScreens(window.Displays);
+            }
+        }
+
+        private void onDisplaysChanged(IEnumerable<Display> displays)
+        {
+            Scheduler.AddOnce(refreshScreens, displays);
+        }
+
+        private void refreshScreens(IEnumerable<Display> displays)
+        {
+            screenContainer.RemoveAll(d => d != windowContainer, false);
+
+            var bounds = new RectangleI();
+
+            foreach (var display in displays)
+            {
+                screenContainer.Add(createScreen(display, window.AsNonNull().CurrentDisplay.Index));
+                bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
+            }
+
+            screenContainerOffset = bounds.Location;
+
+            foreach (var box in screenContainer.Children)
+            {
+                box.Position -= bounds.Location;
+            }
+
+            screenContainer.Size = bounds.Size;
+        }
+
+        private Container createScreen(Display display, int activeDisplayIndex)
+        {
+            bool isActive = display.Index == activeDisplayIndex;
+
+            return new Container
+            {
+                X = display.Bounds.X,
+                Y = display.Bounds.Y,
+                Width = display.Bounds.Width,
+                Height = display.Bounds.Height,
+
+                BorderColour = isActive ? active_stroke : screen_stroke,
+                BorderThickness = 20,
+                Masking = true,
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = isActive ? active_fill : screen_fill
+                    },
+                    new TextFlowContainer(sprite =>
+                    {
+                        sprite.Font = new FontUsage(size: FONT_SIZE);
+                        sprite.Colour = Color4.Black;
+                    })
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Text = $"{display.Name}\n"
+                               + $"{display.Bounds.Width}x{display.Bounds.Height}\n"
+                               + $"Mode: {modeName(display.DisplayModes.First())}",
+                        Padding = new MarginPadding(50),
+                    }
+                }
+            };
+        }
+
+        private string modeName(DisplayMode mode) => $"{mode.Size.Width}x{mode.Size.Height}@{mode.RefreshRate}";
+
+        private void updateWindowContainer()
+        {
+            if (window == null) return;
+
+            bool fullscreen = window.WindowMode.Value == WindowMode.Fullscreen;
+            var currentBounds = window.CurrentDisplayBindable.Value.Bounds;
+
+            windowContainer.X = window.Position.X;
+            windowContainer.Y = window.Position.Y;
+            windowContainer.Width = fullscreen ? currentBounds.Width : window.Size.Width;
+            windowContainer.Height = fullscreen ? currentBounds.Height : window.Size.Height;
+            windowContainer.Position -= screenContainerOffset;
+            windowCaption.Text = $"{windowMode}\nSize: {window.Size.Width}x{window.Size.Height}\nClient: {window.ClientSize.Width}x{window.ClientSize.Height}";
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (window == null)
+                return;
+
+            updateWindowContainer();
+            var scale = Vector2.Divide(paddedContainer.DrawSize, screenContainer.Size);
+            screenContainer.Scale = new Vector2(Math.Min(scale.X, scale.Y));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (window != null)
+                window.DisplaysChanged -= onDisplaysChanged;
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
+++ b/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
@@ -38,6 +38,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private SDL2DesktopWindow? window;
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
+        private readonly Bindable<Display> currentDisplay = new Bindable<Display>();
 
         public WindowDisplaysPreview()
         {
@@ -95,6 +96,9 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window != null)
             {
                 window.DisplaysChanged += onDisplaysChanged;
+                currentDisplay.BindTo(window.CurrentDisplayBindable);
+                currentDisplay.BindValueChanged(_ => Scheduler.AddOnce(() => refreshScreens(window.Displays)));
+
                 refreshScreens(window.Displays);
             }
         }
@@ -112,7 +116,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             foreach (var display in displays)
             {
-                screenContainer.Add(createScreen(display, window.AsNonNull().CurrentDisplay.Index));
+                screenContainer.Add(createScreen(display, window.AsNonNull().CurrentDisplayBindable.Value.Index));
                 bounds = RectangleI.Union(bounds, new RectangleI(display.Bounds.X, display.Bounds.Y, display.Bounds.Width, display.Bounds.Height));
             }
 


### PR DESCRIPTION
The new `WindowDisplaysPreview` might be useful for future tests, so this is a preemptive refactor.

Before:
![image](https://user-images.githubusercontent.com/16479013/194592857-81299e10-0668-40e6-9d53-d4f4f55bac84.png)

After:
![image](https://user-images.githubusercontent.com/16479013/194592873-ca732fd9-119f-428a-9503-f983115ce20d.png)
