### PR TITLE
Fix tablets connected on startup not working properly

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -39,13 +39,18 @@ namespace osu.Framework.Input.Handlers.Tablet
             {
                 // it's worth noting that this event fires on *any* device change system-wide, including non-tablet devices.
                 if (!Tablets.Any() && args.Additions.Any())
-                {
-                    cancellationSource?.Cancel();
-                    cancellationSource = new CancellationTokenSource();
-
-                    Task.Run(() => detectAsync(cancellationSource.Token), cancellationSource.Token);
-                }
+                    detectAsync();
             };
+
+            detectAsync();
+        }
+
+        private void detectAsync()
+        {
+            cancellationSource?.Cancel();
+            cancellationSource = new CancellationTokenSource();
+
+            Task.Run(() => detectAsync(cancellationSource.Token), cancellationSource.Token);
         }
 
         private async Task detectAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/20660

This was never noticed because tablet pointer is still reported correctly as it goes through another flow that's independent from the `TabletDriver` logic. Bit of a weird code, but gonna restrain myself from touching it further for now.