### PR TITLE
Fix colour picker background not rendering correctly on mobile platforms

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
@@ -1,10 +1,10 @@
 #include "sh_Utils.h"
 
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
+varying highp vec2 v_TexCoord;
+varying highp vec4 v_TexRect;
 
 void main(void)
 {
-    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    highp float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
     gl_FragColor = hsv2rgb(vec4(hueValue, 1, 1, 1));
 }

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
@@ -1,10 +1,12 @@
+#define HIGH_PRECISION_VERTEX
+
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 
 void main(void)
 {
-    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    highp float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
     gl_FragColor = getRoundedColor(hsv2rgb(vec4(hueValue, 1, 1, 1)), v_TexCoord);
 }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -1,13 +1,13 @@
 #include "sh_Utils.h"
 
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
+varying highp vec2 v_TexCoord;
+varying highp vec4 v_TexRect;
 
 uniform mediump float hue;
 
 void main(void)
 {
-    vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
-    vec2 pixelPos = v_TexCoord / resolution;
+    highp vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    highp vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0));
 }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -7,7 +7,7 @@ uniform mediump float hue;
 
 void main(void)
 {
-    highp vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0));
 }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
@@ -9,7 +9,7 @@ uniform mediump float hue;
 
 void main(void)
 {
-    highp vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = getRoundedColor(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0)), v_TexCoord);
 }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
@@ -1,13 +1,15 @@
+#define HIGH_PRECISION_VERTEX
+
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 
 uniform mediump float hue;
 
 void main(void)
 {
-    vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
-    vec2 pixelPos = v_TexCoord / resolution;
+    highp vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    highp vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = getRoundedColor(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0)), v_TexCoord);
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/14383

Follows a similar solution to what https://github.com/ppy/osu-framework/pull/5065 did. See https://github.com/ppy/osu-framework/pull/5065#discussion_r825536715 for detailed explanation. Renders correctly on iOS now.