### PR TITLE
Fix fullscreen test failing if window is on non-primary display

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window.SupportedWindowModes.Contains(WindowMode.Fullscreen))
             {
                 AddStep("change to fullscreen", () => windowMode.Value = WindowMode.Fullscreen);
-                AddAssert("window position updated", () => ((SDL2DesktopWindow)window).Position == new Point(0, 0));
+                AddAssert("window position updated", () => ((SDL2DesktopWindow)window).Position, () => Is.EqualTo(window.CurrentDisplayBindable.Value.Bounds.Location));
                 testResolution(1920, 1080);
                 testResolution(1280, 960);
                 testResolution(9999, 9999);


### PR DESCRIPTION
Noticed in https://github.com/ppy/osu-framework/pull/5459#issuecomment-1277748045.