### PR TITLE
Implement antialiasing for CircularProgress shader

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -125,6 +125,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddToggleStep("Toggle masking", m => maskingContainer.Masking = m);
             AddToggleStep("Toggle rounded caps", r => clock.RoundedCaps = r);
             AddToggleStep("Toggle aspect ratio", r => clock.Size = r ? new Vector2(600, 400) : new Vector2(400));
+            AddSliderStep("Scale", 0f, 2f, 1f, s => clock.Scale = new Vector2(s));
             AddSliderStep("Fill", 0f, 1f, 0.5f, f => clock.InnerRadius = f);
         }
 

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -41,8 +41,20 @@ namespace osu.Framework.Graphics.UserInterface
                     throw new ArgumentException($"{nameof(Current)} must be finite, but is {c.NewValue}.");
 
                 Invalidate(Invalidation.DrawNode);
-            }, true);
+            });
+
+            texelSize.BindValueChanged(_ => Invalidate(Invalidation.DrawNode), true);
         }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            // smoothstep looks too sharp with 1px, let's give it a bit more
+            texelSize.Value = 1.5f / ScreenSpaceDrawQuad.Size.X;
+        }
+
+        private readonly BindableFloat texelSize = new BindableFloat();
 
         protected override DrawNode CreateDrawNode() => new CircularProgressDrawNode(this);
 
@@ -99,6 +111,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             private float innerRadius;
             private float progress;
+            private float texelSize;
             private bool roundedCaps;
 
             public override void ApplyState()
@@ -108,6 +121,7 @@ namespace osu.Framework.Graphics.UserInterface
                 innerRadius = Source.innerRadius;
                 progress = Math.Abs((float)Source.current.Value);
                 roundedCaps = Source.roundedCaps;
+                texelSize = Source.texelSize.Value;
             }
 
             protected override void Blit(IRenderer renderer)
@@ -116,6 +130,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 shader.GetUniform<float>("innerRadius").UpdateValue(ref innerRadius);
                 shader.GetUniform<float>("progress").UpdateValue(ref progress);
+                shader.GetUniform<float>("texelSize").UpdateValue(ref texelSize);
                 shader.GetUniform<bool>("roundedCaps").UpdateValue(ref roundedCaps);
 
                 base.Blit(renderer);

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -9,6 +9,7 @@ varying highp vec4 v_TexRect;
 uniform lowp sampler2D m_Sampler;
 uniform mediump float progress;
 uniform mediump float innerRadius;
+uniform highp float texelSize;
 uniform bool roundedCaps;
 
 void main(void)
@@ -22,5 +23,6 @@ void main(void)
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     
-    gl_FragColor = insideProgress(pixelPos, progress, innerRadius, roundedCaps) ? toSRGB(v_Colour * wrappedSampler(wrap(v_TexCoord, v_TexRect), v_TexRect, m_Sampler, -0.9)) : vec4(0.0);
+    lowp vec4 textureColour = toSRGB(v_Colour * wrappedSampler(wrap(v_TexCoord, v_TexRect), v_TexRect, m_Sampler, -0.9));
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
 }

--- a/osu.Framework/Resources/Shaders/sh_CircularProgressRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgressRounded.fs
@@ -10,6 +10,7 @@ varying highp vec2 v_TexCoord;
 uniform lowp sampler2D m_Sampler;
 uniform mediump float progress;
 uniform mediump float innerRadius;
+uniform highp float texelSize;
 uniform bool roundedCaps;
 
 void main(void)
@@ -23,12 +24,8 @@ void main(void)
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     
-    if (!insideProgress(pixelPos, progress, innerRadius, roundedCaps))
-    {
-        gl_FragColor = vec4(0.0);
-        return;
-    }
-
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
-    gl_FragColor = getRoundedColor(toSRGB(wrappedSampler(wrappedCoord, v_TexRect, m_Sampler, -0.9)), wrappedCoord);
+    lowp vec4 textureColour = getRoundedColor(toSRGB(wrappedSampler(wrappedCoord, v_TexRect, m_Sampler, -0.9)), wrappedCoord);
+
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
 }

--- a/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
@@ -1,35 +1,70 @@
 ﻿#define PI 3.1415926536
+#define HALF_PI 1.57079632679
+#define TWO_PI 6.28318530718
 
-bool insideProgress(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps)
+highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
 {
-    // Compute angle of the current pixel in the (0, 2*PI) range
-    mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - PI / 2.0;
-    if (pixelAngle < 0.0)
-        pixelAngle += 2.0 * PI;
+    highp float lineLength = distance(end, start);
 
-    mediump float progressAngle = 2.0 * PI * progress;
+    if (lineLength == 0.0)
+        return distance(pixelPos, start);
+
+    highp vec2 a = (end - start) / lineLength;
+    highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, distance(end, start)) * a + start; // closest point on a line to from given position
+    return distance(closest, pixelPos);
+}
+
+lowp float progressAlphaAt(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps, highp float texelSize)
+{
+    // This is a bit of a hack to make progress appear smooth if it's radius < texelSize by making it more transparent while leaving thickness the same
+    lowp float subAAMultiplier = 1.0;
+
+    if (innerRadius < texelSize * 2.0)
+    {
+        subAAMultiplier = max(innerRadius / (texelSize * 2.0), 0.1);
+        innerRadius = texelSize * 2.0;
+    }
+
+    // Compute angle of the current pixel in the (0, 2*PI) range
+    mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - HALF_PI;
+    if (pixelAngle < 0.0)
+        pixelAngle += TWO_PI;
+
+    mediump float progressAngle = TWO_PI * progress;
 
     if (progress >= 1.0 || pixelAngle < progressAngle) // Pixel inside the sector
     {
         highp float dstFromCentre = distance(pixelPos, vec2(0.5));
+
+        if (dstFromCentre > 0.5 - texelSize) // on the outer side of the ring
+            return smoothstep(0.5, 0.5 - texelSize, dstFromCentre) * subAAMultiplier;
+
         highp float innerBorder = 0.5 * (1.0 - innerRadius);
 
-        // Pixel within a ring
-        return dstFromCentre < 0.5 && dstFromCentre > innerBorder;
+        return smoothstep(innerBorder - texelSize, innerBorder, dstFromCentre) * subAAMultiplier;
     }
+
+    progressAngle = progressAngle - HALF_PI;
+    highp vec2 cs = vec2(cos(progressAngle), sin(progressAngle));
 
     if (roundedCaps) // Pixel outside the sector with rounded caps enabled
     {
         mediump float pathRadius = 0.25 * innerRadius;
+        highp float halfTexel = texelSize * 0.5;
 
-        highp vec2 arcStart = vec2(0.5, pathRadius);
-        highp vec2 arcEnd = vec2(0.5) + vec2(cos(progressAngle - PI / 2.0), sin(progressAngle - PI / 2.0)) * vec2(0.5 - pathRadius);
+        highp vec2 arcStart = vec2(0.5, pathRadius + halfTexel);
+        highp vec2 arcEnd = vec2(0.5) + cs * vec2(0.5 - pathRadius - halfTexel);
 
         highp float dstToArc = min(distance(pixelPos, arcStart), distance(pixelPos, arcEnd));
 
-        // Pixel within a cap
-        return dstToArc < pathRadius;
+        return smoothstep(pathRadius + halfTexel, pathRadius - halfTexel, dstToArc) * subAAMultiplier;
     }
 
-    return false;
+    highp float dstToIdleEdge = dstToLine(vec2(0.5, texelSize), vec2(0.5, 0.5 * innerRadius), pixelPos);
+
+    highp vec2 rotatingEdgeTop = vec2(0.5) + cs * vec2(0.5 - texelSize);
+    highp vec2 rotatingEdgeBottom = vec2(0.5) + cs * vec2(0.5 - 0.5 * innerRadius);
+    highp float dstToRotatingEdge = dstToLine(rotatingEdgeTop, rotatingEdgeBottom, pixelPos);
+
+    return smoothstep(texelSize, 0.0, min(dstToIdleEdge, dstToRotatingEdge)) * subAAMultiplier;
 }


### PR DESCRIPTION
Few caveats:
* **There's probably a better way to get texel size**
* **This aa works the best for 1:1 aspect ratio.** The higher it is - the less smooth progress gets. _(which can probably be fixed by adding some more math, but that's for another day, still better than nothing)_
* To make progress appear smooth when `radius < texelSize` I'm leaving thickness the lowest value possible (at which it still appears smooth) and making the whole progress more transparent. Looks good enough imo.
* You can check how smoothening works by increasing `1.5f` value in the `Update()`