### PR TITLE
Add more quick way to click a drawable using `ManualInputManager`

### DIFF
--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -140,10 +140,21 @@ namespace osu.Framework.Testing.Input
         }
 
         /// <summary>
+        /// Clicks the drawable with the specified button.
+        /// </summary>
+        /// <param name="drawable">Drawable to click.</param>
+        /// <param name="button">Mouse button to use.</param>
+        public void Click(Drawable drawable, MouseButton button = MouseButton.Left)
+        {
+            MoveMouseTo(drawable);
+            Click(button);
+        }
+
+        /// <summary>
         /// Press a mouse button down. Release with <see cref="ReleaseButton"/>.
         /// </summary>
         /// <remarks>
-        /// To press and release a mouse button immediately, use <see cref="Click"/>.
+        /// To press and release a mouse button immediately, use <see cref="Click(osuTK.Input.MouseButton)"/>.
         /// </remarks>
         /// <param name="button">The button to press.</param>
         public void PressButton(MouseButton button) => Input(new MouseButtonInput(button, true));


### PR DESCRIPTION
To emulate input in visual test, `TriggerClick` is used in most cases. It's okay if we test 2-3 buttons component, but may produce false-positive tests in more complex cases.
Examples:
- It bypasses `LoadingLayer`
- https://github.com/ppy/osu/pull/18761

`TriggerClick` is used everywhere because it's simple:
```
AddStep("Click", () => button.TriggerClick());
```
Example with manual input:
```
AddStep("Click", () =>
{
    InputManager.MoveMouseTo(button);
    InputManager.Click(MouseButton.Left);
});
```
Now:
```
AddStep("Click", () => InputManager.Click(button));
```
With this shortcut, using manual input is just several character longer than triggering event directly, and it reads better than before.