### PR TITLE
Fix `CircularProgress` having an opaque interior drawn on FTB pass

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osuTK;
@@ -81,10 +82,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             gradientTextureBoth.SetData(new TextureUpload(image));
 
+            Box background;
             Container maskingContainer;
 
             Children = new Drawable[]
             {
+                background = new Box
+                {
+                    Colour = FrameworkColour.GreenDark,
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0f,
+                },
                 maskingContainer = new Container
                 {
                     Anchor = Anchor.Centre,
@@ -125,6 +133,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddToggleStep("Toggle masking", m => maskingContainer.Masking = m);
             AddToggleStep("Toggle rounded caps", r => clock.RoundedCaps = r);
             AddToggleStep("Toggle aspect ratio", r => clock.Size = r ? new Vector2(600, 400) : new Vector2(400));
+            AddToggleStep("Toggle background", b => background.Alpha = b ? 1 : 0);
             AddSliderStep("Fill", 0f, 1f, 0.5f, f => clock.InnerRadius = f);
         }
 

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -120,6 +120,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                 base.Blit(renderer);
             }
+
+            protected internal override bool CanDrawOpaqueInterior => false;
         }
     }
 


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu-framework/pull/5065

As far as my knowledge in framework rendering goes, "opaque interiors" are for drawables which have a completely opaque rectangular shape such as `Sprite`s with white pixel texture and singular opaque colours. This doesn't fit `CircularProgress`, which has a circular shape with non-opaque areas regardless of the texture/colour.

Before:

<img width="1708" alt="CleanShot 2022-10-17 at 05 11 49@2x" src="https://user-images.githubusercontent.com/22781491/196074461-2102161e-75ac-407f-8cec-b49c291665f5.png">

After:

![CleanShot 2022-10-17 at 05 12 27@2x](https://user-images.githubusercontent.com/22781491/196074501-2955e93c-7504-4f5c-b400-977ea91fcd90.png)
