### PR TITLE
Harden `getClosestDisplayMode()` to return a valid display mode in more scenarios

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1084,5 +1084,23 @@ namespace osu.Framework.Platform.SDL2
                     return "unknown";
             }
         }
+
+        /// <summary>
+        /// Gets the readable string for this <see cref="SDL.SDL_DisplayMode"/>.
+        /// </summary>
+        /// <returns>
+        /// <c>string</c> in the format of <c>1920x1080@60</c>.
+        /// </returns>
+        public static string ReadableString(this SDL.SDL_DisplayMode mode) => $"{mode.w}x{mode.h}@{mode.refresh_rate}";
+
+        /// <summary>
+        /// Gets the SDL error, and then clears it.
+        /// </summary>
+        public static string GetAndClearError()
+        {
+            string error = SDL.SDL_GetError();
+            SDL.SDL_ClearError();
+            return error;
+        }
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -719,6 +719,10 @@ namespace osu.Framework.Platform
         {
             SDL.SDL_ClearError(); // clear any stale error.
 
+            // default size means to use the display's native size.
+            if (size == sizeFullscreen.Default)
+                size = currentDisplay.Bounds.Size;
+
             var targetMode = new SDL.SDL_DisplayMode { w = size.Width, h = size.Height, refresh_rate = refreshRate };
 
             if (SDL.SDL_GetClosestDisplayMode(displayIndex, ref targetMode, out var mode) != IntPtr.Zero)


### PR DESCRIPTION
- Supersedes https://github.com/ppy/osu-framework/pull/5371

Trying to fix:
- https://github.com/ppy/osu/issues/19064
- https://github.com/ppy/osu/discussions/20481
- https://github.com/ppy/osu/issues/19877
- https://github.com/ppy/osu/issues/20347

This PR expands `getClosestDisplayMode()` to use [`SDL_GetDesktopDisplayMode`](https://wiki.libsdl.org/SDL_GetDesktopDisplayMode), and to query the first display mode of a display directly with [`SDL_GetDisplayMode`](https://wiki.libsdl.org/SDL_GetDisplayMode). Also includes additional logging.

Let's get this in for user testing, if it proves to work without crashes then I'd hope to cut down this logic to:
- try requested `display index`, `size`, `refresh rate`
- try requested `display index`, `size`
- try requested `display index` (use default mode - mode index `0`)
- try display 0 (use default mode)
- throw

