### PR TITLE
Optimise `ColourInfo` conversion and add conversion helper method

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
+++ b/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
@@ -23,5 +23,12 @@ namespace osu.Framework.Benchmarks
 
         [Benchmark]
         public Color4 ConvertToColor4() => ((SRGBColour)colourInfo).Linear;
+
+        [Benchmark]
+        public Color4 ExtractAndConvertToColor4()
+        {
+            colourInfo.TryExtractSingleColour(out SRGBColour colour);
+            return colour.Linear;
+        }
     }
 }

--- a/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
+++ b/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics.Colour;
+using osuTK.Graphics;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkColourInfo
+    {
+        private ColourInfo colourInfo;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            colourInfo = ColourInfo.SingleColour(Color4.Transparent);
+        }
+
+        [Benchmark]
+        public SRGBColour ConvertToSRGBColour() => colourInfo;
+
+        [Benchmark]
+        public Color4 ConvertToColor4() => ((SRGBColour)colourInfo).Linear;
+    }
+}

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -86,6 +86,17 @@ namespace osu.Framework.Graphics.Colour
             }
         }
 
+        /// <summary>
+        /// Attempts to extract the single colour represented by this <see cref="ColourInfo"/>.
+        /// </summary>
+        /// <param name="colour">The extracted colour. If <c>false</c> is returned, this represents the top-left colour.</param>
+        /// <returns>Whether the extracted colour is the single colour represented by this <see cref="ColourInfo"/>.</returns>
+        public readonly bool TryExtractSingleColour(out SRGBColour colour)
+        {
+            colour = TopLeft;
+            return HasSingleColour;
+        }
+
         public readonly SRGBColour Interpolate(Vector2 interp) => SRGBColour.FromVector(
             (1 - interp.Y) * ((1 - interp.X) * TopLeft.ToVector() + interp.X * TopRight.ToVector()) +
             interp.Y * ((1 - interp.X) * BottomLeft.ToVector() + interp.X * BottomRight.ToVector()));

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -71,13 +71,8 @@ namespace osu.Framework.Graphics.Colour
         {
             readonly get
             {
-                if (!HasSingleColour)
-                    throwConversionFromMultiColourToSingleColourException();
-
+                Debug.Assert(HasSingleColour);
                 return TopLeft;
-
-                [DoesNotReturn]
-                static void throwConversionFromMultiColourToSingleColourException() => throw new InvalidOperationException("Attempted to read single colour from multi-colour ColourInfo.");
             }
             set
             {
@@ -93,7 +88,7 @@ namespace osu.Framework.Graphics.Colour
         /// <returns>Whether the extracted colour is the single colour represented by this <see cref="ColourInfo"/>.</returns>
         public readonly bool TryExtractSingleColour(out SRGBColour colour)
         {
-            colour = TopLeft;
+            colour = singleColour;
             return HasSingleColour;
         }
 
@@ -241,7 +236,17 @@ namespace osu.Framework.Graphics.Colour
         public override readonly string ToString() => HasSingleColour ? $@"{TopLeft} (Single)" : $@"{TopLeft}, {TopRight}, {BottomLeft}, {BottomRight}";
 
         public static implicit operator ColourInfo(SRGBColour colour) => SingleColour(colour);
-        public static implicit operator SRGBColour(ColourInfo colour) => colour.singleColour;
+
+        public static implicit operator SRGBColour(ColourInfo colour)
+        {
+            if (!colour.HasSingleColour)
+                throwConversionFromMultiColourToSingleColourException();
+
+            return colour.singleColour;
+
+            [DoesNotReturn]
+            static void throwConversionFromMultiColourToSingleColourException() => throw new InvalidOperationException("Attempted to read single colour from multi-colour ColourInfo.");
+        }
 
         public static implicit operator ColourInfo(Color4 colour) => (SRGBColour)colour;
         public static implicit operator Color4(ColourInfo colour) => (SRGBColour)colour;

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -152,17 +152,17 @@ namespace osu.Framework.Graphics.Colour
             if (alpha == 1.0)
                 return this;
 
+            if (TryExtractSingleColour(out SRGBColour single))
+            {
+                single.MultiplyAlpha(alpha);
+                return single;
+            }
+
             ColourInfo result = this;
             result.TopLeft.MultiplyAlpha(alpha);
-
-            if (HasSingleColour)
-                result.BottomLeft = result.TopRight = result.BottomRight = result.TopLeft;
-            else
-            {
-                result.BottomLeft.MultiplyAlpha(alpha);
-                result.TopRight.MultiplyAlpha(alpha);
-                result.BottomRight.MultiplyAlpha(alpha);
-            }
+            result.BottomLeft.MultiplyAlpha(alpha);
+            result.TopRight.MultiplyAlpha(alpha);
+            result.BottomRight.MultiplyAlpha(alpha);
 
             return result;
         }
@@ -181,10 +181,10 @@ namespace osu.Framework.Graphics.Colour
                     BottomRight.Equals(other.BottomRight);
             }
 
-            return other.HasSingleColour && TopLeft.Equals(other.TopLeft);
+            return other.HasSingleColour && singleColour.Equals(other.singleColour);
         }
 
-        public readonly bool Equals(SRGBColour other) => HasSingleColour && TopLeft.Equals(other);
+        public readonly bool Equals(SRGBColour other) => HasSingleColour && singleColour.Equals(other);
 
         /// <summary>
         /// The average colour of all corners.
@@ -194,7 +194,7 @@ namespace osu.Framework.Graphics.Colour
             get
             {
                 if (HasSingleColour)
-                    return TopLeft;
+                    return singleColour;
 
                 return SRGBColour.FromVector(
                     (TopLeft.ToVector() + TopRight.ToVector() + BottomLeft.ToVector() + BottomRight.ToVector()) / 4);

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -88,7 +88,8 @@ namespace osu.Framework.Graphics.Colour
         /// <returns>Whether the extracted colour is the single colour represented by this <see cref="ColourInfo"/>.</returns>
         public readonly bool TryExtractSingleColour(out SRGBColour colour)
         {
-            colour = singleColour;
+            // To make this code branchless, we have to work around the assertion in singleColour.
+            colour = TopLeft;
             return HasSingleColour;
         }
 

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -7,6 +7,7 @@ using System;
 using osuTK;
 using osu.Framework.Graphics.Primitives;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Colour
@@ -71,11 +72,13 @@ namespace osu.Framework.Graphics.Colour
             readonly get
             {
                 if (!HasSingleColour)
-                    throw new InvalidOperationException("Attempted to read single colour from multi-colour ColourInfo.");
+                    throwConversionFromMultiColourToSingleColourException();
 
                 return TopLeft;
-            }
 
+                [DoesNotReturn]
+                static void throwConversionFromMultiColourToSingleColourException() => throw new InvalidOperationException("Attempted to read single colour from multi-colour ColourInfo.");
+            }
             set
             {
                 TopLeft = BottomLeft = TopRight = BottomRight = value;

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -56,8 +56,8 @@ namespace osu.Framework.Graphics.Lines
 
             private Vector2 relativePosition(Vector2 localPos) => Vector2.Divide(localPos, drawSize);
 
-            private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
-                ? ((SRGBColour)DrawColourInfo.Colour).Linear
+            private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.TryExtractSingleColour(out SRGBColour colour)
+                ? colour.Linear
                 : DrawColourInfo.Colour.Interpolate(relativePosition(localPos)).Linear;
 
             private void addLineCap(Vector2 origin, float theta, float thetaDiff, RectangleF texRect)


### PR DESCRIPTION
The performance gains here are mostly theoretical and I can't benchmark them meaningfully in a real-world scenario. Consider this more of a refactoring that adds an optimal (and more user-friendly) method for checking whether a `ColourInfo` represents a single colour and then returning that colour.

This comes off the back of the osu!-side smoke implementation (where I initially noticed this), which potentially uses this method for tens of thousands of vertices (up to 30k is what I was able to achieve after [the recent changes](https://github.com/ppy/osu/pull/20827)). Similar is also done with slider paths (e.g. at some point https://osu.ppy.sh/beatmapsets/756794#osu/1605148 draws some 20k vertices). So _at most_ you'd see ~0.2ms frametime improvement.

Before
|              Method |     Mean |    Error |   StdDev | Allocated |
|-------------------- |---------:|---------:|---------:|----------:|
| ConvertToSRGBColour | 14.31 ns | 0.139 ns | 0.123 ns |         - |
|     ConvertToColor4 | 15.69 ns | 0.122 ns | 0.102 ns |         - |

After:
|                    Method |       Mean |     Error |    StdDev | Allocated |
|-------------------------- |-----------:|----------:|----------:|----------:|
|       ConvertToSRGBColour |  6.9628 ns | 0.0684 ns | 0.0534 ns |         - |
|           ConvertToColor4 | 11.1604 ns | 0.1658 ns | 0.1551 ns |         - |
| ExtractAndConvertToColor4 |  0.4039 ns | 0.0247 ns | 0.0231 ns |         - |

It uses concepts I've learnt over the years:
- Methods with `throw` are not inlined - extract these methods to promote inlining.
- Having strings in methods, even if the code is not hit, leads to a significant increase in ASM putting pressure on the JIT.

For comparisons sake, this is the best "real-world" example I could make, by looping `TestSceneSmoke` over 30 seconds:
| before | after |
| --- | --- |
| ![a](https://user-images.githubusercontent.com/1329837/197166090-243db5c7-d66b-442e-8e02-17fa333353e2.png) | ![b](https://user-images.githubusercontent.com/1329837/197166112-25df9044-cf26-4c6c-abda-d8283dd8352e.png) |

Again, I don't think these are indicative of anything so don't put much weight to them. There's too much noise.