### PR TITLE
Fix replacing items in dropdown changing selection

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -159,19 +159,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select item 2", () => testDropdown.Current.Value = testDropdown.Items.ElementAt(2));
             AddAssert("item 2 is selected", () => testDropdown.Current.Value.Equals(testDropdown.Items.ElementAt(2)));
 
-            AddStep("clear bindable list", () => bindableList.Clear());
-            toggleDropdownViaClick(bindableDropdown, "dropdown3");
-            AddAssert("no elements in bindable dropdown", () => !bindableDropdown.Items.Any());
-
-            AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
-            AddStep("select three", () => bindableDropdown.Current.Value = "three");
-            AddStep("remove first item from bindable", () => bindableList.RemoveAt(0));
-            AddAssert("two items in dropdown", () => bindableDropdown.Items.Count() == 2);
-            AddAssert("current value still three", () => bindableDropdown.Current.Value.Identifier == "three");
-
-            AddStep("remove three", () => bindableList.Remove("three"));
-            AddAssert("current value should be two", () => bindableDropdown.Current.Value.Identifier == "two");
-
             AddStep("close dropdown", () => InputManager.Key(Key.Escape));
         }
 
@@ -354,6 +341,28 @@ namespace osu.Framework.Tests.Visual.UserInterface
             assertDropdownIsClosed(disabledDropdown);
 
             void valueIsUnchanged() => AddAssert("value is unchanged", () => disabledDropdown.Current.Value.Equals(originalValue));
+        }
+
+        /// <summary>
+        /// Basic test for a <see cref="Dropdown{T}"/> that has it's <see cref="Dropdown{T}.ItemSource"/> bound to a <see cref="BindableList{T}"/>.
+        /// </summary>
+        [Test]
+        public void TestItemSource()
+        {
+            AddStep("clear bindable list", () => bindableList.Clear());
+            toggleDropdownViaClick(bindableDropdown, "dropdown3");
+            AddAssert("no elements in bindable dropdown", () => !bindableDropdown.Items.Any());
+
+            AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
+            AddStep("select three", () => bindableDropdown.Current.Value = "three");
+            AddStep("remove first item from bindable", () => bindableList.RemoveAt(0));
+            AddAssert("two items in dropdown", () => bindableDropdown.Items.Count() == 2);
+            AddAssert("current value still three", () => bindableDropdown.Current.Value.Identifier == "three");
+
+            AddStep("remove three", () => bindableList.Remove("three"));
+            AddAssert("current value should be two", () => bindableDropdown.Current.Value.Identifier == "two");
+
+            AddStep("close dropdown", () => InputManager.Key(Key.Escape));
         }
 
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -365,6 +365,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("close dropdown", () => InputManager.Key(Key.Escape));
         }
 
+        [Test]
+        public void TestReplaceItemsInItemSource()
+        {
+            AddStep("clear bindable list", () => bindableList.Clear());
+            toggleDropdownViaClick(bindableDropdown, "dropdown3");
+            AddAssert("no elements in bindable dropdown", () => !bindableDropdown.Items.Any());
+
+            AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
+            AddStep("select three", () => bindableDropdown.Current.Value = "three");
+
+            AddStep("remove and then add items to bindable", () =>
+            {
+                bindableList.Clear();
+                bindableList.AddRange(new[] { "four", "three" }.Select(s => new TestModel(s)));
+            });
+
+            AddAssert("current value still three", () => bindableDropdown.Current.Value.Identifier, () => Is.EqualTo("three"));
+        }
+
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>
         {
             InputManager.MoveMouseTo(dropdown.Header);

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.UserInterface
                     Menu.State = MenuState.Closed;
             };
 
-            ItemSource.CollectionChanged += (_, _) => setItems(ItemSource);
+            ItemSource.CollectionChanged += (_, _) => Scheduler.AddOnce(setItems, ItemSource);
         }
 
         private void preselectionConfirmed(int selectedIndex)


### PR DESCRIPTION
Fixes https://discord.com/channels/188630481301012481/589331078574112768/1033248812862554122.

Scheduling changes is already done for `Current` so doing it for `ItemSource` shouldn't cause problems.

Having an atomic way to replace items in `BindableList` would also be beneficial. Currently, items must first be removed, and only then added.
