### PR TITLE
Fix directory selector crashing when attempting to display a bitlocker locked drive

### DIFF
--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorDirectory.cs
@@ -36,6 +36,13 @@ namespace osu.Framework.Graphics.UserInterface
                 if (isHidden && !isSystemDrive)
                     ApplyHiddenState();
             }
+            catch (IOException)
+            {
+                // various IO exceptions could occur when attempting to read attributes.
+                // one example is when a target directory is a drive which is locked by BitLocker:
+                //
+                // "Unhandled exception. System.IO.IOException: This drive is locked by BitLocker Drive Encryption. You must unlock this drive from Control Panel. : 'D:\'"
+            }
             catch (UnauthorizedAccessException)
             {
                 // checking attributes on access-controlled directories will throw an error so we handle it here to prevent a crash


### PR DESCRIPTION
Closes #5477. Untested.