### PR TITLE
Fix texture uploads potentially disposed too early

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -91,11 +91,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         protected virtual void Dispose(bool isDisposing)
         {
-            while (tryGetNextUpload(out var upload))
-                upload.Dispose();
-
             Renderer.ScheduleDisposal(texture =>
             {
+                while (tryGetNextUpload(out var upload))
+                    upload.Dispose();
+
                 int disposableId = texture.textureId;
 
                 if (disposableId <= 0)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/7477

These texture uploads may be crucial for the few frames before the texture's usage has concluded.