### PR TITLE
Make `GLTexture` disposal action not capturing

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
             Renderer.ScheduleDisposal(texture =>
             {
-                while (tryGetNextUpload(out var upload))
+                while (texture.tryGetNextUpload(out var upload))
                     upload.Dispose();
 
                 int disposableId = texture.textureId;


### PR DESCRIPTION
Just things I find while reviewing my code 100 times over.