### PR TITLE
Create Keyboard Height Utility

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -17,6 +17,7 @@ using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
+using osu.Framework.Utils;
 using Uri = Android.Net.Uri;
 
 namespace osu.Framework.Android
@@ -62,7 +63,9 @@ namespace osu.Framework.Android
 
         public override Storage GetStorage(string path) => new AndroidStorage(path, this);
 
-        public override IEnumerable<string> UserStoragePaths => new[]
+        public override KeyboardUtils GetKeyboardUtils() => new AndroidKeyboardUtils();
+
+    public override IEnumerable<string> UserStoragePaths => new[]
         {
             // not null as internal "external storage" is always available.
             Application.Context.GetExternalFilesDir(string.Empty).AsNonNull().ToString(),

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.Android
 
         public override KeyboardUtils GetKeyboardUtils() => new AndroidKeyboardUtils();
 
-    public override IEnumerable<string> UserStoragePaths => new[]
+        public override IEnumerable<string> UserStoragePaths => new[]
         {
             // not null as internal "external storage" is always available.
             Application.Context.GetExternalFilesDir(string.Empty).AsNonNull().ToString(),

--- a/osu.Framework.Android/AndroidKeyboardUtils.cs
+++ b/osu.Framework.Android/AndroidKeyboardUtils.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Utils;
+
+namespace osu.Framework.Android
+{
+    internal class AndroidKeyboardUtils : KeyboardUtils
+    {
+        public AndroidKeyboardUtils()
+        {
+            // I don't use android and the android emulator is broken.
+            // Add some listener. I'm not an android expert.
+        }
+    }
+}

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -21,6 +21,7 @@ using osu.Framework.iOS.Graphics.Video;
 using osu.Framework.iOS.Input;
 using osu.Framework.Platform;
 using osu.Framework.Platform.MacOS;
+using osu.Framework.Utils;
 using UIKit;
 
 namespace osu.Framework.iOS
@@ -76,6 +77,8 @@ namespace osu.Framework.iOS
             };
 
         public override Storage GetStorage(string path) => new IOSStorage(path, this);
+
+        public override KeyboardUtils GetKeyboardUtils() => new IOSKeyboardUtils();
 
         public override bool OpenFileExternally(string filename) => false;
 

--- a/osu.Framework.iOS/IOSKeyboardUtils.cs
+++ b/osu.Framework.iOS/IOSKeyboardUtils.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Utils;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.iOS
+{
+    internal class IOSKeyboardUtils : KeyboardUtils
+    {
+        public IOSKeyboardUtils()
+        {
+            UIKeyboard.Notifications.ObserveWillChangeFrame(keyboardWillShowChange);
+            UIKeyboard.Notifications.ObserveWillShow(keyboardWillShowChange);
+            UIKeyboard.Notifications.ObserveWillHide(keyboardWillHide);
+
+            UIKeyboard.Notifications.ObserveDidChangeFrame(keyboardDidShowChange);
+            UIKeyboard.Notifications.ObserveDidShow(keyboardDidShowChange);
+            UIKeyboard.Notifications.ObserveDidHide(keyboardDidHide);
+        }
+
+        private Easing translateEasingEffect(UIViewAnimationCurve animationCurve)
+        {
+            switch (animationCurve)
+            {
+                case UIViewAnimationCurve.EaseInOut:
+                    return Easing.InOutSine;
+
+                case UIViewAnimationCurve.EaseIn:
+                    return Easing.InSine;
+
+                case UIViewAnimationCurve.EaseOut:
+                    return Easing.OutSine;
+
+                case UIViewAnimationCurve.Linear:
+                    return Easing.None;
+            }
+
+            return Easing.None;
+        }
+
+        private void keyboardWillShowChange(object sender, UIKeyboardEventArgs args)
+        {
+            // Get ScreenBounds and keyboardFrame
+            CGRect screenBounds = UIScreen.MainScreen.Bounds;
+            CGRect keyboardFrame = ((NSValue)args.Notification.UserInfo![UIKeyboard.FrameEndUserInfoKey]!).CGRectValue;
+
+            // Check if docked using a odd method
+            // https://stackoverflow.com/questions/59871352/is-is-possible-on-ipad-os-to-detect-if-the-keyboard-is-in-floating-mode
+            Docked = screenBounds.GetMaxX() == keyboardFrame.GetMaxX() &&
+                screenBounds.GetMaxY() == keyboardFrame.GetMaxY() &&
+                screenBounds.Width == keyboardFrame.Width;
+
+            Visible = true;
+            TrueHeight = args.FrameEnd.Height;
+            Height = Docked ? args.FrameEnd.Height : 0;
+            AnimationDuration = args.AnimationDuration;
+            AnimationType = translateEasingEffect(args.AnimationCurve);
+        }
+
+        private void keyboardDidShowChange(object sender, UIKeyboardEventArgs args)
+        {
+            AnimationDuration = -1;
+            AnimationType = Easing.InOutSine;
+        }
+
+        private void keyboardWillHide(object sender, UIKeyboardEventArgs args)
+        {
+            Docked = true;
+            Visible = false;
+            Height = 0;
+            TrueHeight = 0;
+            AnimationDuration = args.AnimationDuration;
+            AnimationType = Easing.InOutSine;
+        }
+
+        private void keyboardDidHide(object sender, UIKeyboardEventArgs args)
+        {
+            AnimationDuration = -1;
+            AnimationType = Easing.InOutSine;
+        }
+    }
+}

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -43,7 +43,11 @@ namespace osu.Framework.Platform
         }
 
         public sealed override Storage GetStorage(string path) => new DesktopStorage(path, this);
-        public sealed override KeyboardUtils GetKeyboardUtils() => new DesktopKeyboardUtils();
+        public sealed override KeyboardUtils GetKeyboardUtils() => new DeskopKeyboardUtils();
+
+        private class DeskopKeyboardUtils : KeyboardUtils
+        {
+        }
 
         public override bool IsPrimaryInstance
         {
@@ -135,16 +139,6 @@ namespace osu.Framework.Platform
         {
             ipcProvider?.Dispose();
             base.Dispose(isDisposing);
-        }
-
-        private class DesktopKeyboardUtils : KeyboardUtils
-        {
-            public DesktopKeyboardUtils()
-            {
-                TrueHeight = 0;
-                Height = 0;
-                Visible = false;
-            }
         }
     }
 }

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -16,6 +16,7 @@ using osu.Framework.Input.Handlers.Keyboard;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers.Touch;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Platform
 {
@@ -42,6 +43,7 @@ namespace osu.Framework.Platform
         }
 
         public sealed override Storage GetStorage(string path) => new DesktopStorage(path, this);
+        public sealed override KeyboardUtils GetKeyboardUtils() => new DesktopKeyboardUtils();
 
         public override bool IsPrimaryInstance
         {
@@ -133,6 +135,16 @@ namespace osu.Framework.Platform
         {
             ipcProvider?.Dispose();
             base.Dispose(isDisposing);
+        }
+
+        private class DesktopKeyboardUtils : KeyboardUtils
+        {
+            public DesktopKeyboardUtils()
+            {
+                TrueHeight = 0;
+                Height = 0;
+                Visible = false;
+            }
         }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -48,6 +48,7 @@ using osu.Framework.Localisation;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
 using Size = System.Drawing.Size;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Platform
 {
@@ -194,6 +195,8 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <param name="path">The absolute path to be used as a root for the storage.</param>
         public abstract Storage GetStorage(string path);
+
+        public abstract KeyboardUtils GetKeyboardUtils();
 
         /// <summary>
         /// All valid user storage paths in order of usage priority.

--- a/osu.Framework/Utils/KeyboardUtils.cs
+++ b/osu.Framework/Utils/KeyboardUtils.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Utils
+{
+    public abstract class KeyboardUtils
+    {
+        /// <summary>
+        /// The true target height of the keyboard (even when undocked on iOS)
+        /// </summary>
+        public double TrueHeight = 0;
+
+        /// <summary>
+        /// The target height of the keyboard that can be used safely
+        /// </summary>
+        public double Height = 0;
+
+        /// <summary>
+        /// If the keyboard is docked (iOS)
+        /// </summary>
+        public bool Docked = true;
+
+        /// <summary>
+        /// If the keyboard is visible
+        /// </summary>
+        public bool Visible = false;
+
+        /// <summary>
+        /// The animation duration of the keyboard
+        /// (-1 if the keyboard is not being animated)
+        /// </summary>
+        public double AnimationDuration = -1;
+
+        /// <summary>
+        /// The type of transition. (Linear, EaseInOut, etc.)
+        /// </summary>
+        public Easing AnimationType = Easing.InOutSine;
+    }
+}

--- a/osu.Framework/Utils/KeyboardUtils.cs
+++ b/osu.Framework/Utils/KeyboardUtils.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 
 namespace osu.Framework.Utils
 {
-    public abstract class KeyboardUtils
+    public class KeyboardUtilsData
     {
         /// <summary>
         /// The true target height of the keyboard (even when undocked on iOS)
@@ -38,5 +38,15 @@ namespace osu.Framework.Utils
         /// The type of transition. (Linear, EaseInOut, etc.)
         /// </summary>
         public Easing AnimationType = Easing.InOutSine;
+    }
+
+    public abstract class KeyboardUtils
+    {
+        public readonly Bindable<KeyboardUtilsData> State = new Bindable<KeyboardUtilsData>(new KeyboardUtilsData());
+
+        protected void Update(KeyboardUtilsData update)
+        {
+            State.SetValue(State.Value, update);
+        }
     }
 }


### PR DESCRIPTION
This utility allows osu! to detect the height of the on-screen keyboard. This is important because when the keyboard covers a text box, it has a bad UX experience.