### PR TITLE
Refactor drawable pool statistics output to make more sense

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     consumeDrawable();
             });
 
-            AddAssert("pool saturated", () => pool.CountAvailable == 0);
+            AddAssert("pool saturated", () => pool.CountAvailable, () => Is.EqualTo(0));
 
             AddUntilStep("pool size returned to correct maximum", () => pool.CountAvailable == maxPoolSize);
             AddUntilStep("count in pool is correct", () => consumed.Count(d => d.IsInPool) == maxPoolSize);
@@ -281,7 +281,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             base.Update();
             if (count != null)
-                count.Text = $"available: {pool.CountAvailable} consumed: {consumed.Count} disposed: {consumed.Count(d => d.IsDisposed)}";
+                count.Text = $"available: {pool.CountAvailable} poolSize: {pool.CurrentPoolSize} inUse: {pool.CountInUse} consumed: {consumed.Count} excessConstructed: {pool.CountExcessConstructed} disposed: {consumed.Count(d => d.IsDisposed)}";
         }
 
         private static int displayCount;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -133,6 +133,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddUntilStep("wait until first dead", () => !first.IsAlive);
             AddUntilStep("drawable is disposed", () => first.IsDisposed);
+
+            AddAssert("excess constructed count is one", () => pool.CountExcessConstructed == 1);
         }
 
         [Test]
@@ -154,6 +156,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddAssert("prepare was run", () => drawable2.PreparedCount == 2);
             AddUntilStep("free was run", () => drawable2.FreedCount == 2);
+
+            AddAssert("no excess constructed count", () => pool.CountExcessConstructed == 0);
         }
 
         [Test]
@@ -178,6 +182,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddAssert("prepare was only run once", () => drawable2.PreparedCount == 1);
             AddUntilStep("free was run", () => drawable2.FreedCount == 2);
+
+            AddAssert("no excess constructed count", () => pool.CountExcessConstructed == 0);
         }
 
         [Test]
@@ -211,6 +217,30 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddAssert("all drawables in ready state", () => retrieved.All(d => d.LoadState == LoadState.Ready));
         }
 
+        [Test]
+        public void TestPoolUsageExceedsInitialNoMaximum()
+        {
+            const int requested_drawables = 20;
+            const int initial_size = 10;
+
+            resetWithNewPool(() => new TestPool(TimePerAction * 20, initial_size));
+
+            AddStep("get many pooled drawables", () =>
+            {
+                for (int i = 0; i < requested_drawables; i++)
+                    consumeDrawable();
+            });
+
+            AddAssert("pool saturated", () => pool.CountAvailable, () => Is.EqualTo(0));
+
+            AddUntilStep("pool size returned to correct maximum", () => pool.CountAvailable == requested_drawables);
+
+            AddUntilStep("excess constructed zero", () => pool.CountExcessConstructed, () => Is.Zero);
+
+            AddUntilStep("count in pool is correct", () => consumed.Count(d => d.IsInPool) == requested_drawables);
+            AddAssert("all drawables in pool", () => consumed.All(d => d.IsInPool));
+        }
+
         [TestCase(10)]
         [TestCase(20)]
         public void TestPoolUsageExceedsMaximum(int maxPoolSize)
@@ -226,6 +256,8 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddAssert("pool saturated", () => pool.CountAvailable, () => Is.EqualTo(0));
 
             AddUntilStep("pool size returned to correct maximum", () => pool.CountAvailable == maxPoolSize);
+            AddUntilStep("excess constructed count correct", () => pool.CountExcessConstructed == maxPoolSize);
+
             AddUntilStep("count in pool is correct", () => consumed.Count(d => d.IsInPool) == maxPoolSize);
             AddAssert("excess drawables were used", () => consumed.Any(d => !d.IsInPool));
             AddUntilStep("non-returned drawables disposed", () => consumed.Where(d => !d.IsInPool).All(d => d.IsDisposed));
@@ -280,8 +312,12 @@ namespace osu.Framework.Tests.Visual.Drawables
         protected override void Update()
         {
             base.Update();
+
             if (count != null)
-                count.Text = $"available: {pool.CountAvailable} poolSize: {pool.CurrentPoolSize} inUse: {pool.CountInUse} consumed: {consumed.Count} excessConstructed: {pool.CountExcessConstructed} disposed: {consumed.Count(d => d.IsDisposed)}";
+            {
+                count.Text =
+                    $"available: {pool.CountAvailable} poolSize: {pool.CurrentPoolSize} inUse: {pool.CountInUse} consumed: {consumed.Count} excessConstructed: {pool.CountExcessConstructed} disposed: {consumed.Count(d => d.IsDisposed)}";
+            }
         }
 
         private static int displayCount;

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Graphics.Pooling
             {
                 drawable = create();
 
-                if (currentPoolSize < maximumSize)
+                if (maximumSize == null || currentPoolSize < maximumSize)
                 {
                     CurrentPoolSize++;
                     Debug.Assert(maximumSize == null || CurrentPoolSize <= maximumSize);

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.Graphics.Pooling
         private int countExcessConstructed;
 
         /// <summary>
-        /// The total number of drawables constructed.
+        /// The total number of drawables constructed that were not pooled.
         /// </summary>
         public int CountExcessConstructed
         {

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -42,6 +42,9 @@ namespace osu.Framework.Graphics.Pooling
         /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
         public DrawablePool(int initialSize, int? maximumSize = null)
         {
+            if (initialSize > maximumSize)
+                throw new ArgumentOutOfRangeException(nameof(initialSize), "Initial size must be less than or equal to maximum size.");
+
             this.maximumSize = maximumSize;
             this.initialSize = initialSize;
 
@@ -55,7 +58,8 @@ namespace osu.Framework.Graphics.Pooling
         private void load()
         {
             for (int i = 0; i < initialSize; i++)
-                push(create());
+                pool.Push(create());
+            CurrentPoolSize = initialSize;
 
             LoadComponents(pool.ToArray());
         }
@@ -66,7 +70,7 @@ namespace osu.Framework.Graphics.Pooling
         /// <param name="pooledDrawable">The drawable to return. Should have originally come from this pool.</param>
         public void Return(PoolableDrawable pooledDrawable)
         {
-            if (!(pooledDrawable is T))
+            if (pooledDrawable is not T typedDrawable)
                 throw new ArgumentException("Invalid type", nameof(pooledDrawable));
 
             if (pooledDrawable.Parent != null)
@@ -80,7 +84,21 @@ namespace osu.Framework.Graphics.Pooling
             }
 
             //TODO: check the drawable was sourced from this pool for safety.
-            push((T)pooledDrawable);
+
+            if (CountAvailable >= maximumSize)
+            {
+                // if the drawable can't be returned to the pool, mark it as such so it can be disposed of.
+                pooledDrawable.SetPool(null);
+
+                // then attempt disposal.
+                if (pooledDrawable.DisposeOnDeathRemoval)
+                    DisposeChildAsync(pooledDrawable);
+            }
+            else
+            {
+                pool.Push(typedDrawable);
+            }
+
             CountInUse--;
         }
 
@@ -97,11 +115,19 @@ namespace osu.Framework.Graphics.Pooling
             {
                 drawable = create();
 
+                if (currentPoolSize < maximumSize)
+                {
+                    CurrentPoolSize++;
+                    Debug.Assert(maximumSize == null || CurrentPoolSize <= maximumSize);
+                }
+                else
+                    CountExcessConstructed++;
+
                 if (LoadState >= LoadState.Loading)
                     LoadComponent(drawable);
             }
-            else
-                CountAvailable--;
+
+            CountInUse++;
 
             drawable.Assign();
             drawable.LifetimeStart = double.MinValue;
@@ -109,7 +135,6 @@ namespace osu.Framework.Graphics.Pooling
 
             setupAction?.Invoke(drawable);
 
-            CountInUse++;
             return drawable;
         }
 
@@ -121,30 +146,10 @@ namespace osu.Framework.Graphics.Pooling
         private T create()
         {
             var drawable = CreateNewDrawable();
+
             drawable.SetPool(this);
-            CountConstructed++;
 
             return drawable;
-        }
-
-        private bool push(T poolableDrawable)
-        {
-            if (CountAvailable >= maximumSize)
-            {
-                // if the drawable can't be returned to the pool, mark it as such so it can be disposed of.
-                poolableDrawable.SetPool(null);
-
-                // then attempt disposal.
-                if (poolableDrawable.DisposeOnDeathRemoval)
-                    DisposeChildAsync(poolableDrawable);
-
-                return false;
-            }
-
-            pool.Push(poolableDrawable);
-            CountAvailable++;
-
-            return true;
         }
 
         protected override void Dispose(bool isDisposing)
@@ -155,13 +160,29 @@ namespace osu.Framework.Graphics.Pooling
                 p.Dispose();
 
             CountInUse = 0;
-            CountConstructed = 0;
-            CountAvailable = 0;
+            CountExcessConstructed = 0;
+            CurrentPoolSize = 0;
 
             GlobalStatistics.Remove(statistic);
 
             // Disallow any further Gets/Returns to adjust the statistics.
             statistic = null;
+        }
+
+        private int currentPoolSize;
+
+        /// <summary>
+        /// The current size of the pool.
+        /// </summary>
+        public int CurrentPoolSize
+        {
+            get => currentPoolSize;
+            private set
+            {
+                Debug.Assert(statistic != null);
+
+                statistic.Value.CurrentPoolSize = currentPoolSize = value;
+            }
         }
 
         private int countInUse;
@@ -176,51 +197,37 @@ namespace osu.Framework.Graphics.Pooling
             {
                 Debug.Assert(statistic != null);
 
-                statistic.Value.CountInUse += value - countInUse;
-                countInUse = value;
+                statistic.Value.CountInUse = countInUse = value;
             }
         }
 
-        private int countConstructed;
+        private int countExcessConstructed;
 
         /// <summary>
         /// The total number of drawables constructed.
         /// </summary>
-        public int CountConstructed
+        public int CountExcessConstructed
         {
-            get => countConstructed;
+            get => countExcessConstructed;
             private set
             {
                 Debug.Assert(statistic != null);
 
-                statistic.Value.CountConstructed += value - countConstructed;
-                countConstructed = value;
+                statistic.Value.CountExcessConstructed = countExcessConstructed = value;
             }
         }
-
-        private int countAvailable;
 
         /// <summary>
         /// The number of drawables currently available for consumption.
         /// </summary>
-        public int CountAvailable
-        {
-            get => countAvailable;
-            private set
-            {
-                Debug.Assert(statistic != null);
-
-                statistic.Value.CountAvailable += value - countAvailable;
-                countAvailable = value;
-            }
-        }
+        public int CountAvailable => pool.Count;
 
         private class DrawablePoolUsageStatistic
         {
             /// <summary>
             /// Total number of drawables available for use (in the pool).
             /// </summary>
-            public int CountAvailable;
+            public int CurrentPoolSize;
 
             /// <summary>
             /// Total number of drawables currently in use.
@@ -228,11 +235,11 @@ namespace osu.Framework.Graphics.Pooling
             public int CountInUse;
 
             /// <summary>
-            /// Total number of drawables constructed (can exceed the max count).
+            /// Total number of drawables constructed that were not pooled.
             /// </summary>
-            public int CountConstructed;
+            public int CountExcessConstructed;
 
-            public override string ToString() => $"{CountAvailable}/{CountConstructed} ({CountInUse})";
+            public override string ToString() => $"{CountInUse}/{CurrentPoolSize} ({CountExcessConstructed} excess)";
         }
     }
 }


### PR DESCRIPTION
I was confused by the previous output, as it didn't do a great job showing the current pool usage – specifically it was not showing the current pool size in the denominator portion of the display, but the total usages. Which didn't make much sense at all.

The new format is `currentUsage / poolSize (x excess)`. Hopefully this is self-explanatory, so check that your understanding matches the following:

- `currentUsage` includes all current usages that started with a `Get` from the pool, and is decremented on each `Return`. This includes excess usages (that will not be returned to the pool).
- `poolSize` is the current size of the pool, ranging from `initialSize` to `maximumSize`. It is increased at the point of construction, not `Return`
- `excess` is the total excess drawables constructed which will not be returned to the pool. Note that based on the order of `Return`, the drawable which caused this count to increment may not be the one that is not-returned-to-the-queue. That depends on the order that usages finish.

I have tried to not change the existing flow at all. This is intending to only change accounting so we can display the new statistics output.