### PR TITLE
Fix `Renderer` holding a permanent reference to every texture ever created

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public virtual int Height { get; set; }
         public virtual int GetByteSize() => Width * Height * 4;
         public bool Available { get; private set; } = true;
+
+        ulong INativeTexture.TotalBindCount { get; set; }
+
         public bool BypassTextureUploadQueueing { get; set; }
 
         private int internalWidth;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
@@ -20,12 +20,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public bool BypassTextureUploadQueueing { get; set; }
         public bool UploadComplete => true;
         public bool IsQueuedForUpload { get; set; }
-
-        ulong INativeTexture.TotalBindCount
-        {
-            get => 0;
-            set => throw new System.NotImplementedException();
-        }
+        ulong INativeTexture.TotalBindCount { get; set; }
 
         public DummyNativeTexture(IRenderer renderer)
         {

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
@@ -21,6 +21,12 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public bool UploadComplete => true;
         public bool IsQueuedForUpload { get; set; }
 
+        ulong INativeTexture.TotalBindCount
+        {
+            get => 0;
+            set => throw new System.NotImplementedException();
+        }
+
         public DummyNativeTexture(IRenderer renderer)
         {
             Renderer = renderer;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -194,7 +194,5 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         }
 
         Texture[] IRenderer.GetAllTextures() => Array.Empty<Texture>();
-
-        ulong IRenderer.GetTextureBindCount(Texture texture) => 0;
     }
 }

--- a/osu.Framework/Graphics/Rendering/INativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/INativeTexture.cs
@@ -40,6 +40,11 @@ namespace osu.Framework.Graphics.Rendering
         bool Available { get; }
 
         /// <summary>
+        /// The total number of times this texture has been bound, ever.
+        /// </summary>
+        ulong TotalBindCount { get; internal set; }
+
+        /// <summary>
         /// By default, texture uploads are queued for upload at the beginning of each frame, allowing loading them ahead of time.
         /// When this is true, this will be bypassed and textures will only be uploaded on use. Should be set for every-frame texture uploads
         /// to avoid overloading the global queue.

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -352,11 +352,6 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         internal Texture[] GetAllTextures();
 
-        /// <summary>
-        /// Returns the total amount of times the texture has ever been bound.
-        /// </summary>
-        internal ulong GetTextureBindCount(Texture texture);
-
         #endregion
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -104,8 +104,6 @@ namespace osu.Framework.Graphics.Rendering
         private readonly INativeTexture?[] lastBoundTexture = new INativeTexture?[16];
         private readonly bool[] lastBoundTextureIsAtlas = new bool[16];
 
-        private readonly Dictionary<INativeTexture, ulong> textureBindCount = new Dictionary<INativeTexture, ulong>();
-
         // in case no other textures are used in the project, create a new atlas as a fallback source for the white pixel area (used to draw boxes etc.)
         private readonly Lazy<TextureWhitePixel> whitePixel;
         private readonly LockedWeakList<Texture> allTextures = new LockedWeakList<Texture>();
@@ -793,7 +791,7 @@ namespace osu.Framework.Graphics.Rendering
             lastActiveTextureUnit = unit;
 
             FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
-            textureBindCount[texture] = textureBindCount.GetValueOrDefault(texture) + 1;
+            texture.TotalBindCount++;
 
             return true;
         }
@@ -1055,8 +1053,6 @@ namespace osu.Framework.Graphics.Rendering
         }
 
         Texture[] IRenderer.GetAllTextures() => allTextures.ToArray();
-
-        ulong IRenderer.GetTextureBindCount(Texture texture) => textureBindCount.GetValueOrDefault(texture.NativeTexture);
 
         #endregion
     }

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -215,7 +215,7 @@ namespace osu.Framework.Graphics.Visualisation
                     if (!texture.Available)
                         return;
 
-                    ulong delta = renderer.GetTextureBindCount(texture) - Source.lastBindCount;
+                    ulong delta = texture.NativeTexture.TotalBindCount - Source.lastBindCount;
 
                     Source.AverageUsagesPerFrame = Source.AverageUsagesPerFrame * 0.9f + delta * 0.1f;
 
@@ -228,7 +228,7 @@ namespace osu.Framework.Graphics.Visualisation
                     base.Draw(renderer);
 
                     // intentionally after draw to avoid counting our own bind.
-                    Source.lastBindCount = renderer.GetTextureBindCount(texture);
+                    Source.lastBindCount = texture.NativeTexture.TotalBindCount;
                 }
 
                 protected override void Blit(IRenderer renderer)


### PR DESCRIPTION
Closes #5486.