### PR TITLE
Compute CircularBlob's noise position in the DrawNode

### DIFF
--- a/osu.Framework/Graphics/UserInterface/CircularBlob.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularBlob.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
+using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -96,7 +97,8 @@ namespace osu.Framework.Graphics.UserInterface
             private float texelSize;
             private float frequency;
             private float amplitude;
-            private int seed;
+            private Vector2 noisePosition;
+            private int seed = -1;
 
             public override void ApplyState()
             {
@@ -105,7 +107,15 @@ namespace osu.Framework.Graphics.UserInterface
                 innerRadius = Source.innerRadius;
                 frequency = Source.frequency;
                 amplitude = Source.amplitude;
-                seed = Source.seed;
+
+                int newSeed = Source.seed;
+
+                if (seed != newSeed)
+                {
+                    Random rand = new Random(newSeed);
+                    noisePosition = new Vector2((float)(rand.NextDouble() * 100000), (float)(rand.NextDouble() * 100000));
+                    seed = newSeed;
+                }
 
                 // smoothstep looks too sharp with 1px, let's give it a bit more
                 texelSize = 1.5f / ScreenSpaceDrawQuad.Size.X;
@@ -119,7 +129,7 @@ namespace osu.Framework.Graphics.UserInterface
                 shader.GetUniform<float>("texelSize").UpdateValue(ref texelSize);
                 shader.GetUniform<float>("frequency").UpdateValue(ref frequency);
                 shader.GetUniform<float>("amplitude").UpdateValue(ref amplitude);
-                shader.GetUniform<int>("seed").UpdateValue(ref seed);
+                shader.GetUniform<Vector2>("noisePosition").UpdateValue(ref noisePosition);
 
                 base.Blit(renderer);
             }

--- a/osu.Framework/Graphics/UserInterface/CircularBlob.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularBlob.cs
@@ -113,7 +113,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (seed != newSeed)
                 {
                     Random rand = new Random(newSeed);
-                    noisePosition = new Vector2((float)(rand.NextDouble() * 100000), (float)(rand.NextDouble() * 100000));
+                    noisePosition = new Vector2((float)(rand.NextDouble() * 1000), (float)(rand.NextDouble() * 1000));
                     seed = newSeed;
                 }
 

--- a/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
@@ -10,7 +10,7 @@ uniform lowp sampler2D m_Sampler;
 uniform mediump float innerRadius;
 uniform mediump float frequency;
 uniform mediump float amplitude;
-uniform int seed;
+uniform highp vec2 noisePosition;
 uniform highp float texelSize;
 
 void main(void)
@@ -25,5 +25,5 @@ void main(void)
     highp vec2 pixelPos = v_TexCoord / resolution;
     
     lowp vec4 textureColour = toSRGB(v_Colour * wrappedSampler(wrap(v_TexCoord, v_TexRect), v_TexRect, m_Sampler, -0.9));
-    gl_FragColor = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, seed));
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition));
 }

--- a/osu.Framework/Resources/Shaders/sh_CircularBlobRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlobRounded.fs
@@ -11,7 +11,7 @@ uniform lowp sampler2D m_Sampler;
 uniform mediump float innerRadius;
 uniform mediump float frequency;
 uniform mediump float amplitude;
-uniform int seed;
+uniform highp vec2 noisePosition;
 uniform highp float texelSize;
 
 void main(void)
@@ -28,5 +28,5 @@ void main(void)
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(toSRGB(wrappedSampler(wrappedCoord, v_TexRect, m_Sampler, -0.9)), wrappedCoord);
 
-    gl_FragColor = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, seed));
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition));
 }

--- a/osu.Framework/Resources/Shaders/sh_CircularBlobUtils.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlobUtils.h
@@ -23,7 +23,7 @@ highp float noise(highp vec2 st)
     return mix(a, b, u.x) + (c - a)* u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
 }
 
-lowp float blobAlphaAt(highp vec2 pixelPos, mediump float innerRadius, highp float texelSize, mediump float frequency, mediump float amplitude, int seed)
+lowp float blobAlphaAt(highp vec2 pixelPos, mediump float innerRadius, highp float texelSize, mediump float frequency, mediump float amplitude, highp vec2 noisePosition)
 {
     // Compute angle of the current pixel in the (0, 2*PI) range
     mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - HALF_PI;
@@ -40,9 +40,6 @@ lowp float blobAlphaAt(highp vec2 pixelPos, mediump float innerRadius, highp flo
     highp float shortestDistance = 1.0;
 
     mediump float startAngle = pixelAngle - searchRange * 0.5;
-
-    // Looks to be random enough but still consistent
-    highp vec2 noisePosition = vec2(random(vec2(float(seed) * 0.0001)) * 100000.0, random(vec2(float(seed) * 0.0001)) * 100000.0);
 
     // Path approximation
     // Plot points within a search range and check which one is closest


### PR DESCRIPTION
Should potentially fix iOS visual issue, but it's hard to tell beforehand.
Calculating the same value for each pixel was not clever anyway.