### PR TITLE
Use (high resolution) waitable timers on windows when available

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -60,6 +60,8 @@ namespace osu.Framework.Graphics.Performance
         private double lastUpdateLocalTime;
         private double lastFrameFramesPerSecond;
 
+        private double jitter;
+
         private const int updates_per_second = 10;
 
         protected override void Update()
@@ -100,7 +102,7 @@ namespace osu.Framework.Graphics.Performance
             framesSinceLastUpdate = 0;
             elapsedSinceLastUpdate = 0;
 
-            counter.Text = $"{displayFps:0}fps ({rollingElapsed:0.00}ms)"
+            counter.Text = $"{displayFps:0}fps ({rollingElapsed:0.00}ms ±{jitter:0.00}ms)"
                            + (clock.Throttling ? $"{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}hz" : string.Empty);
         }
 
@@ -126,6 +128,7 @@ namespace osu.Framework.Graphics.Performance
 
             framesSinceLastUpdate++;
             lastFrameFramesPerSecond = frame.FramesPerSecond;
+            jitter = frame.Jitter;
         }
     }
 }

--- a/osu.Framework/Platform/Windows/Native/Execution.cs
+++ b/osu.Framework/Platform/Windows/Native/Execution.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace osu.Framework.Platform.Windows.Native
 {
@@ -22,5 +23,37 @@ namespace osu.Framework.Platform.Windows.Native
             SystemRequired = 0x00000001,
             UserPresent = 0x00000004,
         }
+
+        [DllImport("kernel32.dll")]
+        internal static extern bool SetWaitableTimerEx(IntPtr hTimer, in FILETIME lpDueTime, int lPeriod, TimerApcProc routine, IntPtr lpArgToCompletionRoutine, IntPtr reason, uint tolerableDelay);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr CreateWaitableTimerEx(IntPtr lpTimerAttributes, string lpTimerName, CreateWaitableTimerFlags dwFlags, uint dwDesiredAccess);
+
+        internal const uint TIMER_ALL_ACCESS = 2031619U;
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void TimerApcProc([In] IntPtr lpArgToCompletionRoutine, uint dwTimerLowValue, uint dwTimerHighValue);
+
+        [Flags]
+        internal enum CreateWaitableTimerFlags : uint
+        {
+            CREATE_WAITABLE_TIMER_MANUAL_RESET = 0x00000001,
+            CREATE_WAITABLE_TIMER_HIGH_RESOLUTION = 0x00000002,
+        }
+
+        public const uint INFINITE = 0xffffffff;
+
+        [DllImport("kernel32.dll")]
+        internal static extern bool WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
+
+        internal static FILETIME CreateFileTime(TimeSpan ts)
+        {
+            ulong ul = unchecked((ulong)-ts.Ticks);
+            return new FILETIME { dwHighDateTime = (int)(ul >> 32), dwLowDateTime = (int)(ul & 0xFFFFFFFF) };
+        }
+
+        [DllImport("kernel32.dll")]
+        public static extern bool CloseHandle(IntPtr hObject);
     }
 }

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -20,12 +20,15 @@ namespace osu.Framework.Statistics
 
         internal static readonly long[] COUNTERS = new long[NUM_STATISTICS_COUNTER_TYPES];
 
+        public double Jitter;
+
         internal void Clear()
         {
             CollectedTimes.Clear();
             GarbageCollections.Clear();
             Counts.Clear();
             FramesPerSecond = 0;
+            Jitter = 0;
         }
 
         internal static void Increment(StatisticsCounterType type) => ++COUNTERS[(int)type];

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -153,6 +153,7 @@ namespace osu.Framework.Statistics
                     global.Value = count;
                     currentFrame.Counts[type] = count;
                     currentFrame.FramesPerSecond = Clock.FramesPerSecond;
+                    currentFrame.Jitter = Clock.Jitter;
 
                     FrameStatistics.COUNTERS[i] = 0;
                 }

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -489,6 +489,7 @@ namespace osu.Framework.Threading
                 {
                     case GameThreadState.Exited:
                         Monitor?.Dispose();
+                        Clock?.Dispose();
 
                         if (initializedEvent.IsNotNull())
                             initializedEvent.Dispose();

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -489,7 +489,7 @@ namespace osu.Framework.Threading
                 {
                     case GameThreadState.Exited:
                         Monitor?.Dispose();
-                        Clock?.Dispose();
+                        Clock.Dispose();
 
                         if (initializedEvent.IsNotNull())
                             initializedEvent.Dispose();

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Extensions.TypeExtensions;
 using System;
+using System.Linq;
 
 namespace osu.Framework.Timing
 {
@@ -29,7 +30,13 @@ namespace osu.Framework.Timing
 
         public FrameTimeInfo TimeInfo => new FrameTimeInfo { Elapsed = ElapsedFrameTime, Current = CurrentTime };
 
+        private readonly double[] betweenFrameTimes = new double[256];
+
+        private long totalFramesProcessed;
+
         public double FramesPerSecond { get; private set; }
+
+        public double Jitter { get; private set; }
 
         public virtual double CurrentTime { get; protected set; }
 
@@ -61,6 +68,9 @@ namespace osu.Framework.Timing
 
         public virtual void ProcessFrame()
         {
+            betweenFrameTimes[totalFramesProcessed % betweenFrameTimes.Length] = CurrentTime - LastFrameTime;
+            totalFramesProcessed++;
+
             if (processSource && Source is IFrameBasedClock framedSource)
                 framedSource.ProcessFrame();
 
@@ -69,9 +79,20 @@ namespace osu.Framework.Timing
                 timeUntilNextCalculation += fps_calculation_interval;
 
                 if (framesSinceLastCalculation == 0)
+                {
                     FramesPerSecond = 0;
+                    Jitter = 0;
+                }
                 else
+                {
                     FramesPerSecond = (int)Math.Ceiling(framesSinceLastCalculation * 1000f / timeSinceLastCalculation);
+
+                    // simple stddev
+                    double avg = betweenFrameTimes.Average();
+                    double stddev = Math.Sqrt(betweenFrameTimes.Average(v => Math.Pow(v - avg, 2)));
+                    Jitter = stddev;
+                }
+
                 timeSinceLastCalculation = framesSinceLastCalculation = 0;
             }
 

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Timing
 
         public FrameTimeInfo TimeInfo => new FrameTimeInfo { Elapsed = ElapsedFrameTime, Current = CurrentTime };
 
-        private readonly double[] betweenFrameTimes = new double[256];
+        private readonly double[] betweenFrameTimes = new double[128];
 
         private long totalFramesProcessed;
 

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -104,6 +104,7 @@ namespace osu.Framework.Timing
 
             if (waitableTimer != IntPtr.Zero)
             {
+                // Not sure if we want to fall back to Thread.Sleep on failure here, needs further investigation.
                 if (Execution.SetWaitableTimerEx(waitableTimer, Execution.CreateFileTime(timeSpan), 0, null, default, IntPtr.Zero, 0))
                     Execution.WaitForSingleObject(waitableTimer, Execution.INFINITE);
             }

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -35,20 +35,23 @@ namespace osu.Framework.Timing
 
         internal ThrottledFrameClock()
         {
-            try
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
             {
-                // Attempt to use CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, only available since Windows 10, version 1803.
-                waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET | Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, Execution.TIMER_ALL_ACCESS);
-
-                if (waitableTimer == IntPtr.Zero)
+                try
                 {
-                    // Fall back to a more supported version. This is still far more accurate than Thread.Sleep.
-                    waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET, Execution.TIMER_ALL_ACCESS);
+                    // Attempt to use CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, only available since Windows 10, version 1803.
+                    waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET | Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, Execution.TIMER_ALL_ACCESS);
+
+                    if (waitableTimer == IntPtr.Zero)
+                    {
+                        // Fall back to a more supported version. This is still far more accurate than Thread.Sleep.
+                        waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET, Execution.TIMER_ALL_ACCESS);
+                    }
                 }
-            }
-            catch
-            {
-                // Non-windows systems will not be able to use these timers.
+                catch
+                {
+                    // Any kind of unexpected exception should fall back to Thread.Sleep.
+                }
             }
         }
 

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -38,7 +38,6 @@ namespace osu.Framework.Timing
             try
             {
                 // Attempt to use CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, only available since Windows 10, version 1803.
-                // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
                 waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET | Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, Execution.TIMER_ALL_ACCESS);
 
                 if (waitableTimer == IntPtr.Zero)


### PR DESCRIPTION
Intends to fix the remaining inaccuracy that can be seen when running at frame rates close to the maximum precision provided by `Thread.Sleep` on windows.

A few preliminary notes:

- This is windows only. Other (unix/linux) platforms already had higher precision thread sleep. Of note, this does now perform `Thread.Sleep` using floating point rather than hard `int` rounding, so it may marginally improve results on non-windows platforms
- Frame jitter is now displayed on the frame statistics display. This is standard deviation between `NewFrame` calls averaged over last 256 frames
- Don't trip over the pinvoke code. I considered using [Vanara](https://github.com/dahall/Vanara) for this but that had a few issues (and the DLL is a bit large so we'd want pruning support). See https://github.com/dahall/Vanara/issues/339, may be something we can switch to in the future rather than implementing pinvokes locally, as it's much better documented and tested.
- CPU usage is basically unaffected, which is good.
- This may become available in SDL in a future release (see https://github.com/libsdl-org/SDL/pull/6232) but it's so much of an improvement that implementing local seems worthwhile for now.

Results:

Before (`Thread.Sleep`):
![mpv_2022-11-06_15-01-51](https://user-images.githubusercontent.com/191335/200157123-3e0e6f73-71d3-4ee6-9ff2-ac72bcd21be6.png)

![image](https://user-images.githubusercontent.com/191335/200157134-724c1ba9-6c43-43d9-9bba-6c7fdae2521d.png)

After (`WaitableTimer`):
![mpv_2022-11-06_15-02-07](https://user-images.githubusercontent.com/191335/200157125-a472268c-2658-4e5a-91eb-2179423be9e4.png)

![image](https://user-images.githubusercontent.com/191335/200157140-4e918bfe-6409-45fd-ade6-15576e24d467.png)

You can count the individual frames being run. In both profile runs above, the reported frame rate is 1,000, but in the first multiple frames were being coalesced into single back-to-back executions (which is basically pointless to us).

Note that even when not using `HIGH_PRECISION` mode, the results are basically the same. So this should improve the experience not only on recent window builds but most all.

- [x] Needs testing on machines which are limited in performance (ie. not capping the frame limiter out). Should we still invoke the timer wait when time-to-be-waited is zero?
