### PR TITLE
Change game thread prefixes to suffixes

### DIFF
--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Tests.Audio
                 resetEvent.Set();
             })
             {
-                Name = GameThread.PrefixedThreadNameFor("Audio")
+                Name = GameThread.SuffixedThreadNameFor("Audio")
             }.Start();
 
             if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))

--- a/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Tests.Audio
                 resetEvent.Set();
             })
             {
-                Name = GameThread.PrefixedThreadNameFor("Audio")
+                Name = GameThread.SuffixedThreadNameFor("Audio")
             }.Start();
 
             if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -378,7 +378,7 @@ namespace osu.Framework.Tests.Audio
                 resetEvent.Set();
             })
             {
-                Name = GameThread.PrefixedThreadNameFor("Audio")
+                Name = GameThread.SuffixedThreadNameFor("Audio")
             }.Start();
 
             if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -185,11 +185,11 @@ namespace osu.Framework.Threading
         }
 
         /// <summary>
-        /// Returns a string representation that is prefixed with this thread's identifier.
+        /// Returns a string representation that is suffixed with a game thread identifier.
         /// </summary>
-        /// <param name="name">The content to prefix.</param>
-        /// <returns>A prefixed string.</returns>
-        public static string PrefixedThreadNameFor(string name) => $"{nameof(GameThread)}.{name}";
+        /// <param name="name">The content to suffix.</param>
+        /// <returns>A suffixed string.</returns>
+        public static string SuffixedThreadNameFor(string name) => $"{name} ({nameof(GameThread)})";
 
         /// <summary>
         /// Start this thread.
@@ -400,7 +400,7 @@ namespace osu.Framework.Threading
 
             Thread = new Thread(runWork)
             {
-                Name = PrefixedThreadNameFor(Name),
+                Name = SuffixedThreadNameFor(Name),
                 IsBackground = true,
             };
 


### PR DESCRIPTION
This is just for my own sanity due to limitations in dotTrace. Without this, the actual part we care about (the thread's purpose) is truncated in the dotTrace interface with no way to properly view it.

I'm open to any other proposals

| before | after |
| -- | -- |
|![image](https://user-images.githubusercontent.com/191335/200158184-675891d1-32fb-44b0-a20d-286e892ad32a.png)|![image](https://user-images.githubusercontent.com/191335/200158186-68d785eb-5ca2-4f63-933d-0773be61ad6c.png)|