### PR TITLE
Don't yield when game can't keep up

### DIFF
--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -82,6 +82,11 @@ namespace osu.Framework.Timing
 
         private double sleepAndUpdateCurrent(double milliseconds)
         {
+            // By returning here, in cases where the game is not keeping up, we don't yield.
+            // Not 100% sure if we want to do this, but let's give it a try.
+            if (milliseconds <= 0)
+                return 0;
+
             double before = CurrentTime;
 
             TimeSpan timeSpan = TimeSpan.FromMilliseconds(milliseconds);


### PR DESCRIPTION
As discussed IRL. This might help marginally in cases where the game is not able to keep up with the user's specified frame limiter, by removing the yield overhead (~0.2ms for me, but maybe higher on lower end hardware).

- [x] Depends on #5501.