### PR TITLE
Fix `FrameworkSetting.Locale` not changing `InputThread` culture

### DIFF
--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -67,10 +67,10 @@ namespace osu.Framework.Tests.Localisation
 
             AddStep("query cultures", () =>
             {
-                host.DrawThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
-                host.UpdateThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
-                host.InputThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
-                host.AudioThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
+                host.DrawThread.Scheduler.Add(() => cultures.Add(CultureInfo.CurrentCulture));
+                host.UpdateThread.Scheduler.Add(() => cultures.Add(CultureInfo.CurrentCulture));
+                host.InputThread.Scheduler.Add(() => cultures.Add(CultureInfo.CurrentCulture));
+                host.AudioThread.Scheduler.Add(() => cultures.Add(CultureInfo.CurrentCulture));
             });
 
             AddUntilStep("wait for query", () => cultures.Count == 4);
@@ -81,7 +81,7 @@ namespace osu.Framework.Tests.Localisation
         {
             CultureInfo culture = null;
 
-            AddStep("start new thread", () => new Thread(() => culture = Thread.CurrentThread.CurrentCulture) { IsBackground = true }.Start());
+            AddStep("start new thread", () => new Thread(() => culture = CultureInfo.CurrentCulture) { IsBackground = true }.Start());
             AddUntilStep("wait for culture", () => culture != null);
             AddAssert($"thread culture is {name}", () => culture.Name == name);
         }

--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -69,10 +69,11 @@ namespace osu.Framework.Tests.Localisation
             {
                 host.DrawThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
                 host.UpdateThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
+                host.InputThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
                 host.AudioThread.Scheduler.Add(() => cultures.Add(Thread.CurrentThread.CurrentCulture));
             });
 
-            AddUntilStep("wait for query", () => cultures.Count == 3);
+            AddUntilStep("wait for query", () => cultures.Count == 4);
             AddAssert($"culture is {name}", () => cultures.Select(c => c.Name), () => Is.All.EqualTo(name));
         }
 

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
@@ -240,7 +239,8 @@ namespace osu.Framework.Platform
         public void SetCulture(CultureInfo culture)
         {
             // for single-threaded mode, switch the current (assumed to be main) thread's culture, since it's actually the one that's running the frames.
-            Thread.CurrentThread.CurrentCulture = culture;
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
 
             // for multi-threaded mode, schedule the culture change on all threads.
             // note that if the threads haven't been created yet (e.g. if the game started single-threaded), this will only store the culture in GameThread.CurrentCulture.

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -469,10 +469,12 @@ namespace osu.Framework.Threading
 
         private void updateCulture()
         {
-            if (Thread == null || culture == null) return;
+            if (culture == null) return;
 
-            Thread.CurrentCulture = culture;
-            Thread.CurrentUICulture = culture;
+            Debug.Assert(IsCurrent);
+
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
         }
 
         private void setExitState(GameThreadState exitState)


### PR DESCRIPTION
While the `Thread == null` check does make some sense, `InputThread` never has a backing native `Thread` and the culture change therefore fails there.

In single threaded, it's basically setting the thread culture 5 times on the same thread, but I don't see this causing any problems.

Changed to always use `CultureInfo.CurrentCulture` as per [MS docs recommendations](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.currentculture?view=net-6.0#remarks).
