### PR TITLE
Default `CurrentCulture` to system culture

### DIFF
--- a/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
+++ b/osu.Framework.Tests/Localisation/CultureInfoHelperTest.cs
@@ -10,20 +10,20 @@ namespace osu.Framework.Tests.Localisation
     [TestFixture]
     public class CultureInfoHelperTest
     {
-        private const string invariant_culture = "";
+        private const string system_culture = "";
 
         [TestCase("en-US", true, "en-US")]
-        [TestCase("invalid name", false, invariant_culture)]
-        [TestCase(invariant_culture, true, invariant_culture)]
-        [TestCase("ko_KR", false, invariant_culture)]
+        [TestCase("invalid name", false, system_culture)]
+        [TestCase(system_culture, true, system_culture)]
+        [TestCase("ko_KR", false, system_culture)]
         public void TestTryGetCultureInfo(string name, bool expectedReturnValue, string expectedCultureName)
         {
             CultureInfo expectedCulture;
 
             switch (expectedCultureName)
             {
-                case invariant_culture:
-                    expectedCulture = CultureInfo.InvariantCulture;
+                case system_culture:
+                    expectedCulture = CultureInfo.CurrentCulture;
                     break;
 
                 default:

--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Tests.Visual;
@@ -26,10 +27,10 @@ namespace osu.Framework.Tests.Localisation
         private FrameworkConfigManager config { get; set; }
 
         [Test]
-        public void TestDefaultCultureIsInvariant()
+        public void TestDefaultCultureIsSystem()
         {
             setCulture("");
-            assertCulture("");
+            assertCulture(CultureInfoHelper.SystemCulture.Name);
         }
 
         [Test]
@@ -40,10 +41,10 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
-        public void TestInvalidCultureFallsBackToInvariant()
+        public void TestInvalidCultureFallsBackToSystem()
         {
             setCulture("ko_KR");
-            assertCulture("");
+            assertCulture(CultureInfoHelper.SystemCulture.Name);
         }
 
         [Test]

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -7,6 +7,18 @@ namespace osu.Framework.Localisation
 {
     public static class CultureInfoHelper
     {
+        // there is a possibility that something changes the current culture before this class is used, but the framework currently doesn't do that.
+
+        /// <summary>
+        /// The system-default <see cref="CultureInfo"/> used for number, date, time and other string formatting.
+        /// </summary>
+        public static CultureInfo SystemCulture { get; } = CultureInfo.CurrentCulture;
+
+        /// <summary>
+        /// The system-default <see cref="CultureInfo"/> used for app languages/translations.
+        /// </summary>
+        public static CultureInfo SystemUICulture { get; } = CultureInfo.CurrentUICulture;
+
         /// <summary>
         /// Wrapper around <see cref="CultureInfo.GetCultureInfo(string)"/> providing common behaviour and exception handling.
         /// </summary>
@@ -15,6 +27,12 @@ namespace osu.Framework.Localisation
         /// <returns>Whether the culture was successfully retrieved and a is .NET/OS predefined culture.</returns>
         public static bool TryGetCultureInfo(string name, out CultureInfo culture)
         {
+            if (string.IsNullOrEmpty(name))
+            {
+                culture = SystemCulture;
+                return true;
+            }
+
             try
             {
 #if NET6_0_OR_GREATER
@@ -26,7 +44,7 @@ namespace osu.Framework.Localisation
                 // See https://github.com/dotnet/runtime/blob/5877e8b713742b6d80bd1aa9819094be029e3e1f/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs#L341-L345
                 if (culture.ThreeLetterWindowsLanguageName == "ZZZ")
                 {
-                    culture = CultureInfo.InvariantCulture;
+                    culture = SystemCulture;
                     return false;
                 }
 
@@ -34,7 +52,7 @@ namespace osu.Framework.Localisation
             }
             catch (CultureNotFoundException)
             {
-                culture = CultureInfo.InvariantCulture;
+                culture = SystemCulture;
                 return false;
             }
         }

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -92,13 +92,7 @@ namespace osu.Framework.Localisation
 
             if (currentLocale == null)
             {
-                CultureInfo culture;
-
-                if (string.IsNullOrEmpty(locale.NewValue))
-                {
-                    culture = CultureInfo.CurrentCulture;
-                }
-                else if (!CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out culture))
+                if (!CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out var culture))
                 {
                     if (locale.OldValue == locale.NewValue)
                         // equal values mean invalid locale on startup, no real way to recover other than to set to default.


### PR DESCRIPTION
Changes the default culture (when `FrameworkSetting.Locale` is set to `string.Empty`) to use the system culture (instead of the invariant culture) for all usages (and not only in `LocalisationManager`).

First step towards resolving https://github.com/ppy/osu/issues/21146.