### PR TITLE
Remove all usage of `Add`/`RemoveMemoryPressure`

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Statistics;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Platform;
 using SixLabors.ImageSharp.Memory;
 
 namespace osu.Framework.Graphics.OpenGL.Buffers
@@ -24,6 +25,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private Memory<DepthWrappingVertex<T>> vertexMemory;
         private IMemoryOwner<DepthWrappingVertex<T>> memoryOwner;
+        private NativeMemoryTracker.NativeMemoryLease memoryLease;
 
         private int vboId = -1;
 
@@ -72,6 +74,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             int size = Size * STRIDE;
 
+            memoryLease = NativeMemoryTracker.AddMemory(this, Size * STRIDE);
             GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)size, IntPtr.Zero, usage);
         }
 
@@ -178,6 +181,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (vboId != -1)
             {
                 Unbind();
+
+                memoryLease?.Dispose();
+                memoryLease = null;
 
                 GL.DeleteBuffer(vboId);
                 vboId = -1;

--- a/osu.Framework/Platform/NativeMemoryTracker.cs
+++ b/osu.Framework/Platform/NativeMemoryTracker.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Statistics;
@@ -54,7 +52,7 @@ namespace osu.Framework.Platform
             public override void Dispose()
             {
                 if (isDisposed)
-                    throw new ObjectDisposedException(ToString(), $"{nameof(NativeMemoryLease)} should not be disposed more than once");
+                    return;
 
                 base.Dispose();
                 isDisposed = true;

--- a/osu.Framework/Platform/NativeMemoryTracker.cs
+++ b/osu.Framework/Platform/NativeMemoryTracker.cs
@@ -24,8 +24,6 @@ namespace osu.Framework.Platform
         public static NativeMemoryLease AddMemory(object source, long amount)
         {
             getStatistic(source).Value += amount;
-            GC.AddMemoryPressure(amount);
-
             return new NativeMemoryLease((source, amount), sender => removeMemory(sender.source, sender.amount));
         }
 
@@ -37,7 +35,6 @@ namespace osu.Framework.Platform
         private static void removeMemory(object source, long amount)
         {
             getStatistic(source).Value -= amount;
-            GC.RemoveMemoryPressure(amount);
         }
 
         private static GlobalStatistic<long> getStatistic(object source) => GlobalStatistics.Get<long>("Native", source.GetType().Name);


### PR DESCRIPTION
Especially in cases like song select, we are churning a lot of GPU memory. This will eventually be fixed, but until then it seems that making the GC aware of this usage is detrimental to performance. In some very non-scientific benchmarks, removing these calls reduced gen 2 GC run counts by around 40-50% while paginating at song select.

@smoogipoo mentioned that he noticed this in the past, which resulted in https://github.com/ppy/osu-framework/pull/4298.  This PR undoes the changes there so we can once again see VBO memory usage in the global statistics overlay, but removes the underlying calls to `AddMemoryPressure` and `RemoveMemoryPressure` to maintain the expected behaviour.