### PR TITLE
Log sources of VBO flushes (aka batching interruptions) to global statistics

### DIFF
--- a/osu.Framework/Graphics/Rendering/FlushBatchSource.cs
+++ b/osu.Framework/Graphics/Rendering/FlushBatchSource.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Rendering
+{
+    public enum FlushBatchSource
+    {
+        BindTexture,
+        FinishFrame,
+        SetBlend,
+        SetBlendMask,
+        SetDepthInfo,
+        SetFrameBuffer,
+        SetMasking,
+        SetProjection,
+        SetScissor,
+        SetShader,
+        SetStencilInfo,
+        SetUniform,
+        UnbindTexture,
+        SetActiveBatch
+    }
+}

--- a/osu.Framework/Graphics/Rendering/IVertexBatch.cs
+++ b/osu.Framework/Graphics/Rendering/IVertexBatch.cs
@@ -13,6 +13,10 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         int Size { get; }
 
+        /// <summary>
+        /// Draw any newly added indices in this vertex batch.
+        /// </summary>
+        /// <returns>The number of indices drawn, if any.</returns>
         int Draw();
 
         internal void ResetCounters();

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -141,6 +141,9 @@ namespace osu.Framework.Graphics.Rendering
         /// <param name="windowSize">The full window size.</param>
         protected internal virtual void BeginFrame(Vector2 windowSize)
         {
+            foreach (var source in flush_source_statistics)
+                source.Value = 0;
+
             Debug.Assert(defaultQuadBatch != null);
 
             ResetId++;
@@ -245,7 +248,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         protected internal virtual void FinishFrame()
         {
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.FinishFrame);
         }
 
         public void ScheduleExpensiveOperation(ScheduledDelegate operation)
@@ -304,7 +307,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentBlendingParameters == blendingParameters)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetBlend);
             SetBlendImplementation(blendingParameters);
 
             CurrentBlendingParameters = blendingParameters;
@@ -315,7 +318,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentBlendingMask == blendingMask)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetBlendMask);
             SetBlendMaskImplementation(blendingMask);
 
             CurrentBlendingMask = blendingMask;
@@ -447,7 +450,7 @@ namespace osu.Framework.Graphics.Rendering
             if (Scissor == scissor)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetScissor);
             SetScissorImplementation(scissor);
             Scissor = scissor;
         }
@@ -457,7 +460,7 @@ namespace osu.Framework.Graphics.Rendering
             if (enabled == ScissorState)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetScissor);
             SetScissorStateImplementation(enabled);
             ScissorState = enabled;
         }
@@ -467,7 +470,7 @@ namespace osu.Framework.Graphics.Rendering
             if (ScissorOffset == offset)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetScissor);
             ScissorOffset = offset;
         }
 
@@ -506,7 +509,7 @@ namespace osu.Framework.Graphics.Rendering
             if (ProjectionMatrix == matrix)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetProjection);
 
             GlobalPropertyManager.Set(GlobalProperty.ProjMatrix, matrix);
             ProjectionMatrix = matrix;
@@ -535,7 +538,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentMaskingInfo == maskingInfo)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetMasking);
 
             GlobalPropertyManager.Set(GlobalProperty.MaskingRect, new Vector4(
                 maskingInfo.MaskingRect.Left,
@@ -644,7 +647,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentDepthInfo.Equals(depthInfo))
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetDepthInfo);
             SetDepthInfoImplementation(depthInfo);
 
             CurrentDepthInfo = depthInfo;
@@ -655,7 +658,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentStencilInfo.Equals(stencilInfo))
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetStencilInfo);
             SetStencilInfoImplementation(stencilInfo);
 
             CurrentStencilInfo = stencilInfo;
@@ -704,17 +707,38 @@ namespace osu.Framework.Graphics.Rendering
 
             batchResetList.Add(batch);
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetActiveBatch);
 
             currentActiveBatch = batch;
+        }
+
+        private static readonly GlobalStatistic<int>[] flush_source_statistics;
+
+        static Renderer()
+        {
+            var sources = Enum.GetValues(typeof(FlushBatchSource));
+
+            flush_source_statistics = new GlobalStatistic<int>[sources.Length];
+            foreach (FlushBatchSource source in sources)
+                flush_source_statistics[(int)source] = GlobalStatistics.Get<int>(nameof(FlushBatchSource), source.ToString());
         }
 
         /// <summary>
         /// Flushes the currently active vertex batch.
         /// </summary>
-        protected void FlushCurrentBatch()
+        /// <param name="source">The source performing the flush, for profiling purposes.</param>
+        protected void FlushCurrentBatch(FlushBatchSource? source)
         {
-            currentActiveBatch?.Draw();
+            if (currentActiveBatch?.Draw() > 0)
+                incrementFlushStatistic(source);
+        }
+
+        private void incrementFlushStatistic(FlushBatchSource? source)
+        {
+            if (source == null)
+                return;
+
+            flush_source_statistics[(int)source].Value++;
         }
 
         private void freeUnusedVertexBuffers()
@@ -767,7 +791,7 @@ namespace osu.Framework.Graphics.Rendering
             if (lastActiveTextureUnit == unit && lastBoundTexture[unit] == texture)
                 return true;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.BindTexture);
 
             if (!SetTextureImplementation(texture, unit))
                 return false;
@@ -805,7 +829,7 @@ namespace osu.Framework.Graphics.Rendering
             if (lastBoundTexture[unit] == null)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.UnbindTexture);
             SetTextureImplementation(null, unit);
 
             lastBoundTexture[unit] = null;
@@ -856,7 +880,7 @@ namespace osu.Framework.Graphics.Rendering
             if (frameBuffer == FrameBuffer && !force)
                 return;
 
-            FlushCurrentBatch();
+            FlushCurrentBatch(FlushBatchSource.SetFrameBuffer);
 
             SetFrameBufferImplementation(frameBuffer);
             GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
@@ -905,7 +929,7 @@ namespace osu.Framework.Graphics.Rendering
             {
                 FrameStatistics.Increment(StatisticsCounterType.ShaderBinds);
 
-                FlushCurrentBatch();
+                FlushCurrentBatch(FlushBatchSource.SetShader);
                 SetShaderImplementation(shader);
 
                 // importantly, when a shader is unbound, it remains bound in the implementation.
@@ -918,7 +942,7 @@ namespace osu.Framework.Graphics.Rendering
             where T : unmanaged, IEquatable<T>
         {
             if (uniform.Owner == Shader)
-                FlushCurrentBatch();
+                FlushCurrentBatch(FlushBatchSource.SetUniform);
 
             SetUniformImplementation(uniform);
         }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -114,6 +114,17 @@ namespace osu.Framework.Graphics.Rendering
         private bool isInitialised;
         private int lastActiveTextureUnit;
 
+        private static readonly GlobalStatistic<int>[] flush_source_statistics;
+
+        static Renderer()
+        {
+            var sources = Enum.GetValues(typeof(FlushBatchSource));
+
+            flush_source_statistics = new GlobalStatistic<int>[sources.Length];
+            foreach (FlushBatchSource source in sources)
+                flush_source_statistics[(int)source] = GlobalStatistics.Get<int>(nameof(FlushBatchSource), source.ToString());
+        }
+
         protected Renderer()
         {
             statTextureUploadsPerformed = GlobalStatistics.Get<int>(GetType().Name, "Texture uploads performed");
@@ -712,33 +723,14 @@ namespace osu.Framework.Graphics.Rendering
             currentActiveBatch = batch;
         }
 
-        private static readonly GlobalStatistic<int>[] flush_source_statistics;
-
-        static Renderer()
-        {
-            var sources = Enum.GetValues(typeof(FlushBatchSource));
-
-            flush_source_statistics = new GlobalStatistic<int>[sources.Length];
-            foreach (FlushBatchSource source in sources)
-                flush_source_statistics[(int)source] = GlobalStatistics.Get<int>(nameof(FlushBatchSource), source.ToString());
-        }
-
         /// <summary>
         /// Flushes the currently active vertex batch.
         /// </summary>
         /// <param name="source">The source performing the flush, for profiling purposes.</param>
         protected void FlushCurrentBatch(FlushBatchSource? source)
         {
-            if (currentActiveBatch?.Draw() > 0)
-                incrementFlushStatistic(source);
-        }
-
-        private void incrementFlushStatistic(FlushBatchSource? source)
-        {
-            if (source == null)
-                return;
-
-            flush_source_statistics[(int)source].Value++;
+            if (currentActiveBatch?.Draw() > 0 && source != null)
+                flush_source_statistics[(int)source].Value++;
         }
 
         private void freeUnusedVertexBuffers()


### PR DESCRIPTION
<img width="273" alt="2022-11-12 15 24 40@2x" src="https://user-images.githubusercontent.com/191335/201460677-3c01e6b1-561a-48f2-a177-a656709512f5.png">

<img width="273" alt="2022-11-12 15 24 11@2x" src="https://user-images.githubusercontent.com/191335/201460687-fe9d0e92-7416-43af-823d-ad8efd4a6d13.png">
