### PR TITLE
Remove `internal` access modifier from `CompositeDrawable.AddInternal`

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
@@ -380,6 +380,8 @@ namespace osu.Framework.Tests.Visual.Containers
             }
 
             public new void UpdateSubTree() => base.UpdateSubTree();
+
+            public new void AddInternal(Drawable child) => base.AddInternal(child);
         }
     }
 }

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Animations
                 manualClock.CurrentTime += elapsed;
         }
 
-        protected internal override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(CreateContent)} instead.");
+        protected override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(CreateContent)} instead.");
 
         /// <summary>
         /// Create the content container for animation display.

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -573,7 +573,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Adds a child to <see cref="InternalChildren"/>.
         /// </summary>
-        protected internal virtual void AddInternal(Drawable drawable)
+        protected virtual void AddInternal(Drawable drawable)
         {
             EnsureChildMutationAllowed();
 

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -242,7 +242,7 @@ namespace osu.Framework.Graphics.Containers
                 Add(d);
         }
 
-        protected internal override void AddInternal(Drawable drawable)
+        protected override void AddInternal(Drawable drawable)
         {
             if (Content == this && drawable != null && !(drawable is T))
             {

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.Containers
 
         private readonly Dictionary<Drawable, float> layoutChildren = new Dictionary<Drawable, float>();
 
-        protected internal override void AddInternal(Drawable drawable)
+        protected override void AddInternal(Drawable drawable)
         {
             layoutChildren.Add(drawable, 0f);
             // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Graphics.Containers
             manager.EntryCrossedBoundary += entryCrossedBoundary;
         }
 
-        protected internal override void AddInternal(Drawable drawable) => AddInternal(drawable, true);
+        protected override void AddInternal(Drawable drawable) => AddInternal(drawable, true);
 
         /// <summary>
         /// Adds a <see cref="Drawable"/> to this <see cref="LifetimeManagementContainer"/>.

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics.Containers
         [Resolved]
         private LocalisationManager localisation { get; set; }
 
-        protected internal override void AddInternal(Drawable drawable)
+        protected override void AddInternal(Drawable drawable)
         {
             base.AddInternal(drawable);
             filterValid.Invalidate();

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        protected internal sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
+        protected sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
 
         #region Sizing delegation
 

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Testing
             base.Add(drawable);
         }
 
-        protected internal override void AddInternal(Drawable drawable)
+        protected override void AddInternal(Drawable drawable)
         {
             throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Add)} instead.");
         }


### PR DESCRIPTION
Not actually required.

`RemoveInternal` and `ClearInternal` are a bit more involved to remove, so I've just hit this one for now. It bit me and I didn't like it.