### PR TITLE
Make `IBindable : IFormattable` to allow formatting its value with `InvariantCulture`

### DIFF
--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -380,7 +380,7 @@ namespace osu.Framework.Bindables
 
         public string Description { get; set; }
 
-        public override string ToString() => value?.ToString() ?? string.Empty;
+        public override string ToString() => FormattableString.Invariant($"{Value}");
 
         /// <summary>
         /// Create an unbound clone of this bindable.

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -380,7 +380,9 @@ namespace osu.Framework.Bindables
 
         public string Description { get; set; }
 
-        public override string ToString() => FormattableString.Invariant($"{Value}");
+        public sealed override string ToString() => ToString(null, CultureInfo.CurrentCulture);
+
+        public virtual string ToString(string format, IFormatProvider formatProvider) => string.Format(formatProvider, $"{{0:{format}}}", Value);
 
         /// <summary>
         /// Create an unbound clone of this bindable.

--- a/osu.Framework/Bindables/BindableBool.cs
+++ b/osu.Framework/Bindables/BindableBool.cs
@@ -12,8 +12,6 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString() => Value.ToString();
-
         public override void Parse(object input)
         {
             if (input is "1")

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Bindables
@@ -526,5 +527,7 @@ namespace osu.Framework.Bindables
         }
 
         public bool IsDefault => Count == 0;
+
+        string IFormattable.ToString(string? format, IFormatProvider? formatProvider) => ((FormattableString)$"{GetType().ReadableName()}({nameof(Count)}={Count})").ToString(formatProvider);
     }
 }

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -3,7 +3,7 @@
 
 #nullable disable
 
-using System.Globalization;
+using System;
 
 namespace osu.Framework.Bindables
 {
@@ -14,7 +14,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
+        public override string ToString(string format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<double> CreateInstance() => new BindableDouble();
     }

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -3,7 +3,7 @@
 
 #nullable disable
 
-using System.Globalization;
+using System;
 
 namespace osu.Framework.Bindables
 {
@@ -14,7 +14,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
+        public override string ToString(string format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<float> CreateInstance() => new BindableFloat();
     }

--- a/osu.Framework/Bindables/BindableInt.cs
+++ b/osu.Framework/Bindables/BindableInt.cs
@@ -3,8 +3,6 @@
 
 #nullable disable
 
-using System.Globalization;
-
 namespace osu.Framework.Bindables
 {
     public class BindableInt : BindableNumber<int>
@@ -13,8 +11,6 @@ namespace osu.Framework.Bindables
             : base(defaultValue)
         {
         }
-
-        public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);
 
         protected override Bindable<int> CreateInstance() => new BindableInt();
     }

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Bindables
@@ -655,5 +656,7 @@ namespace osu.Framework.Bindables
         }
 
         public bool IsDefault => Count == 0;
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider) => ((FormattableString)$"{GetType().ReadableName()}({nameof(Count)}={Count})").ToString(formatProvider);
     }
 }

--- a/osu.Framework/Bindables/BindableMarginPadding.cs
+++ b/osu.Framework/Bindables/BindableMarginPadding.cs
@@ -19,8 +19,6 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString() => Value.ToString();
-
         public override void Parse(object input)
         {
             switch (input)

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -297,8 +297,6 @@ namespace osu.Framework.Bindables
 
         public new BindableNumber<T> GetUnboundCopy() => (BindableNumber<T>)base.GetUnboundCopy();
 
-        public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);
-
         public override bool IsDefault
         {
             get

--- a/osu.Framework/Bindables/BindableSize.cs
+++ b/osu.Framework/Bindables/BindableSize.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString() => $"{Value.Width}x{Value.Height}";
+        public override string ToString(string format, IFormatProvider formatProvider) => ((FormattableString)$"{Value.Width}x{Value.Height}").ToString(formatProvider);
 
         public override void Parse(object input)
         {

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Globalization;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;
 
@@ -12,7 +13,7 @@ namespace osu.Framework.Bindables
     /// <summary>
     /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> changes.
     /// </summary>
-    public interface IBindable : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+    public interface IBindable : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription, IFormattable
     {
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind with.
@@ -64,13 +65,17 @@ namespace osu.Framework.Bindables
             copy.BindTo(source);
             return (T)copy;
         }
+
+        string ToString() => ToString(null, CultureInfo.CurrentCulture);
+
+        string ToString(IFormatProvider formatProvider) => ToString(null, formatProvider);
     }
 
     /// <summary>
     /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> and <see cref="IBindable{T}.Value">Value</see> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
-    public interface IBindable<T> : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+    public interface IBindable<T> : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription, IFormattable
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed.
@@ -111,5 +116,9 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindable<T> GetBoundCopy();
+
+        string ToString() => ToString(null, CultureInfo.CurrentCulture);
+
+        string ToString(IFormatProvider formatProvider) => ToString(null, formatProvider);
     }
 }

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -89,7 +90,7 @@ namespace osu.Framework.Configuration
                 using (var w = new StreamWriter(stream))
                 {
                     foreach (var p in ConfigStore)
-                        w.WriteLine(@"{0} = {1}", p.Key, p.Value.ToString().AsNonNull().Replace("\n", "").Replace("\r", ""));
+                        w.WriteLine(@"{0} = {1}", p.Key, p.Value.ToString(CultureInfo.InvariantCulture).AsNonNull().Replace("\n", "").Replace("\r", ""));
                 }
             }
             catch


### PR DESCRIPTION
Noticed while looking into https://discord.com/channels/188630481301012481/589331078574112768/1040392278348398703.

This results in the following problem when decoding osu! config when using `Norsk` language:
```cs
2022-11-13 22:35:08 [important]: Unable to parse config key LastProcessedMetadataId: System.FormatException: Input string was not in a correct format.
2022-11-13 22:35:08 [important]: at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
2022-11-13 22:35:08 [important]: at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
2022-11-13 22:35:08 [important]: at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
2022-11-13 22:35:08 [important]: at osu.Framework.Bindables.Bindable`1.Parse(Object input)
2022-11-13 22:35:08 [important]: at osu.Framework.Configuration.IniConfigManager`1.PerformLoad()
```

Excerpt from `game.ini`:

```ini
ScalingSizeX = 0.8
ScalingSizeY = 0.8
ScalingPositionX = 0.5
ScalingPositionY = 0.5
UIScale = 1.0
UIHoldActivationDelay = 0.0
EditorWaveformOpacity = 0,25
LastProcessedMetadataId = −1

```

That's `U+2212 : MINUS SIGN` and not the regular `U+002D : HYPHEN-MINUS` (also the decimal comma).