### PR TITLE
Fix `Dropdown` calling `GenerateItemText` before it's loaded

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -6,10 +6,14 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
+using osu.Framework.Localisation;
+using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Input;
@@ -384,6 +388,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("current value still three", () => bindableDropdown.Current.Value.Identifier, () => Is.EqualTo("three"));
         }
 
+        [Test]
+        public void TestAccessBdlInGenerateItemText()
+        {
+            AddStep("add dropdown that uses BDL", () => Add(new BdlDropdown
+            {
+                Width = 150,
+                Position = new Vector2(250, 350),
+                Items = new TestModel("test").Yield()
+            }));
+        }
+
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>
         {
             InputManager.MoveMouseTo(dropdown.Header);
@@ -422,6 +437,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             public int SelectedIndex => Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
             public int PreselectedIndex => Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
+        }
+
+        /// <summary>
+        /// Dropdown that will access <see cref="ResolvedAttribute"/> properties in <see cref="GenerateItemText"/>.
+        /// </summary>
+        private class BdlDropdown : TestDropdown
+        {
+            [Resolved]
+            private GameHost host { get; set; }
+
+            protected override LocalisableString GenerateItemText(TestModel item) => $"{host.Name}: {base.GenerateItemText(item)}";
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (boundItemSource != null)
                     throw new InvalidOperationException($"Cannot manually set {nameof(Items)} when an {nameof(ItemSource)} is bound.");
 
-                setItems(value);
+                Scheduler.AddOnce(setItems, value);
             }
         }
 


### PR DESCRIPTION
Ran into this while trying to show system default language in osu! settings.
The following causes a NRE with `localisation`:

```cs
protected class LanguageDropdownControl : DropdownControl
{
    [Resolved]
    private LocalisationManager localisation { get; set; } = null!;

    protected override LocalisableString GenerateItemText(Language item)
    {
        if (item == Language.SystemDefault)
        {
            if (LanguageExtensions.TryParseCultureCode(localisation.SystemDefaultLocaleMapping?.Name, out var language))
                return GeneralSettingsStrings.DefaultLanguage(language.GetDescription());

            return CommonStrings.Default;
        }

        return base.GenerateItemText(item);
    }
}
 ```