### PR TITLE
Refactor `SpriteIcon` tests to allow slowly adding new icons

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -22,57 +22,94 @@ namespace osu.Framework.Tests.Visual.Sprites
     [TestFixture]
     public class TestSceneSpriteIcon : FrameworkTestScene
     {
-        public TestSceneSpriteIcon()
+        [Test]
+        public void TestOneIconAtATime()
         {
-            Box background;
-            FillFlowContainer flow;
+            FillFlowContainer flow = null!;
+            Icon[] icons = null!;
 
-            Add(new TooltipContainer
+            int i = 0;
+
+            AddStep("prepare test", () =>
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                i = 0;
+                icons = getAllIcons().ToArray();
+
+                Child = new TooltipContainer
                 {
-                    background = new Box
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
                     {
-                        Colour = Color4.Teal,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    new BasicScrollContainer
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = flow = new FillFlowContainer
+                        new BasicScrollContainer
                         {
-                            Anchor = Anchor.TopRight,
-                            Origin = Anchor.TopRight,
-                            RelativeSizeAxes = Axes.X,
-                            AutoSizeAxes = Axes.Y,
-                            Spacing = new Vector2(5),
-                            Direction = FillDirection.Full,
-                        },
+                            RelativeSizeAxes = Axes.Both,
+                            Child = flow = new FillFlowContainer
+                            {
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Spacing = new Vector2(5),
+                                Direction = FillDirection.Full,
+                            },
+                        }
                     }
-                }
+                };
             });
 
-            var weights = typeof(FontAwesome).GetNestedTypes();
+            AddRepeatStep("add icon", () => flow.Add(icons[i++]), icons.Length);
+        }
 
-            foreach (var w in weights)
+        [Test]
+        public void TestLoadAllIcons()
+        {
+            Box background = null!;
+            FillFlowContainer flow = null!;
+
+            AddStep("prepare", () =>
             {
-                flow.Add(new SpriteText
+                Child = new TooltipContainer
                 {
-                    Text = w.Name,
-                    Scale = new Vector2(4),
-                    RelativeSizeAxes = Axes.X,
-                    Padding = new MarginPadding(10),
-                });
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        background = new Box
+                        {
+                            Colour = Color4.Teal,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new BasicScrollContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Child = flow = new FillFlowContainer
+                            {
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Spacing = new Vector2(5),
+                                Direction = FillDirection.Full,
+                            },
+                        }
+                    }
+                };
 
-                foreach (var p in w.GetProperties(BindingFlags.Public | BindingFlags.Static))
+                var weights = typeof(FontAwesome).GetNestedTypes();
+
+                foreach (var w in weights)
                 {
-                    object propValue = p.GetValue(null);
-                    Debug.Assert(propValue != null);
+                    flow.Add(new SpriteText
+                    {
+                        Text = w.Name,
+                        Scale = new Vector2(4),
+                        RelativeSizeAxes = Axes.X,
+                        Padding = new MarginPadding(10),
+                    });
 
-                    flow.Add(new Icon($"{nameof(FontAwesome)}.{w.Name}.{p.Name}", (IconUsage)propValue));
+                    foreach (var icon in getAllIconsForWeight(w))
+                        flow.Add(icon);
                 }
-            }
+            });
 
             AddStep("toggle shadows", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Shadow = !i.SpriteIcon.Shadow));
             AddStep("change icons", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Icon = new IconUsage((char)(i.SpriteIcon.Icon.Icon + 1))));
@@ -84,6 +121,28 @@ namespace osu.Framework.Tests.Visual.Sprites
                 {
                     SpriteIcon = { Shadow = true, ShadowColour = Color4.Orange, ShadowOffset = new Vector2(5, 1) }
                 }));
+        }
+
+        private IEnumerable<Icon> getAllIcons()
+        {
+            var weights = typeof(FontAwesome).GetNestedTypes();
+
+            foreach (var w in weights)
+            {
+                foreach (var i in getAllIconsForWeight(w))
+                    yield return i;
+            }
+        }
+
+        private static IEnumerable<Icon> getAllIconsForWeight(Type weight)
+        {
+            foreach (var p in weight.GetProperties(BindingFlags.Public | BindingFlags.Static))
+            {
+                object? propValue = p.GetValue(null);
+                Debug.Assert(propValue != null);
+
+                yield return new Icon($"{nameof(FontAwesome)}.{weight.Name}.{p.Name}", (IconUsage)propValue);
+            }
         }
 
         private class Icon : Container, IHasTooltip

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
+using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
 
@@ -22,6 +23,8 @@ namespace osu.Framework.Tests.Visual.Sprites
     [TestFixture]
     public class TestSceneSpriteIcon : FrameworkTestScene
     {
+        private ScheduledDelegate? scheduledDelegate;
+
         [Test]
         public void TestOneIconAtATime()
         {
@@ -34,6 +37,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             {
                 i = 0;
                 icons = getAllIcons().ToArray();
+                scheduledDelegate?.Cancel();
 
                 Child = new TooltipContainer
                 {
@@ -57,7 +61,16 @@ namespace osu.Framework.Tests.Visual.Sprites
                 };
             });
 
-            AddRepeatStep("add icon", () => flow.Add(icons[i++]), icons.Length);
+            AddStep("start adding icons", () =>
+            {
+                scheduledDelegate = Scheduler.AddDelayed(() =>
+                {
+                    flow.Add(icons[i++]);
+
+                    if (++i > icons.Length - 1)
+                        scheduledDelegate?.Cancel();
+                }, 50, true);
+            });
         }
 
         [Test]
@@ -68,6 +81,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddStep("prepare", () =>
             {
+                scheduledDelegate?.Cancel();
+
                 Child = new TooltipContainer
                 {
                     RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Intended to be used for performance testing overhead of texture uploads in a `TextureAtlas`.

https://user-images.githubusercontent.com/191335/201859146-d7bb821f-f22c-4d10-8af7-4ba870fc912d.mp4

