### PR TITLE
Small code quality pass on `SDL2DesktopWindow`

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow_Input.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Input.cs
@@ -95,8 +95,8 @@ namespace osu.Framework.Platform
 
         private readonly Dictionary<int, SDL2ControllerBindings> controllers = new Dictionary<int, SDL2ControllerBindings>();
 
-        private void updateCursorVisibility(bool visible) =>
-            ScheduleCommand(() => SDL.SDL_ShowCursor(visible ? SDL.SDL_ENABLE : SDL.SDL_DISABLE));
+        private void updateCursorVisibility(bool cursorVisible) =>
+            ScheduleCommand(() => SDL.SDL_ShowCursor(cursorVisible ? SDL.SDL_ENABLE : SDL.SDL_DISABLE));
 
         /// <summary>
         /// Updates OS cursor confinement based on the current <see cref="CursorState"/>, <see cref="CursorConfineRect"/> and <see cref="RelativeMouseMode"/>.
@@ -486,9 +486,9 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Update the host window manager's cursor position based on a location relative to window coordinates.
         /// </summary>
-        /// <param name="position">A position inside the window.</param>
-        public void UpdateMousePosition(Vector2 position) => ScheduleCommand(() =>
-            SDL.SDL_WarpMouseInWindow(SDLWindowHandle, (int)(position.X / Scale), (int)(position.Y / Scale)));
+        /// <param name="mousePosition">A position inside the window.</param>
+        public void UpdateMousePosition(Vector2 mousePosition) => ScheduleCommand(() =>
+            SDL.SDL_WarpMouseInWindow(SDLWindowHandle, (int)(mousePosition.X / Scale), (int)(mousePosition.Y / Scale)));
 
         private void updateConfineMode()
         {

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -309,7 +309,7 @@ namespace osu.Framework.Platform
                 $"Stored displays:\n  {string.Join("\n  ", Displays)}\n\nActual displays:\n  {string.Join("\n  ", actualDisplays)}");
         }
 
-        private IEnumerable<Display> getSDLDisplays()
+        private static IEnumerable<Display> getSDLDisplays()
         {
             return get().ToArray();
 

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -540,7 +540,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Should be run after a local window state change, to propagate the correct SDL actions.
         /// </summary>
-        private void updateWindowStateAndSize(WindowState windowState, Display display, DisplayMode displayMode)
+        private void updateWindowStateAndSize(WindowState state, Display display, DisplayMode displayMode)
         {
             // this reset is required even on changing from one fullscreen resolution to another.
             // if it is not included, the GL context will not get the correct size.
@@ -549,7 +549,7 @@ namespace osu.Framework.Platform
             SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
             SDL.SDL_RestoreWindow(SDLWindowHandle);
 
-            switch (windowState)
+            switch (state)
             {
                 case WindowState.Normal:
                     Size = sizeWindowed.Value;
@@ -558,7 +558,7 @@ namespace osu.Framework.Platform
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
                     SDL.SDL_SetWindowResizable(SDLWindowHandle, Resizable ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE);
 
-                    readWindowPositionFromConfig(windowState, display);
+                    readWindowPositionFromConfig(state, display);
                     break;
 
                 case WindowState.Fullscreen:
@@ -591,10 +591,10 @@ namespace osu.Framework.Platform
                     break;
             }
 
-            if (tryFetchMaximisedState(windowState, out bool maximized))
+            if (tryFetchMaximisedState(state, out bool maximized))
                 windowMaximised = maximized;
 
-            if (tryFetchDisplayMode(SDLWindowHandle, windowState, display, out var newMode))
+            if (tryFetchDisplayMode(SDLWindowHandle, state, display, out var newMode))
                 currentDisplayMode.Value = newMode;
         }
 
@@ -644,9 +644,9 @@ namespace osu.Framework.Platform
             return false;
         }
 
-        private void readWindowPositionFromConfig(WindowState windowState, Display display)
+        private void readWindowPositionFromConfig(WindowState state, Display display)
         {
-            if (windowState != WindowState.Normal)
+            if (state != WindowState.Normal)
                 return;
 
             var configPosition = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
@@ -667,18 +667,18 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Moves the window to be centred around the normalised <paramref name="position"/> on a <paramref name="display"/>.
+        /// Moves the window to be centred around the normalised <paramref name="newPosition"/> on a <paramref name="display"/>.
         /// </summary>
         /// <param name="display">The <see cref="Display"/> to move the window to.</param>
-        /// <param name="position">Relative position on the display, normalised to <c>[-0.5, 1.5]</c>.</param>
-        private void moveWindowTo(Display display, Vector2 position)
+        /// <param name="newPosition">Relative position on the display, normalised to <c>[-0.5, 1.5]</c>.</param>
+        private void moveWindowTo(Display display, Vector2 newPosition)
         {
-            Debug.Assert(position == Vector2.Clamp(position, new Vector2(-0.5f), new Vector2(1.5f)));
+            Debug.Assert(newPosition == Vector2.Clamp(newPosition, new Vector2(-0.5f), new Vector2(1.5f)));
 
             var displayBounds = display.Bounds;
             var windowSize = sizeWindowed.Value;
-            int windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * position.X);
-            int windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * position.Y);
+            int windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * newPosition.X);
+            int windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * newPosition.Y);
 
             Position = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
         }

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -522,7 +522,9 @@ namespace osu.Framework.Platform
             if (windowState != stateBefore)
             {
                 WindowStateChanged?.Invoke(windowState);
-                fetchMaximisedState(windowState);
+
+                if (tryFetchMaximisedState(windowState, out bool maximized))
+                    windowMaximised = maximized;
             }
 
             int newDisplayIndex = SDL.SDL_GetWindowDisplayIndex(SDLWindowHandle);
@@ -589,7 +591,8 @@ namespace osu.Framework.Platform
                     break;
             }
 
-            fetchMaximisedState(windowState);
+            if (tryFetchMaximisedState(windowState, out bool maximized))
+                windowMaximised = maximized;
 
             fetchDisplayMode(windowState, display);
         }
@@ -625,10 +628,16 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void fetchMaximisedState(WindowState windowState)
+        private static bool tryFetchMaximisedState(WindowState windowState, out bool maximized)
         {
-            if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
-                windowMaximised = windowState == WindowState.Maximised;
+            if (windowState is WindowState.Normal or WindowState.Maximised)
+            {
+                maximized = windowState == WindowState.Maximised;
+                return true;
+            }
+
+            maximized = default;
+            return false;
         }
 
         private void readWindowPositionFromConfig(WindowState windowState, Display display)

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Platform
             config.BindWith(FrameworkSetting.LastDisplayDevice, windowDisplayIndexBindable);
             windowDisplayIndexBindable.BindValueChanged(evt =>
             {
-                CurrentDisplay = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay;
+                currentDisplay = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay;
                 pendingWindowState = windowState;
             }, true);
 
@@ -285,7 +285,6 @@ namespace osu.Framework.Platform
         /// <remarks>
         /// Has no effect on values of
         /// <see cref="currentDisplay"/> /
-        /// <see cref="CurrentDisplay"/> /
         /// <see cref="CurrentDisplayBindable"/>.
         /// </remarks>
         private void fetchDisplays()
@@ -365,11 +364,6 @@ namespace osu.Framework.Platform
 
         private Display currentDisplay = null!;
         private int displayIndex = -1;
-
-        /// <summary>
-        /// Gets or sets the <see cref="Display"/> that this window is currently on.
-        /// </summary>
-        public Display CurrentDisplay { get; private set; } = null!;
 
         private readonly Bindable<DisplayMode> currentDisplayMode = new Bindable<DisplayMode>();
 
@@ -512,7 +506,7 @@ namespace osu.Framework.Platform
                 windowState = pendingWindowState.Value;
                 pendingWindowState = null;
 
-                updateWindowStateAndSize(windowState, CurrentDisplay, currentDisplayMode.Value);
+                updateWindowStateAndSize(windowState, currentDisplay, currentDisplayMode.Value);
             }
             else
             {
@@ -688,7 +682,7 @@ namespace osu.Framework.Platform
             if (WindowState != WindowState.Normal)
                 return;
 
-            var displayBounds = CurrentDisplay.Bounds;
+            var displayBounds = currentDisplay.Bounds;
 
             int windowX = Position.X - displayBounds.X;
             int windowY = Position.Y - displayBounds.Y;

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Platform
             windowDisplayIndexBindable.BindValueChanged(evt =>
             {
                 currentDisplay = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay;
-                pendingWindowState = windowState;
+                invalidateWindowSpecifics();
             }, true);
 
             sizeFullscreen.ValueChanged += _ =>
@@ -41,7 +41,7 @@ namespace osu.Framework.Platform
                 if (storingSizeToConfig) return;
                 if (windowState != WindowState.Fullscreen) return;
 
-                pendingWindowState = windowState;
+                invalidateWindowSpecifics();
             };
 
             sizeWindowed.ValueChanged += _ =>
@@ -49,7 +49,7 @@ namespace osu.Framework.Platform
                 if (storingSizeToConfig) return;
                 if (windowState != WindowState.Normal) return;
 
-                pendingWindowState = windowState;
+                invalidateWindowSpecifics();
             };
 
             sizeWindowed.MinValueChanged += min =>
@@ -487,6 +487,15 @@ namespace osu.Framework.Platform
             }
 
             assertDisplaysMatchSDL();
+        }
+
+        /// <summary>
+        /// Invalidates the the state of the window.
+        /// This forces <see cref="updateAndFetchWindowSpecifics"/> to run before the next event loop.
+        /// </summary>
+        private void invalidateWindowSpecifics()
+        {
+            pendingWindowState = windowState;
         }
 
         /// <summary>


### PR DESCRIPTION
Only possible behaviour change is combining `currentDisplay` and `CurrentDisplay` into one field, but looking at the flow, this shouldn't change anything.
Other changes are purely code-quality.