### PR TITLE
Fix displays sometimes not getting updated and failing assertion

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -325,10 +325,6 @@ namespace osu.Framework.Platform
         private const int events_per_peep = 64;
         private readonly SDL.SDL_Event[] events = new SDL.SDL_Event[events_per_peep];
 
-#if DEBUG
-        private bool handledAnyDisplayEvent;
-#endif
-
         /// <summary>
         /// Poll for all pending events.
         /// </summary>
@@ -344,13 +340,6 @@ namespace osu.Framework.Platform
                 for (int i = 0; i < eventsRead; i++)
                     handleSDLEvent(events[i]);
             } while (eventsRead == events_per_peep);
-#if DEBUG
-            if (handledAnyDisplayEvent)
-            {
-                assertDisplaysMatchSDL();
-                handledAnyDisplayEvent = false;
-            }
-#endif
         }
 
         private void handleSDLEvent(SDL.SDL_Event e)
@@ -364,9 +353,6 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_EventType.SDL_DISPLAYEVENT:
                     handleDisplayEvent(e.display);
-#if DEBUG
-                    handledAnyDisplayEvent = true;
-#endif
                     break;
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -325,6 +325,10 @@ namespace osu.Framework.Platform
         private const int events_per_peep = 64;
         private readonly SDL.SDL_Event[] events = new SDL.SDL_Event[events_per_peep];
 
+#if DEBUG
+        private bool handledAnyDisplayEvent;
+#endif
+
         /// <summary>
         /// Poll for all pending events.
         /// </summary>
@@ -340,6 +344,13 @@ namespace osu.Framework.Platform
                 for (int i = 0; i < eventsRead; i++)
                     handleSDLEvent(events[i]);
             } while (eventsRead == events_per_peep);
+#if DEBUG
+            if (handledAnyDisplayEvent)
+            {
+                assertDisplaysMatchSDL();
+                handledAnyDisplayEvent = false;
+            }
+#endif
         }
 
         private void handleSDLEvent(SDL.SDL_Event e)
@@ -353,6 +364,9 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_EventType.SDL_DISPLAYEVENT:
                     handleDisplayEvent(e.display);
+#if DEBUG
+                    handledAnyDisplayEvent = true;
+#endif
                     break;
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -483,6 +483,10 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
                     break;
             }
+
+#if DEBUG
+            EventScheduler.AddOnce(() => assertDisplaysMatchSDL());
+#endif
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -456,8 +456,6 @@ namespace osu.Framework.Platform
                             storeWindowPositionToConfig();
                     }
 
-                    // we may get a SDL_WINDOWEVENT_MOVED when the resolution of a display changes.
-                    fetchDisplays();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
@@ -491,8 +489,6 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
                     break;
             }
-
-            assertDisplaysMatchSDL();
         }
 
         /// <summary>
@@ -592,6 +588,8 @@ namespace osu.Framework.Platform
             fetchMaximisedState(windowState);
 
             fetchDisplayMode(windowState, display);
+
+            fetchDisplays();
         }
 
         private void fetchDisplayMode(WindowState windowState, Display display)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/5451

First idea for a fix was to cover all the cases of `SDL_WindowEvent` that might be sent when displays update, but that quickly spiraled out of control. SDL might send the events in a different order, so the first one would fail the assertion, even though a later event would trigger `fetchDisplays()` as expected. Moving the assert to after the event loop fixed some of those cases.

Fetching the displays in `updateWindowStateAndSize()` also seems amicable as changing the window state will almost always change the displays (if using a non-native resolution).