### PR TITLE
Refactor flow for setting and fetching current SDL display

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -10,6 +10,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
+using osuTK;
 using osuTK.Input;
 using SDL2;
 
@@ -1102,5 +1103,10 @@ namespace osu.Framework.Platform.SDL2
             SDL.SDL_ClearError();
             return error;
         }
+
+        /// <summary>
+        /// Converts <see cref="DisplayIndex"/> to the appropriate display index for use in SDL display-related functions.
+        /// </summary>
+        public static int ToSDLDisplayIndex(this DisplayIndex index) => index == DisplayIndex.Primary ? 0 : (int)index;
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -562,7 +562,7 @@ namespace osu.Framework.Platform
         /// </summary>
         private void invalidateWindowSpecifics()
         {
-            pendingWindowState = windowState;
+            pendingWindowState ??= windowState;
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -553,7 +553,7 @@ namespace osu.Framework.Platform
                     break;
             }
 
-            // assertDisplaysMatchSDL();
+            assertDisplaysMatchSDL();
         }
 
         /// <summary>
@@ -831,7 +831,7 @@ namespace osu.Framework.Platform
 
             // default size means to use the display's native size.
             if (size.Width == 9999 && size.Height == 9999)
-                size = display.Bounds.Size;
+                size = display.DisplayModes[0].Size;
 
             var targetMode = new SDL.SDL_DisplayMode { w = size.Width, h = size.Height, refresh_rate = requestedMode.RefreshRate };
 

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -538,6 +538,7 @@ namespace osu.Framework.Platform
                     // force update displays when gaining keyboard focus to always have up-to-date information.
                     // eg. this covers scenarios when changing resolution outside of the game, and then tabbing in.
                     fetchDisplays();
+                    fetchCurrentDisplay();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/5449

This incorporates some ideas from https://github.com/ppy/osu-framework/issues/5448.
`updateDisplay()` from that proposal was scrapped in favour of `pendingDisplayIndex` to accommodate the startup case where both the `WindowMode` and `currentDisplay` are unknown and need to be updated. More detail about that will be posted in that issue thread.

The old flow assumed that the display can change iff the index changes.
Examples where this doesn't hold:
- changing display resolution/arrangement in windows settings
- setting a different resolution via `SizeFullscreen` in config

The new flow will update the display in more places and avoids feedback loops from the bindables (that was causing the linked issue).

Having `pendingDisplayIndex` and `consumePendingDisplayIndex()` turned out quite well.