### PR TITLE
Add `Bindable<T>.CopyTo` and use in `GetUnboundCopy` implementation

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableInstantiation.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableInstantiation.cs
@@ -20,6 +20,9 @@ namespace osu.Framework.Benchmarks
         [Benchmark(Baseline = true)]
         public Bindable<int> GetBoundCopyOld() => new BindableOld<int>().GetBoundCopy();
 
+        [Benchmark]
+        public Bindable<int> GetUnboundCopy() => new Bindable<int>().GetUnboundCopy();
+
         private class BindableOld<T> : Bindable<T> where T : notnull
         {
             public BindableOld(T defaultValue = default!)

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -181,9 +181,9 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
-        /// Copies all values and value limitations of this bindable to another such.
+        /// Copies all values and value limitations of this bindable to another.
         /// </summary>
-        /// <param name="them">The target to copy to</param>
+        /// <param name="them">The target to copy to.</param>
         public virtual void CopyTo(Bindable<T> them)
         {
             them.Value = Value;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -181,6 +181,17 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
+        /// Copies all values and value limitations of this bindable to another such.
+        /// </summary>
+        /// <param name="them">The target to copy to</param>
+        public virtual void CopyTo(Bindable<T> them)
+        {
+            them.Value = Value;
+            them.Default = Default;
+            them.Disabled = Disabled;
+        }
+
+        /// <summary>
         /// Binds this bindable to another such that bi-directional updates are propagated.
         /// This will adopt any values and value limitations of the bindable bound to.
         /// </summary>
@@ -191,9 +202,7 @@ namespace osu.Framework.Bindables
             if (Bindings?.Contains(them) == true)
                 throw new InvalidOperationException($"This bindable is already bound to the requested bindable ({them}).");
 
-            Value = them.Value;
-            Default = them.Default;
-            Disabled = them.Disabled;
+            them.CopyTo(this);
 
             addWeakReference(them.weakReference);
             them.addWeakReference(weakReference);
@@ -389,9 +398,9 @@ namespace osu.Framework.Bindables
         /// </summary>
         public Bindable<T> GetUnboundCopy()
         {
-            var clone = GetBoundCopy();
-            clone.UnbindAll();
-            return clone;
+            var newBindable = CreateInstance();
+            CopyTo(newBindable);
+            return newBindable;
         }
 
         IBindable IBindable.CreateInstance() => CreateInstance();

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -199,12 +199,12 @@ namespace osu.Framework.Bindables
                 PrecisionChanged?.Invoke(precision);
         }
 
-        public override void BindTo(Bindable<T> them)
+        public override void CopyTo(Bindable<T> them)
         {
             if (them is BindableNumber<T> other)
-                Precision = other.Precision;
+                other.Precision = Precision;
 
-            base.BindTo(them);
+            base.CopyTo(them);
         }
 
         public override void UnbindEvents()

--- a/osu.Framework/Bindables/RangeConstrainedBindable.cs
+++ b/osu.Framework/Bindables/RangeConstrainedBindable.cs
@@ -158,6 +158,17 @@ namespace osu.Framework.Bindables
                 MaxValueChanged?.Invoke(maxValue);
         }
 
+        public override void CopyTo(Bindable<T> them)
+        {
+            base.CopyTo(them);
+
+            if (them is RangeConstrainedBindable<T> other)
+            {
+                other.MinValue = MinValue;
+                other.MaxValue = MaxValue;
+            }
+        }
+
         public override void BindTo(Bindable<T> them)
         {
             if (them is RangeConstrainedBindable<T> other)
@@ -167,9 +178,6 @@ namespace osu.Framework.Bindables
                     throw new ArgumentOutOfRangeException(
                         nameof(them), $"The target bindable has specified an invalid range of [{other.MinValue} - {other.MaxValue}].");
                 }
-
-                MinValue = other.MinValue;
-                MaxValue = other.MaxValue;
             }
 
             base.BindTo(them);


### PR DESCRIPTION
This method is used heavily in `AudioAdjustments`, which is how I got here.

https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Audio/AudioAdjustments.cs#L68

|         Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|--------------- |---------:|--------:|--------:|-------:|----------:|
| GetUnboundCopyOld | 940.6 ns | 6.14 ns | 5.13 ns | 0.0629 |     736 B |
| GetUnboundCopyNew | 38.95 ns | 0.848 ns | 1.160 ns | 0.0153 |     176 B |


## Breaking Changes

### `Bindable<T>.CopyTo` should be implemented for any custom bindables

To improve the performance of creating clones of bindables (ie. via `GetUnboundCopy()`), the copy portion of `BindTo()` has been split out into its own method. If you have any custom bindable types which were copying values across within a `BindTo()` override, please move the copy operation to `CopyTo()` instead. Pay special attention to the direction of assignment, which will reverse from what it was in `BindTo`.

A fix should look something like this:

```diff
diff --git a/osu.Framework/Bindables/BindableNumber.cs b/osu.Framework/Bindables/BindableNumber.cs
index 6d605667f..430da79d0 100644
--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -199,12 +199,12 @@ protected void TriggerPrecisionChange(BindableNumber<T> source = null, bool prop
                 PrecisionChanged?.Invoke(precision);
         }
 
-        public override void BindTo(Bindable<T> them)
+        public override void CopyTo(Bindable<T> them)
         {
             if (them is BindableNumber<T> other)
-                Precision = other.Precision;
+                other.Precision = Precision;
 
-            base.BindTo(them);
+            base.CopyTo(them);
         }
 
         public override void UnbindEvents()

```
