### PR TITLE
Lazy init `AudioAdjustments` in `AdjustableAudioComponent` usage

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Audio
@@ -12,47 +10,67 @@ namespace osu.Framework.Audio
     /// </summary>
     public class AdjustableAudioComponent : AudioComponent, IAdjustableAudioComponent
     {
-        private readonly AudioAdjustments adjustments = new AudioAdjustments();
+        private static readonly object adjustments_acquisition_lock = new object();
+
+        private volatile AudioAdjustments? adjustments;
+
+        protected internal AudioAdjustments Adjustments
+        {
+            get
+            {
+                if (adjustments != null)
+                    return adjustments;
+
+                lock (adjustments_acquisition_lock)
+                {
+                    if (adjustments != null)
+                        return adjustments;
+
+                    var adj = new AudioAdjustments();
+
+                    adj.AggregateVolume.ValueChanged += InvalidateState;
+                    adj.AggregateBalance.ValueChanged += InvalidateState;
+                    adj.AggregateFrequency.ValueChanged += InvalidateState;
+                    adj.AggregateTempo.ValueChanged += InvalidateState;
+
+                    adjustments = adj;
+                }
+
+                return adjustments;
+            }
+        }
 
         /// <summary>
         /// The volume of this component.
         /// </summary>
-        public BindableNumber<double> Volume => adjustments.Volume;
+        public BindableNumber<double> Volume => Adjustments.Volume;
 
         /// <summary>
         /// The playback balance of this sample (-1 .. 1 where 0 is centered)
         /// </summary>
-        public BindableNumber<double> Balance => adjustments.Balance;
+        public BindableNumber<double> Balance => Adjustments.Balance;
 
         /// <summary>
         /// Rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
         /// </summary>
-        public BindableNumber<double> Frequency => adjustments.Frequency;
+        public BindableNumber<double> Frequency => Adjustments.Frequency;
 
         /// <summary>
         /// Rate at which the component is played back (does not affect pitch). 1 is 100% playback speed.
         /// </summary>
-        public BindableNumber<double> Tempo => adjustments.Tempo;
-
-        protected AdjustableAudioComponent()
-        {
-            AggregateVolume.ValueChanged += InvalidateState;
-            AggregateBalance.ValueChanged += InvalidateState;
-            AggregateFrequency.ValueChanged += InvalidateState;
-            AggregateTempo.ValueChanged += InvalidateState;
-        }
+        public BindableNumber<double> Tempo => Adjustments.Tempo;
 
         public void AddAdjustment(AdjustableProperty type, IBindable<double> adjustBindable) =>
-            adjustments.AddAdjustment(type, adjustBindable);
+            Adjustments.AddAdjustment(type, adjustBindable);
 
         public void RemoveAdjustment(AdjustableProperty type, IBindable<double> adjustBindable) =>
-            adjustments.RemoveAdjustment(type, adjustBindable);
+            Adjustments.RemoveAdjustment(type, adjustBindable);
 
-        public void RemoveAllAdjustments(AdjustableProperty type) => adjustments.RemoveAllAdjustments(type);
+        public void RemoveAllAdjustments(AdjustableProperty type) => Adjustments.RemoveAllAdjustments(type);
 
         private bool invalidationPending;
 
-        internal void InvalidateState(ValueChangedEvent<double> valueChangedEvent = null)
+        internal void InvalidateState(ValueChangedEvent<double>? valueChangedEvent = null)
         {
             if (CanPerformInline)
                 OnStateChanged();
@@ -75,17 +93,20 @@ namespace osu.Framework.Audio
             }
         }
 
-        public void BindAdjustments(IAggregateAudioAdjustment component) => adjustments.BindAdjustments(component);
+        public void BindAdjustments(IAggregateAudioAdjustment component)
+        {
+            Adjustments.BindAdjustments(component);
+        }
 
-        public void UnbindAdjustments(IAggregateAudioAdjustment component) => adjustments.UnbindAdjustments(component);
+        public void UnbindAdjustments(IAggregateAudioAdjustment component) => adjustments?.UnbindAdjustments(component);
 
-        public IBindable<double> AggregateVolume => adjustments.AggregateVolume;
+        public IBindable<double> AggregateVolume => Adjustments.AggregateVolume;
 
-        public IBindable<double> AggregateBalance => adjustments.AggregateBalance;
+        public IBindable<double> AggregateBalance => Adjustments.AggregateBalance;
 
-        public IBindable<double> AggregateFrequency => adjustments.AggregateFrequency;
+        public IBindable<double> AggregateFrequency => Adjustments.AggregateFrequency;
 
-        public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
+        public IBindable<double> AggregateTempo => Adjustments.AggregateTempo;
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
This is beneficial due to the number of samples which are retrieves during BDL load but never played. In cases they aren't played the `Sample`s retrieved from a `SampleFactory` can avoid the `AudioAdjustments` overhead, which will now only be instantiated when they are played (see https://github.com/ppy/osu-framework/blob/32e7571aa858c4d055f45cc487c08a11aab64817/osu.Framework/Audio/Sample/SampleBassFactory.cs#L100-L105)

Logging can be performed using this adjustment:

```diff
diff --git a/osu.Framework/Audio/AdjustableAudioComponent.cs b/osu.Framework/Audio/AdjustableAudioComponent.cs
index 41b834da0..f5813a763 100644
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Statistics;
 
 namespace osu.Framework.Audio
 {
@@ -60,8 +61,16 @@ protected internal AudioAdjustments Adjustments
         /// </summary>
         public BindableNumber<double> Tempo => Adjustments.Tempo;
 
-        public void AddAdjustment(AdjustableProperty type, IBindable<double> adjustBindable) =>
+        protected AdjustableAudioComponent()
+        {
+            GlobalStatistics.Get<int>("audio", "aac instantiated").Value++;
+        }
+
+        public void AddAdjustment(AdjustableProperty type, IBindable<double> adjustBindable)
+        {
+            logAdjustment();
             Adjustments.AddAdjustment(type, adjustBindable);
+        }
 
         public void RemoveAdjustment(AdjustableProperty type, IBindable<double> adjustBindable) =>
             Adjustments.RemoveAdjustment(type, adjustBindable);
@@ -95,6 +104,7 @@ protected override void UpdateState()
 
         public void BindAdjustments(IAggregateAudioAdjustment component)
         {
+            logAdjustment();
             Adjustments.BindAdjustments(component);
         }
 
@@ -108,6 +118,17 @@ public void BindAdjustments(IAggregateAudioAdjustment component)
 
         public IBindable<double> AggregateTempo => Adjustments.AggregateTempo;
 
+        private bool wasAdjusted;
+
+        private void logAdjustment()
+        {
+            if (wasAdjusted)
+                return;
+
+            GlobalStatistics.Get<int>("audio", "aac bound").Value++;
+            wasAdjusted = true;
+        }
+
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

```

At song select:

![osu! 2022-11-22 at 05 27 57](https://user-images.githubusercontent.com/191335/203230157-5ae36806-0e4e-4a18-85a6-8635b8e15a61.png)

Before:

![JetBrains Rider-EAP 2022-11-22 at 05 33 42](https://user-images.githubusercontent.com/191335/203232042-ba2e9962-548c-4f16-89f9-b0781447b173.png)

![JetBrains Rider-EAP 2022-11-22 at 05 34 16](https://user-images.githubusercontent.com/191335/203232275-f220d913-02b4-4af8-ac5b-e8dd1e80e85b.png)

After:

![JetBrains Rider-EAP 2022-11-22 at 05 30 53](https://user-images.githubusercontent.com/191335/203231100-3d4fc835-c076-4d63-8e08-ce755c45ea61.png)

![JetBrains Rider-EAP 2022-11-22 at 05 35 59](https://user-images.githubusercontent.com/191335/203232868-26d16593-9e1f-41ff-9907-6b8de62cec5b.png)

Note that there are other potential areas that could also fix this (ie. stopping every single instance of `HoverClickSounds` from fetching its own samples osu! side) but I feel this is beneficial to also optimise at a lower level, since retrieving samples from a `SampleStore` for (potential) future use is a common one.