### PR TITLE
Cleanup `LocalisationManager` and related classes

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -480,7 +480,7 @@ namespace osu.Framework.Tests.Localisation
         }
 
         /// <summary>
-        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in <see cref="LocalisationManager.updateLocale"/>.
+        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in <see cref="LocalisationManager.onLocaleChanged"/>.
         /// </summary>
         [Test]
         public void TestInvalidLocaleToInvalid()

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -200,7 +200,7 @@ namespace osu.Framework
             dependencies.Cache(Fonts);
 
             Localisation = CreateLocalisationManager(config);
-            dependencies.Cache(Localisation);
+            dependencies.CacheAs(Localisation);
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
 

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -68,7 +68,7 @@ namespace osu.Framework.Localisation
             }
         }
 
-        public override string ToString() => GetLocalised(new LocalisationParameters(null, false));
+        public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
 
         public bool Equals(ILocalisableStringData? other) => other is CaseTransformableString transformable && Equals(transformable);
 

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace osu.Framework.Localisation
@@ -55,6 +56,15 @@ namespace osu.Framework.Localisation
                 culture = SystemCulture;
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Enumerates all <see cref="CultureInfo.Parent"/> cultures of this <see cref="CultureInfo"/> (including itself, but excluding <see cref="CultureInfo.InvariantCulture"/>).
+        /// </summary>
+        public static IEnumerable<CultureInfo> EnumerateParentCultures(this CultureInfo cultureInfo)
+        {
+            for (var c = cultureInfo; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
+                yield return c;
         }
     }
 }

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Localisation
                     return;
                 }
 
-                for (var c = culture; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
+                foreach (var c in culture.EnumerateParentCultures())
                 {
                     localeMapping = locales.GetValueOrDefault(c.Name);
                     if (localeMapping != null)

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Localisation
         public LocalisationManager(FrameworkConfigManager config)
         {
             config.BindWith(FrameworkSetting.Locale, configLocale);
-            configLocale.BindValueChanged(updateLocale);
+            configLocale.BindValueChanged(onLocaleChanged);
 
             config.BindWith(FrameworkSetting.ShowUnicode, configPreferUnicode);
             configPreferUnicode.BindValueChanged(_ => UpdateLocalisationParameters(), true);
@@ -98,7 +98,7 @@ namespace osu.Framework.Localisation
 
         private LocaleMapping? currentLocale;
 
-        private void updateLocale(ValueChangedEvent<string> locale)
+        private void onLocaleChanged(ValueChangedEvent<string> locale)
         {
             if (locales.Count == 0)
                 return;

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Localisation
     {
         public IBindable<LocalisationParameters> CurrentParameters => currentParameters;
 
-        private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
+        private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(LocalisationParameters.DEFAULT);
 
         private readonly Dictionary<string, LocaleMapping> locales = new Dictionary<string, LocaleMapping>(StringComparer.OrdinalIgnoreCase);
 

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -37,5 +37,15 @@ namespace osu.Framework.Localisation
             Store = store;
             PreferOriginalScript = preferOriginalScript;
         }
+
+        /// <summary>
+        /// Creates new <see cref="LocalisationParameters"/> from this <see cref="LocalisationParameters"/> with the provided fields changed.
+        /// </summary>
+        /// <returns>New <see cref="LocalisationParameters"/> based on this <see cref="LocalisationParameters"/>.</returns>
+        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null)
+            => new LocalisationParameters(
+                store ?? Store,
+                preferOriginalScript ?? PreferOriginalScript
+            );
     }
 }

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -8,6 +8,8 @@ namespace osu.Framework.Localisation
     /// </summary>
     public class LocalisationParameters
     {
+        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false);
+
         /// <summary>
         /// The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.
         /// </summary>

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Localisation
             return preferUnicode ? Original : Romanised;
         }
 
-        public override string ToString() => GetLocalised(new LocalisationParameters(null, false));
+        public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
 
         public bool Equals(RomanisableString? other)
         {


### PR DESCRIPTION
Just some small changes to be used in follow-up PRs.

The `protected`/`virtual` methods in `LocalisationManager` couldn't ever be used, because inheriting `LocalisationManager` would break everything as it wouldn't be cached as `LocalisationManager`. Therefore a04cb19d074a12f89693e9e8f39c2a2e3816bb81 is not a breaking change.

These methods are also strange in general since inheritors can't use the `private` fields that are required for `LocalisationParameters`.