### PR TITLE
Refactor `LocaleMapping` lookup to require an exact match to `FrameworkSetting.Locale`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -54,6 +54,8 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestConfigSettingRetainedWhenAddingNewLanguage()
         {
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+
             config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
@@ -61,16 +63,17 @@ namespace osu.Framework.Tests.Localisation
             Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
 
             var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
-
-            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
-            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 
         [Test]
         public void TestConfigSettingRetainedWhenAddingLocaleMappings()
         {
+            manager.AddLocaleMappings(new[]
+            {
+                new LocaleMapping("ja-JP", new FakeStorage("ja-JP"))
+            });
+
             config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
@@ -83,14 +86,6 @@ namespace osu.Framework.Tests.Localisation
             Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
 
             var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
-
-            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
-            manager.AddLocaleMappings(new[]
-            {
-                new LocaleMapping("ja-JP", new FakeStorage("ja-JP"))
-            });
-
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -118,6 +118,25 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestLocalisationFallback()
+        {
+            using (CultureInfoHelper.ChangeSystemCulture("ja-JP"))
+            {
+                var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
+
+                // string is still in English as that's the only language
+                Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
+
+                // add a new language that's a better match for the system language.
+                manager.AddLanguage("ja", new FakeStorage("ja"));
+
+                localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
+
+                Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA, localisedText.Value);
+            }
+        }
+
+        [Test]
         public void TestFormatted()
         {
             const string to_format = "this {0} {1} formatted";

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -123,18 +123,6 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
-        public void TestLocalisationFallback()
-        {
-            manager.AddLanguage("ja", new FakeStorage("ja"));
-
-            config.SetValue(FrameworkSetting.Locale, "ja-JP");
-
-            var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA, localisedText.Value);
-        }
-
-        [Test]
         public void TestFormatted()
         {
             const string to_format = "this {0} {1} formatted";

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -1,8 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
+using osu.Framework.Allocation;
 
 namespace osu.Framework.Localisation
 {
@@ -13,12 +15,12 @@ namespace osu.Framework.Localisation
         /// <summary>
         /// The system-default <see cref="CultureInfo"/> used for number, date, time and other string formatting.
         /// </summary>
-        public static CultureInfo SystemCulture { get; } = CultureInfo.CurrentCulture;
+        public static CultureInfo SystemCulture { get; private set; } = CultureInfo.CurrentCulture;
 
         /// <summary>
         /// The system-default <see cref="CultureInfo"/> used for app languages/translations.
         /// </summary>
-        public static CultureInfo SystemUICulture { get; } = CultureInfo.CurrentUICulture;
+        public static CultureInfo SystemUICulture { get; private set; } = CultureInfo.CurrentUICulture;
 
         /// <summary>
         /// Wrapper around <see cref="CultureInfo.GetCultureInfo(string)"/> providing common behaviour and exception handling.
@@ -66,5 +68,30 @@ namespace osu.Framework.Localisation
             for (var c = cultureInfo; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
                 yield return c;
         }
+
+        /// <summary>
+        /// For use in tests only.
+        /// Temporarily changes <see cref="SystemCulture"/> and <see cref="SystemUICulture"/>.
+        /// </summary>
+        internal static IDisposable ChangeSystemCulture(string culture, string uiCulture)
+        {
+            var previousCulture = SystemCulture;
+            var previousUICulture = SystemUICulture;
+
+            SystemCulture = new CultureInfo(culture);
+            SystemUICulture = new CultureInfo(uiCulture);
+
+            return new InvokeOnDisposal(() =>
+            {
+                SystemCulture = previousCulture;
+                SystemUICulture = previousUICulture;
+            });
+        }
+
+        /// <summary>
+        /// For use in tests only.
+        /// Temporarily changes <see cref="SystemCulture"/> and <see cref="SystemUICulture"/>.
+        /// </summary>
+        internal static IDisposable ChangeSystemCulture(string allCultures) => ChangeSystemCulture(allCultures, allCultures);
     }
 }


### PR DESCRIPTION
- [x] Depends on #5536

This PR adds `SystemDefaultLocaleMapping` as a way to get which mapping is the default (for `Locale = ""`).

The `LocaleMapping.Name` now needs to match `FrameworkSetting.Locale` exactly (case-insensitive) for it to be used.
Loose matching doesn't make sense as `FrameworkSetting.Locale` is controlled by the game. The game knows what locales it has added and can set the `Locale` appropriately.

Loose matching is used for the `SystemDefaultLocaleMapping`, where it's needed.

