### PR TITLE
Add a way to customise the `CultureInfo` and `IFormatProvider` used for formatting `LocalisableString`s

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -960,6 +960,7 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catmull/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobjects/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keymods/@EntryIndexedValue">True</s:Boolean>

--- a/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
+++ b/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
+using osu.Framework.Tests.Visual.Localisation;
+
+namespace osu.Framework.Tests.Localisation
+{
+    public class CustomLocalisationManagerTest : LocalisationTestScene
+    {
+        private readonly BindableBool useCustomDateFormatBindable = new BindableBool();
+
+        protected override LocalisationManager CreateLocalisationManager(FrameworkConfigManager config) => new CustomLocalisationManager(config, useCustomDateFormatBindable);
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Manager.AddLocaleMappings(new LocaleMapping(new TestLocalisationStore(new CultureInfo("en-US", false), new Dictionary<string, string>())).Yield());
+        }
+
+        private static readonly DateTimeOffset date_time = new DateTimeOffset(2022, 11, 22, 7, 2, 7, new TimeSpan(1, 0, 0));
+
+        [TestCase("D", "Tuesday, November 22, 2022", "2022 November 22")]
+        [TestCase("y", "November 2022", "Nov 2022")]
+        public void TestFormat(string format, string expected, string expectedCustom)
+        {
+            ILocalisedBindableString localised = null!;
+            AddStep("get localised string", () => localised = Manager.GetLocalisedBindableString(date_time.ToLocalisableString(format)));
+
+            AddStep("set useCustomDateFormat to false", () => useCustomDateFormatBindable.Value = false);
+            AddAssert("localised text matches expected", () => localised.Value, () => Is.EqualTo(expected));
+
+            AddStep("set useCustomDateFormat to true", () => useCustomDateFormatBindable.Value = true);
+            AddAssert("localised text matches expected", () => localised.Value, () => Is.EqualTo(expectedCustom));
+        }
+
+        private class CustomLocalisationManager : LocalisationManager
+        {
+            private readonly BindableBool useCustomDateFormat = new BindableBool();
+
+            public CustomLocalisationManager(FrameworkConfigManager config, BindableBool useCustomDateFormat)
+                : base(config)
+            {
+                this.useCustomDateFormat.BindTo(useCustomDateFormat);
+                this.useCustomDateFormat.BindValueChanged(_ => RefreshCulture());
+            }
+
+            protected override IFormatProvider CustomiseCultureAndFormatProvider(CultureInfo culture)
+            {
+                return new CustomFormatProvider(culture, useCustomDateFormat.Value);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                useCustomDateFormat.UnbindAll();
+                base.Dispose(disposing);
+            }
+        }
+
+        private class CustomFormatProvider : ICustomFormatter, IFormatProvider
+        {
+            private readonly CultureInfo culture;
+            private readonly bool useCustomDateFormat;
+
+            public CustomFormatProvider(CultureInfo culture, bool useCustomDateFormat)
+            {
+                this.culture = culture;
+                this.useCustomDateFormat = useCustomDateFormat;
+
+                if (useCustomDateFormat)
+                    culture.DateTimeFormat.LongDatePattern = "yyyy MMMM dd";
+            }
+
+            object? IFormatProvider.GetFormat(Type? formatType)
+            {
+                if (formatType == typeof(ICustomFormatter))
+                    return this;
+
+                return culture.GetFormat(formatType);
+            }
+
+            string ICustomFormatter.Format(string? format, object? arg, IFormatProvider? formatProvider)
+            {
+                if (useCustomDateFormat && arg is DateTimeOffset dateTime)
+                {
+                    switch (format)
+                    {
+                        case "y":
+                            return dateTime.ToString("MMM yyyy", culture);
+                    }
+                }
+
+                if (arg is IFormattable formattable)
+                    return formattable.ToString(format, culture);
+
+                return arg?.ToString() ?? string.Empty;
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -480,7 +480,7 @@ namespace osu.Framework.Tests.Localisation
         }
 
         /// <summary>
-        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in <see cref="LocalisationManager.updateLocale"/>.
+        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in <see cref="LocalisationManager.onLocaleChanged"/>.
         /// </summary>
         [Test]
         public void TestInvalidLocaleToInvalid()

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -509,14 +509,14 @@ namespace osu.Framework.Tests.Localisation
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_EN = "number {0} with {1} and {2} EN";
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_FR = "number {0} with {1} and {2} FR";
 
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly string locale;
 
             public FakeStorage(string locale)
             {
                 this.locale = locale;
-                EffectiveCulture = new CultureInfo(locale);
+                UICulture = new CultureInfo(locale);
             }
 
             public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -54,6 +54,8 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestConfigSettingRetainedWhenAddingNewLanguage()
         {
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+
             config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
@@ -61,16 +63,17 @@ namespace osu.Framework.Tests.Localisation
             Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
 
             var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
-
-            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
-            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 
         [Test]
         public void TestConfigSettingRetainedWhenAddingLocaleMappings()
         {
+            manager.AddLocaleMappings(new[]
+            {
+                new LocaleMapping("ja-JP", new FakeStorage("ja-JP"))
+            });
+
             config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
@@ -83,14 +86,6 @@ namespace osu.Framework.Tests.Localisation
             Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
 
             var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
-
-            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
-            manager.AddLocaleMappings(new[]
-            {
-                new LocaleMapping("ja-JP", new FakeStorage("ja-JP"))
-            });
-
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -123,18 +123,6 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
-        public void TestLocalisationFallback()
-        {
-            manager.AddLanguage("ja", new FakeStorage("ja"));
-
-            config.SetValue(FrameworkSetting.Locale, "ja-JP");
-
-            var localisedText = manager.GetLocalisedBindableString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
-
-            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA, localisedText.Value);
-        }
-
-        [Test]
         public void TestFormatted()
         {
             const string to_format = "this {0} {1} formatted";

--- a/osu.Framework.Tests/Visual/Localisation/LocalisationTestScene.cs
+++ b/osu.Framework.Tests/Visual/Localisation/LocalisationTestScene.cs
@@ -64,13 +64,13 @@ namespace osu.Framework.Tests.Visual.Localisation
 
         protected class TestLocalisationStore : ILocalisationStore
         {
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly IReadOnlyDictionary<string, string> translations;
 
             public TestLocalisationStore(CultureInfo culture, IReadOnlyDictionary<string, string> translations)
             {
-                EffectiveCulture = culture;
+                UICulture = culture;
                 this.translations = translations;
             }
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -288,14 +288,14 @@ namespace osu.Framework.Tests.Visual.Sprites
             public const string LOCALISABLE_STRING_EN = "localised EN";
             public const string LOCALISABLE_STRING_JA = "localised JA";
 
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly string locale;
 
             public FakeStorage(string locale)
             {
                 this.locale = locale;
-                EffectiveCulture = new CultureInfo(locale);
+                UICulture = new CultureInfo(locale);
             }
 
             public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -200,7 +200,7 @@ namespace osu.Framework
             dependencies.Cache(Fonts);
 
             Localisation = CreateLocalisationManager(config);
-            dependencies.Cache(Localisation);
+            dependencies.CacheAs(Localisation);
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
 

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -68,7 +68,7 @@ namespace osu.Framework.Localisation
             }
         }
 
-        public override string ToString() => GetLocalised(new LocalisationParameters(null, false));
+        public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
 
         public bool Equals(ILocalisableStringData? other) => other is CaseTransformableString transformable && Equals(transformable);
 

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Localisation
         public string GetLocalised(LocalisationParameters parameters)
         {
             string stringData = getStringData(parameters);
-            var cultureText = parameters.Store?.EffectiveCulture?.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
+            var cultureText = parameters.Store?.UICulture.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
 
             switch (Casing)
             {

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Localisation
         public string GetLocalised(LocalisationParameters parameters)
         {
             string stringData = getStringData(parameters);
-            var cultureText = parameters.Store?.UICulture.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
+            var cultureText = parameters.Culture.TextInfo;
 
             switch (Casing)
             {

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Globalization;
 
 namespace osu.Framework.Localisation
@@ -55,6 +56,15 @@ namespace osu.Framework.Localisation
                 culture = SystemCulture;
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Enumerates all <see cref="CultureInfo.Parent"/> cultures of this <see cref="CultureInfo"/> (including itself, but excluding <see cref="CultureInfo.InvariantCulture"/>).
+        /// </summary>
+        public static IEnumerable<CultureInfo> EnumerateParentCultures(this CultureInfo cultureInfo)
+        {
+            for (var c = cultureInfo; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
+                yield return c;
         }
     }
 }

--- a/osu.Framework/Localisation/ILocalisationStore.cs
+++ b/osu.Framework/Localisation/ILocalisationStore.cs
@@ -11,9 +11,8 @@ namespace osu.Framework.Localisation
     public interface ILocalisationStore : IResourceStore<string>
     {
         /// <summary>
-        /// The <see cref="CultureInfo"/> corresponding to the content of this <see cref="ILocalisationStore"/>
-        /// and can be used for formatting numbers etc.
+        /// The <see cref="CultureInfo"/> corresponding to the content of this <see cref="ILocalisationStore"/>.
         /// </summary>
-        CultureInfo EffectiveCulture { get; }
+        CultureInfo UICulture { get; }
     }
 }

--- a/osu.Framework/Localisation/LocaleMapping.cs
+++ b/osu.Framework/Localisation/LocaleMapping.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Localisation
         /// <param name="store">The store to be used.</param>
         public LocaleMapping(ILocalisationStore store)
         {
-            Name = store.EffectiveCulture.Name;
+            Name = store.UICulture.Name;
             Storage = store;
         }
 

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -44,12 +44,9 @@ namespace osu.Framework.Localisation
 
         protected virtual string FormatString(string format, object?[] args, LocalisationParameters parameters)
         {
-            if (parameters.Store == null)
-                return ToString();
-
             try
             {
-                return string.Format(parameters.Store.UICulture, format, args.Select(argument =>
+                return string.Format(parameters.FormatProvider, format, args.Select(argument =>
                 {
                     if (argument is LocalisableString localisableString)
                         argument = localisableString.Data;
@@ -63,7 +60,7 @@ namespace osu.Framework.Localisation
             catch (FormatException e)
             {
                 // The formatting has failed
-                Logger.Log($"Localised format failed. Culture: {parameters.Store.UICulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
+                Logger.Log($"Localised format failed. Format provider: {parameters.FormatProvider}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
                     LoggingTarget.Runtime, LogLevel.Verbose);
             }
 

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Localisation
 
             try
             {
-                return string.Format(parameters.Store.EffectiveCulture, format, args.Select(argument =>
+                return string.Format(parameters.Store.UICulture, format, args.Select(argument =>
                 {
                     if (argument is LocalisableString localisableString)
                         argument = localisableString.Data;
@@ -63,7 +63,7 @@ namespace osu.Framework.Localisation
             catch (FormatException e)
             {
                 // The formatting has failed
-                Logger.Log($"Localised format failed. Culture: {parameters.Store.EffectiveCulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
+                Logger.Log($"Localised format failed. Culture: {parameters.Store.UICulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
                     LoggingTarget.Runtime, LogLevel.Verbose);
             }
 

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Localisation
                     return;
                 }
 
-                for (var c = culture; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
+                foreach (var c in culture.EnumerateParentCultures())
                 {
                     localeMapping = locales.GetValueOrDefault(c.Name);
                     if (localeMapping != null)

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Localisation
         public LocalisationManager(FrameworkConfigManager config)
         {
             config.BindWith(FrameworkSetting.Locale, configLocale);
-            configLocale.BindValueChanged(updateLocale);
+            configLocale.BindValueChanged(onLocaleChanged);
 
             config.BindWith(FrameworkSetting.ShowUnicode, configPreferUnicode);
             configPreferUnicode.BindValueChanged(_ => UpdateLocalisationParameters(), true);
@@ -98,7 +98,7 @@ namespace osu.Framework.Localisation
 
         private LocaleMapping? currentLocale;
 
-        private void updateLocale(ValueChangedEvent<string> locale)
+        private void onLocaleChanged(ValueChangedEvent<string> locale)
         {
             if (locales.Count == 0)
                 return;

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -194,6 +194,19 @@ namespace osu.Framework.Localisation
         }
 
         /// <summary>
+        /// Refreshes <see cref="CurrentParameters"/>.<see cref="LocalisationParameters.Culture"/>, applying <see cref="CustomiseCultureAndFormatProvider"/> customisations.
+        /// </summary>
+        /// <remarks>Should be used in derived classes when culture specifics have changed and <see cref="LocalisationParameters.Culture"/> needs to be updated.</remarks>
+        protected void RefreshCulture()
+        {
+            // get a fresh copy of the specific culture.
+            var culture = (CultureInfo)getSpecificCultureFor(currentParameters.Value.UICulture).Clone();
+            var formatProvider = CustomiseCultureAndFormatProvider(culture);
+
+            currentParameters.Value = currentParameters.Value.With(culture: culture, formatProvider: formatProvider);
+        }
+
+        /// <summary>
         /// Applies customization to the <see cref="CultureInfo"/> used for culture-specific string formatting.
         /// Can optionally return a custom <see cref="IFormatProvider"/> to be used for formatting <see cref="LocalisableFormattableString"/>s.
         /// </summary>

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Localisation
     {
         public IBindable<LocalisationParameters> CurrentParameters => currentParameters;
 
-        private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
+        private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(LocalisationParameters.DEFAULT);
 
         private readonly Dictionary<string, LocaleMapping> locales = new Dictionary<string, LocaleMapping>(StringComparer.OrdinalIgnoreCase);
 

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Globalization;
+
 namespace osu.Framework.Localisation
 {
     /// <summary>
@@ -8,10 +11,10 @@ namespace osu.Framework.Localisation
     /// </summary>
     public class LocalisationParameters
     {
-        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false);
+        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false, CultureInfo.InvariantCulture, CultureInfo.InvariantCulture, CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.
+        /// The <see cref="ILocalisationStore"/> to be used for string lookups.
         /// </summary>
         public readonly ILocalisationStore? Store;
 
@@ -21,33 +24,61 @@ namespace osu.Framework.Localisation
         public readonly bool PreferOriginalScript;
 
         /// <summary>
+        /// Culture that is used for culture-specific string formatting, case transformations, etc.
+        /// </summary>
+        public readonly CultureInfo Culture;
+
+        /// <summary>
+        /// Culture that is used for language/string lookups.
+        /// </summary>
+        /// <remarks>
+        /// Usually corresponds to <see cref="Store"/>.<see cref="ILocalisationStore.UICulture"/>.
+        /// </remarks>
+        public readonly CultureInfo UICulture;
+
+        /// <summary>
+        /// <see cref="IFormatProvider"/> that is used for culture-specific formatting of <see cref="LocalisableFormattableString"/>s.
+        /// </summary>
+        public readonly IFormatProvider FormatProvider;
+
+        /// <summary>
         /// Creates a new instance of <see cref="LocalisationParameters"/> based off another <see cref="LocalisationParameters"/>.
         /// </summary>
         /// <param name="parameters">The <see cref="LocalisationParameters"/> to copy values from.</param>
         protected LocalisationParameters(LocalisationParameters parameters)
-            : this(parameters.Store, parameters.PreferOriginalScript)
+            : this(parameters.Store, parameters.PreferOriginalScript, parameters.Culture, parameters.UICulture, parameters.FormatProvider)
         {
         }
 
         /// <summary>
         /// Creates a new instance of <see cref="LocalisationParameters"/>.
         /// </summary>
-        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.</param>
+        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups.</param>
         /// <param name="preferOriginalScript">Whether to prefer the "original" script of <see cref="RomanisableString"/>s.</param>
-        public LocalisationParameters(ILocalisationStore? store, bool preferOriginalScript)
+        /// <param name="culture">Culture that is used for culture-specific string formatting, case transformations, etc.</param>
+        /// <param name="uiCulture">Culture that is used for language/string lookups.</param>
+        /// <param name="formatProvider"><see cref="IFormatProvider"/> that is used for culture-specific formatting of <see cref="LocalisableFormattableString"/>s.</param>
+        public LocalisationParameters(ILocalisationStore? store, bool preferOriginalScript, CultureInfo culture, CultureInfo uiCulture, IFormatProvider formatProvider)
         {
             Store = store;
             PreferOriginalScript = preferOriginalScript;
+            Culture = culture;
+            UICulture = uiCulture;
+            FormatProvider = formatProvider;
         }
 
         /// <summary>
         /// Creates new <see cref="LocalisationParameters"/> from this <see cref="LocalisationParameters"/> with the provided fields changed.
         /// </summary>
         /// <returns>New <see cref="LocalisationParameters"/> based on this <see cref="LocalisationParameters"/>.</returns>
-        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null)
+        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null, CultureInfo? culture = null, CultureInfo? uiCulture = null,
+                                           IFormatProvider? formatProvider = null)
             => new LocalisationParameters(
                 store ?? Store,
-                preferOriginalScript ?? PreferOriginalScript
+                preferOriginalScript ?? PreferOriginalScript,
+                culture ?? Culture,
+                uiCulture ?? UICulture,
+                formatProvider ?? FormatProvider
             );
     }
 }

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -37,5 +37,15 @@ namespace osu.Framework.Localisation
             Store = store;
             PreferOriginalScript = preferOriginalScript;
         }
+
+        /// <summary>
+        /// Creates new <see cref="LocalisationParameters"/> from this <see cref="LocalisationParameters"/> with the provided fields changed.
+        /// </summary>
+        /// <returns>New <see cref="LocalisationParameters"/> based on this <see cref="LocalisationParameters"/>.</returns>
+        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null)
+            => new LocalisationParameters(
+                store ?? Store,
+                preferOriginalScript ?? PreferOriginalScript
+            );
     }
 }

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -8,6 +8,8 @@ namespace osu.Framework.Localisation
     /// </summary>
     public class LocalisationParameters
     {
+        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false);
+
         /// <summary>
         /// The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.
         /// </summary>

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Localisation
             return preferUnicode ? Original : Romanised;
         }
 
-        public override string ToString() => GetLocalised(new LocalisationParameters(null, false));
+        public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
 
         public bool Equals(RomanisableString? other)
         {


### PR DESCRIPTION
- Depends on #5536
- Depends on #5537

New methods in `LocalisationManager`
---

```cs
protected virtual IFormatProvider CustomiseCultureAndFormatProvider(CultureInfo culture)
```

- This can be used in by inheritors to provide a custom format provider and to customise the culture (by directly modifying it's properties).

```cs
protected void RefreshCulture()
```

- Used in combination with the above, allows to re-run `CustomiseCultureAndFormatProvider()`.
- Example: refresh the culture when `OsuSetting.Prefer24HourTime` changes.

---

This will allow us to address https://github.com/ppy/osu/issues/21157, and have 12/24 hour time preference apply globally to all `LocalisableString`s.

`CustomLocalisationManagerTest` gives a glimpse of how this will work osu!-side.


# Breaking changes

## `ILocalisationStore.EffectiveCulture` renamed to `UICulture`

Renamed to better reflect how it's used.
