### PR TITLE
Correctly return `AVERROR_EOF` in `VideoDecoder`

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -292,8 +292,9 @@ namespace osu.Framework.Graphics.Video
                 return 0;
 
             var span = new Span<byte>(bufferPtr, bufferSize);
+            var bytesRead = decoder.videoStream.Read(span);
 
-            return decoder.videoStream.Read(span);
+            return bytesRead != 0 ? bytesRead : AGffmpeg.AVERROR_EOF;
         }
 
         [MonoPInvokeCallback(typeof(avio_alloc_context_seek))]

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -292,7 +292,7 @@ namespace osu.Framework.Graphics.Video
                 return 0;
 
             var span = new Span<byte>(bufferPtr, bufferSize);
-            var bytesRead = decoder.videoStream.Read(span);
+            int bytesRead = decoder.videoStream.Read(span);
 
             return bytesRead != 0 ? bytesRead : AGffmpeg.AVERROR_EOF;
         }


### PR DESCRIPTION
See: https://github.com/FFmpeg/FFmpeg/blob/98f6c59f4f614f7409b225930a16a2172512c432/libavformat/avio.h#L405