### PR TITLE
Set thread `CurrentCulture` and `CurrentUICulture` based on current `LocalisationParameters`

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -960,6 +960,7 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catmull/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Drawables/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hitobjects/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keymods/@EntryIndexedValue">True</s:Boolean>

--- a/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
+++ b/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
@@ -11,10 +11,12 @@ using osu.Framework.Configuration;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
+using osu.Framework.Testing;
 using osu.Framework.Tests.Visual.Localisation;
 
 namespace osu.Framework.Tests.Localisation
 {
+    [HeadlessTest]
     public class CustomLocalisationManagerTest : LocalisationTestScene
     {
         private readonly BindableBool useCustomDateFormatBindable = new BindableBool();

--- a/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
+++ b/osu.Framework.Tests/Localisation/CustomLocalisationManagerTest.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Localisation;
+using osu.Framework.Tests.Visual.Localisation;
+
+namespace osu.Framework.Tests.Localisation
+{
+    public class CustomLocalisationManagerTest : LocalisationTestScene
+    {
+        private readonly BindableBool useCustomDateFormatBindable = new BindableBool();
+
+        protected override LocalisationManager CreateLocalisationManager(FrameworkConfigManager config) => new CustomLocalisationManager(config, useCustomDateFormatBindable);
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Manager.AddLocaleMappings(new LocaleMapping(new TestLocalisationStore(new CultureInfo("en-US", false), new Dictionary<string, string>())).Yield());
+        }
+
+        private static readonly DateTimeOffset date_time = new DateTimeOffset(2022, 11, 22, 7, 2, 7, new TimeSpan(1, 0, 0));
+
+        [TestCase("D", "Tuesday, November 22, 2022", "2022 November 22")]
+        [TestCase("y", "November 2022", "Nov 2022")]
+        public void TestFormat(string format, string expected, string expectedCustom)
+        {
+            ILocalisedBindableString localised = null!;
+            AddStep("get localised string", () => localised = Manager.GetLocalisedBindableString(date_time.ToLocalisableString(format)));
+
+            AddStep("set useCustomDateFormat to false", () => useCustomDateFormatBindable.Value = false);
+            AddAssert("localised text matches expected", () => localised.Value, () => Is.EqualTo(expected));
+
+            AddStep("set useCustomDateFormat to true", () => useCustomDateFormatBindable.Value = true);
+            AddAssert("localised text matches expected", () => localised.Value, () => Is.EqualTo(expectedCustom));
+        }
+
+        private class CustomLocalisationManager : LocalisationManager
+        {
+            private readonly BindableBool useCustomDateFormat = new BindableBool();
+
+            public CustomLocalisationManager(FrameworkConfigManager config, BindableBool useCustomDateFormat)
+                : base(config)
+            {
+                this.useCustomDateFormat.BindTo(useCustomDateFormat);
+                this.useCustomDateFormat.BindValueChanged(_ => RefreshCulture());
+            }
+
+            protected override IFormatProvider CustomiseCultureAndFormatProvider(CultureInfo culture)
+            {
+                return new CustomFormatProvider(culture, useCustomDateFormat.Value);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                useCustomDateFormat.UnbindAll();
+                base.Dispose(disposing);
+            }
+        }
+
+        private class CustomFormatProvider : ICustomFormatter, IFormatProvider
+        {
+            private readonly CultureInfo culture;
+            private readonly bool useCustomDateFormat;
+
+            public CustomFormatProvider(CultureInfo culture, bool useCustomDateFormat)
+            {
+                this.culture = culture;
+                this.useCustomDateFormat = useCustomDateFormat;
+
+                if (useCustomDateFormat)
+                    culture.DateTimeFormat.LongDatePattern = "yyyy MMMM dd";
+            }
+
+            object? IFormatProvider.GetFormat(Type? formatType)
+            {
+                if (formatType == typeof(ICustomFormatter))
+                    return this;
+
+                return culture.GetFormat(formatType);
+            }
+
+            string ICustomFormatter.Format(string? format, object? arg, IFormatProvider? formatProvider)
+            {
+                if (useCustomDateFormat && arg is DateTimeOffset dateTime)
+                {
+                    switch (format)
+                    {
+                        case "y":
+                            return dateTime.ToString("MMM yyyy", culture);
+                    }
+                }
+
+                if (arg is IFormattable formattable)
+                    return formattable.ToString(format, culture);
+
+                return arg?.ToString() ?? string.Empty;
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -509,14 +509,14 @@ namespace osu.Framework.Tests.Localisation
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_EN = "number {0} with {1} and {2} EN";
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_FR = "number {0} with {1} and {2} FR";
 
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly string locale;
 
             public FakeStorage(string locale)
             {
                 this.locale = locale;
-                EffectiveCulture = new CultureInfo(locale);
+                UICulture = new CultureInfo(locale);
             }
 
             public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>

--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq;
@@ -21,10 +19,10 @@ namespace osu.Framework.Tests.Localisation
     public class ThreadCultureTest : FrameworkTestScene
     {
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         [Resolved]
-        private FrameworkConfigManager config { get; set; }
+        private FrameworkConfigManager config { get; set; } = null!;
 
         [Test]
         public void TestDefaultCultureIsSystem()
@@ -80,11 +78,11 @@ namespace osu.Framework.Tests.Localisation
 
         private void assertThreadCulture(string name)
         {
-            CultureInfo culture = null;
+            CultureInfo? culture = null;
 
             AddStep("start new thread", () => new Thread(() => culture = CultureInfo.CurrentCulture) { IsBackground = true }.Start());
             AddUntilStep("wait for culture", () => culture != null);
-            AddAssert($"thread culture is {name}", () => culture.Name == name);
+            AddAssert($"thread culture is {name}", () => culture!.Name == name);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Localisation/LocalisationTestScene.cs
+++ b/osu.Framework.Tests/Visual/Localisation/LocalisationTestScene.cs
@@ -64,13 +64,13 @@ namespace osu.Framework.Tests.Visual.Localisation
 
         protected class TestLocalisationStore : ILocalisationStore
         {
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly IReadOnlyDictionary<string, string> translations;
 
             public TestLocalisationStore(CultureInfo culture, IReadOnlyDictionary<string, string> translations)
             {
-                EffectiveCulture = culture;
+                UICulture = culture;
                 this.translations = translations;
             }
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -288,14 +288,14 @@ namespace osu.Framework.Tests.Visual.Sprites
             public const string LOCALISABLE_STRING_EN = "localised EN";
             public const string LOCALISABLE_STRING_JA = "localised JA";
 
-            public CultureInfo EffectiveCulture { get; }
+            public CultureInfo UICulture { get; }
 
             private readonly string locale;
 
             public FakeStorage(string locale)
             {
                 this.locale = locale;
-                EffectiveCulture = new CultureInfo(locale);
+                UICulture = new CultureInfo(locale);
             }
 
             public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -76,6 +76,8 @@ namespace osu.Framework
 
         private AudioMixerVisualiser audioMixerVisualiser;
 
+        private IBindable<LocalisationParameters> localisationParameters;
+
         protected override Container<Drawable> Content => content;
 
         /// <summary>
@@ -201,6 +203,9 @@ namespace osu.Framework
 
             Localisation = CreateLocalisationManager(config);
             dependencies.CacheAs(Localisation);
+
+            localisationParameters = Localisation.CurrentParameters.GetBoundCopy();
+            localisationParameters.BindValueChanged(p => Host.SetThreadCulture(p.NewValue.Culture, p.NewValue.UICulture), true);
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
 

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Localisation
         public string GetLocalised(LocalisationParameters parameters)
         {
             string stringData = getStringData(parameters);
-            var cultureText = parameters.Store?.EffectiveCulture?.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
+            var cultureText = parameters.Store?.UICulture.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
 
             switch (Casing)
             {

--- a/osu.Framework/Localisation/CaseTransformableString.cs
+++ b/osu.Framework/Localisation/CaseTransformableString.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Localisation
         public string GetLocalised(LocalisationParameters parameters)
         {
             string stringData = getStringData(parameters);
-            var cultureText = parameters.Store?.UICulture.TextInfo ?? CultureInfo.InvariantCulture.TextInfo;
+            var cultureText = parameters.Culture.TextInfo;
 
             switch (Casing)
             {

--- a/osu.Framework/Localisation/CultureInfoHelper.cs
+++ b/osu.Framework/Localisation/CultureInfoHelper.cs
@@ -10,8 +10,6 @@ namespace osu.Framework.Localisation
 {
     public static class CultureInfoHelper
     {
-        // there is a possibility that something changes the current culture before this class is used, but the framework currently doesn't do that.
-
         /// <summary>
         /// The system-default <see cref="CultureInfo"/> used for number, date, time and other string formatting.
         /// </summary>

--- a/osu.Framework/Localisation/ILocalisationStore.cs
+++ b/osu.Framework/Localisation/ILocalisationStore.cs
@@ -11,9 +11,8 @@ namespace osu.Framework.Localisation
     public interface ILocalisationStore : IResourceStore<string>
     {
         /// <summary>
-        /// The <see cref="CultureInfo"/> corresponding to the content of this <see cref="ILocalisationStore"/>
-        /// and can be used for formatting numbers etc.
+        /// The <see cref="CultureInfo"/> corresponding to the content of this <see cref="ILocalisationStore"/>.
         /// </summary>
-        CultureInfo EffectiveCulture { get; }
+        CultureInfo UICulture { get; }
     }
 }

--- a/osu.Framework/Localisation/LocaleMapping.cs
+++ b/osu.Framework/Localisation/LocaleMapping.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Localisation
         /// <param name="store">The store to be used.</param>
         public LocaleMapping(ILocalisationStore store)
         {
-            Name = store.EffectiveCulture.Name;
+            Name = store.UICulture.Name;
             Storage = store;
         }
 

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -44,12 +44,9 @@ namespace osu.Framework.Localisation
 
         protected virtual string FormatString(string format, object?[] args, LocalisationParameters parameters)
         {
-            if (parameters.Store == null)
-                return ToString();
-
             try
             {
-                return string.Format(parameters.Store.UICulture, format, args.Select(argument =>
+                return string.Format(parameters.FormatProvider, format, args.Select(argument =>
                 {
                     if (argument is LocalisableString localisableString)
                         argument = localisableString.Data;
@@ -63,7 +60,7 @@ namespace osu.Framework.Localisation
             catch (FormatException e)
             {
                 // The formatting has failed
-                Logger.Log($"Localised format failed. Culture: {parameters.Store.UICulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
+                Logger.Log($"Localised format failed. Format provider: {parameters.FormatProvider}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
                     LoggingTarget.Runtime, LogLevel.Verbose);
             }
 

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Localisation
 
             try
             {
-                return string.Format(parameters.Store.EffectiveCulture, format, args.Select(argument =>
+                return string.Format(parameters.Store.UICulture, format, args.Select(argument =>
                 {
                     if (argument is LocalisableString localisableString)
                         argument = localisableString.Data;
@@ -63,7 +63,7 @@ namespace osu.Framework.Localisation
             catch (FormatException e)
             {
                 // The formatting has failed
-                Logger.Log($"Localised format failed. Culture: {parameters.Store.EffectiveCulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
+                Logger.Log($"Localised format failed. Culture: {parameters.Store.UICulture}, format string: \"{format}\", base format string: \"{Format}\". Exception: {e}",
                     LoggingTarget.Runtime, LogLevel.Verbose);
             }
 

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -194,6 +194,19 @@ namespace osu.Framework.Localisation
         }
 
         /// <summary>
+        /// Refreshes <see cref="CurrentParameters"/>.<see cref="LocalisationParameters.Culture"/>, applying <see cref="CustomiseCultureAndFormatProvider"/> customisations.
+        /// </summary>
+        /// <remarks>Should be used in derived classes when culture specifics have changed and <see cref="LocalisationParameters.Culture"/> needs to be updated.</remarks>
+        protected void RefreshCulture()
+        {
+            // get a fresh copy of the specific culture.
+            var culture = (CultureInfo)getSpecificCultureFor(currentParameters.Value.UICulture).Clone();
+            var formatProvider = CustomiseCultureAndFormatProvider(culture);
+
+            currentParameters.Value = currentParameters.Value.With(culture: culture, formatProvider: formatProvider);
+        }
+
+        /// <summary>
         /// Applies customization to the <see cref="CultureInfo"/> used for culture-specific string formatting.
         /// Can optionally return a custom <see cref="IFormatProvider"/> to be used for formatting <see cref="LocalisableFormattableString"/>s.
         /// </summary>

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Globalization;
+
 namespace osu.Framework.Localisation
 {
     /// <summary>
@@ -8,10 +11,10 @@ namespace osu.Framework.Localisation
     /// </summary>
     public class LocalisationParameters
     {
-        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false);
+        public static readonly LocalisationParameters DEFAULT = new LocalisationParameters(null, false, CultureInfo.InvariantCulture, CultureInfo.InvariantCulture, CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.
+        /// The <see cref="ILocalisationStore"/> to be used for string lookups.
         /// </summary>
         public readonly ILocalisationStore? Store;
 
@@ -21,33 +24,61 @@ namespace osu.Framework.Localisation
         public readonly bool PreferOriginalScript;
 
         /// <summary>
+        /// Culture that is used for culture-specific string formatting, case transformations, etc.
+        /// </summary>
+        public readonly CultureInfo Culture;
+
+        /// <summary>
+        /// Culture that is used for language/string lookups.
+        /// </summary>
+        /// <remarks>
+        /// Usually corresponds to <see cref="Store"/>.<see cref="ILocalisationStore.UICulture"/>.
+        /// </remarks>
+        public readonly CultureInfo UICulture;
+
+        /// <summary>
+        /// <see cref="IFormatProvider"/> that is used for culture-specific formatting of <see cref="LocalisableFormattableString"/>s.
+        /// </summary>
+        public readonly IFormatProvider FormatProvider;
+
+        /// <summary>
         /// Creates a new instance of <see cref="LocalisationParameters"/> based off another <see cref="LocalisationParameters"/>.
         /// </summary>
         /// <param name="parameters">The <see cref="LocalisationParameters"/> to copy values from.</param>
         protected LocalisationParameters(LocalisationParameters parameters)
-            : this(parameters.Store, parameters.PreferOriginalScript)
+            : this(parameters.Store, parameters.PreferOriginalScript, parameters.Culture, parameters.UICulture, parameters.FormatProvider)
         {
         }
 
         /// <summary>
         /// Creates a new instance of <see cref="LocalisationParameters"/>.
         /// </summary>
-        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.</param>
+        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups.</param>
         /// <param name="preferOriginalScript">Whether to prefer the "original" script of <see cref="RomanisableString"/>s.</param>
-        public LocalisationParameters(ILocalisationStore? store, bool preferOriginalScript)
+        /// <param name="culture">Culture that is used for culture-specific string formatting, case transformations, etc.</param>
+        /// <param name="uiCulture">Culture that is used for language/string lookups.</param>
+        /// <param name="formatProvider"><see cref="IFormatProvider"/> that is used for culture-specific formatting of <see cref="LocalisableFormattableString"/>s.</param>
+        public LocalisationParameters(ILocalisationStore? store, bool preferOriginalScript, CultureInfo culture, CultureInfo uiCulture, IFormatProvider formatProvider)
         {
             Store = store;
             PreferOriginalScript = preferOriginalScript;
+            Culture = culture;
+            UICulture = uiCulture;
+            FormatProvider = formatProvider;
         }
 
         /// <summary>
         /// Creates new <see cref="LocalisationParameters"/> from this <see cref="LocalisationParameters"/> with the provided fields changed.
         /// </summary>
         /// <returns>New <see cref="LocalisationParameters"/> based on this <see cref="LocalisationParameters"/>.</returns>
-        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null)
+        public LocalisationParameters With(ILocalisationStore? store = null, bool? preferOriginalScript = null, CultureInfo? culture = null, CultureInfo? uiCulture = null,
+                                           IFormatProvider? formatProvider = null)
             => new LocalisationParameters(
                 store ?? Store,
-                preferOriginalScript ?? PreferOriginalScript
+                preferOriginalScript ?? PreferOriginalScript,
+                culture ?? Culture,
+                uiCulture ?? UICulture,
+                formatProvider ?? FormatProvider
             );
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -948,8 +949,6 @@ namespace osu.Framework.Platform
 
         private Bindable<ExecutionMode> executionMode;
 
-        private Bindable<string> threadLocale;
-
         protected virtual void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             if (!defaultOverrides.ContainsKey(FrameworkSetting.WindowMode))
@@ -1016,19 +1015,15 @@ namespace osu.Framework.Platform
 
             bypassFrontToBackPass = DebugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
 
-            threadLocale = Config.GetBindable<string>(FrameworkSetting.Locale);
-            threadLocale.BindValueChanged(locale =>
-            {
-                // return value of TryGet ignored as the failure case gives expected results (CultureInfo.InvariantCulture)
-                CultureInfoHelper.TryGetCultureInfo(locale.NewValue, out var culture);
-
-                CultureInfo.DefaultThreadCurrentCulture = culture;
-                CultureInfo.DefaultThreadCurrentUICulture = culture;
-
-                threadRunner.SetCulture(culture);
-            }, true);
-
             inputConfig = new InputConfigManager(Storage, AvailableInputHandlers);
+        }
+
+        internal void SetThreadCulture(CultureInfo culture, CultureInfo uiCulture)
+        {
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = uiCulture;
+
+            threadRunner.SetCulture(culture, uiCulture);
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -315,6 +315,9 @@ namespace osu.Framework.Platform
 
         protected GameHost([NotNull] string gameName, [CanBeNull] HostOptions options = null)
         {
+            // ensure that SystemCulture and SystemUICulture values are fetched before something can change them.
+            RuntimeHelpers.RunClassConstructor(typeof(CultureInfoHelper).TypeHandle);
+
             Options = options ?? new HostOptions();
 
             Name = gameName;

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -236,18 +236,18 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Sets the current culture of all threads to the supplied <paramref name="culture"/>.
         /// </summary>
-        public void SetCulture(CultureInfo culture)
+        public void SetCulture(CultureInfo culture, CultureInfo uiCulture)
         {
             // for single-threaded mode, switch the current (assumed to be main) thread's culture, since it's actually the one that's running the frames.
             CultureInfo.CurrentCulture = culture;
-            CultureInfo.CurrentUICulture = culture;
+            CultureInfo.CurrentUICulture = uiCulture;
 
             // for multi-threaded mode, schedule the culture change on all threads.
             // note that if the threads haven't been created yet (e.g. if the game started single-threaded), this will only store the culture in GameThread.CurrentCulture.
             // in that case, the stored value will be set on the actual threads after the next Start() call.
             foreach (var t in Threads)
             {
-                t.Scheduler.Add(() => t.CurrentCulture = culture);
+                t.Scheduler.Add(() => t.SetCulture(culture, uiCulture));
             }
         }
     }

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -84,21 +84,16 @@ namespace osu.Framework.Threading
         /// </summary>
         public SynchronizationContext SynchronizationContext => synchronizationContext;
 
-        /// <summary>
-        /// The culture of this thread.
-        /// </summary>
-        public CultureInfo? CurrentCulture
+        private CultureInfo? requestedCulture;
+        private CultureInfo? requestedUICulture;
+
+        public void SetCulture(CultureInfo culture, CultureInfo uiCulture)
         {
-            get => culture;
-            set
-            {
-                culture = value;
+            requestedCulture = culture;
+            requestedUICulture = uiCulture;
 
-                updateCulture();
-            }
+            updateCulture();
         }
-
-        private CultureInfo? culture;
 
         /// <summary>
         /// The target number of updates per second when the game window is active.
@@ -469,12 +464,10 @@ namespace osu.Framework.Threading
 
         private void updateCulture()
         {
-            if (culture == null) return;
-
             Debug.Assert(IsCurrent);
 
-            CultureInfo.CurrentCulture = culture;
-            CultureInfo.CurrentUICulture = culture;
+            if (requestedCulture != null) CultureInfo.CurrentCulture = requestedCulture;
+            if (requestedUICulture != null) CultureInfo.CurrentUICulture = requestedUICulture;
         }
 
         private void setExitState(GameThreadState exitState)


### PR DESCRIPTION
- [ ] Depends on #5538

Having the cultures all be the same makes sense and will ensure that culture-specific formatting/parsing is the same within the context of `LocalisableString` and outside of it.

Uses [`RuntimeHelpers.RunClassConstructor`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.runtimehelpers.runclassconstructor) to force run the `CultureInfoHelper` class initialiser since the new flow would overwrite the current cultures before they could be fetched and saved as system cultures.