### PR TITLE
Fix wrong range constrained bindable value transferal in `CopyTo()`

### DIFF
--- a/osu.Framework.Tests/Bindables/RangeConstrainedBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/RangeConstrainedBindableTest.cs
@@ -101,6 +101,30 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(bindable.Value, Is.EqualTo(3));
         }
 
+        [Test]
+        public void TestBindToAnotherBindableWithDisjointRange()
+        {
+            var first = new BindableDouble
+            {
+                MinValue = -10,
+                MaxValue = -5,
+                Value = -7
+            };
+
+            var second = new BindableDouble
+            {
+                MinValue = 5,
+                MaxValue = 10,
+                Value = 9
+            };
+
+            first.BindTo(second);
+
+            Assert.That(first.MinValue, Is.EqualTo(5));
+            Assert.That(first.MaxValue, Is.EqualTo(10));
+            Assert.That(first.Value, Is.EqualTo(9));
+        }
+
         private class BindableNumberWithDefaultMaxValue : BindableInt
         {
             public BindableNumberWithDefaultMaxValue(int value = 0)

--- a/osu.Framework/Bindables/RangeConstrainedBindable.cs
+++ b/osu.Framework/Bindables/RangeConstrainedBindable.cs
@@ -160,13 +160,15 @@ namespace osu.Framework.Bindables
 
         public override void CopyTo(Bindable<T> them)
         {
-            base.CopyTo(them);
-
+            // if the other bindable is range-constrained, the bounds need to be copied across first,
+            // as Value assignment (in the base call below) automatically clamps to [MinValue, MaxValue].
             if (them is RangeConstrainedBindable<T> other)
             {
                 other.MinValue = MinValue;
                 other.MaxValue = MaxValue;
             }
+
+            base.CopyTo(them);
         }
 
         public override void BindTo(Bindable<T> them)


### PR DESCRIPTION
Regressed in 9faae09581d9c4aa24175ed78197720fd983e40e.

When copying over values of a range-constrained bindable, the range bounds need to be transferred first, because otherwise assignment to `.Value` of a range-constrained bindable will automatically clamp the value to [`MinValue`, `MaxValue`], leading to a scenario where a new value being transferred across would get clamped to stale bounds.

This affected both `.CopyTo()` and `.BindTo()`, as the latter calls the former.