### PR TITLE
Move early return conditions away from CircularProgress and CircularBlob shaders

### DIFF
--- a/osu.Framework/Graphics/UserInterface/CircularBlob.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularBlob.cs
@@ -122,6 +122,9 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected override void Blit(IRenderer renderer)
             {
+                if (innerRadius == 0)
+                    return;
+
                 var shader = TextureShader;
 
                 shader.GetUniform<float>("innerRadius").UpdateValue(ref innerRadius);

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -115,6 +115,9 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected override void Blit(IRenderer renderer)
             {
+                if (innerRadius == 0 || (!roundedCaps && progress == 0))
+                    return;
+
                 var shader = TextureShader;
 
                 shader.GetUniform<float>("innerRadius").UpdateValue(ref innerRadius);

--- a/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
@@ -16,12 +16,6 @@ uniform highp float texelSize;
 
 void main(void)
 {
-    if (innerRadius == 0.0)
-    {
-        gl_FragColor = vec4(0.0);
-        return;
-    }
-
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -15,12 +15,6 @@ uniform bool roundedCaps;
 
 void main(void)
 {
-    if (progress == 0.0 || innerRadius == 0.0)
-    {
-        gl_FragColor = vec4(0.0);
-        return;
-    }
-
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
     


### PR DESCRIPTION
Moved to the `DrawNode` instead.
Also fixes an issue when `CircularProgress` is rendering nothing when `progress = 0` with rounded caps enabled.