### PR TITLE
Add support for macOS ctrl click (right click emulation)

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -6,6 +6,7 @@
 using System;
 using osu.Framework.Platform.MacOS.Native;
 using osuTK;
+using SDL2;
 
 namespace osu.Framework.Platform.MacOS
 {
@@ -32,6 +33,8 @@ namespace osu.Framework.Platform.MacOS
             var viewClass = Class.Get("SDLView");
             scrollWheelHandler = scrollWheel;
             originalScrollWheel = Class.SwizzleMethod(viewClass, "scrollWheel:", "v@:@", scrollWheelHandler);
+
+            SDL.SDL_SetHint(SDL.SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");
         }
 
         /// <summary>


### PR DESCRIPTION
- [ ] Resolves https://github.com/ppy/osu/issues/6612
- [X] Depends on https://github.com/flibitijibibo/SDL2-CS/pull/240
- [ ] Depends on https://github.com/ppy/SDL2-CS bump

Note that this conflicts with `ControlPressed` cases like control-enter in song select for example. I was hoping to redirect it with cmd but there is also a `SuperPressed`. Not sure how to handle that.