### PR TITLE
Additive blend without drawcall

### DIFF
--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -67,13 +67,13 @@ namespace osu.Framework.Extensions.Color4Extensions
         }
 
         /// <summary>
-        /// Returns a version of the color with negated alpha if the parameter is true.
+        /// Returns a version of the color with negated components depending on arguments.
         /// Used for the shader-level additive blend mode.
         /// </summary>
         /// <param name="colour">Original colour</param>
-        /// <param name="value">Negates alpha if true</param>
-        public static Color4 NegateAlphaIfTrue(this Color4 colour, bool value) =>
-            new Color4(colour.R, colour.G, colour.B, value ? -colour.A : colour.A);
+        /// <param name="negateAlpha">Negates alpha if true</param>
+        public static Color4 NegateAlphaIfTrue(this Color4 colour, bool negateAlpha) =>
+            new Color4(colour.R, colour.G, colour.B, negateAlpha ? -colour.A : colour.A);
 
         /// <summary>
         /// Returns a lightened version of the colour.

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -67,6 +67,15 @@ namespace osu.Framework.Extensions.Color4Extensions
         }
 
         /// <summary>
+        /// Returns a version of the color with negated alpha if the parameter is true.
+        /// Used for the shader-level additive blend mode.
+        /// </summary>
+        /// <param name="colour">Original colour</param>
+        /// <param name="value">Negates alpha if true</param>
+        public static Color4 NegateAlphaIfTrue(this Color4 colour, bool value) =>
+            new Color4(colour.R, colour.G, colour.B, value ? -colour.A : colour.A);
+
+        /// <summary>
         /// Returns a lightened version of the colour.
         /// </summary>
         /// <param name="colour">Original colour</param>

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -27,6 +27,14 @@ namespace osu.Framework.Graphics
         public BlendingType Destination;
 
         /// <summary>
+        /// Whether or not blending is additive. If true, the destination color will act as if using
+        /// <see cref="BlendingType.One"/> rather than <see cref="BlendingType.OneMinusSrcAlpha"/>,
+        /// but this is accomplished at the shader level rather than via the rendering backend's
+        /// blend function for performance reasons.
+        /// </summary>
+        public bool DestinationAdditive;
+
+        /// <summary>
         /// The blending factor for the source alpha of the blend.
         /// </summary>
         public BlendingType SourceAlpha;
@@ -54,6 +62,7 @@ namespace osu.Framework.Graphics
         {
             Source = BlendingType.One,
             Destination = BlendingType.Zero,
+            DestinationAdditive = false,
             SourceAlpha = BlendingType.One,
             DestinationAlpha = BlendingType.Zero,
             RGBEquation = BlendingEquation.Add,
@@ -64,6 +73,7 @@ namespace osu.Framework.Graphics
         {
             Source = BlendingType.Inherit,
             Destination = BlendingType.Inherit,
+            DestinationAdditive = false,
             SourceAlpha = BlendingType.Inherit,
             DestinationAlpha = BlendingType.Inherit,
             RGBEquation = BlendingEquation.Inherit,
@@ -72,8 +82,9 @@ namespace osu.Framework.Graphics
 
         public static BlendingParameters Mixture => new BlendingParameters
         {
-            Source = BlendingType.SrcAlpha,
+            Source = BlendingType.One,
             Destination = BlendingType.OneMinusSrcAlpha,
+            DestinationAdditive = false,
             SourceAlpha = BlendingType.One,
             DestinationAlpha = BlendingType.One,
             RGBEquation = BlendingEquation.Add,
@@ -82,8 +93,9 @@ namespace osu.Framework.Graphics
 
         public static BlendingParameters Additive => new BlendingParameters
         {
-            Source = BlendingType.SrcAlpha,
-            Destination = BlendingType.One,
+            Source = BlendingType.One,
+            Destination = BlendingType.OneMinusSrcAlpha,
+            DestinationAdditive = true,
             SourceAlpha = BlendingType.One,
             DestinationAlpha = BlendingType.One,
             RGBEquation = BlendingEquation.Add,
@@ -102,7 +114,10 @@ namespace osu.Framework.Graphics
                 Source = parent.Source;
 
             if (Destination == BlendingType.Inherit)
+            {
                 Destination = parent.Destination;
+                DestinationAdditive = parent.DestinationAdditive;
+            }
 
             if (SourceAlpha == BlendingType.Inherit)
                 SourceAlpha = parent.SourceAlpha;
@@ -115,6 +130,9 @@ namespace osu.Framework.Graphics
 
             if (AlphaEquation == BlendingEquation.Inherit)
                 AlphaEquation = parent.AlphaEquation;
+
+            if (AlphaEquation == BlendingEquation.Inherit)
+                AlphaEquation = parent.AlphaEquation;
         }
 
         /// <summary>
@@ -123,10 +141,13 @@ namespace osu.Framework.Graphics
         public void ApplyDefaultToInherited()
         {
             if (Source == BlendingType.Inherit)
-                Source = BlendingType.SrcAlpha;
+                Source = BlendingType.One;
 
             if (Destination == BlendingType.Inherit)
+            {
                 Destination = BlendingType.OneMinusSrcAlpha;
+                DestinationAdditive = false;
+            }
 
             if (SourceAlpha == BlendingType.Inherit)
                 SourceAlpha = BlendingType.One;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -37,6 +37,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public float BackbufferDrawDepth => 0;
         public bool UsingBackbuffer => false;
         public Texture WhitePixel { get; }
+        public BlendingParameters CurrentBlendingParameters => BlendingParameters.None;
 
         public DummyRenderer()
         {

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -124,6 +124,11 @@ namespace osu.Framework.Graphics.Rendering
         Texture WhitePixel { get; }
 
         /// <summary>
+        /// The current blending parameters.
+        /// </summary>
+        BlendingParameters CurrentBlendingParameters { get; }
+
+        /// <summary>
         /// Performs a once-off initialisation of this <see cref="IRenderer"/>.
         /// </summary>
         internal void Initialise();

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -313,15 +313,18 @@ namespace osu.Framework.Graphics.Rendering
 
         #region Blending
 
+
         public void SetBlend(BlendingParameters blendingParameters)
         {
-            if (CurrentBlendingParameters == blendingParameters)
+            // The assignment is necessary, because the equality operator does not check for additive blending
+            BlendingParameters oldBlendingParameters = CurrentBlendingParameters;
+            CurrentBlendingParameters = blendingParameters;
+
+            if (CurrentBlendingParameters == oldBlendingParameters)
                 return;
 
             FlushCurrentBatch(FlushBatchSource.SetBlend);
             SetBlendImplementation(blendingParameters);
-
-            CurrentBlendingParameters = blendingParameters;
         }
 
         public void SetBlendMask(BlendingMask blendingMask)

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics.Rendering
         public Texture WhitePixel => whitePixel.Value;
 
         protected ClearInfo CurrentClearInfo { get; private set; }
-        protected BlendingParameters CurrentBlendingParameters { get; private set; }
+        public BlendingParameters CurrentBlendingParameters { get; private set; }
         protected BlendingMask CurrentBlendingMask { get; private set; }
 
         /// <summary>

--- a/osu.Framework/Graphics/Rendering/RendererExtensions.cs
+++ b/osu.Framework/Graphics/Rendering/RendererExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Primitives;
@@ -65,13 +66,15 @@ namespace osu.Framework.Graphics.Rendering
             SRGBColour topColour = (drawColour.TopLeft + drawColour.TopRight) / 2;
             SRGBColour bottomColour = (drawColour.BottomLeft + drawColour.BottomRight) / 2;
 
+            bool additive = renderer.CurrentBlendingParameters.DestinationAdditive;
+
             vertexAction(new TexturedVertex2D
             {
                 Position = vertexTriangle.P0,
                 TexturePosition = new Vector2((inflatedCoordRect.Left + inflatedCoordRect.Right) / 2, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = topColour.Linear,
+                Colour = topColour.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -79,7 +82,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = drawColour.BottomLeft.Linear,
+                Colour = drawColour.BottomLeft.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -87,7 +90,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2((inflatedCoordRect.Left + inflatedCoordRect.Right) / 2, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = bottomColour.Linear,
+                Colour = bottomColour.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -95,7 +98,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = drawColour.BottomRight.Linear,
+                Colour = drawColour.BottomRight.Linear.NegateAlphaIfTrue(additive),
             });
 
             long area = (long)vertexTriangle.Area;
@@ -150,13 +153,15 @@ namespace osu.Framework.Graphics.Rendering
 
             vertexAction ??= renderer.DefaultQuadBatch.AddAction;
 
+            bool additive = renderer.CurrentBlendingParameters.DestinationAdditive;
+
             vertexAction(new TexturedVertex2D
             {
                 Position = vertexQuad.BottomLeft,
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.BottomLeft.Linear,
+                Colour = drawColour.BottomLeft.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -164,7 +169,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.BottomRight.Linear,
+                Colour = drawColour.BottomRight.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -172,7 +177,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.TopRight.Linear,
+                Colour = drawColour.TopRight.Linear.NegateAlphaIfTrue(additive),
             });
             vertexAction(new TexturedVertex2D
             {
@@ -180,7 +185,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.TopLeft.Linear,
+                Colour = drawColour.TopLeft.Linear.NegateAlphaIfTrue(additive),
             });
 
             long area = (long)vertexQuad.Area;

--- a/osu.Framework/Graphics/Shaders/GlobalProperty.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalProperty.cs
@@ -25,5 +25,6 @@ namespace osu.Framework.Graphics.Shaders
         WrapModeS,
         WrapModeT,
         BackbufferDraw,
+        TextureHasPremultipliedAlpha,
     }
 }

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -37,6 +37,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.GammaCorrection] = new UniformMapping<bool>("g_GammaCorrection");
             global_properties[(int)GlobalProperty.WrapModeS] = new UniformMapping<int>("g_WrapModeS");
             global_properties[(int)GlobalProperty.WrapModeT] = new UniformMapping<int>("g_WrapModeT");
+            global_properties[(int)GlobalProperty.TextureHasPremultipliedAlpha] = new UniformMapping<bool>("g_TextureHasPremultipliedAlpha");
 
             // Backbuffer internals
             global_properties[(int)GlobalProperty.BackbufferDraw] = new UniformMapping<bool>("g_BackbufferDraw");

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -78,7 +78,7 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 {
 	if (!g_IsMasking && v_BlendRange == vec2(0.0))
 	{
-		return toSRGB(v_Colour * texel);
+		return premultiplyAlpha(toSRGB(v_Colour * texel));
 	}
 
 	highp float dist = distanceFromRoundedRect(vec2(0.0), g_CornerRadius);
@@ -130,11 +130,11 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 
 	if (colourWeight <= 0.0)
 	{
-		return toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor));
+		return premultiplyAlpha(toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor)));
 	}
 
 	lowp vec4 dest = vec4(v_Colour.rgb, v_Colour.a * alphaFactor) * texel;
 	lowp vec4 src = vec4(borderColour.rgb, borderColour.a * (1.0 - colourWeight));
 
-	return blend(toSRGB(src), toSRGB(dest));
+	return premultiplyAlpha(blend(toSRGB(src), toSRGB(dest)));
 }

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -25,6 +25,8 @@ uniform highp vec2 g_EdgeOffset;
 uniform bool g_DiscardInner;
 uniform highp float g_InnerCornerRadius;
 
+uniform bool g_TextureHasPremultipliedAlpha;
+
 highp float distanceFromRoundedRect(highp vec2 offset, highp float radius)
 {
 	highp vec2 maskingPosition = v_MaskingPosition + offset;
@@ -76,10 +78,15 @@ lowp vec4 getBorderColour()
 
 lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 {
+	// The rest of the shader assumes that textures have non-premultiplied alpha
+	if (g_TextureHasPremultipliedAlpha && texel.a > 0.0)
+		texel.rgb /= texel.a;
+
+	bool isEmissive = v_Colour.a < 0.0;
+	vec4 colour = abs(v_Colour);
+
 	if (!g_IsMasking && v_BlendRange == vec2(0.0))
-	{
-		return premultiplyAlpha(toSRGB(v_Colour * texel));
-	}
+		return toEmissive(toPremultipliedAlpha(toSRGB(colour * texel)), isEmissive);
 
 	highp float dist = distanceFromRoundedRect(vec2(0.0), g_CornerRadius);
 	lowp float alphaFactor = 1.0;
@@ -111,14 +118,10 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	alphaFactor *= min(fadeStart - dist, 1.0);
 
 	if (v_BlendRange.x > 0.0 || v_BlendRange.y > 0.0)
-	{
 		alphaFactor *= clamp(1.0 - distanceFromDrawingRect(texCoord), 0.0, 1.0);
-	}
 
 	if (alphaFactor <= 0.0)
-	{
 		return vec4(0.0);
-	}
 
 	// This ends up softening glow without negatively affecting edge smoothness much.
 	alphaFactor = pow(alphaFactor, g_AlphaExponent);
@@ -129,12 +132,10 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	lowp vec4 borderColour = getBorderColour();
 
 	if (colourWeight <= 0.0)
-	{
-		return premultiplyAlpha(toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor)));
-	}
+		return toEmissive(toPremultipliedAlpha(toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor))), isEmissive);
 
-	lowp vec4 dest = vec4(v_Colour.rgb, v_Colour.a * alphaFactor) * texel;
+	lowp vec4 dest = vec4(colour.rgb, colour.a * alphaFactor) * texel;
 	lowp vec4 src = vec4(borderColour.rgb, borderColour.a * (1.0 - colourWeight));
 
-	return premultiplyAlpha(blend(toSRGB(src), toSRGB(dest)));
+	return toEmissive(blend(toPremultipliedAlpha(toSRGB(src)), toPremultipliedAlpha(toSRGB(dest))), isEmissive);
 }

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -47,6 +47,16 @@ lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
     );
 }
 
+lowp vec4 premultiplyAlpha(lowp vec4 colour)
+{
+    if (colour.a >= 0.0)
+        return vec4(colour.rgb * colour.a, colour.a);
+    else
+        // Negative alpha denotes that we would like additive blending, hence the alpha value
+        // (which dictates the attenuation of the destination color) must become zero.
+        return vec4(colour.rgb * -colour.a, 0.0);
+}
+
 // http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 // slightly amended to also handle alpha
 vec4 hsv2rgb(vec4 c)


### PR DESCRIPTION
Moves the distinction between "Additive" and "Mixture" blend modes into the shader. This is controlled by the sign bit of each vertex's alpha channel, which feels slightly hacky, but is the least-intrusive solution I could think of. (And it's basically free, perf-wise.)

A necessary component of this change is the use of premultiplied alpha in the shader outputs, which means that buffered containers need special treatment: their framebuffers become textures with premultiplied alpha, which needs to be unmultiplied further down the line (for backwards compatibility). In this PR, this is handled by an additional shader uniform that denotes whether the input texture has premultiplied alpha or not.

Another thing of note: in the interest of API compatibility, additive blending on the `Drawable` side is controlled by an extra boolean within `BlendingParameters`, which feels hacky. I'd prefer removing the distinction between additive and mixture blend modes as far as the graphics API is concerned... but that'd require changing every single place where additive blending is currently set.

Lastly: some `osu-resources`-side shaders also need to have their output multiplied by alpha. I can make another PR for those -- it's a minor change. Until then, isolated places like osu!'s intro shader look broken.