### PR TITLE
Remove unnecessary caching in dependencies tests

### DIFF
--- a/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
@@ -286,7 +286,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
             Assert.AreEqual(provider, dependencies.Get<Provider1>());
-            Assert.AreEqual(provider, dependencies.Get<Provider26>());
+            Assert.IsNull(dependencies.Get<Provider26>());
         }
 
         [Test]
@@ -472,7 +472,6 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         {
         }
 
-        [Cached]
         private partial class Provider26 : Provider1
         {
         }

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/CachedModelDependenciesTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/CachedModelDependenciesTest.cs
@@ -267,7 +267,6 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             Assert.AreEqual(null, resolver.BindableString.Value);
         }
 
-        [Cached]
         private partial class NonBindablePublicFieldModel : IDependencyInjectionCandidate
         {
 #pragma warning disable 649
@@ -275,7 +274,6 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 #pragma warning restore 649
         }
 
-        [Cached]
         private partial class NonBindablePrivateFieldModel : IDependencyInjectionCandidate
         {
 #pragma warning disable 169
@@ -283,7 +281,6 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 #pragma warning restore 169
         }
 
-        [Cached]
         private partial class NonReadOnlyFieldModel : IDependencyInjectionCandidate
         {
 #pragma warning disable 649
@@ -291,7 +288,6 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 #pragma warning restore 649
         }
 
-        [Cached]
         private partial class PropertyModel : IDependencyInjectionCandidate
         {
             // ReSharper disable once UnusedMember.Local


### PR DESCRIPTION
These were added and documented in https://github.com/ppy/osu-framework/pull/5543, but have been solved now that the `IDependencyInjectionCandidate` interface exists.