### PR TITLE
Rework source generator to promote memoisation

### DIFF
--- a/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
+++ b/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.SourceGeneration.Emitters
             Candidate = candidate;
         }
 
-        public string Emit()
+        public void Emit(AddSourceDelegate addSource)
         {
             StringBuilder result = new StringBuilder();
             result.Append(headers);
@@ -60,7 +60,11 @@ namespace osu.Framework.SourceGeneration.Emitters
                                  .NormalizeWhitespace());
             }
 
-            return result.ToString();
+            // Fully qualified name, with generics replaced with friendly characters.
+            string typeName = Candidate.FullyQualifiedTypeName.Replace('<', '{').Replace('>', '}');
+            string filename = $"g_{typeName}_Dependencies.cs";
+
+            addSource(filename, result.ToString());
         }
 
         private MemberDeclarationSyntax emitDependenciesClass()
@@ -265,4 +269,6 @@ namespace osu.Framework.SourceGeneration.Emitters
                 SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(LOCAL_DEPENDENCIES_VAR_NAME));
         }
     }
+
+    public delegate void AddSourceDelegate(string filename, string sourceText);
 }

--- a/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
+++ b/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.SourceGeneration.Emitters
 
         public void Emit(AddSourceDelegate addSource)
         {
+            if (!Candidate.IsValid)
+                return;
+
             StringBuilder result = new StringBuilder();
             result.Append(headers);
 

--- a/osu.Framework.SourceGeneration/Roslyn3.11/DependencyInjectionSourceGenerator.cs
+++ b/osu.Framework.SourceGeneration/Roslyn3.11/DependencyInjectionSourceGenerator.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using osu.Framework.SourceGeneration.Emitters;
 
 namespace osu.Framework.SourceGeneration
@@ -31,13 +32,10 @@ namespace osu.Framework.SourceGeneration
 
             public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
             {
-                if (!GeneratorClassCandidate.IsCandidate(context.Node))
+                if (!GeneratorClassCandidate.IsSyntaxTarget(context.Node))
                     return;
 
-                GeneratorClassCandidate? candidate = GeneratorClassCandidate.TryCreate(context.Node, context.SemanticModel);
-
-                if (candidate != null)
-                    Candidates.Add(candidate);
+                Candidates.Add(new GeneratorClassCandidate((ClassDeclarationSyntax)context.Node, context.SemanticModel).GetSemanticTarget());
             }
         }
     }

--- a/osu.Framework.SourceGeneration/Roslyn4.0/DependencyInjectionSourceGenerator.cs
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/DependencyInjectionSourceGenerator.cs
@@ -2,8 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using osu.Framework.SourceGeneration.Emitters;
 
 namespace osu.Framework.SourceGeneration
@@ -13,21 +13,20 @@ namespace osu.Framework.SourceGeneration
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
-            IncrementalValuesProvider<GeneratorClassCandidate> candidateClasses =
-                context.SyntaxProvider.CreateSyntaxProvider(selectClasses, extractCandidates)
-                       .Where(c => c != null);
+            IncrementalValuesProvider<GeneratorClassCandidate> syntaxTargets =
+                context.SyntaxProvider.CreateSyntaxProvider(
+                    (n, _) => GeneratorClassCandidate.IsSyntaxTarget(n),
+                    (ctx, _) => new GeneratorClassCandidate((ClassDeclarationSyntax)ctx.Node, ctx.SemanticModel));
+
+            IncrementalValuesProvider<GeneratorClassCandidate> semanticTargets =
+                syntaxTargets
+                    .Select((c, _) => c.GetSemanticTarget());
 
             IncrementalValuesProvider<GeneratorClassCandidate> distinctCandidates =
-                candidateClasses.Collect().SelectMany((c, _) => c.Distinct());
+                semanticTargets.Collect().SelectMany((c, _) => c.Distinct());
 
             context.RegisterImplementationSourceOutput(distinctCandidates, emit);
         }
-
-        private bool selectClasses(SyntaxNode syntaxNode, CancellationToken cancellationToken)
-            => GeneratorClassCandidate.IsCandidate(syntaxNode);
-
-        private GeneratorClassCandidate extractCandidates(GeneratorSyntaxContext context, CancellationToken cancellationToken)
-            => GeneratorClassCandidate.TryCreate(context.Node, context.SemanticModel)!;
 
         private void emit(SourceProductionContext context, GeneratorClassCandidate candidate)
             => new DependenciesFileEmitter(candidate).Emit(context.AddSource);


### PR DESCRIPTION
I have only 60% confidence that this works and won't break in some spectacular way. Caching is one of the hardest things in programming, and combined with Roslyn-level bugs means this is very temperamental.

The general idea here is to use the `ClassDeclarationSyntax` as the equality comparer for `GeneratorClassCandidate`, because this is an immutable object that persists through compilations. Thus, `GeneratorClassCandidate` has to be split into two passes, the first of which is initialising the object (for caching purposes), and the second is populating the semantic members.  
I'm doing something extremely dodgy here in storing the `SemanticModel` at the first stage and clearing it in the second stage, but I'm doing this to avoid a `Compilation`. It seems to work but add it to the list of things that could break and contributes to my 60% confidence level.

My test where I noticed temperamental behaviour is to add a new `public partial class Game : IDependencyInjectionCandidate { }` at the top of `CustomInputManager.cs`. For some reason, adding an `IsValid` check to the pipeline breaks the whole thing with duplicate file errors. I don't know why this is, so I've left the `IsValid` check up to the emit stage.

Before:
![image](https://user-images.githubusercontent.com/1329837/205057215-92546bff-7ccf-42e6-98cf-f80a43e3ec95.png)

After:
![image](https://user-images.githubusercontent.com/1329837/205057235-6b42cd63-65b9-43fd-a55c-223fad43a822.png)

- Tested in osu-framework because my profiling session doesn't capture it in osu.
- Testing process is to add ~70 newlines in `Game.cs`, waiting for the rider inspection to underline the current line before inserting a new one each time.