### PR TITLE
Rework source generator to promote memoisation

### DIFF
--- a/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
+++ b/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.SourceGeneration.Emitters
             Candidate = candidate;
         }
 
-        public string Emit()
+        public void Emit(AddSourceDelegate addSource)
         {
             StringBuilder result = new StringBuilder();
             result.Append(headers);
@@ -60,7 +60,11 @@ namespace osu.Framework.SourceGeneration.Emitters
                                  .NormalizeWhitespace());
             }
 
-            return result.ToString();
+            // Fully qualified name, with generics replaced with friendly characters.
+            string typeName = Candidate.FullyQualifiedTypeName.Replace('<', '{').Replace('>', '}');
+            string filename = $"g_{typeName}_Dependencies.cs";
+
+            addSource(filename, result.ToString());
         }
 
         private MemberDeclarationSyntax emitDependenciesClass()
@@ -265,4 +269,6 @@ namespace osu.Framework.SourceGeneration.Emitters
                 SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(LOCAL_DEPENDENCIES_VAR_NAME));
         }
     }
+
+    public delegate void AddSourceDelegate(string filename, string sourceText);
 }

--- a/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
+++ b/osu.Framework.SourceGeneration/Common/Emitters/DependenciesFileEmitter.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.SourceGeneration.Emitters
 
         public void Emit(AddSourceDelegate addSource)
         {
+            if (!Candidate.IsValid)
+                return;
+
             StringBuilder result = new StringBuilder();
             result.Append(headers);
 

--- a/osu.Framework.SourceGeneration/Common/SyntaxHelpers.cs
+++ b/osu.Framework.SourceGeneration/Common/SyntaxHelpers.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -112,6 +114,33 @@ namespace osu.Framework.SourceGeneration
 
         public static string GetFullyQualifiedTypeName(INamedTypeSymbol type)
             => type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+
+        public static string GetFullyQualifiedSyntaxName(TypeDeclarationSyntax syntax)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            foreach (var node in syntax.AncestorsAndSelf())
+            {
+                switch (node)
+                {
+                    case NamespaceDeclarationSyntax ns:
+                        sb.Append(ns.Name);
+                        break;
+
+                    case ClassDeclarationSyntax cls:
+                        sb.Append(cls.Identifier.ToString());
+
+                        if (cls.TypeParameterList != null)
+                            sb.Append($"{{{string.Join(",", cls.TypeParameterList.Parameters.Select(p => p.Identifier.ToString()))}}}");
+                        break;
+
+                    default:
+                        continue;
+                }
+            }
+
+            return sb.ToString();
+        }
 
         public static IEnumerable<ITypeSymbol> GetDeclaredInterfacesOnType(INamedTypeSymbol type)
         {

--- a/osu.Framework.SourceGeneration/Roslyn3.11/GeneratorClassCandidateComparer.cs
+++ b/osu.Framework.SourceGeneration/Roslyn3.11/GeneratorClassCandidateComparer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Framework.SourceGeneration
+{
+    public class GeneratorClassCandidateComparer : IEqualityComparer<GeneratorClassCandidate>
+    {
+        public static readonly GeneratorClassCandidateComparer DEFAULT = new GeneratorClassCandidateComparer();
+
+        public bool Equals(GeneratorClassCandidate x, GeneratorClassCandidate y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+
+            return string.Equals(x.FullyQualifiedTypeName, y.FullyQualifiedTypeName);
+        }
+
+        public int GetHashCode(GeneratorClassCandidate obj)
+        {
+            return obj.FullyQualifiedTypeName.GetHashCode();
+        }
+    }
+}

--- a/osu.Framework.SourceGeneration/Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj
+++ b/osu.Framework.SourceGeneration/Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj
@@ -8,5 +8,6 @@
 
   <ItemGroup>
     <Compile Include="DependencyInjectionSourceGenerator.cs" />
+    <Compile Include="GeneratorClassCandidateComparer.cs" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.SourceGeneration/Roslyn4.0/DependencyInjectionSourceGenerator.cs
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/DependencyInjectionSourceGenerator.cs
@@ -20,7 +20,8 @@ namespace osu.Framework.SourceGeneration
                 context.SyntaxProvider.CreateSyntaxProvider(
                            (n, _) => GeneratorClassCandidate.IsSyntaxTarget(n),
                            (ctx, _) => new SyntaxTarget((ClassDeclarationSyntax)ctx.Node, ctx.SemanticModel))
-                       .Select((t, _) => t.WithName());
+                       .Select((t, _) => t.WithName())
+                       .Select((t, _) => t.WithSemanticTarget());
 
             // Stage 2: Separate out the old and new syntax targets for the same class object.
             // At this point, there are a bunch of old and new syntax targets that may refer to the same class object.
@@ -56,13 +57,7 @@ namespace osu.Framework.SourceGeneration
                         return result;
                     });
 
-            // Stage 3: Generate the semantic targets for the filtered syntax targets.
-            // For any old syntax targets, this is a no-op. For any new targets, this is a fairly complex operation involving semantic lookup.
-            IncrementalValuesProvider<GeneratorClassCandidate> semanticTargets =
-                distinctSyntaxTargets
-                    .Select((t, _) => t.ResolveSemanticTarget());
-
-            context.RegisterImplementationSourceOutput(semanticTargets, emit);
+            context.RegisterImplementationSourceOutput(distinctSyntaxTargets.Select((t, _) => t.SemanticTarget!), emit);
         }
 
         private void emit(SourceProductionContext context, GeneratorClassCandidate candidate)

--- a/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTarget.cs
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTarget.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace osu.Framework.SourceGeneration
+{
+    public class SyntaxTarget : IEquatable<SyntaxTarget>
+    {
+        public readonly ClassDeclarationSyntax Syntax;
+        public string? SyntaxName { get; set; }
+        public long? GenerationId;
+
+        private SemanticModel? semanticModel;
+        private GeneratorClassCandidate? semanticTarget;
+
+        public SyntaxTarget(ClassDeclarationSyntax syntax, SemanticModel semanticModel)
+        {
+            Syntax = syntax;
+            this.semanticModel = semanticModel;
+        }
+
+        public SyntaxTarget WithName()
+        {
+            SyntaxName ??= SyntaxHelpers.GetFullyQualifiedSyntaxName(Syntax);
+            return this;
+        }
+
+        public GeneratorClassCandidate ResolveSemanticTarget()
+        {
+            semanticTarget ??= new GeneratorClassCandidate(Syntax, semanticModel!);
+            semanticModel = null;
+
+            return semanticTarget;
+        }
+
+        public bool Equals(SyntaxTarget? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Syntax == other.Syntax;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            return Equals((SyntaxTarget)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return Syntax.GetHashCode();
+        }
+    }
+}

--- a/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTarget.cs
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTarget.cs
@@ -12,9 +12,9 @@ namespace osu.Framework.SourceGeneration
         public readonly ClassDeclarationSyntax Syntax;
         public string? SyntaxName { get; set; }
         public long? GenerationId;
+        public GeneratorClassCandidate? SemanticTarget { get; private set; }
 
         private SemanticModel? semanticModel;
-        private GeneratorClassCandidate? semanticTarget;
 
         public SyntaxTarget(ClassDeclarationSyntax syntax, SemanticModel semanticModel)
         {
@@ -28,12 +28,11 @@ namespace osu.Framework.SourceGeneration
             return this;
         }
 
-        public GeneratorClassCandidate ResolveSemanticTarget()
+        public SyntaxTarget WithSemanticTarget()
         {
-            semanticTarget ??= new GeneratorClassCandidate(Syntax, semanticModel!);
+            SemanticTarget ??= new GeneratorClassCandidate(Syntax, semanticModel!);
             semanticModel = null;
-
-            return semanticTarget;
+            return this;
         }
 
         public bool Equals(SyntaxTarget? other)

--- a/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTargetNameComparer.cs
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/SyntaxTargetNameComparer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Framework.SourceGeneration
+{
+    public class SyntaxTargetNameComparer : IEqualityComparer<SyntaxTarget>
+    {
+        public static readonly SyntaxTargetNameComparer DEFAULT = new SyntaxTargetNameComparer();
+
+        public bool Equals(SyntaxTarget x, SyntaxTarget y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+
+            return x.SyntaxName == y.SyntaxName;
+        }
+
+        public int GetHashCode(SyntaxTarget obj)
+        {
+            return obj.SyntaxName!.GetHashCode();
+        }
+    }
+}

--- a/osu.Framework.SourceGeneration/Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj
+++ b/osu.Framework.SourceGeneration/Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj
@@ -8,5 +8,7 @@
 
   <ItemGroup>
     <Compile Include="DependencyInjectionSourceGenerator.cs" />
+    <Compile Include="SyntaxTarget.cs" />
+    <Compile Include="SyntaxTargetNameComparer.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu-framework/pull/5559

The layers are explained in the inline comments of [Roslyn4.0/DependencyInjectionSourceGenerator.cs](https://github.com/ppy/osu-framework/compare/master...smoogipoo:generator-perf-improvements-2?expand=1#diff-19b184a8412fdfa700026f76634239a74d7d87479e7be62b5665d80d9385d3eb), however for a quick explanation:
- In the first layer, `ClassDeclarationSyntax`es arrive and are transformed into `SyntaxTarget`s.
- `SyntaxTarget` initially contributes to caching via the `ClassDeclarationSyntax`. That is, when the same class arrives again, the _previous_ `SyntaxTarget` is used (even though a new one is created, it's discarded right away).
- The above allows us to store some information in the `SyntaxTarget`, with a few caveats:
    - We can temporarily store the `SemanticModel`, but need to be wary of storing it for too long in terms of increasing memory footprint. I'm consuming the `SemanticModel` ASAP in the first layer to avoid this.
    - We can store the `GeneratorClassCandidate` since it stores syntax information, but need to be wary of these objects becoming stale.
    - We will have multiple `SyntaxTarget`s referring to the same semantic class. This is because class syntaxes can exist in multiple locations (`partial class`).
- The second layer is the most important one, and handles the other two caveats. It stores an ever-increasing generation ID for every invocation of the generator thus preventing use of stale syntaxes, and dedupes on the fully-qualified class name to resolve multi-partial classes.
  - The name is manually constructed from the syntax model, however I'm not sure whether this is necessary anymore in favour of the semantic model. I think it's probably okay to leave as is.

Improves performance:
| master | this pr |
| --- | --- |
| ![](https://user-images.githubusercontent.com/1329837/205057215-92546bff-7ccf-42e6-98cf-f80a43e3ec95.png) | ![image](https://user-images.githubusercontent.com/1329837/205375877-7dc9c72d-f277-48e7-9eef-f4939dc478ca.png) |
- Tested in osu-framework because my profiling session doesn't capture it in osu.
- Testing process is to add ~70 newlines in `Game.cs`, waiting for the rider inspection to underline the current line before inserting a new one each time.

Improves correctness:
<table>
<tr>
<th>master</th>
<th>this pr</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/1329837/205376258-3d60b95c-068b-4372-9139-03074a3b24aa.mp4

</td>
<td>

https://user-images.githubusercontent.com/1329837/205376382-58c231ba-d813-4d04-945c-d361b001b0f1.mp4

</td>
</tr>
</table>

- Note how the generator on master misses a lot of cases.

NOTE: This does not yet handle additions of `[Cached]` to interfaces.

cc @X9VoiD if you want to check that this is better than the previous PR :)