### PR TITLE
Bump `dorny/test-reporter` action to 1.6.0

### DIFF
--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Annotate CI run with test results
-        uses: dorny/test-reporter@v1.4.2
+        uses: dorny/test-reporter@v1.6.0
         with:
           artifact: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           name: Test Results (${{matrix.os.prettyname}}, ${{matrix.threadingMode}})


### PR DESCRIPTION
The only reason I'm bothering to do this is that I mistakenly clicked on one of the execution logs of the "Annotate CI with test results" workflow and [noticed a bunch of deprecation warnings](https://github.com/ppy/osu-framework/actions/runs/3609327841).

Judging from the release notes [[1]] and diffstat [[2]] of version 1.6.0 of the action affected, a bump should silence these.

Tested to have the expected result [on my fork's master][3].

[1]: https://github.com/dorny/test-reporter/blob/main/CHANGELOG.md
[2]: https://github.com/dorny/test-reporter/compare/v1.4.2...v1.6.0
[3]: https://github.com/bdach/osu-framework/actions/runs/3610527220