### PR TITLE
Disable source generation on iOS

### DIFF
--- a/osu.Framework.SourceGeneration/targets/ppy.osu.Framework.SourceGeneration.targets
+++ b/osu.Framework.SourceGeneration/targets/ppy.osu.Framework.SourceGeneration.targets
@@ -19,9 +19,12 @@
   </Target>
 
   <Target Name="_ppy_osu_Framework_SourceGenerationRemoveAnalyzers"
-          Condition="'$(DisableOsuFrameworkSourceGenerator)' == 'true'"
+          Condition="'$(DisableOsuFrameworkSourceGenerator)' == 'true' Or '$(Platform)' == 'iPhone' Or '$(Platform)' == 'iPhoneSimulator'"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
           DependsOnTargets="_ppy_osu_Framework_SourceGenerationGatherAnalyzers">
+
+    <!-- As per the conditions above, source generation breaks horribly on Xamarin.iOS projects (specifically due to importing "Xamarin.iOS.CSharp.targets" in *any* project).
+         todo: enable back once iOS targets .NET 6 -->
 
     <!-- Remove all our analyzers -->
     <ItemGroup>


### PR DESCRIPTION
Turns out source generation breaks badly on a solution that includes at least one Xamarin.iOS project, and blocks me completely from building iOS on framework or osu!-side with local checkout:

![CleanShot_2022-12-05_at_18 45 57](https://user-images.githubusercontent.com/22781491/205744137-8a81a381-b1e1-4e72-8ceb-ad666bfd2418.png)

Here's a video showcasing what's going on in complete isolation:

https://user-images.githubusercontent.com/22781491/205741906-ae0217c7-1bec-4b23-b491-a0602858631d.mp4

Once `Xamarin.iOS.CSharp.targets` is imported to the iOS project, the SG analyzer is immediately intercepted from the project that references it and is brought to the iOS project that doesn't even reference it. I have not the slightest clue on how this is even possible, but that appears to be the case here.

Until we migrate iOS projects to .NET 6, disabling source generation is the only way forward as far as I can see.