### PR TITLE
Temporarily disable NRT annotations detection of nullable dependencies

### DIFF
--- a/osu.Framework.SourceGeneration/Common/Data/BackgroundDependencyLoaderParameterData.cs
+++ b/osu.Framework.SourceGeneration/Common/Data/BackgroundDependencyLoaderParameterData.cs
@@ -19,9 +19,13 @@ namespace osu.Framework.SourceGeneration.Data
         public static BackgroundDependencyLoaderParameterData FromParameter(IParameterSymbol parameter)
         {
             string globalPrefixedTypeName = SyntaxHelpers.GetGlobalPrefixedTypeName(parameter.Type)!;
-            bool canBeNull = parameter.NullableAnnotation == NullableAnnotation.Annotated;
 
-            return new BackgroundDependencyLoaderParameterData(globalPrefixedTypeName, canBeNull);
+            // This allows determining whether null is permitted based on the NRT annotation of the parameter.
+            // However, this doesn't work on mobile projects due to using Xamarin, therefore it cannot be relied on and is temporarily disabled.
+            // todo: enable this once all mobile projects target .NET 6
+            // bool canBeNull = parameter.NullableAnnotation == NullableAnnotation.Annotated;
+
+            return new BackgroundDependencyLoaderParameterData(globalPrefixedTypeName, false);
         }
     }
 }

--- a/osu.Framework.SourceGeneration/Common/Data/ResolvedAttributeData.cs
+++ b/osu.Framework.SourceGeneration/Common/Data/ResolvedAttributeData.cs
@@ -47,7 +47,10 @@ namespace osu.Framework.SourceGeneration.Data
                  ?? attributeData.ConstructorArguments.ElementAtOrDefault(2).Value
                  ?? false);
 
-            canBeNull |= symbol.NullableAnnotation == NullableAnnotation.Annotated;
+            // This allows determining whether null is permitted based on the NRT annotation of the property.
+            // However, this doesn't work on mobile projects due to using Xamarin, therefore it cannot be relied on and is temporarily disabled.
+            // todo: enable this once all mobile projects target .NET 6
+            // canBeNull |= symbol.NullableAnnotation == NullableAnnotation.Annotated;
 
             return new ResolvedAttributeData(SyntaxHelpers.GetGlobalPrefixedTypeName(symbol.Type)!, symbol.Name, globalPrefixedParentTypeName, name, canBeNull);
         }

--- a/osu.Framework.Tests/Dependencies/Reflection/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/DependencyContainerTest.cs
@@ -223,6 +223,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
         [TestCase(null)]
         [TestCase(10)]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableInternal(int? testValue)
         {
             var receiver = new Receiver11();
@@ -323,6 +324,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         }
 
         [Test]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveWithNullableReferenceTypes()
         {
             var dependencies = new DependencyContainer();

--- a/osu.Framework.Tests/Dependencies/Reflection/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/ResolvedAttributeTest.cs
@@ -143,6 +143,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
         [TestCase(null)]
         [TestCase(10)]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableInternal(int? testValue)
         {
             var receiver = new Receiver13();
@@ -194,6 +195,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         }
 
         [Test]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableWithNullableReferenceTypes()
         {
             var receiver = new Receiver17();

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/DependencyContainerTest.cs
@@ -226,6 +226,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
         [TestCase(null)]
         [TestCase(10)]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableInternal(int? testValue)
         {
             var receiver = new Receiver11();
@@ -326,6 +327,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         }
 
         [Test]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveWithNullableReferenceTypes()
         {
             var dependencies = new DependencyContainer();

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/ResolvedAttributeTest.cs
@@ -140,6 +140,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
         [TestCase(null)]
         [TestCase(10)]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableInternal(int? testValue)
         {
             var receiver = new Receiver13();
@@ -191,6 +192,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         }
 
         [Test]
+        [Ignore("Temporarily disabled due to Xamarin projects not recognising NRT annotations.")]
         public void TestResolveNullableWithNullableReferenceTypes()
         {
             var receiver = new Receiver17();

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -65,8 +65,14 @@ namespace osu.Framework.Allocation
                     Debug.Assert(attribute != null);
 
                     bool permitNulls = attribute.permitNulls;
+
+                    // This allows determining whether null is permitted based on the NRT annotation of the parameter.
+                    // However, this doesn't work on mobile projects due to using Xamarin, therefore it cannot be relied on and is temporarily disabled.
+                    // todo: enable this once all mobile projects target .NET 6
+                    // permitNulls |= parameter.IsNullable();
+
                     var parameterGetters = method.GetParameters()
-                                                 .Select(parameter => getDependency(parameter.ParameterType, type, permitNulls || parameter.IsNullable())).ToArray();
+                                                 .Select(parameter => getDependency(parameter.ParameterType, type, permitNulls)).ToArray();
 
                     return (target, dc) =>
                     {

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -102,7 +102,14 @@ namespace osu.Framework.Allocation
                     cacheInfo = new CacheInfo(cacheInfo.Name ?? property.Name, attribute.Parent);
                 }
 
-                var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull || property.IsNullable(), cacheInfo);
+                bool permitNulls = attribute.CanBeNull;
+
+                // This allows determining whether null is permitted based on the NRT annotation of the property.
+                // However, this doesn't work on mobile projects due to using Xamarin, therefore it cannot be relied on and is temporarily disabled.
+                // todo: enable this once all mobile projects target .NET 6
+                // permitNulls |= property.IsNullable();
+
+                var fieldGetter = getDependency(property.PropertyType, type, permitNulls, cacheInfo);
 
                 activators.Add((target, dc) => property.SetValue(target, fieldGetter(dc)));
             }


### PR DESCRIPTION
As this has backfired twice before (https://github.com/ppy/osu/pull/19677, https://github.com/ppy/osu/pull/21512), this feature is unreliable as long as mobile projects are not updated to .NET 6. Disabling it would avoid those catastrophes from happening again for the time being.

# vNext
## NRT-based detection of nullable dependencies has been temporarily disabled

This feature never worked on mobile projects since they're not targeting .NET 6 yet. We cannot continue to have this feature enabled for the time being.