### PR TITLE
Remove `IBindable.ToString()` default interface implementations

### DIFF
--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Globalization;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;
 
@@ -65,10 +64,6 @@ namespace osu.Framework.Bindables
             copy.BindTo(source);
             return (T)copy;
         }
-
-        string ToString() => ToString(null, CultureInfo.CurrentCulture);
-
-        string ToString(IFormatProvider formatProvider) => ToString(null, formatProvider);
     }
 
     /// <summary>
@@ -116,9 +111,5 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindable<T> GetBoundCopy();
-
-        string ToString() => ToString(null, CultureInfo.CurrentCulture);
-
-        string ToString(IFormatProvider formatProvider) => ToString(null, formatProvider);
     }
 }

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;

--- a/osu.Framework/Extensions/FormattableExtensions.cs
+++ b/osu.Framework/Extensions/FormattableExtensions.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace osu.Framework.Extensions
 {
-    public static class IFormattableExtensions
+    public static class FormattableExtensions
     {
         /// <summary>
         /// Formats the value of <paramref name="formattable"/> using the default format string and the supplied <paramref name="formatProvider"/>.

--- a/osu.Framework/Extensions/IFormattableExtensions.cs
+++ b/osu.Framework/Extensions/IFormattableExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Extensions
+{
+    public static class IFormattableExtensions
+    {
+        /// <summary>
+        /// Formats the value of <paramref name="formattable"/> using the default format string and the supplied <paramref name="formatProvider"/>.
+        /// </summary>
+        public static string ToString(this IFormattable formattable, IFormatProvider formatProvider) => formattable.ToString(null, formatProvider);
+    }
+}


### PR DESCRIPTION
This is essentially a workaround for what is ostensibly going to be a xamarin or mono bug which is causing https://github.com/ppy/osu/issues/21530.

The explanation is thus: The reason why the config files were zero-byte is that an exception was being thrown ([and silenced](https://github.com/ppy/osu-framework/blob/07ef9aa7f3053eeb750e8e4a43fd8a6f19bbe5b0/osu.Framework/Configuration/IniConfigManager.cs#L96-L99)) in `PerformSave()`. This is the exception:

```
System.InvalidCastException: Object must implement IConvertible.
  at System.Convert.ChangeType (System.Object value, System.Type conversionType, System.IFormatProvider provider) [0x00040] in /Users/builder/jenkins/workspace/archive-mono/2020-02/android/release/external/corefx/src/Common/src/CoreLib/System/Convert.cs:340 
  at osu.Framework.Bindables.Bindable`1[T].Parse (System.Object input) [0x000c7] in D:\Open Source\osu-framework\osu.Framework\Bindables\Bindable.cs:269 
  at osu.Framework.Configuration.IniConfigManager`1[TLookup].PerformSave () [0x0004c] in D:\Open Source\osu-framework\osu.Framework\Configuration\IniConfigManager.cs:93 
```

This stack trace is nonsense. There is no conceivable pathway wherein `IniConfigManager` can call `Bindable.Parse()`. The arguments didn't make sense either, it was trying to parse `CultureInfo.InvariantCulture` as a string.

@frenzibyte [suggested on discord](https://discordapp.com/channels/188630481301012481/589331078574112768/1049754711328313394) that we've [seen this sort of black magic before](https://github.com/mono/mono/issues/19900#issuecomment-637831405) and it was caused by default interface method implementations. It tracked, since the symptoms did look suspiciously like the correct arguments were being passed to the completely wrong method. I tried removing them and that fixed the bug. Hence this diff.

I am very explicitly not looking at the xamarin bug, as to me it is not worth the time to do so and my goal is to keep things mostly working until we can collectively turn our heads towards net6 ([relevant discord conversation](https://discordapp.com/channels/188630481301012481/188630652340404224/1049546362632556574) from earlier today).

Now:

* The `.ToString()` default implementations are, as far as I can tell, 100% dead code. I have no idea what can call these ever. [A quick sharplab](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUHgNwEMwACASwFsAHAG01IF5SoBTAd1IEkbbXLWUYEWDkA9lEwAKAJQBuPFy5DWYAGZEAxqwobtDZlTqYFuYmSO10TFh269+g4aInpZppSvVad5Pa2tDXnRTPFRMAE4pS0wAOgAVMQBlYDByKABzWXkwyOj/OMSUtMzs03Coy3QE5NT0rJkc3Ar8n2qiutLG0Nx04FV/bmV+721SAG88UmnScIAGUg6ShqYAPlIAImAAC3IAZwoDvbFSOAhKACMN0wBfPDDrHjpHIRFxSVIQIa9Bydw7/DNR4OASvFxQaxfTwjX5TGaoADMpDEBFUaTgOnmi1qy1ka02tHIAGtWDBSOxtgBPcliCC0OCkSm0ihQNSEzTAUg7fakahEdLIqCkIhQJlsa54G5AA===) suggests that it is impossible for these to be called, so they are removed without replacement.
* The `.ToString(IFormatProvider)` overload was the one actually causing the bug. I considered just removing it, but then ended up adding an extension method to cover for it, and all `IFormattable`s to ever possibly exist. Which is arguably cleaner than duplicating the default implementations in `IBindable<T>`, at the cost of an extra `using`.