### PR TITLE
Fix source generator csproj wildcard

### DIFF
--- a/osu.Framework.SourceGeneration/Build.targets
+++ b/osu.Framework.SourceGeneration/Build.targets
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <AssemblyName>osu.Framework.SourceGeneration</AssemblyName>
 
@@ -46,6 +46,6 @@
   <ItemGroup Label="Package">
     <None Include="$(MSBuildThisFileDirectory)targets\ppy.osu.Framework.SourceGeneration.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
     <None Include="$(MSBuildThisFileDirectory)targets\ppy.osu.Framework.SourceGeneration.targets" PackagePath="build\netstandard2.0" Pack="true" />
-    <None Include="$(MSBuildThisFileDirectory)artifacts\" Pack="true" PackagePath="analyzers/dotnet/" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)artifacts\**" Pack="true" PackagePath="analyzers/dotnet/" Visible="false" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.SourceGeneration/pack.sh
+++ b/osu.Framework.SourceGeneration/pack.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-dotnet pack ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj $@
-dotnet pack ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj $@
+dotnet build ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj --no-incremental
+dotnet build ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj --no-incremental
+
+dotnet pack ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj --no-build $@
+dotnet pack ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj --no-build $@

--- a/osu.Framework.SourceGeneration/pack.sh
+++ b/osu.Framework.SourceGeneration/pack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-dotnet build ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj --no-incremental
-dotnet build ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj --no-incremental
+dotnet build ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj --no-incremental $@
+dotnet build ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj --no-incremental $@
 
 dotnet pack ./Roslyn3.11/osu.Framework.SourceGeneration.Roslyn3.11.csproj --no-build $@
 dotnet pack ./Roslyn4.0/osu.Framework.SourceGeneration.Roslyn4.0.csproj --no-build $@


### PR DESCRIPTION
Getting this error when loading the project in Visual Studio 2022 (v17.4.1):

![image](https://user-images.githubusercontent.com/46171121/206058094-76c9f794-960a-48b2-87dc-de02c17130d6.png)
