### PR TITLE
Retrieve span outside of loop to improve performance of glyph texture creation

### DIFF
--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -157,10 +157,13 @@ namespace osu.Framework.IO.Stores
                 for (int y = 0; y < character.Height; y++)
                 {
                     var pixelRowMemory = image.DangerousGetPixelRowMemory(y);
+                    var span = pixelRowMemory.Span;
                     int readOffset = y * pageWidth + character.X;
 
                     for (int x = 0; x < character.Width; x++)
-                        pixelRowMemory.Span[x] = new Rgba32(255, 255, 255, x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0);
+                    {
+                        span[x] = new Rgba32(255, 255, 255, x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0);
+                    }
                 }
 
                 return new TextureUpload(image);


### PR DESCRIPTION
Just happened across this while profiling something completely unrelated and it was too good to pass on:

Before:

| Method                   | FetchCount |           Mean |        Error |       StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------------------|------------|---------------:|-------------:|-------------:|------:|--------:|----------:|----------:|----------:|----------:|
| BenchmarkRawCachingReuse | 1          |       901.2 us |      4.16 us |      3.89 us |  0.07 |    0.00 |    1.9531 |    0.9766 |         - |     28 KB |
| BenchmarkRawCaching      | 1          |    12,293.7 us |    122.75 us |    108.82 us |  1.00 |    0.00 |   15.6250 |   15.6250 |   15.6250 |     78 KB |
|                          |            |                |              |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 10         |     3,344.8 us |     20.39 us |     19.07 us |  0.09 |    0.00 |    3.9063 |         - |         - |     70 KB |
| BenchmarkRawCaching      | 10         |    38,449.7 us |    495.65 us |    413.89 us |  1.00 |    0.00 |   76.9231 |   76.9231 |   76.9231 |    264 KB |
|                          |            |                |              |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 100        |    18,436.6 us |    221.25 us |    206.96 us |  0.26 |    0.00 |         - |         - |         - |    239 KB |
| BenchmarkRawCaching      | 100        |    72,181.5 us |    808.96 us |    717.12 us |  1.00 |    0.00 |  142.8571 |  142.8571 |  142.8571 |    562 KB |
|                          |            |                |              |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 1000       |   170,391.3 us |  2,867.34 us |  2,541.82 us |  0.73 |    0.02 |         - |         - |         - |  2,834 KB |
| BenchmarkRawCaching      | 1000       |   232,904.4 us |  4,409.59 us |  4,124.74 us |  1.00 |    0.00 | 1000.0000 | 1000.0000 | 1000.0000 |  3,993 KB |
|                          |            |                |              |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 10000      | 1,655,587.7 us |  7,575.88 us |  6,715.82 us |  0.93 |    0.01 | 1000.0000 |         - |         - | 15,631 KB |
| BenchmarkRawCaching      | 10000      | 1,782,215.8 us | 28,011.43 us | 24,831.41 us |  1.00 |    0.00 | 2000.0000 | 1000.0000 | 1000.0000 | 16,797 KB |

After:

| Method                   | FetchCount |         Mean |       Error |       StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|--------------------------|------------|-------------:|------------:|-------------:|------:|--------:|----------:|----------:|----------:|----------:|
| BenchmarkRawCachingReuse | 1          |     679.7 us |    12.76 us |     12.53 us |  0.06 |    0.00 |    1.9531 |    0.9766 |         - |     28 KB |
| BenchmarkRawCaching      | 1          |  12,186.4 us |   220.54 us |    206.30 us |  1.00 |    0.00 |   15.6250 |   15.6250 |   15.6250 |     78 KB |
|                          |            |              |             |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 10         |   1,997.4 us |    23.66 us |     22.13 us |  0.05 |    0.00 |    3.9063 |         - |         - |     70 KB |
| BenchmarkRawCaching      | 10         |  37,398.4 us |   627.78 us |    587.22 us |  1.00 |    0.00 |   71.4286 |   71.4286 |   71.4286 |    254 KB |
|                          |            |              |             |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 100        |   6,058.7 us |   120.90 us |    113.09 us |  0.10 |    0.00 |   15.6250 |    7.8125 |         - |    222 KB |
| BenchmarkRawCaching      | 100        |  59,745.7 us | 1,001.20 us |    936.52 us |  1.00 |    0.00 |  111.1111 |  111.1111 |  111.1111 |    505 KB |
|                          |            |              |             |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 1000       |  37,690.2 us |   559.95 us |    523.77 us |  0.41 |    0.01 |   71.4286 |         - |         - |  1,592 KB |
| BenchmarkRawCaching      | 1000       |  91,646.2 us |   825.82 us |    772.47 us |  1.00 |    0.00 |  166.6667 |  166.6667 |  166.6667 |  1,986 KB |
|                          |            |              |             |              |       |         |           |           |           |           |
| BenchmarkRawCachingReuse | 10000      | 354,639.3 us | 5,273.00 us |  4,932.36 us |  0.81 |    0.03 | 1000.0000 |         - |         - | 15,633 KB |
| BenchmarkRawCaching      | 10000      | 424,413.0 us | 8,385.47 us | 14,464.53 us |  1.00 |    0.00 | 2000.0000 | 1000.0000 | 1000.0000 | 16,790 KB |

I ran the benchmarks twice because the results kind of surprised me, but it was roughly equal both runs.