### PR TITLE
Fix WhitePixel texture rectangle doesn't respect provided area

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
+++ b/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Textures
@@ -21,7 +19,7 @@ namespace osu.Framework.Graphics.Textures
             // Let's be very conservative and use a tenth of the size of a pixel in the
             // largest possible texture.
             float smallestPixelTenth = 0.1f / NativeTexture.MaxSize;
-            return new RectangleF(0, 0, smallestPixelTenth, smallestPixelTenth);
+            return base.GetTextureRect(area) * smallestPixelTenth;
         }
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu-framework/pull/5575 as an actual fix.