### PR TITLE
Fix one more case of using AutoGen's `ffmpeg` class for constants

### DIFF
--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -126,7 +126,7 @@ namespace osu.Framework.Graphics.Video
         public SwsGetCachedContextDelegate sws_getCachedContext;
         public SwsScaleDelegate sws_scale;
 
-        // Touching AGffmpeg or its LibraryLoader in any way on non-Desktop platforms
+        // Touching AutoGen.ffmpeg or its LibraryLoader in any way on non-Desktop platforms
         // will cause it to throw in static constructor, which can't be bypassed.
         // Define our own constants to avoid touching the class.
 

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -26,7 +26,6 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Platform.Linux.Native;
-using AGffmpeg = FFmpeg.AutoGen.ffmpeg;
 
 namespace osu.Framework.Graphics.Video
 {
@@ -809,9 +808,9 @@ namespace osu.Framework.Graphics.Video
         {
             // other frameworks should handle native libraries themselves
 #if NET6_0_OR_GREATER
-            AGffmpeg.GetOrLoadLibrary = name =>
+            FFmpeg.AutoGen.ffmpeg.GetOrLoadLibrary = name =>
             {
-                int version = AGffmpeg.LibraryVersionMap[name];
+                int version = FFmpeg.AutoGen.ffmpeg.LibraryVersionMap[name];
 
                 string libraryName;
 
@@ -840,42 +839,42 @@ namespace osu.Framework.Graphics.Video
 
             return new FFmpegFuncs
             {
-                av_frame_alloc = AGffmpeg.av_frame_alloc,
-                av_frame_free = AGffmpeg.av_frame_free,
-                av_frame_unref = AGffmpeg.av_frame_unref,
-                av_frame_move_ref = AGffmpeg.av_frame_move_ref,
-                av_frame_get_buffer = AGffmpeg.av_frame_get_buffer,
-                av_strdup = AGffmpeg.av_strdup,
-                av_strerror = AGffmpeg.av_strerror,
-                av_malloc = AGffmpeg.av_malloc,
-                av_freep = AGffmpeg.av_freep,
-                av_packet_alloc = AGffmpeg.av_packet_alloc,
-                av_packet_unref = AGffmpeg.av_packet_unref,
-                av_packet_free = AGffmpeg.av_packet_free,
-                av_read_frame = AGffmpeg.av_read_frame,
-                av_seek_frame = AGffmpeg.av_seek_frame,
-                av_hwdevice_ctx_create = AGffmpeg.av_hwdevice_ctx_create,
-                av_hwframe_transfer_data = AGffmpeg.av_hwframe_transfer_data,
-                av_codec_iterate = AGffmpeg.av_codec_iterate,
-                av_codec_is_decoder = AGffmpeg.av_codec_is_decoder,
-                avcodec_get_hw_config = AGffmpeg.avcodec_get_hw_config,
-                avcodec_alloc_context3 = AGffmpeg.avcodec_alloc_context3,
-                avcodec_free_context = AGffmpeg.avcodec_free_context,
-                avcodec_parameters_to_context = AGffmpeg.avcodec_parameters_to_context,
-                avcodec_open2 = AGffmpeg.avcodec_open2,
-                avcodec_receive_frame = AGffmpeg.avcodec_receive_frame,
-                avcodec_send_packet = AGffmpeg.avcodec_send_packet,
-                avcodec_flush_buffers = AGffmpeg.avcodec_flush_buffers,
-                avformat_alloc_context = AGffmpeg.avformat_alloc_context,
-                avformat_close_input = AGffmpeg.avformat_close_input,
-                avformat_find_stream_info = AGffmpeg.avformat_find_stream_info,
-                avformat_open_input = AGffmpeg.avformat_open_input,
-                av_find_best_stream = AGffmpeg.av_find_best_stream,
-                avio_alloc_context = AGffmpeg.avio_alloc_context,
-                avio_context_free = AGffmpeg.avio_context_free,
-                sws_freeContext = AGffmpeg.sws_freeContext,
-                sws_getCachedContext = AGffmpeg.sws_getCachedContext,
-                sws_scale = AGffmpeg.sws_scale
+                av_frame_alloc = FFmpeg.AutoGen.ffmpeg.av_frame_alloc,
+                av_frame_free = FFmpeg.AutoGen.ffmpeg.av_frame_free,
+                av_frame_unref = FFmpeg.AutoGen.ffmpeg.av_frame_unref,
+                av_frame_move_ref = FFmpeg.AutoGen.ffmpeg.av_frame_move_ref,
+                av_frame_get_buffer = FFmpeg.AutoGen.ffmpeg.av_frame_get_buffer,
+                av_strdup = FFmpeg.AutoGen.ffmpeg.av_strdup,
+                av_strerror = FFmpeg.AutoGen.ffmpeg.av_strerror,
+                av_malloc = FFmpeg.AutoGen.ffmpeg.av_malloc,
+                av_freep = FFmpeg.AutoGen.ffmpeg.av_freep,
+                av_packet_alloc = FFmpeg.AutoGen.ffmpeg.av_packet_alloc,
+                av_packet_unref = FFmpeg.AutoGen.ffmpeg.av_packet_unref,
+                av_packet_free = FFmpeg.AutoGen.ffmpeg.av_packet_free,
+                av_read_frame = FFmpeg.AutoGen.ffmpeg.av_read_frame,
+                av_seek_frame = FFmpeg.AutoGen.ffmpeg.av_seek_frame,
+                av_hwdevice_ctx_create = FFmpeg.AutoGen.ffmpeg.av_hwdevice_ctx_create,
+                av_hwframe_transfer_data = FFmpeg.AutoGen.ffmpeg.av_hwframe_transfer_data,
+                av_codec_iterate = FFmpeg.AutoGen.ffmpeg.av_codec_iterate,
+                av_codec_is_decoder = FFmpeg.AutoGen.ffmpeg.av_codec_is_decoder,
+                avcodec_get_hw_config = FFmpeg.AutoGen.ffmpeg.avcodec_get_hw_config,
+                avcodec_alloc_context3 = FFmpeg.AutoGen.ffmpeg.avcodec_alloc_context3,
+                avcodec_free_context = FFmpeg.AutoGen.ffmpeg.avcodec_free_context,
+                avcodec_parameters_to_context = FFmpeg.AutoGen.ffmpeg.avcodec_parameters_to_context,
+                avcodec_open2 = FFmpeg.AutoGen.ffmpeg.avcodec_open2,
+                avcodec_receive_frame = FFmpeg.AutoGen.ffmpeg.avcodec_receive_frame,
+                avcodec_send_packet = FFmpeg.AutoGen.ffmpeg.avcodec_send_packet,
+                avcodec_flush_buffers = FFmpeg.AutoGen.ffmpeg.avcodec_flush_buffers,
+                avformat_alloc_context = FFmpeg.AutoGen.ffmpeg.avformat_alloc_context,
+                avformat_close_input = FFmpeg.AutoGen.ffmpeg.avformat_close_input,
+                avformat_find_stream_info = FFmpeg.AutoGen.ffmpeg.avformat_find_stream_info,
+                avformat_open_input = FFmpeg.AutoGen.ffmpeg.avformat_open_input,
+                av_find_best_stream = FFmpeg.AutoGen.ffmpeg.av_find_best_stream,
+                avio_alloc_context = FFmpeg.AutoGen.ffmpeg.avio_alloc_context,
+                avio_context_free = FFmpeg.AutoGen.ffmpeg.avio_context_free,
+                sws_freeContext = FFmpeg.AutoGen.ffmpeg.sws_freeContext,
+                sws_getCachedContext = FFmpeg.AutoGen.ffmpeg.sws_getCachedContext,
+                sws_scale = FFmpeg.AutoGen.ffmpeg.sws_scale
             };
         }
 

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -294,7 +294,7 @@ namespace osu.Framework.Graphics.Video
             var span = new Span<byte>(bufferPtr, bufferSize);
             int bytesRead = decoder.videoStream.Read(span);
 
-            return bytesRead != 0 ? bytesRead : AGffmpeg.AVERROR_EOF;
+            return bytesRead != 0 ? bytesRead : FFmpegFuncs.AVERROR_EOF;
         }
 
         [MonoPInvokeCallback(typeof(avio_alloc_context_seek))]


### PR DESCRIPTION
As we shifted towards using `FFmpegFuncs` for constants to avoid runtime exceptions on mobile platforms, one more case popped up recently from https://github.com/ppy/osu-framework/pull/5539 which wasn't updated before merging https://github.com/ppy/osu-framework/pull/5080.

I've also removed the namespace alias of the class as it's no longer used frequently.