### PR TITLE
Fix SDL error on startup caused by setting min/max size before window creation

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -52,6 +52,8 @@ namespace osu.Framework.Platform
                 invalidateWindowSpecifics();
             };
 
+            config.BindWith(FrameworkSetting.WindowedSize, sizeWindowed);
+
             sizeWindowed.MinValueChanged += min =>
             {
                 if (min.Width < 0 || min.Height < 0)
@@ -75,7 +77,6 @@ namespace osu.Framework.Platform
             };
 
             config.BindWith(FrameworkSetting.SizeFullscreen, sizeFullscreen);
-            config.BindWith(FrameworkSetting.WindowedSize, sizeWindowed);
 
             config.BindWith(FrameworkSetting.WindowedPositionX, windowPositionX);
             config.BindWith(FrameworkSetting.WindowedPositionY, windowPositionY);


### PR DESCRIPTION
This just fixes the error on startup, the min and max size worked fine and applied properly on startup here:

https://github.com/ppy/osu-framework/blob/1e54caf879c4abb7c382e7f182cab589f4e51040/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs#L109

The error in the logs:
```cs
2022-12-15 20:37:37 [verbose]: SDL error log [debug]: Invalid window
2022-12-15 20:37:37 [verbose]: SDL error log [debug]: Invalid window
```