### PR TITLE
Fix some issues with Veldrid/Vulkan on Linux

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -87,8 +87,10 @@ namespace osu.Framework.Graphics.Veldrid
                     break;
 
                 case RuntimeInfo.Platform.Linux:
-                    // todo: needs fix. either we expose SDL_SysWMInfo to SDL2WindowGraphics, define a WindowsSubsystem enum, or a boolean in RuntimeInfo to decide between x11 and wayland.
-                    // swapchain.Source = SwapchainSource.CreateXlib(graphics.DisplayHandle, graphics.WindowHandle);
+                    var linuxGraphics = (ILinuxGraphicsSurface)graphicsSurface;
+                    swapchain.Source = linuxGraphics.IsWayland
+                        ? SwapchainSource.CreateWayland(graphicsSurface.DisplayHandle, graphicsSurface.WindowHandle)
+                        : SwapchainSource.CreateXlib(graphicsSurface.DisplayHandle, graphicsSurface.WindowHandle);
                     break;
             }
 

--- a/osu.Framework/Platform/ILinuxGraphicsSurface.cs
+++ b/osu.Framework/Platform/ILinuxGraphicsSurface.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    public interface ILinuxGraphicsSurface
+    {
+        /// <summary>
+        /// Whether the current display server is Wayland.
+        /// </summary>
+        bool IsWayland { get; }
+    }
+}

--- a/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
@@ -13,7 +13,7 @@ using SDL2;
 
 namespace osu.Framework.Platform.SDL2
 {
-    public class SDL2GraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface, IMetalGraphicsSurface
+    public class SDL2GraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface, IMetalGraphicsSurface, ILinuxGraphicsSurface
     {
         private readonly SDL2DesktopWindow window;
 
@@ -170,6 +170,12 @@ namespace osu.Framework.Platform.SDL2
         #region Metal-specific implementation
 
         IntPtr IMetalGraphicsSurface.CreateMetalView() => SDL.SDL_Metal_CreateView(window.SDLWindowHandle);
+
+        #endregion
+
+        #region Linux-specific implementation
+
+        bool ILinuxGraphicsSurface.IsWayland => window.IsWayland;
 
         #endregion
     }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -159,6 +159,7 @@ namespace osu.Framework.Platform
                 return default;
 
             var wmInfo = new SDL.SDL_SysWMinfo();
+            SDL.SDL_GetVersion(out wmInfo.version);
             SDL.SDL_GetWindowWMInfo(SDLWindowHandle, ref wmInfo);
             return wmInfo;
         }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -74,6 +74,20 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
+        /// Whether the current display server is Wayland.
+        /// </summary>
+        internal bool IsWayland
+        {
+            get
+            {
+                if (SDLWindowHandle == IntPtr.Zero)
+                    return false;
+
+                return getWindowWMInfo().subsystem == SDL.SDL_SYSWM_TYPE.SDL_SYSWM_WAYLAND;
+            }
+        }
+
+        /// <summary>
         /// Gets the native window handle as provided by the operating system.
         /// </summary>
         public IntPtr WindowHandle


### PR DESCRIPTION
- Selects X11/Wayland surface.
- Fixes nulled pointers caused by lack of passing the version via `SDL_GetWindowWMInfo`.

It works to the point I can get it to run, but crashes soon after with
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Veldrid.Vk.VkSwapchainFramebuffer.get_ColorTargets()
   at Veldrid.Vk.VkCommandList.SetFramebufferCore(Framebuffer fb)
   at Veldrid.CommandList.SetFramebuffer(Framebuffer fb)
   at osu.Framework.Graphics.Veldrid.VeldridRenderer.SetFrameBufferImplementation(IFrameBuffer frameBuffer) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs:line 244
   at osu.Framework.Graphics.Rendering.Renderer.setFrameBuffer(IFrameBuffer frameBuffer, Boolean force) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Rendering/Renderer.cs:line 919
   at osu.Framework.Graphics.Rendering.Renderer.BeginFrame(Vector2 windowSize) in /home/smgi/Repos/osu-framework/osu.Framework/Graphics/Rendering/Renderer.cs:line 214
```
The above is a Veldrid issue though - I don't believe we're doing something incorrectly.