### PR TITLE
Add footnote support to Markdown container

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -316,6 +316,17 @@ soft break with '\'";
 ```");
         }
 
+        [Test]
+        public void TestFootnotes()
+        {
+            AddStep("set content", () => markdownContainer.Text = @"This text has a footnote[^test].
+
+Here's some more text[^test2] with another footnote!
+
+[^test]: This is a **footnote**.
+[^test2]: This is another footnote [with a link](https://google.com/)!");
+        }
+
         private partial class TestMarkdownContainer : MarkdownContainer
         {
             public new string DocumentUrl

--- a/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnote.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnote.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Extensions.Footnotes;
+using Markdig.Syntax;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.Containers.Markdown.Footnotes
+{
+    /// <summary>
+    /// Visualises a single <see cref="Markdig.Extensions.Footnotes.Footnote"/> within a <see cref="FootnoteGroup"/>.
+    /// </summary>
+    public partial class MarkdownFootnote : CompositeDrawable, IMarkdownTextComponent, IMarkdownTextFlowComponent
+    {
+        public readonly Footnote Footnote;
+
+        [Resolved]
+        private IMarkdownTextComponent parentTextComponent { get; set; } = null!;
+
+        [Resolved]
+        private IMarkdownTextFlowComponent parentFlowComponent { get; set; } = null!;
+
+        public MarkdownFootnote(Footnote footnote)
+        {
+            Footnote = footnote;
+
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            MarkdownTextFlowContainer textFlow;
+
+            InternalChildren = new Drawable[]
+            {
+                CreateOrderMarker(Footnote.Order),
+                textFlow = CreateTextFlow()
+            };
+
+            if (Footnote.LastChild is ParagraphBlock paragraphBlock)
+                textFlow.AddInlineText(paragraphBlock.Inline);
+        }
+
+        public virtual SpriteText CreateOrderMarker(int order) => CreateSpriteText().With(text =>
+        {
+            text.Text = order.ToLocalisableString();
+        });
+
+        public SpriteText CreateSpriteText() => parentTextComponent.CreateSpriteText();
+
+        public virtual MarkdownTextFlowContainer CreateTextFlow() => parentFlowComponent.CreateTextFlow().With(flow =>
+        {
+            flow.Margin = new MarginPadding { Left = 20 };
+        });
+    }
+}

--- a/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteBacklink.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteBacklink.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Extensions.Footnotes;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Containers.Markdown.Footnotes
+{
+    /// <summary>
+    /// Visualises a backlink from a <see cref="Footnote"/> to the <see cref="FootnoteLink"/> that referenced it.
+    /// These backlinks are usually placed in <see cref="FootnoteGroup"/>s.
+    /// </summary>
+    public partial class MarkdownFootnoteBacklink : CompositeDrawable
+    {
+        [Resolved]
+        private IMarkdownTextComponent parentTextComponent { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            float fontSize = parentTextComponent.CreateSpriteText().Font.Size;
+
+            AutoSizeAxes = Axes.X;
+            Height = fontSize;
+
+            InternalChild = new SpriteIcon
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Margin = new MarginPadding { Left = 5 },
+                Size = new Vector2(fontSize / 2),
+                Icon = FontAwesome.Solid.ArrowUp,
+                Colour = Color4.DodgerBlue
+            };
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteGroup.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteGroup.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Extensions.Footnotes;
+using osuTK;
+
+namespace osu.Framework.Graphics.Containers.Markdown.Footnotes
+{
+    /// <summary>
+    /// Visualises a <see cref="FootnoteGroup"/>.
+    /// </summary>
+    public partial class MarkdownFootnoteGroup : FillFlowContainer
+    {
+        public MarkdownFootnoteGroup()
+        {
+            AutoSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.X;
+
+            Direction = FillDirection.Vertical;
+
+            Spacing = new Vector2(10);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteLink.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/Footnotes/MarkdownFootnoteLink.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Extensions.Footnotes;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
+
+namespace osu.Framework.Graphics.Containers.Markdown.Footnotes
+{
+    /// <summary>
+    /// Visualises an in-text <see cref="FootnoteLink"/> which references a <see cref="Footnote"/>.
+    /// </summary>
+    public partial class MarkdownFootnoteLink : CompositeDrawable
+    {
+        private readonly FootnoteLink footnoteLink;
+
+        [Resolved]
+        private IMarkdownTextComponent parentTextComponent { get; set; } = null!;
+
+        public MarkdownFootnoteLink(FootnoteLink footnoteLink)
+        {
+            this.footnoteLink = footnoteLink;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var spriteText = parentTextComponent.CreateSpriteText();
+
+            AutoSizeAxes = Axes.Both;
+            InternalChild = spriteText.With(t =>
+            {
+                float baseSize = t.Font.Size;
+                t.Font = t.Font.With(size: baseSize * 0.58f);
+                t.Margin = new MarginPadding { Bottom = 0.33f * baseSize };
+                t.Text = footnoteLink.Index.ToLocalisableString();
+            });
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -7,12 +7,14 @@ using System;
 using System.Linq;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
+using Markdig.Extensions.Footnotes;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics.Containers.Markdown.Footnotes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
 using osuTK;
@@ -267,6 +269,18 @@ namespace osu.Framework.Graphics.Containers.Markdown
                     // Link reference doesn't need to be displayed.
                     break;
 
+                case FootnoteGroup footnoteGroup:
+                    var footnoteGroupContainer = CreateFootnoteGroup(footnoteGroup);
+                    container.Add(footnoteGroupContainer);
+                    foreach (var single in footnoteGroup)
+                        AddMarkdownComponent(single, footnoteGroupContainer, level);
+                    break;
+
+                case Footnote footnote:
+                    var footnoteContainer = CreateFootnote(footnote);
+                    container.Add(footnoteContainer);
+                    break;
+
                 default:
                     container.Add(CreateNotImplemented(markdownObject));
                     break;
@@ -321,6 +335,16 @@ namespace osu.Framework.Graphics.Containers.Markdown
         /// </summary>
         /// <returns>The visualiser.</returns>
         protected virtual MarkdownSeparator CreateSeparator(ThematicBreakBlock thematicBlock) => new MarkdownSeparator();
+
+        /// <summary>
+        /// Creates the visualiser for a <see cref="FootnoteGroup"/>.
+        /// </summary>
+        protected virtual MarkdownFootnoteGroup CreateFootnoteGroup(FootnoteGroup footnoteGroup) => new MarkdownFootnoteGroup();
+
+        /// <summary>
+        /// Creates the visualiser for a <see cref="Footnote"/>.
+        /// </summary>
+        protected virtual MarkdownFootnote CreateFootnote(Footnote footnote) => new MarkdownFootnote(footnote);
 
         /// <summary>
         /// Creates the visualiser for an element that isn't implemented.

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -7,9 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Markdig.Extensions.CustomContainers;
+using Markdig.Extensions.Footnotes;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Containers.Markdown.Footnotes;
 using osu.Framework.Graphics.Sprites;
 using osuTK.Graphics;
 
@@ -119,6 +121,13 @@ namespace osu.Framework.Graphics.Containers.Markdown
                         AddAutoLink(autoLink);
                         break;
 
+                    case FootnoteLink footnoteLink:
+                        if (footnoteLink.IsBackLink)
+                            AddFootnoteBacklink(footnoteLink);
+                        else
+                            AddFootnoteLink(footnoteLink);
+                        break;
+
                     default:
                         AddNotImplementedInlineText(single);
                         break;
@@ -143,6 +152,12 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
         protected virtual void AddImage(LinkInline linkInline)
             => AddDrawable(new MarkdownImage(linkInline.Url));
+
+        protected virtual void AddFootnoteLink(FootnoteLink footnoteLink)
+            => AddDrawable(new MarkdownFootnoteLink(footnoteLink));
+
+        protected virtual void AddFootnoteBacklink(FootnoteLink footnoteBacklink)
+            => AddDrawable(new MarkdownFootnoteBacklink());
 
         protected virtual void AddCustomComponent(CustomContainerInline customContainerInline)
             => AddNotImplementedInlineText(customContainerInline);


### PR DESCRIPTION
Step one for https://github.com/ppy/osu/issues/21666.

The framework-side implementation is purposefully ~~barebones~~ basic. I didn't want to spend too much time on it and instead focused on the game-side implementation. But if you think there were too many shortcuts taken here, then do let me know and I'll revisit.

There is a test scene to preview this in available:

![1671228604](https://user-images.githubusercontent.com/20418176/208198106-7ea0ef08-9c25-46c6-9492-6a18e998bdf4.png)