### PR TITLE
Include missing properties to iOS templates

### DIFF
--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
@@ -4,6 +4,17 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
+    <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
+         It only warns about not copying the library to the app bundle to save space,
+         so there's nothing to be worried about. -->
+    <NoWarn>MT7091</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
+    <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhoneSimulator'">
+    <RuntimeIdentifiers>iossimulator-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <Import Project="..\..\..\..\osu.Framework.iOS.props" />
   <ItemGroup>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
@@ -4,6 +4,17 @@
     <TargetFramework>net6.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
+    <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
+         It only warns about not copying the library to the app bundle to save space,
+         so there's nothing to be worried about. -->
+    <NoWarn>MT7091</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
+    <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'iPhoneSimulator'">
+    <RuntimeIdentifiers>iossimulator-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <Import Project="..\..\..\..\osu.Framework.iOS.props" />
   <ItemGroup>


### PR DESCRIPTION
Brought from `osu.Framework.iOS.props`, required properties for consumers to have their projects build successfully.