### PR TITLE
Replace project references during packing templates in GH workflow

### DIFF
--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -72,23 +72,23 @@ jobs:
 
   pack-template:
     name: Pack (Templates)
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: [check-if-tag]
-    defaults:
-      run:
-        shell: powershell
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set Artifacts Directory
         id: artifactsPath
-        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
 
       - name: Install .NET 6.0.x
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "6.0.x"
+
+      - name: Replace Project References
+        run: osu.Framework.Templates/replace-references.sh ${{needs.check-if-tag.outputs.version}}
 
       - name: Pack (Template)
         run: dotnet pack -c Release osu.Framework.Templates /p:Configuration=Release /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
@@ -119,7 +119,7 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      - name: Restore .NET workloads
+      - name: Restore .NET Workloads
         run: dotnet workload restore
 
       - name: Pack (Android Framework)
@@ -151,7 +151,7 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      - name: Restore .NET workloads
+      - name: Restore .NET Workloads
         run: dotnet workload restore
 
       - name: Pack (iOS Framework)

--- a/osu.Framework.Templates/replace-references.sh
+++ b/osu.Framework.Templates/replace-references.sh
@@ -1,0 +1,18 @@
+game_projects=(./**/**/**/*.Game.csproj)
+ios_projects=(./**/**/**/*.iOS.csproj)
+
+cd "$(dirname "$0")"
+
+for game_project in ${game_projects[@]}
+do
+    dotnet remove ${game_project} reference ../osu.Framework/osu.Framework.csproj
+    dotnet add $game_project package ppy.osu.Framework -v $1 --no-restore
+done
+
+for ios_project in ${ios_projects[@]}
+do
+    dotnet remove $ios_project reference ../osu.Framework.iOS/osu.Framework.iOS.csproj
+    dotnet add $ios_project package ppy.osu.Framework.iOS -v $1 --no-restore
+done
+
+sed -i '/osu.Framework.iOS.props/d' ./**/**/**/*.iOS.csproj

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
@@ -11,7 +11,6 @@
     <ProjectReference Include="..\TemplateGame.Resources\TemplateGame.Resources.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <ProjectReference Include="..\..\..\..\osu.Framework\osu.Framework.csproj" />
     <ProjectReference Include="..\..\..\..\osu.Framework.iOS\osu.Framework.iOS.csproj" />
   </ItemGroup>
   <!-- OpenTabletDriver contains P/Invokes to the "Quartz" framework for native macOS code.

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\FlappyDon.Game\FlappyDon.Game.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <ProjectReference Include="..\..\..\..\osu.Framework\osu.Framework.csproj" />
     <ProjectReference Include="..\..\..\..\osu.Framework.iOS\osu.Framework.iOS.csproj" />
   </ItemGroup>
   <!-- OpenTabletDriver contains P/Invokes to the "Quartz" framework for native macOS code.


### PR DESCRIPTION
Allows the workflow to be used in favour of AppVeyor, which is practically dead recently with the migration to net6.0-ios (see https://ci.appveyor.com/project/peppy/osu-framework-a4n7e/build/job/451dtsr68hu8hepa).