### PR TITLE
Handle graphics backend differences on depth range and UV origin

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -43,6 +43,8 @@ namespace osu.Framework.Graphics.OpenGL
 
         public override bool DepthStartsFromNegativeOne => true;
 
+        public override bool TextureOriginAtBottomLeft => true;
+
         protected virtual int BackbufferFramebuffer => 0;
 
         private readonly int[] lastBoundBuffers = new int[2];

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -41,6 +41,8 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         public bool IsEmbedded { get; private set; }
 
+        public override bool DepthStartsFromNegativeOne => true;
+
         protected virtual int BackbufferFramebuffer => 0;
 
         private readonly int[] lastBoundBuffers = new int[2];

--- a/osu.Framework/Graphics/Rendering/DepthValue.cs
+++ b/osu.Framework/Graphics/Rendering/DepthValue.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Graphics.Rendering
 {
     /// <summary>
     /// The depth value used to draw 2D objects to the screen.
-    /// Starts at -1f and increments to 1f for each <see cref="Drawable"/> which draws a opaque interior through <see cref="DrawNode.DrawOpaqueInterior"/>.
+    /// Starts at <see cref="minimum"/> and increments to 1f for each <see cref="Drawable"/> which draws a opaque interior through <see cref="DrawNode.DrawOpaqueInterior"/>.
     /// </summary>
     public class DepthValue
     {
@@ -16,17 +16,19 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         private const float increment = 0.001f;
 
-        /// <summary>
-        /// Calculated as (1 - (-1)) / increment - 1.
-        /// -1 is subtracted since a depth of 1.0f conflicts with the default backbuffer clear value.
-        /// </summary>
-        private const int max_count = 1999;
+        private readonly int minimum;
+        private readonly int maxCount;
 
         private float depth;
         private int count;
 
-        public DepthValue()
+        public DepthValue(IRenderer renderer)
         {
+            minimum = renderer.DepthStartsFromNegativeOne ? -1 : 0;
+
+            // -1 is subtracted since a depth of 1.0f may conflict with the default backbuffer clear value.
+            maxCount = (int)((1 - minimum) / increment - 1);
+
             Reset();
         }
 
@@ -37,7 +39,7 @@ namespace osu.Framework.Graphics.Rendering
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal float Increment()
         {
-            if (count == max_count)
+            if (count == maxCount)
                 return depth;
 
             depth += increment;
@@ -51,7 +53,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         internal void Reset()
         {
-            depth = -1;
+            depth = minimum;
             count = 0;
         }
 
@@ -61,7 +63,7 @@ namespace osu.Framework.Graphics.Rendering
         internal bool CanIncrement
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => count < max_count;
+            get => count < maxCount;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -22,6 +22,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public int MaxTexturesUploadedPerFrame { get; set; } = int.MaxValue;
         public int MaxPixelsUploadedPerFrame { get; set; } = int.MaxValue;
         public string ShaderFilenameSuffix => string.Empty;
+        public bool DepthStartsFromNegativeOne => false;
 
         public ref readonly MaskingInfo CurrentMaskingInfo => ref maskingInfo;
         private readonly MaskingInfo maskingInfo;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -23,6 +23,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public int MaxPixelsUploadedPerFrame { get; set; } = int.MaxValue;
         public string ShaderFilenameSuffix => string.Empty;
         public bool DepthStartsFromNegativeOne => false;
+        public bool TextureOriginAtBottomLeft => false;
 
         public ref readonly MaskingInfo CurrentMaskingInfo => ref maskingInfo;
         private readonly MaskingInfo maskingInfo;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -21,6 +21,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public int MaxTextureSize => int.MaxValue;
         public int MaxTexturesUploadedPerFrame { get; set; } = int.MaxValue;
         public int MaxPixelsUploadedPerFrame { get; set; } = int.MaxValue;
+        public string ShaderFilenameSuffix => string.Empty;
 
         public ref readonly MaskingInfo CurrentMaskingInfo => ref maskingInfo;
         private readonly MaskingInfo maskingInfo;
@@ -80,10 +81,6 @@ namespace osu.Framework.Graphics.Rendering.Dummy
 
         public bool BindTexture(Texture texture, int unit = 0, WrapMode? wrapModeS = null, WrapMode? wrapModeT = null)
             => true;
-
-        public void UseProgram(IShader? shader)
-        {
-        }
 
         public void Clear(ClearInfo clearInfo)
         {

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -65,6 +65,12 @@ namespace osu.Framework.Graphics.Rendering
         int MaxPixelsUploadedPerFrame { get; set; }
 
         /// <summary>
+        /// A suffix to apply to shader filenames during lookup,
+        /// for interacting with compatible shader formats.
+        /// </summary>
+        string ShaderFilenameSuffix { get; }
+
+        /// <summary>
         /// The current masking parameters.
         /// </summary>
         ref readonly MaskingInfo CurrentMaskingInfo { get; }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -76,6 +76,11 @@ namespace osu.Framework.Graphics.Rendering
         bool DepthStartsFromNegativeOne { get; }
 
         /// <summary>
+        /// Whether the origin point of texture coordinates is at the bottom-left rather than top-left. This is usually true for OpenGL backends.
+        /// </summary>
+        bool TextureOriginAtBottomLeft { get; }
+
+        /// <summary>
         /// The current masking parameters.
         /// </summary>
         ref readonly MaskingInfo CurrentMaskingInfo { get; }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -71,6 +71,11 @@ namespace osu.Framework.Graphics.Rendering
         string ShaderFilenameSuffix { get; }
 
         /// <summary>
+        /// Whether depth value should start from -1 rather than 0. This is usually true for OpenGL backends.
+        /// </summary>
+        bool DepthStartsFromNegativeOne { get; }
+
+        /// <summary>
         /// The current masking parameters.
         /// </summary>
         ref readonly MaskingInfo CurrentMaskingInfo { get; }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -44,6 +44,8 @@ namespace osu.Framework.Graphics.Rendering
 
         public abstract bool DepthStartsFromNegativeOne { get; }
 
+        public abstract bool TextureOriginAtBottomLeft { get; }
+
         /// <summary>
         /// The current reset index.
         /// </summary>

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Graphics.Rendering
 
         public virtual string ShaderFilenameSuffix => string.Empty;
 
+        public abstract bool DepthStartsFromNegativeOne { get; }
+
         /// <summary>
         /// The current reset index.
         /// </summary>

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -40,6 +40,8 @@ namespace osu.Framework.Graphics.Rendering
         public int MaxTexturesUploadedPerFrame { get; set; } = 32;
         public int MaxPixelsUploadedPerFrame { get; set; } = 1024 * 1024 * 2;
 
+        public virtual string ShaderFilenameSuffix => string.Empty;
+
         /// <summary>
         /// The current reset index.
         /// </summary>

--- a/osu.Framework/Graphics/Rendering/RendererExtensions.cs
+++ b/osu.Framework/Graphics/Rendering/RendererExtensions.cs
@@ -230,8 +230,13 @@ namespace osu.Framework.Graphics.Rendering
         public static void DrawFrameBuffer(this IRenderer renderer, IFrameBuffer frameBuffer, Quad vertexQuad, ColourInfo drawColour, Action<TexturedVertex2D>? vertexAction = null,
                                            Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
-            // The strange Y coordinate and Height are a result of OpenGL coordinate systems having Y grow upwards and not downwards.
-            RectangleF textureRect = new RectangleF(0, frameBuffer.Texture.Height, frameBuffer.Texture.Width, -frameBuffer.Texture.Height);
+            RectangleF textureRect = new RectangleF(0, 0, frameBuffer.Texture.Width, frameBuffer.Texture.Height);
+
+            if (renderer.TextureOriginAtBottomLeft)
+            {
+                textureRect.Y = frameBuffer.Texture.Height;
+                textureRect.Height = -frameBuffer.Texture.Height;
+            }
 
             renderer.DrawQuad(frameBuffer.Texture, vertexQuad, drawColour, textureRect, vertexAction, inflationPercentage, blendRangeOverride);
         }

--- a/osu.Framework/Graphics/Rendering/Vertices/VertexMemberAttribute.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/VertexMemberAttribute.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         /// The type of each component of this vertex attribute member.
         /// E.g. a <see cref="osuTK.Vector2"/> is represented by 2 **<see cref="VertexAttribPointerType.Float"/>** components.
         /// </summary>
+        // todo: this should be replaced by an enum defined in o!f.
         public VertexAttribPointerType Type { get; private set; }
 
         /// <summary>

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.IO.Stores;
+using Path = System.IO.Path;
 
 namespace osu.Framework.Graphics.Shaders
 {
@@ -32,7 +33,15 @@ namespace osu.Framework.Graphics.Shaders
         /// Use <see cref="Load"/> to retrieve a usable <see cref="IShader"/> instead.
         /// </summary>
         /// <param name="name">The shader name.</param>
-        public virtual byte[]? LoadRaw(string name) => store.Get(name);
+        public virtual byte[]? LoadRaw(string name)
+        {
+            name = Path.Combine(Path.GetDirectoryName(name) ?? string.Empty, string.Concat(
+                Path.GetFileNameWithoutExtension(name),
+                renderer.ShaderFilenameSuffix,
+                Path.GetExtension(name)));
+
+            return store.Get(name);
+        }
 
         /// <summary>
         /// Retrieves a usable <see cref="IShader"/> given the vertex and fragment shaders.

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Veldrid.Buffers;
+using Veldrid;
+using BufferUsage = Veldrid.BufferUsage;
+
+namespace osu.Framework.Graphics.Veldrid.Batches
+{
+    internal class VeldridLinearBatch<T> : VeldridVertexBatch<T>
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        private readonly PrimitiveTopology type;
+
+        public VeldridLinearBatch(VeldridRenderer renderer, int size, int maxBuffers, PrimitiveTopology type)
+            : base(renderer, size, maxBuffers)
+        {
+            this.type = type;
+        }
+
+        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridLinearBuffer<T>(renderer, Size, type, BufferUsage.Dynamic);
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Veldrid.Buffers;
+using BufferUsage = Veldrid.BufferUsage;
+
+namespace osu.Framework.Graphics.Veldrid.Batches
+{
+    internal class VeldridQuadBatch<T> : VeldridVertexBatch<T>
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        public VeldridQuadBatch(VeldridRenderer renderer, int size, int maxBuffers)
+            : base(renderer, size, maxBuffers)
+        {
+            if (size > VeldridQuadBuffer<T>.MAX_QUADS)
+                throw new OverflowException($"Attempted to initialise a {nameof(VeldridQuadBuffer<T>)} with more than {nameof(VeldridQuadBuffer<T>)}.{nameof(VeldridQuadBuffer<T>.MAX_QUADS)} quads ({VeldridQuadBuffer<T>.MAX_QUADS}).");
+        }
+
+        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridQuadBuffer<T>(renderer, Size, BufferUsage.Dynamic);
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Veldrid.Buffers;
+using osu.Framework.Statistics;
+
+namespace osu.Framework.Graphics.Veldrid.Batches
+{
+    internal abstract class VeldridVertexBatch<T> : IVertexBatch<T>
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        public List<VeldridVertexBuffer<T>> VertexBuffers = new List<VeldridVertexBuffer<T>>();
+
+        /// <summary>
+        /// The number of vertices in each VertexBuffer.
+        /// </summary>
+        public int Size { get; }
+
+        private int changeBeginIndex = -1;
+        private int changeEndIndex = -1;
+
+        private int currentBufferIndex;
+        private int currentVertexIndex;
+
+        private readonly VeldridRenderer renderer;
+        private readonly int maxBuffers;
+
+        private VeldridVertexBuffer<T> currentVertexBuffer => VertexBuffers[currentBufferIndex];
+
+        protected VeldridVertexBatch(VeldridRenderer renderer, int bufferSize, int maxBuffers)
+        {
+            Size = bufferSize;
+            this.renderer = renderer;
+            this.maxBuffers = maxBuffers;
+
+            AddAction = Add;
+        }
+
+        #region Disposal
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (VeldridVertexBuffer<T> vbo in VertexBuffers)
+                    vbo.Dispose();
+            }
+        }
+
+        #endregion
+
+        void IVertexBatch.ResetCounters()
+        {
+            changeBeginIndex = -1;
+            currentBufferIndex = 0;
+            currentVertexIndex = 0;
+        }
+
+        protected abstract VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer);
+
+        /// <summary>
+        /// Adds a vertex to this <see cref="VeldridVertexBatch{T}"/>.
+        /// </summary>
+        /// <param name="v">The vertex to add.</param>
+        public void Add(T v)
+        {
+            renderer.SetActiveBatch(this);
+
+            if (currentBufferIndex < VertexBuffers.Count && currentVertexIndex >= currentVertexBuffer.Size)
+            {
+                Draw();
+                FrameStatistics.Increment(StatisticsCounterType.VBufOverflow);
+            }
+
+            // currentIndex will change after Draw() above, so this cannot be in an else-condition
+            while (currentBufferIndex >= VertexBuffers.Count)
+                VertexBuffers.Add(CreateVertexBuffer(renderer));
+
+            if (currentVertexBuffer.SetVertex(currentVertexIndex, v))
+            {
+                if (changeBeginIndex == -1)
+                    changeBeginIndex = currentVertexIndex;
+
+                changeEndIndex = currentVertexIndex + 1;
+            }
+
+            ++currentVertexIndex;
+        }
+
+        /// <summary>
+        /// Adds a vertex to this <see cref="VeldridVertexBatch{T}"/>.
+        /// This is a cached delegate of <see cref="Add"/> that should be used in memory-critical locations such as <see cref="DrawNode"/>s.
+        /// </summary>
+        public Action<T> AddAction { get; private set; }
+
+        public int Draw()
+        {
+            if (currentVertexIndex == 0)
+                return 0;
+
+            VeldridVertexBuffer<T> vertexBuffer = currentVertexBuffer;
+            if (changeBeginIndex >= 0)
+                vertexBuffer.UpdateRange(changeBeginIndex, changeEndIndex);
+
+            vertexBuffer.DrawRange(0, currentVertexIndex);
+
+            int count = currentVertexIndex;
+
+            // When using multiple buffers we advance to the next one with every draw to prevent contention on the same buffer with future vertex updates.
+            //TODO: let us know if we exceed and roll over to zero here.
+            currentBufferIndex = (currentBufferIndex + 1) % maxBuffers;
+            currentVertexIndex = 0;
+            changeBeginIndex = -1;
+
+            FrameStatistics.Increment(StatisticsCounterType.DrawCalls);
+            FrameStatistics.Add(StatisticsCounterType.VerticesDraw, count);
+
+            return count;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -1,0 +1,131 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Veldrid.Textures;
+using osuTK;
+using Veldrid;
+using Texture = osu.Framework.Graphics.Textures.Texture;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    internal class VeldridFrameBuffer : IFrameBuffer
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly PixelFormat[] formats;
+        private readonly VeldridTexture veldridTexture;
+
+        public Texture Texture { get; }
+
+        public Framebuffer Framebuffer { get; private set; }
+
+        private Vector2 size = Vector2.One;
+
+        public Vector2 Size
+        {
+            get => size;
+            set
+            {
+                if (value == size)
+                    return;
+
+                size = value;
+
+                veldridTexture.Width = (int)Math.Ceiling(size.X);
+                veldridTexture.Height = (int)Math.Ceiling(size.Y);
+                veldridTexture.SetData(new TextureUpload());
+                veldridTexture.Upload();
+
+                initialiseFramebuffer();
+            }
+        }
+
+        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
+        {
+            this.renderer = renderer;
+            this.formats = formats ?? Array.Empty<PixelFormat>();
+
+            Texture = renderer.CreateTexture(veldridTexture = new FrameBufferTexture(renderer, filteringMode));
+
+            initialiseFramebuffer();
+            Debug.Assert(Framebuffer != null);
+        }
+
+        private void initialiseFramebuffer()
+        {
+            Debug.Assert(veldridTexture.Resource != null);
+
+            // todo: we probably want the arguments separated to "PixelFormat[] colorFormats, PixelFormat depthFormat".
+            if (formats.Length > 1)
+                throw new ArgumentException("Veldrid framebuffer cannot contain more than one depth target.");
+
+            FramebufferDescription description = new FramebufferDescription { ColorTargets = new FramebufferAttachmentDescription[1] };
+            description.ColorTargets[0].Target = veldridTexture.Resource.Texture;
+
+            if (formats.Length > 0)
+            {
+                TextureDescription depthDescription = TextureDescription.Texture2D((uint)Size.X, (uint)Size.Y, 1, 1, formats[0], TextureUsage.DepthStencil);
+                description.DepthTarget = new FramebufferAttachmentDescription(renderer.Factory.CreateTexture(ref depthDescription), 0);
+            }
+
+            Framebuffer = renderer.Factory.CreateFramebuffer(ref description);
+        }
+
+        public void Bind() => renderer.BindFrameBuffer(this);
+        public void Unbind() => renderer.UnbindFrameBuffer(this);
+
+        ~VeldridFrameBuffer()
+        {
+            renderer.ScheduleDisposal(b => b.Dispose(false), this);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool isDisposed;
+
+        protected void Dispose(bool disposing)
+        {
+            if (isDisposed)
+                return;
+
+            veldridTexture.Dispose();
+
+            renderer.DeleteFrameBuffer(this);
+
+            isDisposed = true;
+        }
+
+        private class FrameBufferTexture : VeldridTexture
+        {
+            protected override TextureUsage Usages => base.Usages | TextureUsage.RenderTarget;
+
+            public FrameBufferTexture(VeldridRenderer renderer, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
+                : base(renderer, 1, 1, true, filteringMode)
+            {
+                BypassTextureUploadQueueing = true;
+
+                SetData(new TextureUpload());
+                Upload();
+            }
+
+            public override int Width
+            {
+                get => base.Width;
+                set => base.Width = Math.Clamp(value, 1, Renderer.MaxTextureSize);
+            }
+
+            public override int Height
+            {
+                get => base.Height;
+                set => base.Height = Math.Clamp(value, 1, Renderer.MaxTextureSize);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridIndexData.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridIndexData.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    // todo: this feels too janky
+    internal class VeldridIndexData
+    {
+        private readonly VeldridRenderer renderer;
+
+        private int capacity;
+
+        public int Capacity
+        {
+            get => capacity;
+            set
+            {
+                if (value == capacity)
+                    return;
+
+                capacity = value;
+
+                buffer?.Dispose();
+                buffer = null;
+            }
+        }
+
+        public VeldridIndexData(VeldridRenderer renderer)
+        {
+            this.renderer = renderer;
+        }
+
+        private DeviceBuffer buffer;
+
+        public DeviceBuffer Buffer => buffer ??= renderer.Factory.CreateBuffer(new BufferDescription((uint)(Capacity * sizeof(ushort)), BufferUsage.IndexBuffer));
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -10,31 +10,6 @@ using BufferUsage = Veldrid.BufferUsage;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
 {
-    internal static class VeldridLinearIndexData
-    {
-        private static int maxAmountIndices;
-
-        public static int MaxAmountIndices
-        {
-            get => maxAmountIndices;
-            set
-            {
-                if (value == maxAmountIndices)
-                    return;
-
-                maxAmountIndices = value;
-
-                indexBuffer?.Dispose();
-                indexBuffer = null;
-            }
-        }
-
-        private static DeviceBuffer indexBuffer;
-
-        // todo: uhhhhhhhhhh....
-        public static DeviceBuffer IndexBuffer => indexBuffer ??= Vd.Factory.CreateBuffer(new BufferDescription((uint)(MaxAmountIndices * sizeof(ushort)), BufferUsage.IndexBuffer));
-    }
-
     /// <summary>
     /// This type of vertex buffer lets the ith vertex be referenced by the ith index.
     /// </summary>
@@ -56,23 +31,23 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             base.Initialise();
 
-            if (amountVertices > VeldridLinearIndexData.MaxAmountIndices)
+            if (amountVertices > renderer.SharedLinearIndex.Capacity)
             {
-                VeldridLinearIndexData.MaxAmountIndices = amountVertices;
+                renderer.SharedLinearIndex.Capacity = amountVertices;
 
                 ushort[] indices = new ushort[amountVertices];
 
                 for (ushort i = 0; i < amountVertices; i++)
                     indices[i] = i;
 
-                renderer.Commands.UpdateBuffer(VeldridLinearIndexData.IndexBuffer, 0, indices);
+                renderer.Commands.UpdateBuffer(renderer.SharedLinearIndex.Buffer, 0, indices);
             }
         }
 
         public override void Bind()
         {
             base.Bind();
-            renderer.BindIndexBuffer(VeldridLinearIndexData.IndexBuffer, IndexFormat.UInt16);
+            renderer.BindIndexBuffer(renderer.SharedLinearIndex.Buffer, IndexFormat.UInt16);
         }
 
         protected override PrimitiveTopology Type { get; }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using osu.Framework.Graphics.Rendering.Vertices;
+using Veldrid;
+using BufferUsage = Veldrid.BufferUsage;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    internal static class VeldridLinearIndexData
+    {
+        private static int maxAmountIndices;
+
+        public static int MaxAmountIndices
+        {
+            get => maxAmountIndices;
+            set
+            {
+                if (value == maxAmountIndices)
+                    return;
+
+                maxAmountIndices = value;
+
+                indexBuffer?.Dispose();
+                indexBuffer = null;
+            }
+        }
+
+        private static DeviceBuffer indexBuffer;
+
+        // todo: uhhhhhhhhhh....
+        public static DeviceBuffer IndexBuffer => indexBuffer ??= Vd.Factory.CreateBuffer(new BufferDescription((uint)(MaxAmountIndices * sizeof(ushort)), BufferUsage.IndexBuffer));
+    }
+
+    /// <summary>
+    /// This type of vertex buffer lets the ith vertex be referenced by the ith index.
+    /// </summary>
+    internal class VeldridLinearBuffer<T> : VeldridVertexBuffer<T>
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly int amountVertices;
+
+        internal VeldridLinearBuffer(VeldridRenderer renderer, int amountVertices, PrimitiveTopology type, BufferUsage usage)
+            : base(renderer, amountVertices, usage)
+        {
+            this.renderer = renderer;
+            this.amountVertices = amountVertices;
+            Type = type;
+        }
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+
+            if (amountVertices > VeldridLinearIndexData.MaxAmountIndices)
+            {
+                VeldridLinearIndexData.MaxAmountIndices = amountVertices;
+
+                ushort[] indices = new ushort[amountVertices];
+
+                for (ushort i = 0; i < amountVertices; i++)
+                    indices[i] = i;
+
+                renderer.Commands.UpdateBuffer(VeldridLinearIndexData.IndexBuffer, 0, indices);
+            }
+        }
+
+        public override void Bind()
+        {
+            base.Bind();
+            renderer.BindIndexBuffer(VeldridLinearIndexData.IndexBuffer, IndexFormat.UInt16);
+        }
+
+        protected override PrimitiveTopology Type { get; }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -13,31 +13,6 @@ using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
 {
-    internal static class VeldridQuadIndexData
-    {
-        private static int maxAmountIndices;
-
-        public static int MaxAmountIndices
-        {
-            get => maxAmountIndices;
-            set
-            {
-                if (value == maxAmountIndices)
-                    return;
-
-                maxAmountIndices = value;
-
-                indexBuffer?.Dispose();
-                indexBuffer = null;
-            }
-        }
-
-        private static DeviceBuffer indexBuffer;
-
-        // todo: uhhhhhhhhhh....
-        public static DeviceBuffer IndexBuffer => indexBuffer ??= Vd.Factory.CreateBuffer(new BufferDescription((uint)(MaxAmountIndices * sizeof(ushort)), BufferUsage.IndexBuffer));
-    }
-
     internal class VeldridQuadBuffer<T> : VeldridVertexBuffer<T>
         where T : unmanaged, IEquatable<T>, IVertex
     {
@@ -63,9 +38,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             base.Initialise();
 
-            if (amountIndices > VeldridQuadIndexData.MaxAmountIndices)
+            if (amountIndices > renderer.SharedQuadIndex.Capacity)
             {
-                VeldridQuadIndexData.MaxAmountIndices = amountIndices;
+                renderer.SharedQuadIndex.Capacity = amountIndices;
 
                 ushort[] indices = new ushort[amountIndices];
 
@@ -79,14 +54,14 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                     indices[j + 5] = (ushort)(i + 1);
                 }
 
-                renderer.Commands.UpdateBuffer(VeldridQuadIndexData.IndexBuffer, 0, indices);
+                renderer.Commands.UpdateBuffer(renderer.SharedQuadIndex.Buffer, 0, indices);
             }
         }
 
         public override void Bind()
         {
             base.Bind();
-            renderer.BindIndexBuffer(VeldridQuadIndexData.IndexBuffer, IndexFormat.UInt16);
+            renderer.BindIndexBuffer(renderer.SharedQuadIndex.Buffer, IndexFormat.UInt16);
         }
 
         protected override int ToElements(int vertices) => 3 * vertices / 2;

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using Veldrid;
+using BufferUsage = Veldrid.BufferUsage;
+using PrimitiveTopology = Veldrid.PrimitiveTopology;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    internal static class VeldridQuadIndexData
+    {
+        private static int maxAmountIndices;
+
+        public static int MaxAmountIndices
+        {
+            get => maxAmountIndices;
+            set
+            {
+                if (value == maxAmountIndices)
+                    return;
+
+                maxAmountIndices = value;
+
+                indexBuffer?.Dispose();
+                indexBuffer = null;
+            }
+        }
+
+        private static DeviceBuffer indexBuffer;
+
+        // todo: uhhhhhhhhhh....
+        public static DeviceBuffer IndexBuffer => indexBuffer ??= Vd.Factory.CreateBuffer(new BufferDescription((uint)(MaxAmountIndices * sizeof(ushort)), BufferUsage.IndexBuffer));
+    }
+
+    internal class VeldridQuadBuffer<T> : VeldridVertexBuffer<T>
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly int amountIndices;
+
+        private const int indices_per_quad = IRenderer.VERTICES_PER_QUAD + 2;
+
+        /// <summary>
+        /// The maximum number of quads supported by this buffer.
+        /// </summary>
+        public const int MAX_QUADS = ushort.MaxValue / indices_per_quad;
+
+        internal VeldridQuadBuffer(VeldridRenderer renderer, int amountQuads, BufferUsage usage)
+            : base(renderer, amountQuads * IRenderer.VERTICES_PER_QUAD, usage)
+        {
+            this.renderer = renderer;
+            amountIndices = amountQuads * indices_per_quad;
+            Debug.Assert(amountIndices <= ushort.MaxValue);
+        }
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+
+            if (amountIndices > VeldridQuadIndexData.MaxAmountIndices)
+            {
+                VeldridQuadIndexData.MaxAmountIndices = amountIndices;
+
+                ushort[] indices = new ushort[amountIndices];
+
+                for (ushort i = 0, j = 0; j < amountIndices; i += IRenderer.VERTICES_PER_QUAD, j += indices_per_quad)
+                {
+                    indices[j] = i;
+                    indices[j + 1] = (ushort)(i + 1);
+                    indices[j + 2] = (ushort)(i + 3);
+                    indices[j + 3] = (ushort)(i + 2);
+                    indices[j + 4] = (ushort)(i + 3);
+                    indices[j + 5] = (ushort)(i + 1);
+                }
+
+                renderer.Commands.UpdateBuffer(VeldridQuadIndexData.IndexBuffer, 0, indices);
+            }
+        }
+
+        public override void Bind()
+        {
+            base.Bind();
+            renderer.BindIndexBuffer(VeldridQuadIndexData.IndexBuffer, IndexFormat.UInt16);
+        }
+
+        protected override int ToElements(int vertices) => 3 * vertices / 2;
+
+        protected override int ToElementIndex(int vertexIndex) => 3 * vertexIndex / 2;
+
+        protected override PrimitiveTopology Type => PrimitiveTopology.TriangleList;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -1,0 +1,183 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Buffers;
+using osu.Framework.Development;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Veldrid.Vertices;
+using osu.Framework.Statistics;
+using SixLabors.ImageSharp.Memory;
+using Veldrid;
+using BufferUsage = Veldrid.BufferUsage;
+using PrimitiveTopology = Veldrid.PrimitiveTopology;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    internal abstract class VeldridVertexBuffer<T> : IVertexBuffer
+        where T : unmanaged, IEquatable<T>, IVertex
+    {
+        protected static readonly int STRIDE = VeldridVertexUtils<DepthWrappingVertex<T>>.STRIDE;
+
+        private readonly VeldridRenderer renderer;
+        private readonly BufferUsage usage;
+
+        private Memory<DepthWrappingVertex<T>> vertexMemory;
+        private IMemoryOwner<DepthWrappingVertex<T>> memoryOwner;
+
+        private DeviceBuffer buffer;
+
+        protected VeldridVertexBuffer(VeldridRenderer renderer, int amountVertices, BufferUsage usage)
+        {
+            this.renderer = renderer;
+            this.usage = usage;
+
+            Size = amountVertices;
+        }
+
+        /// <summary>
+        /// Sets the vertex at a specific index of this <see cref="VeldridVertexBuffer{T}"/>.
+        /// </summary>
+        /// <param name="vertexIndex">The index of the vertex.</param>
+        /// <param name="vertex">The vertex.</param>
+        /// <returns>Whether the vertex changed.</returns>
+        public bool SetVertex(int vertexIndex, T vertex)
+        {
+            ref var currentVertex = ref getMemory().Span[vertexIndex];
+
+            bool isNewVertex = !currentVertex.Vertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != renderer.BackbufferDrawDepth;
+
+            currentVertex.Vertex = vertex;
+            currentVertex.BackbufferDrawDepth = renderer.BackbufferDrawDepth;
+
+            return isNewVertex;
+        }
+
+        /// <summary>
+        /// Gets the number of vertices in this <see cref="VeldridVertexBuffer{T}"/>.
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// Initialises this <see cref="VeldridVertexBuffer{T}"/>. Guaranteed to be run on the draw thread.
+        /// </summary>
+        protected virtual void Initialise()
+        {
+            ThreadSafety.EnsureDrawThread();
+
+            var description = new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage);
+            buffer = renderer.Factory.CreateBuffer(description);
+        }
+
+        ~VeldridVertexBuffer()
+        {
+            renderer.ScheduleDisposal(v => v.Dispose(false), this);
+        }
+
+        public void Dispose()
+        {
+            renderer.ScheduleDisposal(v => v.Dispose(true), this);
+            GC.SuppressFinalize(this);
+        }
+
+        protected bool IsDisposed { get; private set; }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+                return;
+
+            ((IVertexBuffer)this).Free();
+
+            IsDisposed = true;
+        }
+
+        public virtual void Bind()
+        {
+            if (IsDisposed)
+                throw new ObjectDisposedException(ToString(), "Can not bind disposed vertex buffers.");
+
+            if (buffer == null)
+                Initialise();
+
+            renderer.BindVertexBuffer(buffer, VeldridVertexUtils<DepthWrappingVertex<T>>.Layout);
+        }
+
+        public virtual void Unbind()
+        {
+        }
+
+        protected virtual int ToElements(int vertices) => vertices;
+
+        protected virtual int ToElementIndex(int vertexIndex) => vertexIndex;
+
+        protected abstract PrimitiveTopology Type { get; }
+
+        public void Draw()
+        {
+            DrawRange(0, Size);
+        }
+
+        public void DrawRange(int startIndex, int endIndex)
+        {
+            Bind();
+
+            int countVertices = endIndex - startIndex;
+            renderer.DrawVertices(Type, ToElementIndex(startIndex) * sizeof(ushort), ToElements(countVertices));
+
+            Unbind();
+        }
+
+        public void Update()
+        {
+            UpdateRange(0, Size);
+        }
+
+        public void UpdateRange(int startIndex, int endIndex)
+        {
+            if (buffer == null)
+                Initialise();
+
+            int countVertices = endIndex - startIndex;
+            renderer.Commands.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
+
+            FrameStatistics.Add(StatisticsCounterType.VerticesUpl, countVertices);
+        }
+
+        private ref Memory<DepthWrappingVertex<T>> getMemory()
+        {
+            ThreadSafety.EnsureDrawThread();
+
+            if (!InUse)
+            {
+                memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<DepthWrappingVertex<T>>(Size, AllocationOptions.Clean);
+                vertexMemory = memoryOwner.Memory;
+
+                renderer.RegisterVertexBufferUse(this);
+            }
+
+            LastUseResetId = renderer.ResetId;
+
+            return ref vertexMemory;
+        }
+
+        public ulong LastUseResetId { get; private set; }
+
+        public bool InUse => LastUseResetId > 0;
+
+        public void Free()
+        {
+            buffer?.Dispose();
+            buffer = null;
+
+            memoryOwner?.Dispose();
+            memoryOwner = null;
+            vertexMemory = Memory<DepthWrappingVertex<T>>.Empty;
+
+            LastUseResetId = 0;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Shaders/IVeldridUniformGroup.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/IVeldridUniformGroup.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal interface IVeldridUniformGroup
+    {
+        IReadOnlyList<VeldridUniformInfo> Uniforms { get; }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
@@ -1,0 +1,210 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Logging;
+using osu.Framework.Threading;
+using Veldrid;
+using Veldrid.SPIRV;
+using static osu.Framework.Threading.ScheduledDelegate;
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal class VeldridShader : IShader
+    {
+        private readonly string name;
+        private readonly VeldridShaderPart[] parts;
+        private readonly VeldridRenderer renderer;
+
+        private Shader[]? shaders;
+
+        private Dictionary<string, IUniform>? uniforms;
+        private DeviceBuffer? uniformBuffer;
+        private ResourceSet? uniformResourceSet;
+
+        private readonly ScheduledDelegate shaderInitialiseDelegate;
+
+        public bool IsLoaded => shaders != null;
+
+        public bool IsBound { get; private set; }
+
+        /// <summary>
+        /// The underlying Veldrid shaders.
+        /// </summary>
+        public Shader[] Shaders
+        {
+            get
+            {
+                if (!IsLoaded)
+                    throw new InvalidOperationException("Can not obtain shader parts for an uninitialised shader.");
+
+                Debug.Assert(shaders != null);
+                return shaders;
+            }
+        }
+
+        IReadOnlyDictionary<string, IUniform> IShader.Uniforms
+        {
+            get
+            {
+                if (!IsLoaded)
+                    throw new InvalidOperationException("Can not obtain uniforms for an uninitialised shader.");
+
+                Debug.Assert(uniforms != null);
+                return uniforms;
+            }
+        }
+
+        /// <summary>
+        /// The uniform buffer object for this shader.
+        /// </summary>
+        public DeviceBuffer UniformBuffer
+        {
+            get
+            {
+                if (!IsLoaded)
+                    throw new InvalidOperationException("Can not obtain uniform buffer for an uninitialised shader.");
+
+                Debug.Assert(uniformBuffer != null);
+                return uniformBuffer;
+            }
+        }
+
+        /// <summary>
+        /// A resource set wrapping the uniform buffer object for binding.
+        /// </summary>
+        public ResourceSet UniformResourceSet
+        {
+            get
+            {
+                if (!IsLoaded)
+                    throw new InvalidOperationException("Can not obtain uniform resource set for an uninitialised shader.");
+
+                Debug.Assert(uniformResourceSet != null);
+                return uniformResourceSet;
+            }
+        }
+
+        public VeldridShader(VeldridRenderer renderer, string name, params VeldridShaderPart[] parts)
+        {
+            this.name = name;
+            this.parts = parts;
+            this.renderer = renderer;
+
+            renderer.ScheduleExpensiveOperation(shaderInitialiseDelegate = new ScheduledDelegate(initialise));
+        }
+
+        internal void EnsureShaderInitialised()
+        {
+            if (isDisposed)
+                throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");
+
+            if (shaderInitialiseDelegate.State == RunState.Waiting)
+                shaderInitialiseDelegate.RunTask();
+        }
+
+        public void Bind()
+        {
+            if (IsBound)
+                return;
+
+            EnsureShaderInitialised();
+
+            renderer.BindShader(this);
+
+            Debug.Assert(uniforms != null);
+
+            foreach (var uniform in uniforms)
+                uniform.Value.Update();
+
+            IsBound = true;
+        }
+
+        public void Unbind()
+        {
+            if (!IsBound)
+                return;
+
+            renderer.UnbindShader(this);
+            IsBound = false;
+        }
+
+        public Uniform<T> GetUniform<T>(string name)
+            where T : unmanaged, IEquatable<T>
+        {
+            if (isDisposed)
+                throw new ObjectDisposedException("Can not retrieve uniforms from a disposed shader.");
+
+            EnsureShaderInitialised();
+
+            Debug.Assert(uniforms != null);
+            return (Uniform<T>)uniforms[name];
+        }
+
+        private void initialise()
+        {
+            Debug.Assert(parts.Length == 2);
+
+            VeldridShaderPart vertex = parts.Single(p => p.Type == ShaderPartType.Vertex);
+            VeldridShaderPart fragment = parts.Single(p => p.Type == ShaderPartType.Fragment);
+
+            var allUniforms = new VeldridUniformGroup(vertex.Uniforms, fragment.Uniforms);
+            uniformBuffer = allUniforms.CreateBuffer(renderer, this, out uniforms);
+            uniformResourceSet = renderer.CreateUniformResourceSet(uniformBuffer);
+
+            // todo: maybe use better entry point?
+            var vertexDescription = new ShaderDescription(ShaderStages.Vertex, vertex.GetData(allUniforms), "main");
+            var fragmentDescription = new ShaderDescription(ShaderStages.Fragment, fragment.GetData(allUniforms), "main");
+
+            try
+            {
+                shaders = renderer.Factory.CreateFromSpirv(vertexDescription, fragmentDescription, new CrossCompileOptions
+                {
+                    FixClipSpaceZ = !renderer.Device.IsDepthRangeZeroToOne,
+                    InvertVertexOutputY = renderer.Device.IsClipSpaceYInverted,
+                });
+
+                GlobalPropertyManager.Register(this);
+            }
+            catch (SpirvCompilationException e)
+            {
+                Logger.Error(e, $"Failed to initialise shader \"{name}\"");
+            }
+        }
+
+        private bool isDisposed;
+
+        ~VeldridShader()
+        {
+            renderer.ScheduleDisposal(s => s.Dispose(false), this);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
+            GlobalPropertyManager.Unregister(this);
+
+            if (shaders != null)
+            {
+                for (int i = 0; i < shaders.Length; i++)
+                    shaders[i].Dispose();
+
+                shaders = null;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
@@ -1,0 +1,220 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal class VeldridShaderPart : IShaderPart
+    {
+        private const string backbuffer_draw_depth_name = "m_BackbufferDrawDepth";
+
+        private readonly string data;
+
+        private readonly VeldridUniformGroup uniforms = new VeldridUniformGroup();
+
+        public IVeldridUniformGroup Uniforms => uniforms;
+
+        public ShaderPartType Type { get; }
+
+        private static readonly Regex include_regex = new Regex("^\\s*#\\s*include\\s+[\"<](.*)[\">]");
+
+        // private static readonly Regex shader_resource_regex = new Regex(@"^\s*(?>uniform)\s+(?:(?:lowp|mediump|highp)\s+)?(texture2D|sampler)\s+\w+;", RegexOptions.Multiline);
+        private static readonly Regex shader_uniform_regex = new Regex(@"^\s*(?>uniform)\s+(?:(lowp|mediump|highp)\s+)?(\w+)\s+(\w+);", RegexOptions.Multiline);
+        private static readonly Regex shader_attribute_location_regex = new Regex(@"(layout\(location\s=\s)(-?\d+)(\)\s(?>attribute|in).*)", RegexOptions.Multiline);
+
+        public VeldridShaderPart(ShaderManager shaders, byte[]? rawData, ShaderPartType type)
+        {
+            Type = type;
+            data = loadShader(rawData, type, shaders, uniforms);
+        }
+
+        /// <summary>
+        /// Returns compilable shader data.
+        /// </summary>
+        /// <param name="allUniforms">Uniforms declared on all shader parts of the grouping shader.</param>
+        public byte[] GetData(IVeldridUniformGroup allUniforms)
+        {
+            string result = includeUniformStructure(data, allUniforms);
+
+            if (!result.StartsWith("#version", StringComparison.Ordinal))
+                result = $"#version 450\n{result}";
+
+            return Encoding.UTF8.GetBytes(result);
+        }
+
+        /// <summary>
+        /// Loads a given shader data and fills the given uniform group as defined by the shader.
+        /// </summary>
+        /// <param name="rawData">The raw data of the shader.</param>
+        /// <param name="type">The shader type.</param>
+        /// <param name="shaders">The shader manager for looking up header/internal files.</param>
+        /// <param name="uniforms">The uniform group to fill with the data.</param>
+        /// <param name="mainFile">Whether this is the main file of the shader, used for recursion.</param>
+        private static string loadShader(byte[]? rawData, ShaderPartType type, ShaderManager shaders, VeldridUniformGroup uniforms, bool mainFile = true)
+        {
+            if (rawData == null)
+                return string.Empty;
+
+            using (MemoryStream ms = new MemoryStream(rawData))
+            using (StreamReader sr = new StreamReader(ms))
+            {
+                string data = string.Empty;
+
+                while (sr.Peek() != -1)
+                {
+                    string? line = sr.ReadLine();
+
+                    if (string.IsNullOrEmpty(line))
+                        continue;
+
+                    Match includeMatch = include_regex.Match(line);
+
+                    if (includeMatch.Success)
+                    {
+                        string includeName = includeMatch.Groups[1].Value.Trim();
+
+                        data += loadShader(shaders.LoadRaw(includeName), type, shaders, uniforms, false) + '\n';
+                    }
+                    else
+                        data += line + '\n';
+                }
+
+                if (!mainFile)
+                    return data;
+
+                data = loadShader(shaders.LoadRaw("sh_Precision_Internal.h"), type, shaders, uniforms, false) + "\n" + data;
+
+                if (type == ShaderPartType.Vertex)
+                    data = appendBackbuffer(data, shaders, uniforms);
+
+                // data = resolveResources(data);
+                data = omitUniforms(data, uniforms);
+
+                return data;
+            }
+        }
+
+        /// <summary>
+        /// Appends the "sh_Backbuffer_Internal.h" file to the given data.
+        /// </summary>
+        /// <param name="data">The data to append the header to.</param>
+        /// <param name="shaders">The shader manager for looking up the backbuffer file.</param>
+        /// <param name="uniforms">The uniform group to fill with the data.</param>
+        private static string appendBackbuffer(string data, ShaderManager shaders, VeldridUniformGroup uniforms)
+        {
+            string realMainName = "real_main_" + Guid.NewGuid().ToString("N");
+
+            string backbufferCode = loadShader(shaders.LoadRaw("sh_Backbuffer_Internal.h"), ShaderPartType.Vertex, shaders, uniforms, false);
+
+            backbufferCode = backbufferCode.Replace("{{ real_main }}", realMainName);
+            data = Regex.Replace(data, @"void main\((.*)\)", $"void {realMainName}()") + backbufferCode + '\n';
+
+            Match attributeLocationMatch = shader_attribute_location_regex.Match(data);
+
+            int count = 0;
+
+            while (attributeLocationMatch.Success)
+            {
+                int location = int.Parse(attributeLocationMatch.Groups[2].Value);
+                if (location == -1)
+                    break;
+
+                count = Math.Max(location + 1, count);
+                attributeLocationMatch = attributeLocationMatch.NextMatch();
+            }
+
+            // place the backbuffer draw depth member at the bottom of the vertex structure.
+            Debug.Assert(attributeLocationMatch.Value.Contains(backbuffer_draw_depth_name));
+            data = data.Replace(attributeLocationMatch.Value, shader_attribute_location_regex.Replace(attributeLocationMatch.Value, m => m.Groups[1] + count.ToString() + m.Groups[3]));
+            return data;
+        }
+
+        // private static string resolveResources(string data)
+        // {
+        //     Match resourceMatch = shader_resource_regex.Match(data);
+        //
+        //     while (resourceMatch.Success)
+        //     {
+        //         int index;
+        //
+        //         switch (resourceMatch.Groups[1].Value)
+        //         {
+        //             case "texture2D":
+        //                 index = Array.FindIndex(Vd.TEXTURE_LAYOUT.Elements, e => e.Kind == ResourceKind.TextureReadOnly);
+        //                 break;
+        //
+        //             case "sampler":
+        //                 index = Array.FindIndex(Vd.TEXTURE_LAYOUT.Elements, e => e.Kind == ResourceKind.Sampler);
+        //                 break;
+        //
+        //             default:
+        //                 throw new ArgumentOutOfRangeException(nameof(data));
+        //         }
+        //
+        //         data = data.Replace(resourceMatch.Value, $"layout(set = {Vd.TEXTURE_RESOURCE_SLOT}, binding = {index}) {resourceMatch.Value}");
+        //
+        //         resourceMatch = resourceMatch.NextMatch();
+        //     }
+        //
+        //     return data;
+        // }
+
+        /// <summary>
+        /// Omits all uniform declarations inside the given data, and fills them up in the given uniform group.
+        /// </summary>
+        /// <param name="data">The data to omit uniform declarations from.</param>
+        /// <param name="uniforms">The uniform group to fill the uniforms in.</param>
+        private static string omitUniforms(string data, VeldridUniformGroup uniforms)
+        {
+            Match uniformMatch = shader_uniform_regex.Match(data);
+
+            if (!uniformMatch.Success)
+                return data;
+
+            do
+            {
+                uniforms.AddUniform(uniformMatch.Groups[3].Value.Trim(), uniformMatch.Groups[2].Value.Trim(), uniformMatch.Groups[1].Value.Trim());
+                data = data.Replace(uniformMatch.Value, string.Empty);
+            } while ((uniformMatch = uniformMatch.NextMatch()).Success);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Includes a structure of the uniform buffer from the given uniform group.
+        /// </summary>
+        /// <param name="data">The data to include the structure in.</param>
+        /// <param name="allUniforms">A list of all uniforms defined by any shader part in the grouping shader.</param>
+        private string includeUniformStructure(string data, IVeldridUniformGroup allUniforms)
+        {
+            if (allUniforms.Uniforms.Count == 0)
+                return data;
+
+            string uniformBufferName = VeldridRenderer.UNIFORM_LAYOUT.Elements.Single().Name;
+
+            var uniformBuilder = new StringBuilder();
+            uniformBuilder.AppendLine($"layout(std140, set = {VeldridRenderer.UNIFORM_RESOURCES_SLOT}, binding = 0) uniform {uniformBufferName}");
+            uniformBuilder.AppendLine("{");
+
+            foreach (var uniform in allUniforms.Uniforms)
+                uniformBuilder.AppendLine($"{uniform.Precision} {uniform.Type} {uniform.Name};".Trim());
+
+            uniformBuilder.AppendLine("};");
+            uniformBuilder.AppendLine();
+
+            return $"{uniformBuilder}{data}";
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridUniformGroup.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridUniformGroup.cs
@@ -1,0 +1,154 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Shaders;
+using osuTK;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal class VeldridUniformGroup : IVeldridUniformGroup
+    {
+        private readonly List<VeldridUniformInfo> uniforms = new List<VeldridUniformInfo>();
+
+        /// <summary>
+        /// All uniforms declared by any shader part in the <see cref="VeldridShader"/>.
+        /// </summary>
+        public IReadOnlyList<VeldridUniformInfo> Uniforms => uniforms;
+
+        public VeldridUniformGroup(params IVeldridUniformGroup[] groups)
+        {
+            foreach (var group in groups)
+            {
+                foreach (var uniform in group.Uniforms)
+                    addUniform(uniform);
+            }
+        }
+
+        public void AddUniform(string name, string type, string precision) => addUniform(new VeldridUniformInfo
+        {
+            Name = name,
+            Type = type,
+            Precision = precision
+        });
+
+        private void addUniform(VeldridUniformInfo uniform)
+        {
+            // todo: make uniform with higher precision override lower uniform
+            if (uniforms.Any(u => u.Name == uniform.Name))
+                return;
+
+            uniforms.Add(uniform);
+        }
+
+        /// <summary>
+        /// Creates a uniform buffer object for all uniforms in this group.
+        /// </summary>
+        /// <param name="renderer">The renderer to create the uniform buffer.</param>
+        /// <param name="owner">The owner of the uniforms.</param>
+        /// <param name="uniforms">A list of <see cref="IUniform"/>s instantiated for the buffer structure.</param>
+        public DeviceBuffer CreateBuffer(VeldridRenderer renderer, VeldridShader owner, out Dictionary<string, IUniform> uniforms)
+        {
+            uniforms = new Dictionary<string, IUniform>(Uniforms.Count);
+
+            int bufferSize = 0;
+
+            for (int i = 0; i < Uniforms.Count; i++)
+            {
+                string name = Uniforms[i].Name;
+
+                IUniform uniform;
+
+                switch (Uniforms[i].Type)
+                {
+                    case "bool":
+                        uniform = createUniform<bool>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "float":
+                        uniform = createUniform<float>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "int":
+                        uniform = createUniform<int>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "mat3":
+                        uniform = createUniform<Matrix3>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "mat4":
+                        uniform = createUniform<Matrix4>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "vec2":
+                        uniform = createUniform<Vector2>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "vec3":
+                        uniform = createUniform<Vector3>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "vec4":
+                        uniform = createUniform<Vector4>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    case "texture2D":
+                        uniform = createUniform<int>(renderer, owner, name, ref bufferSize);
+                        break;
+
+                    default:
+                        continue;
+                }
+
+                uniforms[name] = uniform;
+            }
+
+            if (bufferSize % 16 > 0)
+                bufferSize += 16 - (bufferSize % 16);
+
+            return renderer.Factory.CreateBuffer(new BufferDescription((uint)bufferSize, BufferUsage.UniformBuffer));
+        }
+
+        private static IUniform createUniform<T>(VeldridRenderer renderer, VeldridShader shader, string name, ref int bufferSize)
+            where T : unmanaged, IEquatable<T>
+        {
+            int uniformSize = Marshal.SizeOf<T>();
+            int baseAlignment;
+
+            // see https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159.
+            if (typeof(T) == typeof(Vector3))
+            {
+                // vec3 has a base alignment of 4N (vec4).
+                baseAlignment = uniformSize = Marshal.SizeOf<Vector4>();
+            }
+            else if (typeof(T) == typeof(Matrix3) || typeof(T) == typeof(Matrix4))
+            {
+                // mat3 has a base alignment of vec4 for each column.
+                if (typeof(T) == typeof(Matrix3))
+                    uniformSize = Marshal.SizeOf<Matrix3x4>();
+
+                baseAlignment = Marshal.SizeOf<Vector4>();
+            }
+            else
+                baseAlignment = uniformSize;
+
+            // offset the location of this uniform with the calculated base alignment.
+            if (bufferSize % baseAlignment > 0)
+                bufferSize += baseAlignment - (bufferSize % baseAlignment);
+
+            int location = bufferSize;
+
+            bufferSize += uniformSize;
+
+            if (GlobalPropertyManager.CheckGlobalExists(name))
+                return new GlobalUniform<T>(renderer, shader, name, location);
+
+            return new Uniform<T>(renderer, shader, name, location);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridUniformInfo.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridUniformInfo.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal struct VeldridUniformInfo
+    {
+        /// <summary>
+        /// The declared name of this uniform.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The type of this uniform.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The precision applied to this uniform.
+        /// </summary>
+        public string Precision { get; set; }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -1,0 +1,372 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using osu.Framework.Development;
+using osu.Framework.Extensions.ImageExtensions;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Platform;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Veldrid;
+using PixelFormat = Veldrid.PixelFormat;
+using Texture = Veldrid.Texture;
+
+namespace osu.Framework.Graphics.Veldrid.Textures
+{
+    internal class VeldridTexture : INativeTexture
+    {
+        private readonly Queue<ITextureUpload> uploadQueue = new Queue<ITextureUpload>();
+
+        IRenderer INativeTexture.Renderer => Renderer;
+
+        public string Identifier
+        {
+            get
+            {
+                if (!Available || texture == null)
+                    return "-";
+
+                return texture.Name;
+            }
+        }
+
+        public int MaxSize => Renderer.MaxTextureSize;
+
+        public virtual int Width { get; set; }
+        public virtual int Height { get; set; }
+        public virtual int GetByteSize() => Width * Height * 4;
+        public bool Available { get; private set; } = true;
+
+        ulong INativeTexture.TotalBindCount { get; set; }
+
+        public bool BypassTextureUploadQueueing { get; set; }
+
+        private readonly bool manualMipmaps;
+
+        private readonly SamplerFilter filteringMode;
+        private readonly Rgba32 initialisationColour;
+
+        public ulong BindCount { get; protected set; }
+
+        public RectangleI Bounds => new RectangleI(0, 0, Width, Height);
+
+        protected virtual TextureUsage Usages
+        {
+            get
+            {
+                var usages = TextureUsage.Sampled;
+
+                if (!manualMipmaps)
+                    usages |= TextureUsage.GenerateMipmaps;
+
+                return usages;
+            }
+        }
+
+        protected readonly VeldridRenderer Renderer;
+
+        /// <summary>
+        /// Creates a new <see cref="VeldridTexture"/>.
+        /// </summary>
+        /// <param name="renderer">The renderer.</param>
+        /// <param name="width">The width of the texture.</param>
+        /// <param name="height">The height of the texture.</param>
+        /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
+        /// <param name="filteringMode">The filtering mode.</param>
+        /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads).</param>
+        public VeldridTexture(VeldridRenderer renderer, int width, int height, bool manualMipmaps = false, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear, Rgba32 initialisationColour = default)
+        {
+            this.manualMipmaps = manualMipmaps;
+            this.filteringMode = filteringMode;
+            this.initialisationColour = initialisationColour;
+
+            Renderer = renderer;
+            Width = width;
+            Height = height;
+        }
+
+        #region Disposal
+
+        ~VeldridTexture()
+        {
+            Dispose(false);
+        }
+
+        private bool isDisposed;
+
+        public void Dispose()
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool isDisposing)
+        {
+            Renderer.ScheduleDisposal(texture =>
+            {
+                while (texture.tryGetNextUpload(out var upload))
+                    upload.Dispose();
+
+                if (texture.texture == null)
+                    return;
+
+                texture.memoryLease?.Dispose();
+
+                texture.resource?.Dispose();
+                texture.resource = null;
+
+                texture.sampler?.Dispose();
+                texture.sampler = null;
+
+                texture.texture?.Dispose();
+                texture.texture = null;
+
+                texture.Available = false;
+            }, this);
+        }
+
+        #endregion
+
+        #region Memory Tracking
+
+        private List<long> levelMemoryUsage = new List<long>();
+
+        private NativeMemoryTracker.NativeMemoryLease memoryLease;
+
+        private void updateMemoryUsage(int level, long newUsage)
+        {
+            levelMemoryUsage ??= new List<long>();
+
+            while (level >= levelMemoryUsage.Count)
+                levelMemoryUsage.Add(0);
+
+            levelMemoryUsage[level] = newUsage;
+
+            memoryLease?.Dispose();
+            memoryLease = NativeMemoryTracker.AddMemory(this, getMemoryUsage());
+        }
+
+        private long getMemoryUsage()
+        {
+            long usage = 0;
+
+            for (int i = 0; i < levelMemoryUsage.Count; i++)
+                usage += levelMemoryUsage[i];
+
+            return usage;
+        }
+
+        #endregion
+
+        private Texture texture;
+        private Sampler sampler;
+
+        private VeldridTextureSamplerSet resource;
+
+        [CanBeNull]
+        public VeldridTextureSamplerSet Resource
+        {
+            get
+            {
+                if (!Available)
+                    throw new ObjectDisposedException(ToString(), "Can not obtain resource set of a disposed texture.");
+
+                return resource;
+            }
+        }
+
+        public void FlushUploads()
+        {
+            while (tryGetNextUpload(out var upload))
+                upload.Dispose();
+        }
+
+        public void SetData(ITextureUpload upload)
+        {
+            lock (uploadQueue)
+            {
+                bool requireUpload = uploadQueue.Count == 0;
+                uploadQueue.Enqueue(upload);
+
+                if (requireUpload && !BypassTextureUploadQueueing)
+                    Renderer.EnqueueTextureUpload(this);
+            }
+        }
+
+        public virtual bool Bind(int unit, WrapMode wrapModeS, WrapMode wrapModeT)
+        {
+            if (!Available)
+                throw new ObjectDisposedException(ToString(), "Can not bind a disposed texture.");
+
+            Upload();
+
+            if (resource == null)
+                return false;
+
+            if (Renderer.BindTexture(this, wrapModeS: wrapModeS, wrapModeT: wrapModeT))
+                BindCount++;
+
+            return true;
+        }
+
+        public bool Upload()
+        {
+            if (!Available)
+                return false;
+
+            // We should never run raw Veldrid calls on another thread than the draw thread due to race conditions.
+            ThreadSafety.EnsureDrawThread();
+
+            bool didUpload = false;
+
+            while (tryGetNextUpload(out ITextureUpload upload))
+            {
+                using (upload)
+                {
+                    DoUpload(upload);
+                    didUpload = true;
+                }
+            }
+
+            if (didUpload && !(manualMipmaps || maximumUploadedLod > 0))
+                Renderer.Commands.GenerateMipmaps(texture);
+
+            return didUpload;
+        }
+
+        public bool UploadComplete
+        {
+            get
+            {
+                lock (uploadQueue)
+                    return uploadQueue.Count == 0;
+            }
+        }
+
+        /// <summary>
+        /// Whether the texture is currently queued for upload.
+        /// </summary>
+        public bool IsQueuedForUpload { get; set; }
+
+        private bool tryGetNextUpload(out ITextureUpload upload)
+        {
+            lock (uploadQueue)
+            {
+                if (uploadQueue.Count == 0)
+                {
+                    upload = null;
+                    return false;
+                }
+
+                upload = uploadQueue.Dequeue();
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The maximum number of mip levels provided by a <see cref="ITextureUpload"/>.
+        /// </summary>
+        /// <remarks>
+        /// This excludes automatic generation of mipmaps via the graphics backend.
+        /// </remarks>
+        private int maximumUploadedLod;
+
+        protected virtual void DoUpload(ITextureUpload upload)
+        {
+            if (texture == null || texture.Width != Width || texture.Height != Height)
+            {
+                resource?.Dispose();
+                resource = null;
+
+                sampler?.Dispose();
+                sampler = null;
+
+                texture?.Dispose();
+
+                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)calculateMipmapLevels(Width, Height), 1, PixelFormat.R8_G8_B8_A8_UNorm_SRgb, Usages);
+                texture = Renderer.Factory.CreateTexture(ref textureDescription);
+
+                // todo: we may want to look into not having to allocate chunks of zero byte region for initialising textures
+                // similar to how OpenGL allows calling glTexImage2D with null data pointer.
+                initialiseLevel(0, Width, Height);
+
+                maximumUploadedLod = 0;
+            }
+
+            int lastMaximumUploadedLod = maximumUploadedLod;
+
+            if (!upload.Data.IsEmpty)
+            {
+                // ensure all mip levels up to the target level are initialised.
+                if (upload.Level > maximumUploadedLod)
+                {
+                    for (int i = maximumUploadedLod + 1; i <= upload.Level; i++)
+                        initialiseLevel(i, Width >> i, Height >> i);
+
+                    maximumUploadedLod = upload.Level;
+                }
+
+                Renderer.UpdateTexture(texture, upload.Bounds.X >> upload.Level, upload.Bounds.Y >> upload.Level, upload.Bounds.Width >> upload.Level, upload.Bounds.Height >> upload.Level, upload.Level, upload.Data);
+            }
+
+            if (sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
+            {
+                resource?.Dispose();
+                resource = null;
+
+                sampler?.Dispose();
+
+                bool useUploadMipmaps = manualMipmaps || maximumUploadedLod > 0;
+
+                var samplerDescription = new SamplerDescription
+                {
+                    AddressModeU = SamplerAddressMode.Clamp,
+                    AddressModeV = SamplerAddressMode.Clamp,
+                    AddressModeW = SamplerAddressMode.Clamp,
+                    Filter = filteringMode,
+                    MinimumLod = 0,
+                    MaximumLod = useUploadMipmaps ? (uint)maximumUploadedLod : IRenderer.MAX_MIPMAP_LEVELS,
+                    MaximumAnisotropy = 0,
+                };
+
+                sampler = Renderer.Factory.CreateSampler(ref samplerDescription);
+            }
+
+            resource ??= new VeldridTextureSamplerSet(Renderer, texture, sampler);
+        }
+
+        private unsafe void initialiseLevel(int level, int width, int height)
+        {
+            using (var image = createBackingImage(width, height))
+            using (var pixels = image.CreateReadOnlyPixelSpan())
+            {
+                updateMemoryUsage(level, (long)width * height * sizeof(Rgba32));
+                Renderer.UpdateTexture(texture, 0, 0, width, height, level, pixels.Span);
+            }
+        }
+
+        private Image<Rgba32> createBackingImage(int width, int height)
+        {
+            // it is faster to initialise without a background specification if transparent black is all that's required.
+            return initialisationColour == default
+                ? new Image<Rgba32>(width, height)
+                : new Image<Rgba32>(width, height, initialisationColour);
+        }
+
+        // todo: should this be limited to MAX_MIPMAP_LEVELS or was that constant supposed to be for automatic mipmap generation only?
+        // previous implementation was allocating mip levels all the way to 1x1 size when an ITextureUpload.Level > 0, therefore it's not limited there.
+        private static int calculateMipmapLevels(int width, int height) => 1 + (int)Math.Floor(Math.Log(Math.Max(width, height), 2));
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureSamplerSet.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureSamplerSet.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Textures
+{
+    /// <summary>
+    /// Represents a texture-sampler resource usable by <see cref="VeldridRenderer"/> to bind textures, acting similar to an OpenGL texture ID.
+    /// </summary>
+    internal class VeldridTextureSamplerSet : IDisposable
+    {
+        public IReadOnlyList<Texture> Textures { get; }
+        public Texture Texture => Textures.Single();
+
+        public Sampler Sampler { get; }
+
+        public ResourceLayout Layout { get; }
+
+        private readonly ResourceSet resourceSet;
+
+        public VeldridTextureSamplerSet(VeldridRenderer renderer, Texture texture, Sampler sampler)
+            : this(renderer, new[] { texture }, sampler)
+        {
+        }
+
+        public VeldridTextureSamplerSet(VeldridRenderer renderer, Texture[] textures, Sampler sampler)
+        {
+            Textures = textures;
+            Sampler = sampler;
+
+            Layout = renderer.GetTextureResourceLayout(textures.Length);
+
+            resourceSet = renderer.Factory.CreateResourceSet(new ResourceSetDescription(Layout, textures.Append<BindableResource>(sampler).ToArray()));
+        }
+
+        public void Dispose()
+        {
+            resourceSet?.Dispose();
+        }
+
+        public static implicit operator ResourceSet(VeldridTextureSamplerSet veldridTextureSet) => veldridTextureSet.resourceSet;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osuTK.Graphics;
 using SharpGen.Runtime;
@@ -112,6 +113,21 @@ namespace osu.Framework.Graphics.Veldrid
             if (mask.HasFlagFast(BlendingMask.Alpha)) writeMask |= ColorWriteMask.Alpha;
 
             return writeMask;
+        }
+
+        public static SamplerFilter ToSamplerFilter(this TextureFilteringMode mode)
+        {
+            switch (mode)
+            {
+                case TextureFilteringMode.Linear:
+                    return SamplerFilter.MinLinear_MagLinear_MipLinear;
+
+                case TextureFilteringMode.Nearest:
+                    return SamplerFilter.MinPoint_MagPoint_MipPoint;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
         }
 
         public static ComparisonKind ToComparisonKind(this BufferTestFunction function)

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -115,6 +115,38 @@ namespace osu.Framework.Graphics.Veldrid
             return writeMask;
         }
 
+        public static PixelFormat[] ToPixelFormats(this RenderBufferFormat[] renderBufferFormats)
+        {
+            var pixelFormats = new PixelFormat[renderBufferFormats.Length];
+
+            for (int i = 0; i < pixelFormats.Length; i++)
+            {
+                switch (renderBufferFormats[i])
+                {
+                    case RenderBufferFormat.D16:
+                        pixelFormats[i] = PixelFormat.R16_UNorm;
+                        break;
+
+                    case RenderBufferFormat.D32:
+                        pixelFormats[i] = PixelFormat.R32_Float;
+                        break;
+
+                    case RenderBufferFormat.D24S8:
+                        pixelFormats[i] = PixelFormat.D24_UNorm_S8_UInt;
+                        break;
+
+                    case RenderBufferFormat.D32S8:
+                        pixelFormats[i] = PixelFormat.D32_Float_S8_UInt;
+                        break;
+
+                    default:
+                        throw new ArgumentException($"Unsupported render buffer format: {renderBufferFormats[i]}", nameof(renderBufferFormats));
+                }
+            }
+
+            return pixelFormats;
+        }
+
         public static SamplerFilter ToSamplerFilter(this TextureFilteringMode mode)
         {
             switch (mode)

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -18,6 +18,7 @@ using Vortice.DXGI;
 using Vulkan;
 using GetPName = Veldrid.OpenGLBinding.GetPName;
 using GraphicsBackend = Veldrid.GraphicsBackend;
+using PrimitiveTopology = Veldrid.PrimitiveTopology;
 using StencilOperation = Veldrid.StencilOperation;
 using StringName = Veldrid.OpenGLBinding.StringName;
 using VertexAttribPointerType = osuTK.Graphics.ES30.VertexAttribPointerType;
@@ -254,6 +255,30 @@ namespace osu.Framework.Graphics.Veldrid
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+        }
+
+        public static PrimitiveTopology ToPrimitiveTopology(this Rendering.PrimitiveTopology type)
+        {
+            switch (type)
+            {
+                case Rendering.PrimitiveTopology.Points:
+                    return PrimitiveTopology.PointList;
+
+                case Rendering.PrimitiveTopology.Lines:
+                    return PrimitiveTopology.LineList;
+
+                case Rendering.PrimitiveTopology.LineStrip:
+                    return PrimitiveTopology.LineStrip;
+
+                case Rendering.PrimitiveTopology.Triangles:
+                    return PrimitiveTopology.TriangleList;
+
+                case Rendering.PrimitiveTopology.TriangleStrip:
+                    return PrimitiveTopology.TriangleStrip;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type));
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -20,6 +20,7 @@ using GetPName = Veldrid.OpenGLBinding.GetPName;
 using GraphicsBackend = Veldrid.GraphicsBackend;
 using StencilOperation = Veldrid.StencilOperation;
 using StringName = Veldrid.OpenGLBinding.StringName;
+using VertexAttribPointerType = osuTK.Graphics.ES30.VertexAttribPointerType;
 
 namespace osu.Framework.Graphics.Veldrid
 {
@@ -175,6 +176,84 @@ namespace osu.Framework.Graphics.Veldrid
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(operation));
+            }
+        }
+
+        public static VertexElementFormat ToVertexElementFormat(this VertexAttribPointerType type, int count)
+        {
+            switch (type)
+            {
+                case VertexAttribPointerType.Byte when count == 2:
+                    return VertexElementFormat.SByte2;
+
+                case VertexAttribPointerType.Byte when count == 4:
+                    return VertexElementFormat.SByte4;
+
+                case VertexAttribPointerType.UnsignedByte when count == 2:
+                    return VertexElementFormat.Byte2;
+
+                case VertexAttribPointerType.UnsignedByte when count == 4:
+                    return VertexElementFormat.Byte4;
+
+                case VertexAttribPointerType.Short when count == 2:
+                    return VertexElementFormat.Short2;
+
+                case VertexAttribPointerType.Short when count == 4:
+                    return VertexElementFormat.Short4;
+
+                case VertexAttribPointerType.UnsignedShort when count == 2:
+                    return VertexElementFormat.UShort2;
+
+                case VertexAttribPointerType.UnsignedShort when count == 4:
+                    return VertexElementFormat.UShort4;
+
+                case VertexAttribPointerType.Int when count == 1:
+                    return VertexElementFormat.Int1;
+
+                case VertexAttribPointerType.Int when count == 2:
+                    return VertexElementFormat.Int2;
+
+                case VertexAttribPointerType.Int when count == 3:
+                    return VertexElementFormat.Int3;
+
+                case VertexAttribPointerType.Int when count == 4:
+                    return VertexElementFormat.Int4;
+
+                case VertexAttribPointerType.UnsignedInt when count == 1:
+                    return VertexElementFormat.UInt1;
+
+                case VertexAttribPointerType.UnsignedInt when count == 2:
+                    return VertexElementFormat.UInt2;
+
+                case VertexAttribPointerType.UnsignedInt when count == 3:
+                    return VertexElementFormat.UInt3;
+
+                case VertexAttribPointerType.UnsignedInt when count == 4:
+                    return VertexElementFormat.UInt4;
+
+                case VertexAttribPointerType.Float when count == 1:
+                    return VertexElementFormat.Float1;
+
+                case VertexAttribPointerType.Float when count == 2:
+                    return VertexElementFormat.Float2;
+
+                case VertexAttribPointerType.Float when count == 3:
+                    return VertexElementFormat.Float3;
+
+                case VertexAttribPointerType.Float when count == 4:
+                    return VertexElementFormat.Float4;
+
+                case VertexAttribPointerType.HalfFloat when count == 1:
+                    return VertexElementFormat.Half1;
+
+                case VertexAttribPointerType.HalfFloat when count == 2:
+                    return VertexElementFormat.Half2;
+
+                case VertexAttribPointerType.HalfFloat when count == 4:
+                    return VertexElementFormat.Half4;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -12,12 +12,8 @@ using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Batches;
 using osu.Framework.Platform;
-using osu.Framework.Graphics.Veldrid.Batches;
 using osu.Framework.Graphics.Veldrid.Buffers;
-using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Statistics;
-using osu.Framework.Threading;
-using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp.PixelFormats;
@@ -46,6 +42,8 @@ namespace osu.Framework.Graphics.Veldrid
 
         internal VeldridIndexData SharedLinearIndex { get; }
         internal VeldridIndexData SharedQuadIndex { get; }
+
+        private DeviceBuffer? boundVertexBuffer;
 
         private GraphicsPipelineDescription pipeline = new GraphicsPipelineDescription
         {
@@ -267,6 +265,21 @@ namespace osu.Framework.Graphics.Veldrid
             Commands.SetFramebuffer(Device.SwapchainFramebuffer);
             pipeline.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }
+
+        public void BindVertexBuffer(DeviceBuffer buffer, VertexLayoutDescription layout)
+        {
+            if (buffer == boundVertexBuffer)
+                return;
+
+            Commands.SetVertexBuffer(0, buffer);
+            pipeline.ShaderSet.VertexLayouts[0] = layout;
+
+            FrameStatistics.Increment(StatisticsCounterType.VBufBinds);
+
+            boundVertexBuffer = buffer;
+        }
+
+        public void BindIndexBuffer(DeviceBuffer buffer, IndexFormat format) => Commands.SetIndexBuffer(buffer, format);
 
         public void DrawVertices(PrimitiveTopology type, int indexStart, int indicesCount)
         {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -39,6 +39,9 @@ namespace osu.Framework.Graphics.Veldrid
         }
 
         public override string ShaderFilenameSuffix => @"-veldrid";
+
+        public override bool DepthStartsFromNegativeOne => !Device.IsDepthRangeZeroToOne;
+
         private IGraphicsSurface graphicsSurface = null!;
 
         public GraphicsDevice Device { get; private set; } = null!;

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -196,8 +196,6 @@ namespace osu.Framework.Graphics.Veldrid
             base.BeginFrame(windowSize);
 
             boundTextureSet = defaultTextureSet;
-
-            Clear(new ClearInfo(Color4.FromHsv(new Vector4(ResetId % 360 / 360f, 0.5f, 0.5f, 1f))));
         }
 
         protected internal override void FinishFrame()

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Batches;
 using osu.Framework.Platform;
 using osu.Framework.Graphics.Veldrid.Batches;
+using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
@@ -43,6 +44,9 @@ namespace osu.Framework.Graphics.Veldrid
 
         private IGraphicsSurface graphicsSurface = null!;
 
+        internal VeldridIndexData SharedLinearIndex { get; }
+        internal VeldridIndexData SharedQuadIndex { get; }
+
         private GraphicsPipelineDescription pipeline = new GraphicsPipelineDescription
         {
             RasterizerState = RasterizerStateDescription.CullNone,
@@ -51,6 +55,12 @@ namespace osu.Framework.Graphics.Veldrid
         };
 
         private static readonly GlobalStatistic<int> stat_graphics_pipeline_created = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Total pipelines created");
+
+        public VeldridRenderer()
+        {
+            SharedLinearIndex = new VeldridIndexData(this);
+            SharedQuadIndex = new VeldridIndexData(this);
+        }
 
         protected override void Initialise(IGraphicsSurface graphicsSurface)
         {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -41,6 +41,7 @@ namespace osu.Framework.Graphics.Veldrid
         public override string ShaderFilenameSuffix => @"-veldrid";
 
         public override bool DepthStartsFromNegativeOne => !Device.IsDepthRangeZeroToOne;
+        public override bool TextureOriginAtBottomLeft => Device.IsClipSpaceYInverted;
 
         private IGraphicsSurface graphicsSurface = null!;
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Batches;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Graphics.Veldrid.Shaders;
+using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osuTK;
@@ -23,6 +24,7 @@ using Veldrid;
 using Veldrid.OpenGL;
 using PixelFormat = Veldrid.PixelFormat;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
+using Texture = Veldrid.Texture;
 
 namespace osu.Framework.Graphics.Veldrid
 {
@@ -56,6 +58,9 @@ namespace osu.Framework.Graphics.Veldrid
 
         internal static readonly ResourceLayoutDescription UNIFORM_LAYOUT = new ResourceLayoutDescription(
             new ResourceLayoutElementDescription("m_Uniforms", ResourceKind.UniformBuffer, ShaderStages.Fragment | ShaderStages.Vertex));
+        internal static readonly ResourceLayoutDescription TEXTURE_LAYOUT = new ResourceLayoutDescription(
+            new ResourceLayoutElementDescription("m_Texture", ResourceKind.TextureReadOnly, ShaderStages.Fragment),
+            new ResourceLayoutElementDescription("m_Sampler", ResourceKind.Sampler, ShaderStages.Fragment));
 
         private GraphicsPipelineDescription pipeline = new GraphicsPipelineDescription
         {
@@ -226,6 +231,59 @@ namespace osu.Framework.Graphics.Veldrid
         protected override void SetScissorStateImplementation(bool enabled) => pipeline.RasterizerState.ScissorTestEnabled = enabled;
 
         protected override bool SetTextureImplementation(INativeTexture? texture, int unit) => true;
+        /// <summary>
+        /// Updates a <see cref="Texture"/> with a <paramref name="data"/> at the specified coordinates.
+        /// </summary>
+        /// <param name="texture">The <see cref="Texture"/> to update.</param>
+        /// <param name="x">The X coordinate of the update region.</param>
+        /// <param name="y">The Y coordinate of the update region.</param>
+        /// <param name="width">The width of the update region.</param>
+        /// <param name="height">The height of the update region.</param>
+        /// <param name="level">The texture level.</param>
+        /// <param name="data">The textural data.</param>
+        /// <param name="bufferRowLength">An optional length per row on the given <paramref name="data"/>.</param>
+        /// <typeparam name="T">The pixel type.</typeparam>
+        public unsafe void UpdateTexture<T>(Texture texture, int x, int y, int width, int height, int level, ReadOnlySpan<T> data, int? bufferRowLength = null)
+            where T : unmanaged
+        {
+            fixed (T* ptr = data)
+            {
+                if (bufferRowLength != null)
+                {
+                    var staging = Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, texture.Format, TextureUsage.Staging));
+
+                    for (uint yi = 0; yi < height; yi++)
+                        Device.UpdateTexture(staging, (IntPtr)(ptr + yi * bufferRowLength.Value), (uint)width, 0, yi, 0, (uint)width, 1, 1, 0, 0);
+
+                    Commands.CopyTexture(staging, texture);
+                    staging.Dispose();
+                }
+                else
+                    Device.UpdateTexture(texture, (IntPtr)ptr, (uint)(data.Length * sizeof(T)), (uint)x, (uint)y, 0, (uint)width, (uint)height, 1, (uint)level, 0);
+            }
+        }
+
+        private static readonly Dictionary<int, ResourceLayout> texture_layouts = new Dictionary<int, ResourceLayout>();
+
+        /// <summary>
+        /// Retrieves a <see cref="ResourceLayout"/> for a texture-sampler resource set.
+        /// </summary>
+        /// <param name="textureCount">The number of textures in the resource layout.</param>
+        /// <returns></returns>
+        public ResourceLayout GetTextureResourceLayout(int textureCount)
+        {
+            if (texture_layouts.TryGetValue(textureCount, out var layout))
+                return layout;
+
+            var description = new ResourceLayoutDescription(new ResourceLayoutElementDescription[textureCount + 1]);
+            var textureElement = TEXTURE_LAYOUT.Elements.Single(e => e.Kind == ResourceKind.TextureReadOnly);
+
+            for (int i = 0; i < textureCount; i++)
+                description.Elements[i] = new ResourceLayoutElementDescription($"{textureElement.Name}{i}", textureElement.Kind, textureElement.Stages);
+
+            description.Elements[^1] = TEXTURE_LAYOUT.Elements.Single(e => e.Kind == ResourceKind.Sampler);
+            return texture_layouts[textureCount] = Factory.CreateResourceLayout(ref description);
+        }
 
         protected override void SetShaderImplementation(IShader shader)
         {
@@ -340,7 +398,7 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected override INativeTexture CreateNativeTexture(int width, int height, bool manualMipmaps = false, TextureFilteringMode filteringMode = TextureFilteringMode.Linear,
                                                               Rgba32 initialisationColour = default)
-            => new DummyNativeTexture(this);
+            => new VeldridTexture(this, width, height, manualMipmaps, filteringMode.ToSamplerFilter(), initialisationColour);
 
         protected override INativeTexture CreateNativeVideoTexture(int width, int height) => new DummyNativeTexture(this);
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -31,6 +31,7 @@ namespace osu.Framework.Graphics.Veldrid
     internal class VeldridRenderer : Renderer
     {
         public const int UNIFORM_RESOURCES_SLOT = 0;
+        public const int TEXTURE_RESOURCES_SLOT = 1;
 
         protected internal override bool VerticalSync
         {
@@ -39,6 +40,7 @@ namespace osu.Framework.Graphics.Veldrid
         }
 
         public override string ShaderFilenameSuffix => @"-veldrid";
+        private IGraphicsSurface graphicsSurface = null!;
 
         public GraphicsDevice Device { get; private set; } = null!;
 
@@ -46,7 +48,8 @@ namespace osu.Framework.Graphics.Veldrid
 
         public CommandList Commands { get; private set; } = null!;
 
-        private IGraphicsSurface graphicsSurface = null!;
+        private VeldridTextureSamplerSet defaultTextureSet = null!;
+        private VeldridTextureSamplerSet boundTextureSet = null!;
 
         internal VeldridIndexData SharedLinearIndex { get; }
         internal VeldridIndexData SharedQuadIndex { get; }
@@ -172,6 +175,10 @@ namespace osu.Framework.Graphics.Veldrid
             pipeline.ResourceLayouts = new ResourceLayout[2];
             pipeline.ResourceLayouts[UNIFORM_RESOURCES_SLOT] = uniformLayout;
             pipeline.Outputs = Device.SwapchainFramebuffer.OutputDescription;
+
+            var defaultTexture = Factory.CreateTexture(TextureDescription.Texture2D(1, 1, 1, 1, PixelFormat.R8_G8_B8_A8_UNorm_SRgb, TextureUsage.Sampled));
+            Device.UpdateTexture(defaultTexture, new ReadOnlySpan<Rgba32>(new[] { new Rgba32(0, 0, 0) }), 0, 0, 0, 1, 1, 1, 0, 0);
+            boundTextureSet = defaultTextureSet = new VeldridTextureSamplerSet(this, defaultTexture, Device.LinearSampler);
         }
 
         private Vector2 currentSize;
@@ -187,6 +194,8 @@ namespace osu.Framework.Graphics.Veldrid
             Commands.Begin();
 
             base.BeginFrame(windowSize);
+
+            boundTextureSet = defaultTextureSet;
 
             Clear(new ClearInfo(Color4.FromHsv(new Vector4(ResetId % 360 / 360f, 0.5f, 0.5f, 1f))));
         }
@@ -230,7 +239,18 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected override void SetScissorStateImplementation(bool enabled) => pipeline.RasterizerState.ScissorTestEnabled = enabled;
 
-        protected override bool SetTextureImplementation(INativeTexture? texture, int unit) => true;
+        protected override bool SetTextureImplementation(INativeTexture? texture, int unit)
+        {
+            var veldridTexture = texture as VeldridTexture; // texture may be DummyNativeTexture coming from a DummyFramebuffer, since framebuffers are not supported yet.
+            if (veldridTexture != null && veldridTexture.Resource == null)
+                return false;
+
+            var textureSet = veldridTexture?.Resource ?? defaultTextureSet;
+            pipeline.ResourceLayouts[TEXTURE_RESOURCES_SLOT] = textureSet.Layout;
+            boundTextureSet = textureSet;
+            return true;
+        }
+
         /// <summary>
         /// Updates a <see cref="Texture"/> with a <paramref name="data"/> at the specified coordinates.
         /// </summary>
@@ -363,9 +383,10 @@ namespace osu.Framework.Graphics.Veldrid
         {
             pipeline.PrimitiveTopology = type;
 
-            // we still can't draw yet as we're missing texture support.
-            // Commands.SetPipeline(getPipelineInstance());
-            // Commands.DrawIndexed((uint)indicesCount, 1, (uint)indexStart, 0, 0);
+            Commands.SetPipeline(getPipelineInstance());
+            Commands.SetGraphicsResourceSet(UNIFORM_RESOURCES_SLOT, boundUniformSet);
+            Commands.SetGraphicsResourceSet(TEXTURE_RESOURCES_SLOT, boundTextureSet);
+            Commands.DrawIndexed((uint)indicesCount, 1, (uint)indexStart, 0, 0);
         }
 
         private readonly Dictionary<GraphicsPipelineDescription, Pipeline> pipelineCache = new Dictionary<GraphicsPipelineDescription, Pipeline>();

--- a/osu.Framework/Graphics/Veldrid/Vertices/VeldridVertexUtils.cs
+++ b/osu.Framework/Graphics/Veldrid/Vertices/VeldridVertexUtils.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Veldrid.Vertices
     /// Utility class providing functionality to generate <see cref="VertexLayoutDescription"/> from vertex structures for Veldrid.
     /// </summary>
     internal static class VeldridVertexUtils<T>
-        where T : struct, IVertex
+        where T : unmanaged, IVertex
     {
         /// <summary>
         /// The stride of the vertex of type <typeparamref name="T"/>.

--- a/osu.Framework/Graphics/Veldrid/Vertices/VeldridVertexUtils.cs
+++ b/osu.Framework/Graphics/Veldrid/Vertices/VeldridVertexUtils.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable StaticMemberInGenericType
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Rendering.Vertices;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Vertices
+{
+    /// <summary>
+    /// Utility class providing functionality to generate <see cref="VertexLayoutDescription"/> from vertex structures for Veldrid.
+    /// </summary>
+    internal static class VeldridVertexUtils<T>
+        where T : struct, IVertex
+    {
+        /// <summary>
+        /// The stride of the vertex of type <typeparamref name="T"/>.
+        /// </summary>
+        public static readonly int STRIDE = Marshal.SizeOf(default(T));
+
+        public static VertexLayoutDescription Layout { get; }
+
+        private static readonly List<VertexElementDescription> elements = new List<VertexElementDescription>();
+
+        static VeldridVertexUtils()
+        {
+            addAttributesRecursive(typeof(T), 0);
+
+            Layout = new VertexLayoutDescription(elements.ToArray());
+        }
+
+        private static void addAttributesRecursive(Type type, int currentOffset)
+        {
+            foreach (FieldInfo field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                int fieldOffset = currentOffset + Marshal.OffsetOf(type, field.Name).ToInt32();
+
+                if (typeof(IVertex).IsAssignableFrom(field.FieldType))
+                {
+                    // Vertices may contain others, but the attributes of contained vertices belong to the parent when marshalled, so they are recursively added for their parent
+                    // Their field offsets must be adjusted to reflect the position of the child attribute in the parent vertex
+                    addAttributesRecursive(field.FieldType, fieldOffset);
+                }
+                else if (field.IsDefined(typeof(VertexMemberAttribute), true))
+                {
+                    var attrib = field.GetCustomAttribute<VertexMemberAttribute>();
+                    Debug.Assert(attrib != null);
+
+                    elements.Add(new VertexElementDescription($"m_{field.Name}", default, attrib.Type.ToVertexElementFormat(attrib.Count), (uint)fieldOffset));
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -458,7 +458,7 @@ namespace osu.Framework.Platform
                 buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false);
         }
 
-        private readonly DepthValue depthValue = new DepthValue();
+        private DepthValue depthValue;
 
         protected virtual void DrawFrame()
         {
@@ -467,6 +467,8 @@ namespace osu.Framework.Platform
 
             if (ExecutionState != ExecutionState.Running)
                 return;
+
+            depthValue ??= new DepthValue(Renderer);
 
             ObjectUsage<DrawNode> buffer;
 

--- a/osu.Framework/Resources/Shaders/sh_Backbuffer_Internal-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_Backbuffer_Internal-veldrid.h
@@ -1,0 +1,16 @@
+// Automatically included for every vertex shader.
+
+// The -1 is a placeholder value to offset all vertex input members
+// of the actual vertex shader during inclusion of this header.
+layout(location = -1) in highp float m_BackbufferDrawDepth;
+
+// Whether the backbuffer is currently being drawn to
+uniform bool g_BackbufferDraw;
+
+void main()
+{
+    {{ real_main }}(); // Invoke real main func
+
+    if (g_BackbufferDraw)
+        gl_Position.z = m_BackbufferDrawDepth;
+}

--- a/osu.Framework/Resources/Shaders/sh_Bloom-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_Bloom-veldrid.fs
@@ -1,0 +1,55 @@
+layout(location = 0) in vec2 v_MaskingPosition;
+layout(location = 1) in vec4 v_Colour;
+layout(location = 2) in vec2 v_TexCoord;
+layout(location = 3) in vec4 v_TexRect;
+layout(location = 4) in vec2 v_BlendRange;
+
+layout(set = 1, binding = 0) uniform texture2D m_Texture;
+layout(set = 1, binding = 1) uniform sampler m_Sampler;
+
+//Width to sample from
+uniform float mag;
+
+//Alpha value
+uniform float alpha;
+
+uniform float redtint;
+
+//Operate on a high range (0.5 - 1.0) or the full range (0.0 - 1.0)
+uniform bool hirange;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void)
+{
+    vec4 sum = pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord), vec4(2.0));
+
+    //Accumulate the colour from 12 neighbouring pixels
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.326212, -0.405805) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.840144, -0.073580) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.695914,  0.457137) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.203345,  0.620716) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.962340, -0.194983) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.473434, -0.480026) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.519456,  0.767022) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.185461, -0.893124) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.507431,  0.064425) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(0.896420,  0.412458) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.321940, -0.932615) * mag)), vec4(2.0));
+    sum += pow(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord + (vec2(-0.791559, -0.597705) * mag)), vec4(2.0));
+
+    //Average the sum
+    sum /= 13.0;
+    sum = sqrt(sum);
+
+    //Fix alpha
+    sum.a *= alpha;
+
+    //Expand the higher range if applicable
+    if (hirange)
+        sum.rgb = (sum.rgb - 0.5) * 2.0;
+
+    sum.r += redtint;
+
+	o_Colour = v_Colour * sum;
+}

--- a/osu.Framework/Resources/Shaders/sh_Blur-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_Blur-veldrid.fs
@@ -1,0 +1,50 @@
+#include "sh_Utils.h"
+
+#define INV_SQRT_2PI 0.39894
+
+layout(location = 0) in highp vec2 v_MaskingPosition;
+layout(location = 1) in lowp vec4 v_Colour;
+layout(location = 2) in mediump vec2 v_TexCoord;
+layout(location = 3) in mediump vec4 v_TexRect;
+layout(location = 4) in mediump vec2 v_BlendRange;
+
+layout(set = 1, binding = 0) uniform texture2D m_Texture;
+layout(set = 1, binding = 1) uniform sampler m_Sampler;
+
+uniform mediump vec2 g_TexSize;
+uniform int g_Radius;
+uniform mediump float g_Sigma;
+uniform highp vec2 g_BlurDirection;
+
+layout(location = 0) out vec4 o_Colour;
+
+mediump float computeGauss(in mediump float x, in mediump float sigma)
+{
+	return INV_SQRT_2PI * exp(-0.5*x*x / (sigma*sigma)) / sigma;
+}
+
+lowp vec4 blur(texture2D tex, sampler samp, int radius, highp vec2 direction, mediump vec2 texCoord, mediump vec2 texSize, mediump float sigma)
+{
+	mediump float factor = computeGauss(0.0, sigma);
+	mediump vec4 sum = texture(sampler2D(tex, samp), texCoord) * factor;
+
+	mediump float totalFactor = factor;
+
+	for (int i = 2; i <= 200; i += 2)
+	{
+		mediump float x = float(i) - 0.5;
+		factor = computeGauss(x, sigma) * 2.0;
+		totalFactor += 2.0 * factor;
+		sum += texture(sampler2D(tex, samp), texCoord + direction * x / texSize) * factor;
+		sum += texture(sampler2D(tex, samp), texCoord - direction * x / texSize) * factor;
+		if (i >= radius)
+			break;
+	}
+
+    return toSRGB(sum / totalFactor);
+}
+
+void main(void)
+{
+	o_Colour = blur(m_Texture, m_Sampler, g_Radius, g_BlurDirection, v_TexCoord, g_TexSize, g_Sigma);
+}

--- a/osu.Framework/Resources/Shaders/sh_CircularBlob-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlob-veldrid.fs
@@ -1,0 +1,28 @@
+﻿#define HIGH_PRECISION_VERTEX
+
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_TextureWrapping.h"
+#include "sh_CircularBlobUtils.h"
+
+layout(location = 2) in highp vec2 v_TexCoord;
+
+layout(set = 1, binding = 0) uniform lowp texture2D m_Texture;
+layout(set = 1, binding = 1) uniform lowp sampler m_Sampler;
+
+uniform mediump float innerRadius;
+uniform mediump float frequency;
+uniform mediump float amplitude;
+uniform highp vec2 noisePosition;
+uniform highp float texelSize;
+
+void main(void)
+{
+    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
+    highp vec2 pixelPos = v_TexCoord / resolution;
+
+    highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+    lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Sampler, -0.9), wrappedCoord);
+
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition));
+}

--- a/osu.Framework/Resources/Shaders/sh_CircularBlobUtils-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlobUtils-veldrid.h
@@ -1,0 +1,58 @@
+﻿#define HALF_PI 1.57079632679
+#define TWO_PI 6.28318530718
+
+// 2D noise and random https://thebookofshaders.com/11/
+
+highp float random(highp vec2 st)
+{
+    return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+}
+
+highp float noise(highp vec2 st)
+{
+    vec2 i = floor(st);
+    vec2 f = fract(st);
+
+    highp float a = random(i);
+    highp float b = random(i + vec2(1.0, 0.0));
+    highp float c = random(i + vec2(0.0, 1.0));
+    highp float d = random(i + vec2(1.0, 1.0));
+
+    highp vec2 u = f * f * (3.0 - 2.0 * f);
+
+    return mix(a, b, u.x) + (c - a)* u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+}
+
+lowp float blobAlphaAt(highp vec2 pixelPos, mediump float innerRadius, highp float texelSize, mediump float frequency, mediump float amplitude, highp vec2 noisePosition)
+{
+    // Compute angle of the current pixel in the (0, 2*PI) range
+    mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - HALF_PI;
+    if (pixelAngle < 0.0)
+        pixelAngle += TWO_PI;
+
+    mediump float complexity = (frequency + amplitude) * 0.5 + 1.0;
+
+    int pointCount = int(ceil(5.0 * complexity));
+    mediump float searchRange = 0.1 * complexity; // in radians
+
+    mediump float pathRadius = innerRadius * 0.25;
+
+    highp float shortestDistance = 1.0;
+
+    mediump float startAngle = pixelAngle - searchRange * 0.5;
+
+    // Path approximation
+    // Plot points within a search range and check which one is closest
+    for (int i = 0; i < pointCount; i++)
+    {
+        mediump float angle = startAngle + searchRange * float(i) / float(pointCount);
+        highp vec2 cs = vec2(cos(angle - HALF_PI), sin(angle - HALF_PI));
+
+        highp float noiseValue = noise(noisePosition + cs * vec2(frequency));
+        highp vec2 pos = vec2(0.5) + cs * vec2(0.5 - pathRadius - texelSize - noiseValue * 0.5 * amplitude);
+
+        shortestDistance = min(shortestDistance, distance(pixelPos, pos));
+    }
+    
+    return smoothstep(texelSize, 0.0, shortestDistance - pathRadius);
+}

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress-veldrid.fs
@@ -1,0 +1,29 @@
+﻿#define HIGH_PRECISION_VERTEX
+
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_TextureWrapping.h"
+#include "sh_CircularProgressUtils.h"
+
+layout(location = 2) in highp vec2 v_TexCoord;
+
+layout(set = 1, binding = 0) uniform lowp texture2D m_Texture;
+layout(set = 1, binding = 1) uniform lowp sampler m_Sampler;
+
+layout(location = 0) out vec4 o_Colour;
+
+uniform mediump float progress;
+uniform mediump float innerRadius;
+uniform highp float texelSize;
+uniform bool roundedCaps;
+
+void main(void)
+{
+    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
+    highp vec2 pixelPos = v_TexCoord / resolution;
+    
+    highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+    lowp vec4 textureColour = getRoundedColor(wrappedTexture(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
+
+    o_Colour = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
+}

--- a/osu.Framework/Resources/Shaders/sh_CircularProgressUtils-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgressUtils-veldrid.h
@@ -1,0 +1,59 @@
+﻿#define PI 3.1415926536
+#define HALF_PI 1.57079632679
+#define TWO_PI 6.28318530718
+
+highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
+{
+    highp float lineLength = distance(end, start);
+
+    if (lineLength < 0.001)
+        return distance(pixelPos, start);
+
+    highp vec2 a = (end - start) / lineLength;
+    highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, distance(end, start)) * a + start; // closest point on a line from given position
+    return distance(closest, pixelPos);
+}
+
+// Returns distance to the progress shape (to closest pixel on it's border)
+highp float distanceToProgress(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps, highp float texelSize)
+{
+    // Compute angle of the current pixel in the (0, 2*PI) range
+    mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - HALF_PI;
+    if (pixelAngle < 0.0)
+        pixelAngle += TWO_PI;
+
+    mediump float progressAngle = TWO_PI * progress;
+    mediump float pathRadius = 0.25 * innerRadius;
+    highp float halfTexel = texelSize * 0.5;
+
+    if (progress >= 1.0 || pixelAngle < progressAngle) // Pixel inside the sector
+        return abs(distance(pixelPos, vec2(0.5)) - (0.5 - pathRadius - halfTexel)) - pathRadius + halfTexel;
+
+    highp vec2 cs = vec2(cos(progressAngle - HALF_PI), sin(progressAngle - HALF_PI));
+
+    if (roundedCaps) // Pixel outside the sector with rounded caps enabled
+    {
+        highp vec2 arcStart = vec2(0.5, pathRadius + halfTexel);
+        highp vec2 arcEnd = vec2(0.5) + cs * vec2(0.5 - pathRadius - halfTexel);
+
+        return min(distance(pixelPos, arcStart), distance(pixelPos, arcEnd)) + halfTexel - pathRadius;
+    }
+
+    highp float dstToIdleEdge = dstToLine(vec2(0.5, texelSize), vec2(0.5, 2.0 * pathRadius), pixelPos);
+
+    highp vec2 rotatingEdgeTop = vec2(0.5) + cs * vec2(0.5 - texelSize);
+    highp vec2 rotatingEdgeBottom = vec2(0.5) + cs * vec2(0.5 - 2.0 * pathRadius);
+    highp float dstToRotatingEdge = dstToLine(rotatingEdgeTop, rotatingEdgeBottom, pixelPos);
+
+    return min(dstToIdleEdge, dstToRotatingEdge);
+}
+
+lowp float progressAlphaAt(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps, highp float texelSize)
+{
+    // This is a bit of a hack to make progress appear smooth if it's radius < texelSize by making it more transparent while leaving thickness the same
+    lowp float subAAMultiplier = 1.0;
+    subAAMultiplier = clamp(innerRadius / (texelSize * 2.0), 0.1, 1.0);
+    innerRadius = max(innerRadius, texelSize * 2.0);
+    
+    return smoothstep(texelSize, 0.0, distanceToProgress(pixelPos, progress, innerRadius, roundedCaps, texelSize)) * subAAMultiplier;
+}

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackground-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackground-veldrid.fs
@@ -1,0 +1,12 @@
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void)
+{
+    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    o_Colour = getRoundedColor(hsv2rgb(vec4(hueValue, 1, 1, 1)), v_TexCoord);
+}

--- a/osu.Framework/Resources/Shaders/sh_Masking-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking-veldrid.h
@@ -1,0 +1,140 @@
+﻿layout(location = 0) in highp vec2 v_MaskingPosition;
+layout(location = 1) in lowp vec4 v_Colour;
+
+#ifdef HIGH_PRECISION_VERTEX
+    layout(location = 3) in highp vec4 v_TexRect;
+#else
+    layout(location = 3) in mediump vec4 v_TexRect;
+#endif
+
+layout(location = 4) in mediump vec2 v_BlendRange;
+
+uniform highp float g_CornerRadius;
+uniform highp float g_CornerExponent;
+uniform bool g_IsMasking;
+uniform highp vec4 g_MaskingRect;
+uniform highp float g_BorderThickness;
+uniform lowp mat4 g_BorderColour;
+
+uniform mediump float g_MaskingBlendRange;
+
+uniform lowp float g_AlphaExponent;
+
+uniform highp vec2 g_EdgeOffset;
+
+uniform bool g_DiscardInner;
+uniform highp float g_InnerCornerRadius;
+
+highp float distanceFromRoundedRect(highp vec2 offset, highp float radius)
+{
+	highp vec2 maskingPosition = v_MaskingPosition + offset;
+
+	// Compute offset distance from masking rect in masking space.
+	highp vec2 topLeftOffset = g_MaskingRect.xy - maskingPosition;
+	highp vec2 bottomRightOffset = maskingPosition - g_MaskingRect.zw;
+
+	highp vec2 distanceFromShrunkRect = max(
+		bottomRightOffset + vec2(radius),
+		topLeftOffset + vec2(radius));
+
+	highp float maxDist = max(distanceFromShrunkRect.x, distanceFromShrunkRect.y);
+
+	// Inside the shrunk rectangle
+	if (maxDist <= 0.0)
+		return maxDist;
+	// Outside of the shrunk rectangle
+	else
+	{
+		distanceFromShrunkRect = max(vec2(0.0), distanceFromShrunkRect);
+		return pow(pow(distanceFromShrunkRect.x, g_CornerExponent) + pow(distanceFromShrunkRect.y, g_CornerExponent), 1.0 / g_CornerExponent);
+	}
+}
+
+highp float distanceFromDrawingRect(mediump vec2 texCoord)
+{
+	highp vec2 topLeftOffset = v_TexRect.xy - texCoord;
+	topLeftOffset = vec2(
+		v_BlendRange.x > 0.0 ? topLeftOffset.x / v_BlendRange.x : 0.0,
+		v_BlendRange.y > 0.0 ? topLeftOffset.y / v_BlendRange.y : 0.0);
+
+	highp vec2 bottomRightOffset = texCoord - v_TexRect.zw;
+	bottomRightOffset = vec2(
+		v_BlendRange.x > 0.0 ? bottomRightOffset.x / v_BlendRange.x : 0.0,
+		v_BlendRange.y > 0.0 ? bottomRightOffset.y / v_BlendRange.y : 0.0);
+
+	highp vec2 xyDistance = max(topLeftOffset, bottomRightOffset);
+	return max(xyDistance.x, xyDistance.y);
+}
+
+lowp vec4 getBorderColour()
+{
+    highp vec2 relativeTexCoord = v_MaskingPosition / (g_MaskingRect.zw - g_MaskingRect.xy);
+    lowp vec4 top = mix(g_BorderColour[0], g_BorderColour[2], relativeTexCoord.x);
+    lowp vec4 bottom = mix(g_BorderColour[1], g_BorderColour[3], relativeTexCoord.x);
+    return mix(top, bottom, relativeTexCoord.y);
+}
+
+lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
+{
+	if (!g_IsMasking && v_BlendRange == vec2(0.0))
+	{
+		return toSRGB(v_Colour * texel);
+	}
+
+	highp float dist = distanceFromRoundedRect(vec2(0.0), g_CornerRadius);
+	lowp float alphaFactor = 1.0;
+
+	// Discard inner pixels
+	if (g_DiscardInner)
+	{
+		highp float innerDist = (g_EdgeOffset == vec2(0.0) && g_InnerCornerRadius == g_CornerRadius) ?
+			dist : distanceFromRoundedRect(g_EdgeOffset, g_InnerCornerRadius);
+
+		// v_BlendRange is set from outside in a hacky way to tell us the g_MaskingBlendRange used for the rounded
+		// corners of the edge effect container itself. We can then derive the alpha factor for smooth inner edge
+		// effect from that.
+		highp float innerBlendFactor = (g_InnerCornerRadius - g_MaskingBlendRange - innerDist) / v_BlendRange.x;
+		if (innerBlendFactor > 1.0)
+		{
+			return vec4(0.0);
+		}
+
+		// We exponentiate our factor to exactly counteract the later exponentiation by g_AlphaExponent for a smoother inner border.
+		alphaFactor = pow(min(1.0 - innerBlendFactor, 1.0), 1.0 / g_AlphaExponent);
+	}
+
+	dist /= g_MaskingBlendRange;
+
+	// This correction is needed to avoid fading of the alpha value for radii below 1px.
+	highp float radiusCorrection = g_CornerRadius <= 0.0 ? g_MaskingBlendRange : max(0.0, g_MaskingBlendRange - g_CornerRadius);
+	highp float fadeStart = (g_CornerRadius + radiusCorrection) / g_MaskingBlendRange;
+	alphaFactor *= min(fadeStart - dist, 1.0);
+
+	if (v_BlendRange.x > 0.0 || v_BlendRange.y > 0.0)
+	{
+		alphaFactor *= clamp(1.0 - distanceFromDrawingRect(texCoord), 0.0, 1.0);
+	}
+
+	if (alphaFactor <= 0.0)
+	{
+		return vec4(0.0);
+	}
+
+	// This ends up softening glow without negatively affecting edge smoothness much.
+	alphaFactor = pow(alphaFactor, g_AlphaExponent);
+
+	highp float borderStart = 1.0 + fadeStart - g_BorderThickness;
+	lowp float colourWeight = min(borderStart - dist, 1.0);
+
+	lowp vec4 borderColour = getBorderColour();
+
+	if (colourWeight <= 0.0)
+	{
+		return toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor));
+	}
+
+	lowp vec4 dest = vec4(v_Colour.rgb, v_Colour.a * alphaFactor) * texel;
+	lowp vec4 src = vec4(borderColour.rgb, borderColour.a * (1.0 - colourWeight));
+
+	return blend(toSRGB(src), toSRGB(dest));
+}

--- a/osu.Framework/Resources/Shaders/sh_Particle-veldrid.vs
+++ b/osu.Framework/Resources/Shaders/sh_Particle-veldrid.vs
@@ -1,0 +1,24 @@
+layout(location = 0) in vec2 m_Position;
+layout(location = 1) in vec4 m_Colour;
+layout(location = 2) in vec2 m_TexCoord;
+layout(location = 3) in float m_Time;
+layout(location = 4) in vec2 m_Direction;
+
+layout(location = 0) out vec4 v_Colour;
+layout(location = 1) out vec2 v_TexCoord;
+
+uniform mat4 g_ProjMatrix;
+uniform float g_FadeClock;
+uniform float g_Gravity;
+
+void main(void)
+{
+	vec2 targetPosition =
+		m_Position +
+		m_Direction * clamp((g_FadeClock + 100.0) / (m_Time + 100.0), 0.0, 1.0) +
+		vec2(0.0, g_Gravity * g_FadeClock * g_FadeClock / 1000000.0);
+
+	gl_Position = g_ProjMatrix * vec4(targetPosition, 1.0, 1.0);
+	v_Colour = vec4(1.0, 1.0, 1.0, 1.0 - clamp(g_FadeClock / m_Time, 0.0, 1.0));
+	v_TexCoord = m_TexCoord;
+}

--- a/osu.Framework/Resources/Shaders/sh_Position-veldrid.vs
+++ b/osu.Framework/Resources/Shaders/sh_Position-veldrid.vs
@@ -1,0 +1,11 @@
+layout(location = 0) in highp vec2 m_Position;
+
+layout(location = 0) out highp vec2 v_Position;
+
+uniform highp mat4 g_ProjMatrix;
+
+void main(void)
+{
+	gl_Position = g_ProjMatrix * vec4(m_Position.xy, 1.0, 1.0);
+	v_Position = m_Position;
+}

--- a/osu.Framework/Resources/Shaders/sh_Precision_Internal-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_Precision_Internal-veldrid.h
@@ -1,0 +1,10 @@
+// This file is automatically included in every shader
+
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground-veldrid.fs
@@ -1,0 +1,15 @@
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+uniform mediump float hue;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void)
+{
+    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
+    highp vec2 pixelPos = v_TexCoord / resolution;
+    o_Colour = getRoundedColor(toLinear(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0))), v_TexCoord);
+}

--- a/osu.Framework/Resources/Shaders/sh_Texture-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_Texture-veldrid.fs
@@ -1,0 +1,16 @@
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_TextureWrapping.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+layout(set = 1, binding = 0) uniform lowp texture2D m_Texture;
+layout(set = 1, binding = 1) uniform lowp sampler m_Sampler;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void) 
+{
+    vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+    o_Colour = getRoundedColor(toSRGB(wrappedTexture(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9)), wrappedCoord);
+}

--- a/osu.Framework/Resources/Shaders/sh_Texture2D-veldrid.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture2D-veldrid.vs
@@ -1,0 +1,30 @@
+#include "sh_Utils.h"
+
+layout(location = 0) in highp vec2 m_Position;
+layout(location = 1) in lowp vec4 m_Colour;
+layout(location = 2) in mediump vec2 m_TexCoord;
+layout(location = 3) in mediump vec4 m_TexRect;
+layout(location = 4) in mediump vec2 m_BlendRange;
+
+layout(location = 0) out highp vec2 v_MaskingPosition;
+layout(location = 1) out lowp vec4 v_Colour;
+layout(location = 2) out mediump vec2 v_TexCoord;
+layout(location = 3) out mediump vec4 v_TexRect;
+layout(location = 4) out mediump vec2 v_BlendRange;
+
+uniform highp mat4 g_ProjMatrix;
+uniform highp mat3 g_ToMaskingSpace;
+
+void main(void)
+{
+	// Transform from screen space to masking space.
+	highp vec3 maskingPos = g_ToMaskingSpace * vec3(m_Position, 1.0);
+	v_MaskingPosition = maskingPos.xy / maskingPos.z;
+
+	v_Colour = m_Colour;
+	v_TexCoord = m_TexCoord;
+	v_TexRect = m_TexRect;
+	v_BlendRange = m_BlendRange;
+
+    gl_Position = g_ProjMatrix * vec4(m_Position, 1.0, 1.0);
+}

--- a/osu.Framework/Resources/Shaders/sh_Texture3D-veldrid.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture3D-veldrid.vs
@@ -1,0 +1,28 @@
+#include "sh_Utils.h"
+
+layout(location = 0) in highp vec3 m_Position;
+layout(location = 1) in lowp vec4 m_Colour;
+layout(location = 2) in mediump vec2 m_TexCoord;
+
+layout(location = 0) out highp vec2 v_MaskingPosition;
+layout(location = 1) out lowp vec4 v_Colour;
+layout(location = 2) out mediump vec2 v_TexCoord;
+layout(location = 3) out mediump vec4 v_TexRect;
+layout(location = 4) out mediump vec2 v_BlendRange;
+
+uniform highp mat4 g_ProjMatrix;
+uniform highp mat3 g_ToMaskingSpace;
+
+void main(void)
+{
+	// Transform to position to masking space.
+	vec3 maskingPos = g_ToMaskingSpace * vec3(m_Position.xy, 1.0);
+	v_MaskingPosition = maskingPos.xy / maskingPos.z;
+
+	v_TexRect = vec4(0.0);
+	v_BlendRange = vec2(0.0);
+
+	v_Colour = m_Colour;
+	v_TexCoord = m_TexCoord;
+	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0);
+}

--- a/osu.Framework/Resources/Shaders/sh_TextureWrapping-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_TextureWrapping-veldrid.h
@@ -1,0 +1,35 @@
+// 0 -> None
+// 1 -> ClampToEdge
+// 2 -> ClampToBorder
+// 3 -> Repeat
+
+uniform int g_WrapModeS;
+uniform int g_WrapModeT;
+
+float wrap(float coord, int mode, float rangeMin, float rangeMax)
+{
+    if (mode == 1)
+    {
+        return clamp(coord, rangeMin, rangeMax);
+    }
+    else if (mode == 3)
+    {
+        return mod(coord - rangeMin, rangeMax - rangeMin) + rangeMin;
+    }
+    
+    return coord;
+}
+
+vec2 wrap(vec2 texCoord, vec4 texRect)
+{
+    return vec2(wrap(texCoord.x, g_WrapModeS, texRect[0], texRect[2]), wrap(texCoord.y, g_WrapModeT, texRect[1], texRect[3]));
+}
+
+vec4 wrappedTexture(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, sampler wrapSampler, float lodBias)
+{
+    if (g_WrapModeS == 2 && (wrappedCoord.x < texRect[0] || wrappedCoord.x > texRect[2]) ||
+        g_WrapModeT == 2 && (wrappedCoord.y < texRect[1] || wrappedCoord.y > texRect[3]))
+        return vec4(0.0);
+
+    return texture(sampler2D(wrapTexture, wrapSampler), wrappedCoord, lodBias);
+}

--- a/osu.Framework/Resources/Shaders/sh_Utils-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils-veldrid.h
@@ -1,0 +1,49 @@
+﻿#define GAMMA 2.4
+
+uniform bool g_GammaCorrection;
+
+lowp float toLinear(lowp float color)
+{
+    return color <= 0.04045 ? (color / 12.92) : pow((color + 0.055) / 1.055, GAMMA);
+}
+
+lowp vec4 toLinear(lowp vec4 colour)
+{
+    return g_GammaCorrection ? vec4(toLinear(colour.r), toLinear(colour.g), toLinear(colour.b), colour.a) : colour;
+}
+
+lowp float toSRGB(lowp float color)
+{
+    return color < 0.0031308 ? (12.92 * color) : (1.055 * pow(color, 1.0 / GAMMA) - 0.055);
+}
+
+lowp vec4 toSRGB(lowp vec4 colour)
+{
+    return g_GammaCorrection ? vec4(toSRGB(colour.r), toSRGB(colour.g), toSRGB(colour.b), colour.a) : colour;
+    // The following implementation using mix and step may be faster, but stackoverflow indicates it is in fact a lot slower on some GPUs.
+    //return vec4(mix(colour.rgb * 12.92, 1.055 * pow(colour.rgb, vec3(1.0 / GAMMA)) - vec3(0.055), step(0.0031308, colour.rgb)), colour.a);
+}
+
+// perform alpha compositing of two colour components.
+// see http://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha.html
+lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
+{
+    lowp float finalAlpha = src.a + dst.a * (1.0 - src.a);
+
+    if (finalAlpha == 0.0)
+        return vec4(0);
+
+    return vec4(
+        (src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / finalAlpha,
+        finalAlpha
+    );
+}
+
+// http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
+// slightly amended to also handle alpha
+vec4 hsv2rgb(vec4 c)
+{
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return vec4(c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y), c.w);
+}

--- a/osu.Framework/Resources/Shaders/sh_Video-veldrid.fs
+++ b/osu.Framework/Resources/Shaders/sh_Video-veldrid.fs
@@ -1,0 +1,13 @@
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_yuv2rgb.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void)
+{
+    vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+    o_Colour = getRoundedColor(wrappedSamplerRgb(wrappedCoord, v_TexRect, 0.0), wrappedCoord);
+}

--- a/osu.Framework/Resources/Shaders/sh_yuv2rgb-veldrid.h
+++ b/osu.Framework/Resources/Shaders/sh_yuv2rgb-veldrid.h
@@ -1,0 +1,23 @@
+#include "sh_TextureWrapping.h"
+
+layout(set = 1, binding = 0) uniform texture2D m_TextureY;
+layout(set = 1, binding = 1) uniform texture2D m_TextureU;
+layout(set = 1, binding = 2) uniform texture2D m_TextureV;
+layout(set = 1, binding = 3) uniform sampler m_Sampler;
+
+uniform mediump mat3 yuvCoeff;
+
+// Y - 16, Cb - 128, Cr - 128
+const mediump vec3 offsets = vec3(-0.0625, -0.5, -0.5);
+
+lowp vec4 wrappedSamplerRgb(vec2 wrappedCoord, vec4 texRect, float lodBias) 
+{
+    if (g_WrapModeS == 2 && (wrappedCoord.x < texRect[0] || wrappedCoord.x > texRect[2]) ||
+        g_WrapModeT == 2 && (wrappedCoord.y < texRect[1] || wrappedCoord.y > texRect[3]))
+        return vec4(0.0);
+
+    lowp float y = texture(sampler2D(m_TextureY, m_Sampler), wrappedCoord, lodBias).r;
+    lowp float u = texture(sampler2D(m_TextureU, m_Sampler), wrappedCoord, lodBias).r;
+    lowp float v = texture(sampler2D(m_TextureV, m_Sampler), wrappedCoord, lodBias).r;
+    return vec4(yuvCoeff * (vec3(y, u, v) + offsets), 1.0);
+}


### PR DESCRIPTION
- [ ] Depends on #5598 

Unlike OpenGL, all other backends usually use a depth range that starts from 0 up to 1, and a UV origin placed at the top left of a texture. To handle these differences, I've added properties for it on an `IRenderer` level to define the correct specifications to the codebase for the active renderer.