### PR TITLE
Avoid performing GL occlusion queries on Veldrid

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -18,7 +18,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Veldrid;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Tests.Visual.Containers
 {

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -17,6 +17,8 @@ using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Veldrid;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
@@ -45,19 +47,9 @@ namespace osu.Framework.Tests.Visual.Containers
             var edgeClampedTexture = store.Get(@"sample-texture", WrapMode.ClampToEdge, WrapMode.ClampToEdge);
             var borderClampedTexture = store.Get(@"sample-texture", WrapMode.ClampToBorder, WrapMode.ClampToBorder);
 
-            AddStep("add sprites", () => addMoreDrawables(texture, new RectangleF(0, 0, 1, 1)));
-            AddStep("add sprites with shrink", () => addMoreDrawables(texture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
-            AddStep("add sprites with repeat", () => addMoreDrawables(repeatedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
-            AddStep("add sprites with edge clamp", () => addMoreDrawables(edgeClampedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
-            AddStep("add sprites with border clamp", () => addMoreDrawables(borderClampedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
-            AddStep("add boxes", () => addMoreDrawables(renderer.WhitePixel, new RectangleF(0, 0, 1, 1)));
-            AddToggleStep("disable front to back", val =>
-            {
-                debugConfig.SetValue(DebugSetting.BypassFrontToBackPass, val);
-                Invalidate(Invalidation.DrawNode); // reset counts
-            });
+            Container content;
 
-            Add(new Container
+            Add(content = new Container
             {
                 AutoSizeAxes = Axes.Both,
                 Depth = float.NegativeInfinity,
@@ -85,6 +77,33 @@ namespace osu.Framework.Tests.Visual.Containers
                         }
                     },
                 }
+            });
+
+            if (renderer is VeldridRenderer)
+            {
+                content.Hide();
+
+                Add(new SpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = "Veldrid currently has no support for occlusion queries.",
+                    Font = FontUsage.Default.With(size: 32),
+                });
+
+                return;
+            }
+
+            AddStep("add sprites", () => addMoreDrawables(texture, new RectangleF(0, 0, 1, 1)));
+            AddStep("add sprites with shrink", () => addMoreDrawables(texture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
+            AddStep("add sprites with repeat", () => addMoreDrawables(repeatedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
+            AddStep("add sprites with edge clamp", () => addMoreDrawables(edgeClampedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
+            AddStep("add sprites with border clamp", () => addMoreDrawables(borderClampedTexture, new RectangleF(0.25f, 0.25f, 0.5f, 0.5f)));
+            AddStep("add boxes", () => addMoreDrawables(renderer.WhitePixel, new RectangleF(0, 0, 1, 1)));
+            AddToggleStep("disable front to back", val =>
+            {
+                debugConfig.SetValue(DebugSetting.BypassFrontToBackPass, val);
+                Invalidate(Invalidation.DrawNode); // reset counts
             });
         }
 
@@ -135,6 +154,12 @@ namespace osu.Framework.Tests.Visual.Containers
 
             internal override void DrawOpaqueInteriorSubTree(IRenderer renderer, DepthValue depthValue)
             {
+                if (renderer is VeldridRenderer)
+                {
+                    base.DrawOpaqueInteriorSubTree(renderer, depthValue);
+                    return;
+                }
+
                 startQuery();
                 base.DrawOpaqueInteriorSubTree(renderer, depthValue);
                 DrawOpaqueInteriorSubTreeSamples = endQuery();
@@ -149,6 +174,12 @@ namespace osu.Framework.Tests.Visual.Containers
 
             public override void Draw(IRenderer renderer)
             {
+                if (renderer is VeldridRenderer)
+                {
+                    base.Draw(renderer);
+                    return;
+                }
+
                 startQuery();
                 base.Draw(renderer);
                 DrawSamples = endQuery();


### PR DESCRIPTION
Was an annoying one to me, as the moment I accidentally switch to this test scene everything crashes because of the GL occlusion queries being performed in the draw node, and there's no way to escape this crash without commenting the entire test scene.