### PR TITLE
Fix bypassing front-to-back not actually disabling depth test

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -502,7 +502,7 @@ namespace osu.Framework.Platform
                 else
                 {
                     // Disable depth testing
-                    Renderer.PushDepthInfo(new DepthInfo());
+                    Renderer.PushDepthInfo(new DepthInfo(false, false));
                 }
 
                 // Back pass


### PR DESCRIPTION
This has been causing Metal to not render anything on my end when I bypass front-to-back pass, and looks to be an actual oversight that has miraculously not affected OpenGL all these years.