### PR TITLE
Remove unnecessary `yield return` from `getSDLDisplays()` and log errors

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -324,7 +324,7 @@ namespace osu.Framework.Platform
                 if (tryGetDisplayFromSDL(i, out Display? display))
                     builder.Add(display);
                 else
-                    Debug.Fail($"Failed to retrieve display at index ({i})");
+                    Logger.Log($"Failed to retrieve SDL display at index ({i})", level: LogLevel.Error);
             }
 
             return builder.ToImmutable();


### PR DESCRIPTION
Having `yield return` here is weird and unnecessary. Using a plain `ImmutableArray` makes things clearer.