### PR TITLE
Fix wrong path separator used in templates pack CI

### DIFF
--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: osu-framework-templates
-          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}/*.nupkg
 
   pack-android:
     name: Pack (Android)


### PR DESCRIPTION
Oversight from #5594, explains why the templates package wasn't included in the artifacts output.