### PR TITLE
Fix iOS workflow failing to restore workloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,9 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Restore .NET workloads
-        run: dotnet workload restore
+        # `dotnet workload restore` is bugged in .NET 7.0.101+ when restoring iOS projects,
+        # see https://github.com/xamarin/xamarin-macios/issues/16400.
+        run: dotnet workload install ios
 
       - name: Compile
         run: dotnet build -c Debug osu-framework.iOS.slnf


### PR DESCRIPTION
GH actions recently rolled a new image for macOS that comes with .NET 7.0.1 installed, and apparently restoring workloads with it on .NET 6 macOS/iOS projects no longer works correctly (see https://github.com/xamarin/xamarin-macios/issues/16400). Until .NET 8, explicitly install the required workloads instead.