### PR TITLE
Move `CircularProgress` alpha hack to the draw node

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -132,7 +132,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddToggleStep("Toggle masking", m => maskingContainer.Masking = m);
             AddToggleStep("Toggle rounded caps", r => clock.RoundedCaps = r);
-            AddToggleStep("Toggle aspect ratio", r => clock.Size = r ? new Vector2(600, 400) : new Vector2(400));
+            AddToggleStep("Toggle aspect ratio", r => clock.Size = r ? new Vector2(600, 200) : new Vector2(400));
             AddToggleStep("Toggle background", b => background.Alpha = b ? 1 : 0);
             AddSliderStep("Scale", 0f, 2f, 1f, s => clock.Scale = new Vector2(s));
             AddSliderStep("Fill", 0f, 1f, 0.5f, f => clock.InnerRadius = f);

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Contains the colour and blending information of this <see cref="DrawNode"/>.
         /// </summary>
-        protected DrawColourInfo DrawColourInfo { get; private set; }
+        protected DrawColourInfo DrawColourInfo { get; set; }
 
         /// <summary>
         /// Identifies the state of this draw node with an invalidation state of its corresponding

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Graphics.UserInterface
                 roundedCaps = Source.roundedCaps;
 
                 // Looks too sharp with 1px, let's give it a bit more
-                texelSize = 2f / ScreenSpaceDrawQuad.Size.X;
+                texelSize = 2f / Math.Min(ScreenSpaceDrawQuad.Width, ScreenSpaceDrawQuad.Height);
             }
 
             protected override void Blit(IRenderer renderer)

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -109,8 +109,8 @@ namespace osu.Framework.Graphics.UserInterface
                 progress = Math.Abs((float)Source.current.Value);
                 roundedCaps = Source.roundedCaps;
 
-                // smoothstep looks too sharp with 1px, let's give it a bit more
-                texelSize = 1.5f / ScreenSpaceDrawQuad.Size.X;
+                // Looks too sharp with 1px, let's give it a bit more
+                texelSize = 2f / ScreenSpaceDrawQuad.Size.X;
             }
 
             protected override void Blit(IRenderer renderer)

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -4,12 +4,10 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
-using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Graphics.UserInterface
                 progress = Math.Abs((float)Source.current.Value);
                 roundedCaps = Source.roundedCaps;
 
-                // Looks too sharp with 1px, let's give it a bit more
+                // smoothstep looks too sharp with 1px, let's give it a bit more
                 texelSize = 2f / Math.Min(ScreenSpaceDrawQuad.Width, ScreenSpaceDrawQuad.Height);
             }
 

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -9,17 +9,16 @@ varying highp vec2 v_TexCoord;
 
 uniform lowp sampler2D m_Sampler;
 uniform mediump float progress;
-uniform mediump float innerRadius;
+uniform highp float pathRadius;
 uniform highp float texelSize;
 uniform bool roundedCaps;
 
 void main(void)
 {
-    highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    highp vec2 pixelPos = v_TexCoord / resolution;
+    highp vec2 pixelPos = v_TexCoord / (v_TexRect.zw - v_TexRect.xy);
     
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Sampler, -0.9), wrappedCoord);
 
-    gl_FragColor = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
+    gl_FragColor = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, pathRadius, roundedCaps, texelSize));
 }

--- a/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
@@ -1,5 +1,4 @@
-﻿#define PI 3.1415926536
-#define HALF_PI 1.57079632679
+﻿#define HALF_PI 1.57079632679
 #define TWO_PI 6.28318530718
 
 highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
@@ -10,50 +9,42 @@ highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
         return distance(pixelPos, start);
 
     highp vec2 a = (end - start) / lineLength;
-    highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, distance(end, start)) * a + start; // closest point on a line from given position
+    highp vec2 closest = clamp(dot(a, pixelPos - start), 0.0, lineLength) * a + start; // closest point on a line from given position
     return distance(closest, pixelPos);
 }
 
 // Returns distance to the progress shape (to closest pixel on it's border)
-highp float distanceToProgress(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps, highp float texelSize)
+highp float distanceToProgress(highp vec2 pixelPos, mediump float progress, highp float pathRadius, bool roundedCaps, highp float texelSize)
 {
     // Compute angle of the current pixel in the (0, 2*PI) range
     mediump float pixelAngle = atan(0.5 - pixelPos.y, 0.5 - pixelPos.x) - HALF_PI;
-    if (pixelAngle < 0.0)
-        pixelAngle += TWO_PI;
+    pixelAngle += float(pixelAngle < 0.0) * TWO_PI;
 
     mediump float progressAngle = TWO_PI * progress;
-    mediump float pathRadius = 0.25 * innerRadius;
-    highp float halfTexel = texelSize * 0.5;
 
     if (progress >= 1.0 || pixelAngle < progressAngle) // Pixel inside the sector
-        return abs(distance(pixelPos, vec2(0.5)) - (0.5 - pathRadius - halfTexel)) - pathRadius + halfTexel;
+        return abs(distance(pixelPos, vec2(0.5)) - (0.5 - pathRadius)) - pathRadius + texelSize;
 
     highp vec2 cs = vec2(cos(progressAngle - HALF_PI), sin(progressAngle - HALF_PI));
 
     if (roundedCaps) // Pixel outside the sector with rounded caps enabled
     {
-        highp vec2 arcStart = vec2(0.5, pathRadius + halfTexel);
-        highp vec2 arcEnd = vec2(0.5) + cs * vec2(0.5 - pathRadius - halfTexel);
+        highp vec2 arcStart = vec2(0.5, pathRadius);
+        highp vec2 arcEnd = vec2(0.5) + cs * vec2(0.5 - pathRadius);
 
-        return min(distance(pixelPos, arcStart), distance(pixelPos, arcEnd)) + halfTexel - pathRadius;
+        return min(distance(pixelPos, arcStart), distance(pixelPos, arcEnd)) + texelSize - pathRadius;
     }
 
-    highp float dstToIdleEdge = dstToLine(vec2(0.5, texelSize), vec2(0.5, 2.0 * pathRadius), pixelPos);
+    highp float dstToIdleEdge = dstToLine(vec2(0.5, texelSize), vec2(0.5, 2.0 * pathRadius - texelSize), pixelPos);
 
     highp vec2 rotatingEdgeTop = vec2(0.5) + cs * vec2(0.5 - texelSize);
-    highp vec2 rotatingEdgeBottom = vec2(0.5) + cs * vec2(0.5 - 2.0 * pathRadius);
+    highp vec2 rotatingEdgeBottom = vec2(0.5) + cs * vec2(0.5 - 2.0 * pathRadius + texelSize);
     highp float dstToRotatingEdge = dstToLine(rotatingEdgeTop, rotatingEdgeBottom, pixelPos);
 
     return min(dstToIdleEdge, dstToRotatingEdge);
 }
 
-lowp float progressAlphaAt(highp vec2 pixelPos, mediump float progress, mediump float innerRadius, bool roundedCaps, highp float texelSize)
+lowp float progressAlphaAt(highp vec2 pixelPos, mediump float progress, highp float pathRadius, bool roundedCaps, highp float texelSize)
 {
-    // This is a bit of a hack to make progress appear smooth if it's radius < texelSize by making it more transparent while leaving thickness the same
-    lowp float subAAMultiplier = 1.0;
-    subAAMultiplier = clamp(innerRadius / (texelSize * 2.0), 0.1, 1.0);
-    innerRadius = max(innerRadius, texelSize * 2.0);
-    
-    return smoothstep(texelSize, 0.0, distanceToProgress(pixelPos, progress, innerRadius, roundedCaps, texelSize)) * subAAMultiplier;
+    return smoothstep(texelSize, 0.0, distanceToProgress(pixelPos, progress, pathRadius, roundedCaps, texelSize));
 }


### PR DESCRIPTION
Depends on:
 - [ ] https://github.com/ppy/osu-framework/pull/5604 (well, not really, that pr is fairly small and probably can be skipped since this one contains these changes anyway)

**The hack in question**
To make progress appear smooth if it's thickness < texelSize we are making it more transparent while leaving thickness the same. Previously calculated in the shader and one of potential breaking points on some platforms due to `mediump / highp`. (latter is my guess, not proven atm). Also was calculated a bit wrong, so the minimum thickness was thicker than it could be.
To closely inspect the result just increase the `texelSize` value to something big (like 40 instead of 2) and play around with the fill slider. You will see at which point the thickness will no longer be thinner and alpha multiplier starts to have effect.

Also I upped the precision of `pathRadius` to `highp` just in case.