### PR TITLE
Fix iPad devices not rendering colour pickers and circular progresses/blobs

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_Texture2D.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture2D.vs
@@ -2,14 +2,14 @@
 
 attribute highp vec2 m_Position;
 attribute lowp vec4 m_Colour;
-attribute mediump vec2 m_TexCoord;
-attribute mediump vec4 m_TexRect;
+attribute highp vec2 m_TexCoord;
+attribute highp vec4 m_TexRect;
 attribute mediump vec2 m_BlendRange;
 
 varying highp vec2 v_MaskingPosition;
 varying lowp vec4 v_Colour;
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
+varying highp vec2 v_TexCoord;
+varying highp vec4 v_TexRect;
 varying mediump vec2 v_BlendRange;
 
 uniform highp mat4 g_ProjMatrix;

--- a/osu.Framework/Resources/Shaders/sh_Texture3D.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture3D.vs
@@ -2,12 +2,12 @@
 
 attribute highp vec3 m_Position;
 attribute lowp vec4 m_Colour;
-attribute mediump vec2 m_TexCoord;
+attribute highp vec2 m_TexCoord;
 
 varying highp vec2 v_MaskingPosition;
 varying lowp vec4 v_Colour;
-varying mediump vec2 v_TexCoord;
-varying mediump vec4 v_TexRect;
+varying highp vec2 v_TexCoord;
+varying highp vec4 v_TexRect;
 varying mediump vec2 v_BlendRange;
 
 uniform mat4 g_ProjMatrix;


### PR DESCRIPTION
- Closes ppy/osu#21775

As deduced by @NiceAesth in https://github.com/ppy/osu/issues/21775#issuecomment-1364735197 after thorough investigation and trial-and-error. It appears that due to iPads having a maximum texture size of 16384x16384, the texture coords/rectangle of a white pixel texture (which exceed `mediump` range due to max texture size being high) already get lost while plotting fragments for colour picker shaders and circular progresses/blobs, and that turns out to be due to the vertex shader being limited to `mediump`. 

I am not sure why this isn't the case on my iPhone, but my humble guess is that the way OpenGL determines the best precision for each variable differs between an iPhone and an iPad for unknown reasons. I'm also assuming this doesn't happen on Android devices due to not having an enormous maximum texture size, but I could be wrong.

I'm not 100% sure about increasing the precision on the general `Texture2D` shader, but since it's only for vertex stage I don't think that could result in a performance hit (double-checking in mobile would be appreciated though). The alternative way would be to define a different `HighTexture2D` vertex shader and use that for those specific components, but I'm not sure if that's gonna be worth it at all.

@peppy would appreciate checking whether this does indeed fix the issue for you (checking test scenes of each component should be enough), would be a good one to get in before app store release.