### PR TITLE
Add "toggle target visibility" in draw visualizer

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -39,6 +39,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override bool BlockPositionalInput => Searching;
 
+        private readonly Dictionary<Drawable, bool> originalTargetVisibilityStates = new Dictionary<Drawable, bool>();
+
         public DrawVisualiser()
         {
             RelativeSizeAxes = Axes.Both;
@@ -55,6 +57,7 @@ namespace osu.Framework.Graphics.Visualisation
                     },
                     GoUpOneParent = goUpOneParent,
                     ToggleInspector = toggleInspector,
+                    ToggleTargetVisibility = toggleTargetVisibility
                 },
                 new CursorContainer()
             };
@@ -106,11 +109,30 @@ namespace osu.Framework.Graphics.Visualisation
         {
             if (targetVisualiser == null)
                 return;
-
             drawableInspector.ToggleVisibility();
 
             if (drawableInspector.State.Value == Visibility.Visible)
                 setHighlight(targetVisualiser);
+        }
+
+        private void toggleTargetVisibility()
+        {
+            if (Target == null)
+                return;
+
+            if (!originalTargetVisibilityStates.ContainsKey(Target))
+            {
+                originalTargetVisibilityStates.Add(Target, Target.IsPresent);
+            }
+
+            if (Target.IsPresent)
+            {
+                Target.Hide();
+            }
+            else
+            {
+                Target.Show();
+            }
         }
 
         protected override void LoadComplete()
@@ -135,6 +157,20 @@ namespace osu.Framework.Graphics.Visualisation
             drawableInspector.Hide();
 
             recycleVisualisers();
+
+            foreach (var state in originalTargetVisibilityStates)
+            {
+                if (state.Value)
+                {
+                    state.Key.Show();
+                }
+                else
+                {
+                    state.Key.Hide();
+                }
+            }
+
+            originalTargetVisibilityStates.Clear();
         }
 
         void IContainVisualisedDrawables.AddVisualiser(VisualisedDrawable visualiser)

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -17,6 +17,8 @@ namespace osu.Framework.Graphics.Visualisation
         public Action ChooseTarget;
         public Action GoUpOneParent;
         public Action ToggleInspector;
+        public Action ToggleDependencyView;
+        public Action ToggleTargetVisibility;
 
         internal DrawableInspector DrawableInspector { get; private set; }
 
@@ -48,6 +50,8 @@ namespace osu.Framework.Graphics.Visualisation
             AddButton(@"choose target", () => ChooseTarget?.Invoke());
             AddButton(@"up one parent", () => GoUpOneParent?.Invoke());
             AddButton(@"toggle inspector", () => ToggleInspector?.Invoke());
+            AddButton(@"toggle dependency view", () => ToggleDependencyView?.Invoke());
+            AddButton(@"toggle target visibility", () => ToggleTargetVisibility?.Invoke());
 
             MainHorizontalContent.Add(DrawableInspector = new DrawableInspector());
         }


### PR DESCRIPTION
This PR adds the ability to hide drawables via the draw visualizer.

When the draw visualizer gets closed, the original states get reset.