### PR TITLE
Disallow using `AddInternal` in game class

### DIFF
--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/FlappyDonGame.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/FlappyDonGame.cs
@@ -71,7 +71,7 @@ namespace FlappyDon.Game
             // but changing the X-axis (ie window width) has no effect on scaling.
             gameScreen.Strategy = DrawSizePreservationStrategy.Minimum;
             gameScreen.TargetDrawSize = new Vector2(0, 768);
-            AddInternal(gameScreen);
+            Add(gameScreen);
 
             // Register a method to be triggered each time the bird crosses a pipe threshold
             obstacles.ThresholdCrossed = _ =>

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -120,7 +120,7 @@ namespace osu.Framework
             });
         }
 
-        protected sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
+        protected sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Add)} or {nameof(Content)} instead.");
 
         /// <summary>
         /// As Load is run post host creation, you can override this method to alter properties of the host before it makes itself visible to the user.

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -106,21 +106,21 @@ namespace osu.Framework
         {
             RelativeSizeAxes = Axes.Both;
 
-            AddRangeInternal(new Drawable[]
+            base.AddInternal(content = new Container
             {
-                content = new Container
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                },
-                overlayContent = new DrawSizePreservingFillContainer
-                {
-                    TargetDrawSize = new Vector2(1280, 960),
-                    RelativeSizeAxes = Axes.Both,
-                },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+            });
+
+            base.AddInternal(overlayContent = new DrawSizePreservingFillContainer
+            {
+                TargetDrawSize = new Vector2(1280, 960),
+                RelativeSizeAxes = Axes.Both,
             });
         }
+
+        protected sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
 
         /// <summary>
         /// As Load is run post host creation, you can override this method to alter properties of the host before it makes itself visible to the user.


### PR DESCRIPTION
- Companion to https://github.com/ppy/osu/pull/22141 

`Game` already wraps a container for `Content`, so there have been two ways to add components to a game, which lead to broken drawable order as seen in ppy/osu#22141 due to using both ways (`AddInternal` and `Add`). 

To limit this from happening, `AddInternal` has been completely disabled in favour of using `Add` instead.