### PR TITLE
Move `IconGroup` out of `osu.Framework.Platform.Windows.Native` namespace and annotate with `SupportedOSPlatformAttribute`

### DIFF
--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Platform;
 using osu.Framework.Platform.Linux;
 using osu.Framework.Platform.MacOS;
@@ -17,7 +18,8 @@ namespace osu.Framework
         {
             switch (RuntimeInfo.OS)
             {
-                case RuntimeInfo.Platform.Windows when OperatingSystem.IsWindows():
+                case RuntimeInfo.Platform.Windows:
+                    Debug.Assert(OperatingSystem.IsWindows());
                     return new WindowsGameHost(gameName, hostOptions);
 
                 case RuntimeInfo.Platform.Linux:

--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -17,7 +17,7 @@ namespace osu.Framework
         {
             switch (RuntimeInfo.OS)
             {
-                case RuntimeInfo.Platform.Windows:
+                case RuntimeInfo.Platform.Windows when OperatingSystem.IsWindows():
                     return new WindowsGameHost(gameName, hostOptions);
 
                 case RuntimeInfo.Platform.Linux:

--- a/osu.Framework/Platform/IconGroup.cs
+++ b/osu.Framework/Platform/IconGroup.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.Versioning;
 using osu.Framework.Platform.Windows.Native;
 
 namespace osu.Framework.Platform
@@ -138,6 +139,7 @@ namespace osu.Framework.Platform
         /// <param name="bpp">The maximum desired bit count. Defaults to 32 bit.</param>
         /// <returns>An <see cref="Icon"/> instance, or null if a valid size could not be found.</returns>
         /// <exception cref="InvalidOperationException">If the native icon handle could not be created.</exception>
+        [SupportedOSPlatform("windows")]
         public Icon? CreateIcon(int width, int height, int bpp = 32)
         {
             int closest = findClosestEntry(width, height, bpp, false);
@@ -177,6 +179,7 @@ namespace osu.Framework.Platform
             return span.ToArray();
         }
 
+        [SupportedOSPlatform("windows")]
         [DllImport("user32.dll")]
         private static extern IntPtr CreateIconFromResourceEx(byte[] pbIconBits, uint cbIconBits, bool fIcon, uint dwVersion, int cxDesired, int cyDesired, uint uFlags);
     }

--- a/osu.Framework/Platform/IconGroup.cs
+++ b/osu.Framework/Platform/IconGroup.cs
@@ -6,8 +6,9 @@ using System.Runtime.InteropServices;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using osu.Framework.Platform.Windows.Native;
 
-namespace osu.Framework.Platform.Windows.Native
+namespace osu.Framework.Platform
 {
     internal class IconGroup
     {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -11,7 +11,6 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform.SDL2;
-using osu.Framework.Platform.Windows.Native;
 using osu.Framework.Threading;
 using SDL2;
 using SixLabors.ImageSharp;

--- a/osu.Framework/Platform/Windows/Native/Icon.cs
+++ b/osu.Framework/Platform/Windows/Native/Icon.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace osu.Framework.Platform.Windows.Native
 {
+    [SupportedOSPlatform("windows")]
     internal class Icon : IDisposable
     {
         [DllImport("user32.dll", SetLastError = true)]

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -17,6 +17,7 @@ using osu.Framework.Platform.Windows.Native;
 
 namespace osu.Framework.Platform.Windows
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsGameHost : DesktopGameHost
     {
         private TimePeriod? timePeriod;
@@ -29,7 +30,6 @@ namespace osu.Framework.Platform.Windows
             // on windows this is guaranteed to exist (and be usable) so don't fallback to the base/default.
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
 
-        [SupportedOSPlatform("windows")]
         public override bool CapsLockEnabled => Console.CapsLock;
 
         internal WindowsGameHost(string gameName, HostOptions? options)

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Drawing;
+using System.Runtime.Versioning;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.StateChanges;
@@ -18,6 +19,7 @@ namespace osu.Framework.Platform.Windows
     /// A windows specific mouse input handler which overrides the SDL2 implementation of raw input.
     /// This is done to better handle quirks of some devices.
     /// </summary>
+    [SupportedOSPlatform("windows")]
     internal unsafe class WindowsMouseHandler : MouseHandler
     {
         private const int raw_input_coordinate_space = 65535;

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Platform.SDL2;
 using osu.Framework.Platform.Windows.Native;
@@ -13,6 +14,7 @@ using Icon = osu.Framework.Platform.Windows.Native.Icon;
 
 namespace osu.Framework.Platform.Windows
 {
+    [SupportedOSPlatform("windows")]
     public class WindowsWindow : SDL2DesktopWindow
     {
         private const int seticon_message = 0x0080;


### PR DESCRIPTION
It was really wrong that `SDL2DesktopWindow` was using `osu.Framework.Platform.Windows.Native`. This was caused by `IconGroup` being in that namespace, even though most of `IconGroup` is platform-agnostic.

This PR moves `IconGroup` to the more general `osu.Framework.Platform` namespace and then appropriately annotates the windows-specific `Icon`/`CreateIcon` API usage with [`SupportedOSPlatform`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.supportedosplatformattribute?view=net-7.0).