### PR TITLE
Add `Pad{Left,Right}` extensions for `LocalisableString` and `ILocalisableStringData`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -458,6 +458,40 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestPadLeftILocalisableStringData()
+        {
+            const string str = FakeStorage.LOCALISABLE_STRING_EN;
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+
+            int padAmount = str.Length + 1;
+
+            var padded = manager.GetLocalisedBindableString(new TranslatableString(str, str).PadLeft(padAmount));
+
+            Assert.AreEqual(str.PadLeft(padAmount), padded.Value);
+
+            config.SetValue(FrameworkSetting.Locale, "ja-jp");
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP.PadLeft(padAmount), padded.Value);
+        }
+
+        [Test]
+        public void TestPadRightLocalisableString()
+        {
+            const string str = FakeStorage.LOCALISABLE_STRING_EN;
+
+            int padAmount = str.Length + 1;
+
+            LocalisableString localisable = new TranslatableString(str, str);
+
+            var padded = manager.GetLocalisedBindableString(localisable.PadRight(padAmount));
+
+            Assert.AreEqual(str.PadRight(padAmount), padded.Value);
+
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP.PadRight(padAmount), padded.Value);
+        }
+
+        [Test]
         public void TestInvalidLocaleWhileRunning()
         {
             string localeBefore = config.Get<string>(FrameworkSetting.Locale);

--- a/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
+++ b/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
@@ -70,5 +70,33 @@ namespace osu.Framework.Extensions.LocalisationExtensions
         /// <param name="data">The string data.</param>
         /// <returns>A case transformable string with its string data transformed to sentence case.</returns>
         public static CaseTransformableString ToSentence(this ILocalisableStringData data) => new LocalisableString(data).ToSentence();
+
+        /// <summary>
+        /// Returns a <see cref="LocalisableString"/> with the specified underlying localisable string right-aligned by padding it with spaces on the left, for the specified <paramref name="totalWidth"/>.
+        /// </summary>
+        /// <param name="str">The localisable string.</param>
+        /// <param name="totalWidth">The minimum number of characters desired in the resulting <see cref="LocalisableString"/>. Should be a positive number.</param>
+        public static LocalisableString PadLeft(this LocalisableString str, int totalWidth) => LocalisableString.Format($"{{0,{totalWidth}}}", str);
+
+        /// <summary>
+        /// Returns a <see cref="LocalisableString"/> with the specified underlying string data right-aligned by padding it with spaces on the left, for the specified <paramref name="totalWidth"/>.
+        /// </summary>
+        /// <param name="data">The string data.</param>
+        /// <param name="totalWidth">The minimum number of characters desired in the resulting <see cref="LocalisableString"/>. Should be a positive number.</param>
+        public static LocalisableString PadLeft(this ILocalisableStringData data, int totalWidth) => LocalisableString.Format($"{{0,{totalWidth}}}", data);
+
+        /// <summary>
+        /// Returns a <see cref="LocalisableString"/> with the specified underlying localisable string left-aligned by padding it with spaces on the right, for the specified <paramref name="totalWidth"/>.
+        /// </summary>
+        /// <param name="str">The localisable string.</param>
+        /// <param name="totalWidth">The minimum number of characters desired in the resulting <see cref="LocalisableString"/>. Should be a positive number.</param>
+        public static LocalisableString PadRight(this LocalisableString str, int totalWidth) => LocalisableString.Format($"{{0,{-totalWidth}}}", str);
+
+        /// <summary>
+        /// Returns a <see cref="LocalisableString"/> with the specified underlying string data left-aligned by padding it with spaces on the right, for the specified <paramref name="totalWidth"/>.
+        /// </summary>
+        /// <param name="data">The string data.</param>
+        /// <param name="totalWidth">The minimum number of characters desired in the resulting <see cref="LocalisableString"/>. Should be a positive number.</param>
+        public static LocalisableString PadRight(this ILocalisableStringData data, int totalWidth) => LocalisableString.Format($"{{0,{-totalWidth}}}", data);
     }
 }


### PR DESCRIPTION
For use in https://github.com/ppy/osu/pull/22208#discussion_r1070462373. Mirrors `string.Pad{Left,Right}` methods.