### PR TITLE
Fix nativelibs deployment script installing outdated .NET version

### DIFF
--- a/.github/workflows/deploy-nativelibs.yml
+++ b/.github/workflows/deploy-nativelibs.yml
@@ -46,10 +46,10 @@ jobs:
         id: artifactsPath
         run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
 
-      - name: Setup .NET 5.0.x
+      - name: Setup .NET 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
 
       - name: Build NativeLibs
         run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}


### PR DESCRIPTION
Noticed while checking #5629. 
 - Failed run: https://github.com/frenzibyte/osu-framework/actions/runs/3967472136/jobs/6799488672. 
 - "Successful" run: https://github.com/frenzibyte/osu-framework/actions/runs/3967529353/jobs/6799603895 (failed because I'm pushing with wrong package ID).