### PR TITLE
Fix emphasised markdown text not flowing correctly

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -184,6 +184,11 @@ __bold with underscore__
 *__italic with asterisk, bold with underscore__*
 _**italic with underscore, bold with asterisk**_";
             });
+
+            AddStep("Wiki notice", () =>
+            {
+                markdownContainer.Text = @"*Notice: We are still figuring out game balance and mechanics. For now, **scores set on lazer should not be considered permanent**.*";
+            });
         }
 
         [Test]

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -186,28 +186,19 @@ namespace osu.Framework.Graphics.Containers.Markdown
                 }
             }
 
-            var textDrawable = CreateEmphasisedSpriteText(hasBold, hasItalic);
-            textDrawable.Text = text;
-
-            AddDrawable(textDrawable);
+            AddText(text, t => ApplyEmphasisedCreationParameters(t, hasBold, hasItalic));
         }
 
         protected internal override SpriteText CreateSpriteText() => parentTextComponent.CreateSpriteText();
 
         /// <summary>
-        /// Creates an emphasised <see cref="SpriteText"/>.
+        /// Applies emphasised creation parameters to <see cref="SpriteText"/>.
         /// </summary>
+        /// <param name="spriteText">The <see cref="SpriteText"/> to be emphasised.</param>
         /// <param name="bold">Whether the text should be emboldened.</param>
         /// <param name="italic">Whether the text should be italicised.</param>
-        /// <returns>The <see cref="SpriteText"/> with emphases applied.</returns>
-        protected virtual SpriteText CreateEmphasisedSpriteText(bool bold, bool italic)
-        {
-            var textDrawable = CreateSpriteText();
-
-            textDrawable.Font = textDrawable.Font.With(weight: bold ? "Bold" : null, italics: italic);
-
-            return textDrawable;
-        }
+        protected virtual void ApplyEmphasisedCreationParameters(SpriteText spriteText, bool bold, bool italic)
+            => spriteText.Font = spriteText.Font.With(weight: bold ? "Bold" : null, italics: italic);
 
         SpriteText IMarkdownTextComponent.CreateSpriteText() => CreateSpriteText();
     }

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -106,7 +106,7 @@ namespace osu.Framework.Graphics.Containers
         protected virtual TSpriteText CreateSpriteText(TextFlowContainer textFlowContainer)
         {
             var spriteText = creationFunc.Invoke();
-            textFlowContainer.ApplyDefaultCreationParamters(spriteText);
+            textFlowContainer.ApplyDefaultCreationParameters(spriteText);
             creationParameters?.Invoke(spriteText);
             return spriteText;
         }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -277,7 +277,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected internal virtual SpriteText CreateSpriteText() => new SpriteText();
 
-        internal void ApplyDefaultCreationParamters(SpriteText spriteText) => defaultCreationParameters?.Invoke(spriteText);
+        internal void ApplyDefaultCreationParameters(SpriteText spriteText) => defaultCreationParameters?.Invoke(spriteText);
 
         public override void Add(Drawable drawable)
         {


### PR DESCRIPTION
Before:
![chrome_6FlAF9cz2f](https://user-images.githubusercontent.com/35318437/213793873-a74f23d4-cd6c-4ea6-be1d-b63d6d0e17ea.gif)

After:
![chrome_hqjKkCM4A7](https://user-images.githubusercontent.com/35318437/213794097-55db6dd5-8c46-41da-aeb4-05cdbe0c5749.gif)