### PR TITLE
Add composite text chunks

### DIFF
--- a/osu.Framework.Tests/Visual/Localisation/TestSceneCompositeChunkLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneCompositeChunkLocalisation.cs
@@ -1,0 +1,135 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Localisation
+{
+    public partial class TestSceneCompositeChunkLocalisation : LocalisationTestScene
+    {
+        private const string rank = "rank";
+        private const string rank_default = "[0] achieved rank #[1] on [2] ([3])";
+        private const string simple = "simple";
+
+        private CompositeTextChunk<SpriteText>? chunk;
+        private Color4 color = Color4.Cyan;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // strings sourced from osu-web crowdin (https://crowdin.com/translate/osu-web/)
+            Manager.AddLanguage("en", new TestLocalisationStore("en", new Dictionary<string, string>
+            {
+                [rank] = rank_default,
+                [simple] = "simple english",
+            }));
+
+            Manager.AddLanguage("fr", new TestLocalisationStore("fr", new Dictionary<string, string>
+            {
+                [rank] = "[0] a atteint le rang #[1] sur [2] ([3])",
+                [simple] = "simple french",
+            }));
+
+            Manager.AddLanguage("tr", new TestLocalisationStore("tr", new Dictionary<string, string>
+            {
+                [rank] = "[0] [2] ([3]) beatmapinde #[1] sıralamaya ulaştı",
+                [simple] = "simple turkish",
+            }));
+        }
+
+        [Test]
+        public void TestTextFlowLocalisation()
+        {
+            Container? textFlowParent = null;
+            TextFlowContainer? textFlowContainer = null;
+
+            AddStep("create text flow", () => Child = textFlowParent = new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.FromHex("#333")
+                    },
+                    textFlowContainer = new TextFlowContainer(text => text.Font = FrameworkFont.Condensed)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                    },
+                }
+            });
+            AddStep("add text", () =>
+            {
+                const string player = "spaceman_atlas";
+                var rankAchieved = 12_345_678.ToLocalisableString("N0");
+                var beatmap = new RomanisableString(
+                    "ELFENSJóN - ASH OF ROUGE (HeTo's Normal)",
+                    "ELFENSJoN - ASH OF ROUGE (HeTo's Normal)");
+                const string mode = "osu!";
+
+                chunk = textFlowContainer!.AddText(new TranslatableString(rank, rank_default), new (LocalisableString, Action<SpriteText>)[]
+                {
+                    (player, applyColors),
+                    (rankAchieved, applyColors),
+                    (beatmap, applyColors),
+                    (mode, applyColors)
+                }, text =>
+                {
+                    text.Font = FontUsage.Default;
+                    text.Colour = Colour4.LimeGreen;
+                });
+            });
+
+            SetLocale("en");
+            SetLocale("fr");
+            SetLocale("tr");
+
+            AddToggleStep("toggle romanisation", romanised => ShowUnicode.Value = romanised);
+
+            AddSliderStep("color of inner parts", 0f, 1f, 0.5f, c =>
+            {
+                color = new Color4(1f, c, c, 1f);
+                updColors();
+            });
+
+            AddSliderStep("change text flow width", 0, 1f, 1f, width =>
+            {
+                if (textFlowParent != null)
+                    textFlowParent.Width = width;
+            });
+        }
+
+        private void applyColors(SpriteText text) => text.Colour = color;
+
+        private void updColors()
+        {
+            if (chunk == null)
+                return;
+
+            foreach (var subPart in chunk.Children)
+            {
+                foreach (var drawable in subPart.Drawables)
+                {
+                    drawable.Colour = color;
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeTextChunk.cs
+++ b/osu.Framework/Graphics/Containers/CompositeTextChunk.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// Implementation of <see cref="TextChunk{TSpriteText}"/> that support substitution of other <see cref="TextChunk{TSpriteText}"/>s for arbitrary placeholders.
+    /// </summary>
+    public class CompositeTextChunk<TSpriteText> : FormattableTextChunk<TSpriteText>
+        where TSpriteText : SpriteText, new()
+    {
+        public readonly TextChunk<TSpriteText>[] Children;
+
+        public CompositeTextChunk(LocalisableString text, bool newLineIsParagraph, Func<TSpriteText> creationFunc, TextChunk<TSpriteText>[] children, Action<TSpriteText>? creationParameters = null)
+            : base(text, newLineIsParagraph, creationFunc, creationParameters)
+        {
+            Children = children;
+        }
+
+        protected override IEnumerable<Drawable>? GetDrawablesForSubstitution(string placeholder, TextFlowContainer textFlowContainer)
+        {
+            if (int.TryParse(placeholder, out int subpartIndex))
+            {
+                if (subpartIndex < 0)
+                    throw new ArgumentException($"Negative indices are invalid. Index {subpartIndex} was used.");
+                if (subpartIndex >= Children.Length)
+                    throw new ArgumentException($"Index {subpartIndex} is outside the bounds of providen children text chunks.");
+
+                var child = Children[subpartIndex];
+                child.RecreateDrawablesFor(textFlowContainer);
+                return child.Drawables;
+            }
+
+            throw new ArgumentException($"Index must be a number. {subpartIndex} was used.");
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Localisation;
 
 namespace osu.Framework.Graphics.Containers
@@ -88,9 +87,10 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="name">The name of the placeholder.</param>
         /// <param name="iconFactory">The icon factory matching <paramref name="name"/>, if the method returned <see langword="true"/>.</param>
         /// <returns>Whether an icon factory was found for the given <paramref name="name"/>.</returns>
-        internal bool TryGetIconFactory(string name, out Delegate iconFactory) => iconFactories.TryGetValue(name, out iconFactory);
+        internal bool TryGetIconFactory(string name, [MaybeNullWhen(false)] out Delegate iconFactory) => iconFactories.TryGetValue(name, out iconFactory);
 
-        protected internal override TextChunk<TSpriteText> CreateChunkFor<TSpriteText>(LocalisableString text, bool newLineIsParagraph, Func<TSpriteText> creationFunc, Action<TSpriteText> creationParameters = null)
+        protected internal override TextChunk<TSpriteText> CreateChunkFor<TSpriteText>(LocalisableString text, bool newLineIsParagraph, Func<TSpriteText> creationFunc,
+                                                                                       Action<TSpriteText>? creationParameters = null)
             => new CustomizableTextChunk<TSpriteText>(text, newLineIsParagraph, creationFunc, creationParameters);
 
         protected override void RecreateAllParts()

--- a/osu.Framework/Graphics/Containers/FormattableTextChunk.cs
+++ b/osu.Framework/Graphics/Containers/FormattableTextChunk.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// Base class for implementations of <see cref="TextChunk{TSpriteText}"/> those support substitution for arbitrary drawables.
+    /// </summary>
+    /// <typeparam name="TSpriteText"></typeparam>
+    public abstract class FormattableTextChunk<TSpriteText> : TextChunk<TSpriteText>
+        where TSpriteText : SpriteText, new()
+    {
+        protected FormattableTextChunk(LocalisableString text, bool newLineIsParagraph, Func<TSpriteText> creationFunc, Action<TSpriteText>? creationParameters = null)
+            : base(text, newLineIsParagraph, creationFunc, creationParameters)
+        {
+        }
+
+        protected abstract IEnumerable<Drawable>? GetDrawablesForSubstitution(string placeholder, TextFlowContainer textFlowContainer);
+
+        protected override IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
+        {
+            var sprites = new List<Drawable>();
+            int index = 0;
+            string str = text;
+
+            while (index < str.Length)
+            {
+                IEnumerable<Drawable>? placeholderDrawables = null;
+                int nextPlaceholderIndex = str.IndexOf(CustomizableTextContainer.UNESCAPED_LEFT, index, StringComparison.Ordinal);
+                // make sure we skip ahead to the next [ as long as the current [ is escaped
+                while (nextPlaceholderIndex != -1 && str.IndexOf(CustomizableTextContainer.ESCAPED_LEFT, nextPlaceholderIndex, StringComparison.Ordinal) == nextPlaceholderIndex)
+                    nextPlaceholderIndex = str.IndexOf(CustomizableTextContainer.UNESCAPED_LEFT, nextPlaceholderIndex + 2, StringComparison.Ordinal);
+
+                string? strPiece = null;
+
+                if (nextPlaceholderIndex != -1)
+                {
+                    int placeholderEnd = str.IndexOf(CustomizableTextContainer.UNESCAPED_RIGHT, nextPlaceholderIndex, StringComparison.Ordinal);
+                    // make sure we skip  ahead to the next ] as long as the current ] is escaped
+                    while (placeholderEnd != -1 && str.IndexOf(CustomizableTextContainer.ESCAPED_RIGHT, placeholderEnd, StringComparison.InvariantCulture) == placeholderEnd)
+                        placeholderEnd = str.IndexOf(CustomizableTextContainer.UNESCAPED_RIGHT, placeholderEnd + 2, StringComparison.Ordinal);
+
+                    if (placeholderEnd != -1)
+                    {
+                        strPiece = str[index..nextPlaceholderIndex];
+                        string placeholderStr = str.AsSpan(nextPlaceholderIndex + 1, placeholderEnd - nextPlaceholderIndex - 1).Trim().ToString();
+                        placeholderDrawables = GetDrawablesForSubstitution(placeholderStr, textFlowContainer);
+
+                        index = placeholderEnd + 1;
+                    }
+                }
+
+                if (strPiece == null)
+                {
+                    strPiece = str.Substring(index);
+                    index = str.Length;
+                }
+
+                // unescape stuff
+                strPiece = CustomizableTextContainer.Unescape(strPiece);
+                sprites.AddRange(base.CreateDrawablesFor(strPiece, textFlowContainer));
+
+                if (placeholderDrawables != null)
+                    sprites.AddRange(placeholderDrawables);
+            }
+
+            return sprites;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -244,6 +244,29 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
+        /// Add new text to this text flow. The \n character will create a new paragraph. Placeholders will be replaced by children TextChunks.
+        /// </summary>
+        /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
+        /// <param name="text">The text to add.</param>
+        /// <param name="subParts">Texts and creation callbacks for each children TextChunk.</param>
+        /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text. Children chunks will raise their own callbacks.</param>
+        public CompositeTextChunk<TSpriteText> AddText<TSpriteText>(LocalisableString text, (LocalisableString text, Action<TSpriteText> creationParameters)[] subParts,
+                                                                    Action<TSpriteText> creationParameters = null)
+            where TSpriteText : SpriteText, new()
+        {
+            var subChunks = new TextChunk<TSpriteText>[subParts.Length];
+
+            for (int i = 0; i < subParts.Length; i++)
+            {
+                subChunks[i] = new TextChunk<TSpriteText>(subParts[i].text, true, () => new TSpriteText(), subParts[i].creationParameters);
+            }
+
+            var part = new CompositeTextChunk<TSpriteText>(text, true, () => new TSpriteText(), subChunks, creationParameters);
+            AddPart(part);
+            return part;
+        }
+
+        /// <summary>
         /// Add a new paragraph to this text flow. The \n character will create a line break
         /// If you need \n to be a new paragraph, not just a line break, use <see cref="AddText{TSpriteText}(LocalisableString, Action{TSpriteText})"/> instead.
         /// </summary>


### PR DESCRIPTION
Their main purpose is to allow localization of text flows which have parts with different formatting. 

- I moved code which parsed `[xyz]` things from text to base class to avoid dublicating.
- "`\n` = new paragraph" is forced here because children chunks add line breaks before themselves when not.
- Not sure about `drawable = (Drawable?)cb.DynamicInvoke(args);` `if (drawable == null)` thing in customizable chunk - when it may return null? Maybe it's better to throw?