### PR TITLE
Fix bindable list/dictionary not correctly checking for already bound instances

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
 
-            Assert.Throws<InvalidOperationException>(() => bindable1.BindTo(bindable2));
+            Assert.Throws<ArgumentException>(() => bindable1.BindTo(bindable2));
         }
 
         [Test]

--- a/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
@@ -58,7 +58,19 @@ namespace osu.Framework.Tests.Bindables
 
         #endregion
 
-        #region BindTarget
+        #region Bind
+
+        /// <summary>
+        /// Tests binding to a bindable that has already been bound.
+        /// </summary>
+        [Test]
+        public void TestBindToAlreadyBound()
+        {
+            BindableDictionary<string, byte> bindable1 = new BindableDictionary<string, byte>();
+            BindableDictionary<string, byte> bindable2 = bindable1.GetBoundCopy();
+
+            Assert.Throws<ArgumentException>(() => bindable1.BindTo(bindable2));
+        }
 
         /// <summary>
         /// Tests binding via the various <see cref="BindableDictionary{TKey,TValue}"/> methods.

--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -53,7 +53,19 @@ namespace osu.Framework.Tests.Bindables
 
         #endregion
 
-        #region BindTarget
+        #region Bind
+
+        /// <summary>
+        /// Tests binding to a bindable that has already been bound.
+        /// </summary>
+        [Test]
+        public void TestBindToAlreadyBound()
+        {
+            BindableList<int> bindable1 = new BindableList<int>();
+            BindableList<int> bindable2 = bindable1.GetBoundCopy();
+
+            Assert.Throws<ArgumentException>(() => bindable1.BindTo(bindable2));
+        }
 
         /// <summary>
         /// Tests binding via the various <see cref="BindableList{T}.BindTarget"/> methods.

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -199,8 +199,8 @@ namespace osu.Framework.Bindables
         /// <exception cref="InvalidOperationException">Thrown when attempting to bind to an already bound object.</exception>
         public virtual void BindTo(Bindable<T> them)
         {
-            if (Bindings?.Contains(them) == true)
-                throw new InvalidOperationException($"This bindable is already bound to the requested bindable ({them}).");
+            if (Bindings?.Contains(them.weakReference) == true)
+                throw new ArgumentException("An already bound bindable cannot be bound again.");
 
             them.CopyTo(this);
 

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -454,10 +454,10 @@ namespace osu.Framework.Bindables
         {
             ArgumentNullException.ThrowIfNull(them);
 
-            if (bindings?.Contains(weakReference) == true)
-                throw new ArgumentException("An already bound collection can not be bound again.");
+            if (bindings?.Contains(them.weakReference) == true)
+                throw new ArgumentException("An already bound dictionary can not be bound again.");
             if (them == this)
-                throw new ArgumentException("A collection can not be bound to itself");
+                throw new ArgumentException("A dictionary can not be bound to itself");
 
             // copy state and content over
             Parse(them);

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -589,7 +589,7 @@ namespace osu.Framework.Bindables
         {
             ArgumentNullException.ThrowIfNull(them);
 
-            if (bindings?.Contains(weakReference) == true)
+            if (bindings?.Contains(them.weakReference) == true)
                 throw new ArgumentException("An already bound collection can not be bound again.");
             if (them == this)
                 throw new ArgumentException("A collection can not be bound to itself");


### PR DESCRIPTION
I've also changed `Bindable` to match the message (and removed the instance string output part because it's already bound and will share the same value, therefore pointless). 

This may be the ultimate key as to why we're seeing these `IndexOutOfRangeException`s osu!-side with multiplayer tests (cc @smoogipoo, might interest you). It's significantly hinted in the error output:

![CleanShot 2023-01-21 at 21 39 19](https://user-images.githubusercontent.com/22781491/213882163-d2bd7e04-4d55-42a9-8dac-ca998607dcb0.png)

As it can be seen, `MultiplayerClient` removes the playlist item via index, and that first propagates the change from the first bindable to the second bindable, which then propagates to another bindable that since fails with the `IndexOutOfRangeException`. What I'm thinking is that the third bindable is actually the original bindable, and that couldn't be caught both in `removeAt` because that only checks one level above, and in `BindTo` because the check was broken.

I'll run the tests locally with local framework checkout in hopes I still get to reproduce the failure, but failing that, time will tell on osu! CI where the unnecessary binding is coming from.