### PR TITLE
Return the handling drawable on calling `TriggerPressed`

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -357,14 +357,14 @@ namespace osu.Framework.Input.Bindings
 
         public void TriggerReleased(T released) => PropagateReleased(KeyBindingInputQueue, GetContainingInputManager()?.CurrentState ?? new InputState(), released);
 
-        public void TriggerPressed(T pressed)
+        public Drawable TriggerPressed(T pressed)
         {
             var state = GetContainingInputManager()?.CurrentState ?? new InputState();
 
             if (simultaneousMode == SimultaneousBindingMode.None)
                 releasePressedActions(state);
 
-            PropagatePressed(KeyBindingInputQueue, state, pressed);
+            return PropagatePressed(KeyBindingInputQueue, state, pressed);
         }
 
         private List<Drawable> getInputQueue(IKeyBinding binding, bool rebuildIfEmpty = false)


### PR DESCRIPTION
A change i have floating around which may or may not be used for touch support, but good to have anyway.