### PR TITLE
Fix `AudioManager.GetSampleStore()` mutating provided store 

### DIFF
--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
@@ -3,9 +3,12 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 
@@ -21,18 +24,37 @@ namespace osu.Framework.Tests.Visual.Audio
         public void TestSampleStoreCreationDoesNotMutateOriginalResourceStore()
         {
             TestResourceStore resourceStore = null!;
+            ISampleStore sampleStore = null!;
             List<string> filenames = null!;
 
             AddStep("create resource store", () => resourceStore = new TestResourceStore());
             AddStep("store lookups for sample file", () => filenames = resourceStore.GetFilenames("test").ToList());
 
-            AddStep("create sample store", () => audioManager.GetSampleStore(resourceStore));
+            AddStep("create sample store", () => sampleStore = audioManager.GetSampleStore(resourceStore));
             AddAssert("resource store lookups unchanged", () => resourceStore.GetFilenames("test"), () => Is.EquivalentTo(filenames));
+
+            AddStep("attempt to look up sample", () => sampleStore.Get("sample"));
+            AddAssert("extension lookups attempted", () => resourceStore.AttemptedLookups, () => Is.EquivalentTo(new[] { "sample", "sample.wav", "sample.mp3" }));
         }
 
         private class TestResourceStore : ResourceStore<byte[]>
         {
             public new IEnumerable<string> GetFilenames(string lookup) => base.GetFilenames(lookup);
+
+            private readonly List<string> attemptedLookups = new List<string>();
+            public IEnumerable<string> AttemptedLookups => attemptedLookups;
+
+            public override byte[] Get(string name)
+            {
+                attemptedLookups.Add(name);
+                return base.Get(name);
+            }
+
+            public override Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
+            {
+                attemptedLookups.Add(name);
+                return base.GetAsync(name, cancellationToken);
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.IO.Stores;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.Audio
+{
+    [HeadlessTest]
+    public partial class TestSceneAudioManager : FrameworkTestScene
+    {
+        [Resolved]
+        private AudioManager audioManager { get; set; } = null!;
+
+        [Test]
+        public void TestSampleStoreCreationDoesNotMutateOriginalResourceStore()
+        {
+            TestResourceStore resourceStore = null!;
+            List<string> filenames = null!;
+
+            AddStep("create resource store", () => resourceStore = new TestResourceStore());
+            AddStep("store lookups for sample file", () => filenames = resourceStore.GetFilenames("test").ToList());
+
+            AddStep("create sample store", () => audioManager.GetSampleStore(resourceStore));
+            AddAssert("resource store lookups unchanged", () => resourceStore.GetFilenames("test"), () => Is.EquivalentTo(filenames));
+        }
+
+        private class TestResourceStore : ResourceStore<byte[]>
+        {
+            public new IEnumerable<string> GetFilenames(string lookup) => base.GetFilenames(lookup);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioManager.cs
@@ -37,6 +37,21 @@ namespace osu.Framework.Tests.Visual.Audio
             AddAssert("extension lookups attempted", () => resourceStore.AttemptedLookups, () => Is.EquivalentTo(new[] { "sample", "sample.wav", "sample.mp3" }));
         }
 
+        [Test]
+        public void TestSampleStoreWithAdditionalExtensions()
+        {
+            TestResourceStore resourceStore = null!;
+            ISampleStore sampleStore = null!;
+
+            AddStep("create resource store", () => resourceStore = new TestResourceStore());
+            AddStep("create sample store", () => sampleStore = audioManager.GetSampleStore(resourceStore));
+            AddStep("add another extension", () => sampleStore.AddExtension("ogg"));
+
+            AddStep("attempt to look up sample", () => sampleStore.Get("sample"));
+            AddAssert("extension lookups attempted", () => resourceStore.AttemptedLookups,
+                () => Is.EquivalentTo(new[] { "sample", "sample.wav", "sample.mp3", "sample.ogg" }));
+        }
+
         private class TestResourceStore : ResourceStore<byte[]>
         {
             public new IEnumerable<string> GetFilenames(string lookup) => base.GetFilenames(lookup);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -273,6 +273,11 @@ namespace osu.Framework.Audio
         /// Obtains the <see cref="SampleStore"/> corresponding to a given resource store.
         /// Returns the global <see cref="SampleStore"/> if no resource store is passed.
         /// </summary>
+        /// <remarks>
+        /// By default, <c>.wav</c> and <c>.ogg</c> extensions will be automatically appended to lookups on the returned store
+        /// if the lookup does not correspond directly to an existing filename.
+        /// Additional extensions can be added via <see cref="ISampleStore.AddExtension"/>.
+        /// </remarks>
         /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="SampleStore"/>.</param>
         /// <param name="mixer">The <see cref="AudioMixer"/> to use for samples created by this store. Defaults to the global <see cref="SampleMixer"/>.</param>
         public ISampleStore GetSampleStore(IResourceStore<byte[]> store = null, AudioMixer mixer = null)

--- a/osu.Framework/Audio/Sample/ISampleStore.cs
+++ b/osu.Framework/Audio/Sample/ISampleStore.cs
@@ -9,5 +9,10 @@ namespace osu.Framework.Audio.Sample
         /// How many instances of a single sample should be allowed to playback concurrently before stopping the longest playing.
         /// </summary>
         int PlaybackConcurrency { get; set; }
+
+        /// <summary>
+        /// Add a file extension to automatically append to any lookups on this store.
+        /// </summary>
+        void AddExtension(string extension);
     }
 }

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Audio.Sample
 {
     internal class SampleStore : AudioCollectionManager<AdjustableAudioComponent>, ISampleStore
     {
-        private readonly IResourceStore<byte[]> store;
+        private readonly ResourceStore<byte[]> store;
         private readonly AudioMixer mixer;
 
         private readonly Dictionary<string, SampleBassFactory> factories = new Dictionary<string, SampleBassFactory>();
@@ -27,11 +27,11 @@ namespace osu.Framework.Audio.Sample
 
         internal SampleStore([NotNull] IResourceStore<byte[]> store, [NotNull] AudioMixer mixer)
         {
-            this.store = store;
+            this.store = new ResourceStore<byte[]>(store);
             this.mixer = mixer;
 
-            (store as ResourceStore<byte[]>)?.AddExtension(@"wav");
-            (store as ResourceStore<byte[]>)?.AddExtension(@"mp3");
+            this.store.AddExtension(@"wav");
+            this.store.AddExtension(@"mp3");
         }
 
         public Sample Get(string name)

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -30,9 +30,11 @@ namespace osu.Framework.Audio.Sample
             this.store = new ResourceStore<byte[]>(store);
             this.mixer = mixer;
 
-            this.store.AddExtension(@"wav");
-            this.store.AddExtension(@"mp3");
+            AddExtension(@"wav");
+            AddExtension(@"mp3");
         }
+
+        public void AddExtension(string extension) => store.AddExtension(extension);
 
         public Sample Get(string name)
         {


### PR DESCRIPTION
This PR intends to resolve what I perceive to be the root cause of https://github.com/ppy/osu/issues/22084. Namely, `AudioManager.GetSampleStore()` is not a pure method, as it mutates the store provided to it in the constructor, which is a footgun if the same store is then provided to some other component.

In the case of the aforementioned issue, [the same store is used to create a sample store and a texture store](https://github.com/ppy/osu/blob/d38316bf4f552629cf86dc5ccfe78c3f2fd95f27/osu.Game/Skinning/Skin.cs#L71-L80), which then caused the texture store to receive audio streams (as its underlying storage would be biased towards returning audio), which it then attempted to read as images and invariably failed in doing so.

Initially I fixed this game-side, but then upon noticing that `TextureLoaderStore` does this properly:

https://github.com/ppy/osu-framework/blob/9a50bc4b11def8aecff3f6eb0aa49cfd5c1278dd/osu.Framework/Graphics/Textures/TextureLoaderStore.cs#L26-L28

I decided this is the generally more correct approach.

Note that isolating the passed-in storage alone would lead to a bit of a decrease in flexibility, as you may want to be able to add automatic lookups for other extensions (as osu! already did for `.ogg` files in the snippet linked above). This is why `ISampleStore` also gains an `AddExtension(string)` method, to compensate for this.

The osu!-side changes that need to be applied combined with this pull to fix the game-side issue can be previewed at https://github.com/ppy/osu/compare/master...bdach:osu:conflicting-filenames-in-skin-alt?expand=1.