### PR TITLE
Remove improper usage causing double-disposing of `Game` 

### DIFF
--- a/SampleGame.Desktop/Program.cs
+++ b/SampleGame.Desktop/Program.cs
@@ -13,8 +13,7 @@ namespace SampleGame.Desktop
         public static void Main(string[] args)
         {
             using (GameHost host = Host.GetSuitableDesktopHost(@"sample-game"))
-            using (Game game = new SampleGameGame())
-                host.Run(game);
+                host.Run(new SampleGameGame());
         }
     }
 }

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Desktop/Program.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Desktop/Program.cs
@@ -9,8 +9,7 @@ namespace TemplateGame.Desktop
         public static void Main()
         {
             using (GameHost host = Host.GetSuitableDesktopHost(@"TemplateGame"))
-            using (osu.Framework.Game game = new TemplateGameGame())
-                host.Run(game);
+                host.Run(new TemplateGameGame());
         }
     }
 }

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Program.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Program.cs
@@ -8,8 +8,7 @@ namespace TemplateGame.Game.Tests
         public static void Main()
         {
             using (GameHost host = Host.GetSuitableDesktopHost("visual-tests"))
-            using (var game = new TemplateGameTestBrowser())
-                host.Run(game);
+                host.Run(new TemplateGameTestBrowser());
         }
     }
 }

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Desktop/Program.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Desktop/Program.cs
@@ -9,10 +9,7 @@ namespace FlappyDon.Desktop
         public static void Main()
         {
             using (GameHost host = Host.GetSuitableDesktopHost(@"FlappyDon"))
-            using (osu.Framework.Game game = new FlappyDonGame())
-            {
-                host.Run(game);
-            }
+                host.Run(new FlappyDonGame());
         }
     }
 }

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Program.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Program.cs
@@ -9,8 +9,7 @@ namespace FlappyDon.Game.Tests
         public static void Main()
         {
             using (GameHost host = Host.GetSuitableDesktopHost("visual-tests"))
-            using (var game = new FlappyDonTestBrowser())
-                host.Run(game);
+                host.Run(new FlappyDonTestBrowser());
         }
     }
 }

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -247,22 +247,21 @@ namespace osu.Framework.Tests.Exceptions
             {
                 using (var host = new TestRunHeadlessGameHost($"{GetType().Name}-{Guid.NewGuid()}", new HostOptions()))
                 {
-                    using (var game = new TestGame())
+                    var game = new TestGame();
+
+                    game.Schedule(() =>
                     {
-                        game.Schedule(() =>
+                        storage = host.Storage;
+                        host.UpdateThread.Scheduler.AddDelayed(() =>
                         {
-                            storage = host.Storage;
-                            host.UpdateThread.Scheduler.AddDelayed(() =>
-                            {
-                                if (exitCondition?.Invoke(game) == true)
-                                    host.Exit();
-                            }, 0, true);
+                            if (exitCondition?.Invoke(game) == true)
+                                host.Exit();
+                        }, 0, true);
 
-                            logic(game);
-                        });
+                        logic(game);
+                    });
 
-                        host.Run(game);
-                    }
+                    host.Run(game);
                 }
             }
             finally

--- a/osu.Framework.Tests/Platform/ComponentAsyncDisposalTest.cs
+++ b/osu.Framework.Tests/Platform/ComponentAsyncDisposalTest.cs
@@ -60,8 +60,6 @@ namespace osu.Framework.Tests.Platform
 
             Assert.IsTrue(task.Wait(timeout));
 
-            game.Dispose();
-
             Assert.IsTrue(container.DisposedSuccessfully.Wait(timeout));
         }
 


### PR DESCRIPTION
While a `Game` is `IDisposable`, it's the responsibility of the `GameHost` to dispose it when exiting. So disposing with `using` or manually by calling `Dispose()` is not necessary. Luckily, this double-dispose doesn't have any side-effects, as `CompositeDrawable` would early return and stop any potential disposal chain.

I've checked osu!-side and there are no improper usages there (except an [intended one](https://github.com/ppy/osu/blob/845bbf55fe5d48293afb159c603a177d00bffb65/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs#L692)).

This was checked by adding a disposed check and throw in `Game`/`OsuGameBase` and running all tests locally:
```cs
        protected override void Dispose(bool isDisposing)
        {
            if (IsDisposed)
                throw new ObjectDisposedException("Game is disposed twice");

            // ...
        }
```