### PR TITLE
Add a way to raise the window

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneRaiseWindow.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRaiseWindow.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Visual.Platform
+{
+    [Ignore("This test cannot be run in headless mode (a window instance is required).")]
+    public partial class TestSceneRaiseWindow : FrameworkTestScene
+    {
+        private IWindow window = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            window = host.Window!;
+            AddStep("nothing", () => { }); // so the test doesn't switch to windowed on startup.
+        }
+
+        [TestCase(WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless)]
+        [TestCase(WindowMode.Fullscreen)]
+        public void TestRaise(WindowMode windowMode)
+        {
+            AddStep($"set mode to {windowMode}", () => window.WindowMode.Value = windowMode);
+            AddUntilStep("wait for window to lose focus", () => window.IsActive.Value, () => Is.False);
+            AddWaitStep("do nothing to give the WM breathing room", 5);
+            AddStep("raise window", () => window.Raise());
+            AddAssert("window has focus", () => window.IsActive.Value, () => Is.True);
+        }
+    }
+}

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -147,6 +147,11 @@ namespace osu.Framework.Platform
         void Close();
 
         /// <summary>
+        /// Attempts to raise the window, bringing it above other windows and requesting input focus.
+        /// </summary>
+        void Raise();
+
+        /// <summary>
         /// Start the window's run loop.
         /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
         /// </summary>

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -77,6 +77,10 @@ namespace osu.Framework.Platform
         {
         }
 
+        public void Raise()
+        {
+        }
+
         public abstract bool Focused { get; }
 
         public abstract IBindable<bool> IsActive { get; }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -305,6 +305,16 @@ namespace osu.Framework.Platform
         /// </summary>
         public void Close() => ScheduleCommand(() => Exists = false);
 
+        public void Raise() => ScheduleCommand(() =>
+        {
+            var flags = (SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(SDLWindowHandle);
+
+            if (flags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
+                SDL.SDL_RestoreWindow(SDLWindowHandle);
+
+            SDL.SDL_RaiseWindow(SDLWindowHandle);
+        });
+
         /// <summary>
         /// Attempts to set the window's icon to the specified image.
         /// </summary>


### PR DESCRIPTION
Use case is raising the primary window when opening files/links via IPC (non-primary instance passing arguments to the primary), see https://github.com/ppy/osu/issues/22519.

Only implemented on desktop platforms. Raising a window is not a thing on mobile platforms, the OS has full control there (on Android we set `LaunchMode.SingleInstance` so every intent is passed to the same instance).

The tests are finicky on windows, as windows doesn't allow a window to raise/focus itself and will instead flash the taskbar button orange. If the window is minimised beforehand, there is a much better chance of the raise working.
For the use case described above, the raise always works. Windows probably does some heuristics to figure out if this is a "valid" raise request, and doing IPC like this is a common pattern.