### PR TITLE
Add a way to hide visual tests by using ``(Un)SupportedOSPlatformAttribute``

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Drawing;
+using System.Runtime.Versioning;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -13,6 +14,9 @@ using osu.Framework.Platform;
 namespace osu.Framework.Tests.Visual.Platform
 {
     [Ignore("This test cannot be run in headless mode (a window instance is required).")]
+    [SupportedOSPlatform("windows")]
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
     public partial class TestSceneWindowed : FrameworkTestScene
     {
         [Resolved]

--- a/osu.Framework/Extensions/OSPlatformExtensions.cs
+++ b/osu.Framework/Extensions/OSPlatformExtensions.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Versioning;
+
+namespace osu.Framework.Extensions
+{
+    public static class OSPlatformExtensions
+    {
+        /// <summary>
+        /// Checks whether this <see cref="MemberInfo"/> is supported on the current runtime platform as specified by
+        /// <see cref="SupportedOSPlatformAttribute"/> and <see cref="UnsupportedOSPlatformAttribute"/>.
+        /// </summary>
+        /// <param name="member">The <see cref="MemberInfo"/> to check the attributes of.</param>
+        /// <returns><c>true</c> if this <paramref name="member"/> is supported, false otherwise.</returns>
+        /// <remarks>
+        /// This is only a naive check of attributes defined directly on this member, and doesn't account for the (un)supported platforms of the containing class or assembly.
+        /// </remarks>
+        public static bool IsSupportedOnCurrentOSPlatform(this MemberInfo member)
+        {
+            var supported = member.GetCustomAttributes<SupportedOSPlatformAttribute>().ToArray();
+            var unsupported = member.GetCustomAttributes<UnsupportedOSPlatformAttribute>();
+
+            if (unsupported.Any(matchesCurrentPlatform))
+                return false;
+
+            if (supported.Length == 0) // no explicit SupportedOSPlatformAttribute means that it's supported on all platforms.
+                return true;
+
+            return supported.Any(matchesCurrentPlatform);
+        }
+
+        /// <summary>
+        /// Returns whether the provided <see cref="OSPlatformAttribute"/> matches the current (runtime) platform.
+        /// </summary>
+        /// <remarks>This is currently a naive check which doesn't support specific OS versions.</remarks>
+        private static bool matchesCurrentPlatform(OSPlatformAttribute attribute)
+        {
+            if (attribute.PlatformName.Contains('.'))
+                throw new NotImplementedException($"{nameof(OSPlatformExtensions)} doesn't currently support version identifiers in {nameof(OSPlatformAttribute)}.");
+
+            return OperatingSystem.IsOSPlatform(attribute.PlatformName);
+        }
+    }
+}

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Testing
             TestTypes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
         }
 
-        private bool isValidVisualTest(Type t) => t.IsSubclassOf(typeof(TestScene)) && !t.IsAbstract && t.IsPublic && !t.GetCustomAttributes<HeadlessTestAttribute>().Any();
+        private bool isValidVisualTest(Type t) => t.IsSubclassOf(typeof(TestScene)) && !t.IsAbstract && t.IsPublic && !t.GetCustomAttributes<HeadlessTestAttribute>().Any() && t.IsSupportedOnCurrentOSPlatform();
 
         private void updateList(ValueChangedEvent<Assembly> args)
         {


### PR DESCRIPTION
- Alternative to https://github.com/ppy/osu-framework/pull/5641

This allows test classes to be marked with `SupportedOSPlatform` and `UnsupportedOSPlatform` to specify on which platforms the tests should be visible in the test browser.

This is [supposed to work](https://github.com/nunit/nunit/issues/3866) for automated nunit tests, but doesn't currently.