### PR TITLE
Show game name in reason of sleep inhibition

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.Platform.Linux
         protected override void SetupForRun()
         {
             SDL.SDL_SetHint(SDL.SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, BypassCompositor ? "1" : "0");
+            SDL.SDL_SetHint(SDL.SDL_APP_NAME, Name);
             base.SetupForRun();
         }
 


### PR DESCRIPTION
With https://github.com/libsdl-org/SDL/pull/4704 it's possible to provide the game name to DBus. This allows the battery widget in Plasma show the game name instead of "My SDL application".

|Before|After|
|-|-|
|![图片](https://user-images.githubusercontent.com/23738961/218235303-83c305fc-33d6-4e17-95dc-f5391254152c.png)|![图片](https://user-images.githubusercontent.com/23738961/218235431-9ffc177a-9850-458e-bcc5-dafce327dde0.png)|


