### PR TITLE
Fix veldrid pipeline caching not working properly

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -282,6 +282,22 @@ namespace osu.Framework.Graphics.Veldrid
             }
         }
 
+        public static GraphicsPipelineDescription Clone(this GraphicsPipelineDescription pipeline)
+        {
+            pipeline.BlendState.AttachmentStates = (BlendAttachmentDescription[])pipeline.BlendState.AttachmentStates.Clone();
+            pipeline.ShaderSet.Shaders = (Shader[])pipeline.ShaderSet.Shaders.Clone();
+            pipeline.ShaderSet.VertexLayouts = (VertexLayoutDescription[])pipeline.ShaderSet.VertexLayouts.Clone();
+
+            for (int i = 0; i < pipeline.ShaderSet.VertexLayouts.Length; i++)
+                pipeline.ShaderSet.VertexLayouts[i].Elements = (VertexElementDescription[])pipeline.ShaderSet.VertexLayouts[i].Elements.Clone();
+
+            pipeline.ShaderSet.Specializations = (SpecializationConstant[]?)pipeline.ShaderSet.Specializations?.Clone();
+            pipeline.ResourceLayouts = (ResourceLayout[])pipeline.ResourceLayouts.Clone();
+            pipeline.Outputs.ColorAttachments = (OutputAttachmentDescription[])pipeline.Outputs.ColorAttachments.Clone();
+
+            return pipeline;
+        }
+
         public static void LogD3D11(this GraphicsDevice device, out int maxTextureSize)
         {
             Debug.Assert(device.BackendType == GraphicsBackend.Direct3D11);

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -296,7 +296,7 @@ namespace osu.Framework.Graphics.Veldrid
         {
             if (!pipelineCache.TryGetValue(pipeline, out var instance))
             {
-                pipelineCache[pipeline] = instance = Factory.CreateGraphicsPipeline(ref pipeline);
+                pipelineCache[pipeline.Clone()] = instance = Factory.CreateGraphicsPipeline(ref pipeline);
                 stat_graphics_pipeline_created.Value++;
             }
 


### PR DESCRIPTION
Noticed in #5647. Pipeline descriptions contain array fields, which are stored by reference. Modifying those arrays affect stored lookup keys in the cache dictionary, therefore cloning for the arrays are required before storing the description as a lookup key.

This resolves the first issue mentioned in https://github.com/ppy/osu-framework/pull/5647#issuecomment-1421562057.