### PR TITLE
Prefer the SDL2 Wayland backend over X11 on Linux

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.Platform.Linux
         protected override void SetupForRun()
         {
             SDL.SDL_SetHint(SDL.SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, BypassCompositor ? "1" : "0");
+            SDL.SDL_SetHint("SDL_VIDEODRIVER", "wayland,x11");
             base.SetupForRun();
         }
 


### PR DESCRIPTION
Using the SDL2 backend for X11 with XWayland results in some [issues with handling external tablet input](https://opentabletdriver.net/Wiki/FAQ/Linux).

SDL [reverted their "Prefer Wayland over X11" change due to certain issues](https://github.com/libsdl-org/SDL/commit/254fcc90eb22bb159ab365ad956222a9c5632841) and scheduled it for SDL3 instead, but considering that osu-framework has a much smaller scope, let's try to change the preferred order for ourselves.

Fixes ppy/osu#21939