### PR TITLE
Fix potential crash when displaying `DirectorySelector` on AOT platforms

### DIFF
--- a/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelector.cs
@@ -138,8 +138,6 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 directoryChanging = true;
 
-                directoryFlow.Clear();
-
                 var newDirectory = CurrentPath.Value;
                 bool notifyError = false;
                 ICollection<DirectorySelectorItem> items = Array.Empty<DirectorySelectorItem>();
@@ -160,16 +158,27 @@ namespace osu.Framework.Graphics.UserInterface
 
                 if (newDirectory == null)
                 {
-                    var drives = DriveInfo.GetDrives();
+                    try
+                    {
+                        // This will throw on AOT platforms (System.ExecutionEngineException: Attempting to JIT compile method).
+                        var drives = DriveInfo.GetDrives();
 
-                    foreach (var drive in drives)
-                        directoryFlow.Add(CreateDirectoryItem(drive.RootDirectory));
+                        directoryFlow.Clear();
+
+                        foreach (var drive in drives)
+                            directoryFlow.Add(CreateDirectoryItem(drive.RootDirectory));
+                    }
+                    catch
+                    {
+                        NotifySelectionError();
+                    }
 
                     return;
                 }
 
                 CurrentPath.Value = newDirectory;
 
+                directoryFlow.Clear();
                 directoryFlow.Add(CreateParentDirectoryItem(newDirectory.Parent));
                 directoryFlow.AddRange(items);
             }


### PR DESCRIPTION
Ran into this while tapping around visual tests on iOS. `TestSceneFileSelector` would result in a startup crash due to the call to `DriveInfo.GetDrives()` throwing an AOT failure exception.