### PR TITLE
Fix `osu.Framework.iOS.props` overwriting previous warning exclusions

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -5,7 +5,7 @@
     <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
          It only warns about not copying the library to the app bundle to save space,
          so there's nothing to be worried about. -->
-    <NoWarn>MT7091</NoWarn>
+    <NoWarn>$(NoWarn);MT7091</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>


### PR DESCRIPTION
Noticed while trying to figure out a good diff for local framework reference on `osu.iOS` solution.