### PR TITLE
Add BindableColour4

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableColour4Test.cs
+++ b/osu.Framework.Tests/Bindables/BindableColour4Test.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableColour4Test
+    {
+        [TestCase(0, 0, 0, 255)]
+        [TestCase(255, 255, 255, 255)]
+        [TestCase(255, 102, 170, 128)]
+        public void TestSet(byte r, byte g, byte b, byte a)
+        {
+            var value = new Colour4(r, g, b, a);
+
+            var bindable = new BindableColour4 { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        private static readonly object[][] hex_parsed_colours =
+        {
+            new object[] { "#fff", Colour4.White },
+            new object[] { "#ff0000", Colour4.Red },
+            new object[] { "ffff0080", Colour4.Yellow.Opacity(half_alpha) },
+            new object[] { "00ff0080", Colour4.Lime.Opacity(half_alpha) },
+            new object[] { "123", new Colour4(17, 34, 51, 255), },
+            new object[] { "#123", new Colour4(17, 34, 51, 255) },
+            new object[] { "1234", new Colour4(17, 34, 51, 68) },
+            new object[] { "#1234", new Colour4(17, 34, 51, 68) },
+            new object[] { "123456", new Colour4(18, 52, 86, 255) },
+            new object[] { "#123456", new Colour4(18, 52, 86, 255) },
+            new object[] { "12345678", new Colour4(18, 52, 86, 120) },
+            new object[] { "#12345678", new Colour4(18, 52, 86, 120) }
+        };
+
+        [TestCaseSource(nameof(hex_parsed_colours))]
+        public void TestParsingString(string value, Colour4 expected)
+        {
+            var bindable = new BindableColour4();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        private static readonly object[][] hex_serialized_colours =
+        {
+            new object[] { Colour4.Black, "#000000" },
+            new object[] { Colour4.White, "#FFFFFF" },
+            new object[] { Colour4.Tan, "#D2B48C" },
+            new object[] { Colour4.CornflowerBlue.Opacity(half_alpha), "#6495ED80" }
+        };
+
+        [TestCaseSource(nameof(hex_serialized_colours))]
+        public void TestToString(Colour4 value, string expected)
+        {
+            var bindable = new BindableColour4 { Value = value };
+            Assert.AreEqual(expected, bindable.ToString());
+        }
+
+        // 0x80 alpha is slightly more than half
+        private const float half_alpha = 128f / 255f;
+    }
+}

--- a/osu.Framework/Bindables/BindableColour4.cs
+++ b/osu.Framework/Bindables/BindableColour4.cs
@@ -18,10 +18,19 @@ namespace osu.Framework.Bindables
 
         public override void Parse(object input)
         {
-            if (input is string hex && Colour4.TryParseHex(hex, out Colour4 colour))
-                Value = colour;
-            else
-                base.Parse(input);
+            switch (input)
+            {
+                case string str:
+                    if (!Colour4.TryParseHex(str, out Colour4 colour))
+                        throw new ArgumentException($"Input string was in wrong format! (expected valid hex colour, actual: '{str}')");
+
+                    Value = colour;
+                    break;
+
+                default:
+                    base.Parse(input);
+                    break;
+            }
         }
 
         protected override Bindable<Colour4> CreateInstance() => new BindableColour4();

--- a/osu.Framework/Bindables/BindableColour4.cs
+++ b/osu.Framework/Bindables/BindableColour4.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Bindables
+{
+    public class BindableColour4 : Bindable<Colour4>
+    {
+        public BindableColour4(Colour4 value = default)
+            : base(value)
+        {
+        }
+
+        // 8-bit precision should probably be enough for serialization.
+        public override string ToString(string format, IFormatProvider formatProvider) => Value.ToHex();
+
+        public override void Parse(object input)
+        {
+            if (input is string hex && Colour4.TryParseHex(hex, out Colour4 colour))
+                Value = colour;
+            else
+                base.Parse(input);
+        }
+
+        protected override Bindable<Colour4> CreateInstance() => new BindableColour4();
+    }
+}

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration.Tracking;
+using osu.Framework.Graphics;
 
 namespace osu.Framework.Configuration
 {
@@ -217,6 +218,31 @@ namespace osu.Framework.Configuration
             bindable.Default = value;
             if (min.HasValue) bindable.MinValue = min.Value;
             if (max.HasValue) bindable.MaxValue = max.Value;
+
+            return bindable;
+        }
+
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
+        protected BindableColour4 SetDefault(TLookup lookup, Colour4 value)
+        {
+            value = getDefault(lookup, value);
+
+            if (!(GetOriginalBindable<Colour4>(lookup) is BindableColour4 bindable))
+            {
+                bindable = new BindableColour4(value);
+                AddBindable(lookup, bindable);
+            }
+            else
+            {
+                bindable.Value = value;
+            }
+
+            bindable.Default = value;
 
             return bindable;
         }


### PR DESCRIPTION
For osu!-side config stuff.

Serialization uses hex codes to make it easier for users to edit. This sacrifices precision but I assume that's okay given that `BindableFloat`/`BindableDouble` serialize with a limited number of significant figures.