### PR TITLE
Fix dropdown menu not scrolling correctly when hovering first/last visible item

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -399,6 +399,40 @@ namespace osu.Framework.Tests.Visual.UserInterface
             }));
         }
 
+        [Test]
+        public void TestScrollWhenHoveringFirstVisibleItem()
+        {
+            toggleDropdownViaClick(testDropdownMenu);
+            assertDropdownIsOpen(testDropdownMenu);
+
+            AddStep("hover item 0", () => InputManager.MoveMouseTo(testDropdownMenu.Menu.Children[0]));
+
+            AddStep("user scroll down by 1", () => InputManager.ScrollVerticalBy(-1));
+            AddUntilStep("item 3 is hovered", () => testDropdownMenu.Menu.Children[3].IsHovered);
+
+            AddStep("user scroll up by 1", () => InputManager.ScrollVerticalBy(1));
+            AddUntilStep("item 0 is hovered", () => testDropdownMenu.Menu.Children[0].IsHovered);
+
+            AddStep("close dropdown", () => InputManager.Key(Key.Escape));
+        }
+
+        [Test]
+        public void TestScrollWhenHoveringLastVisibleItem()
+        {
+            toggleDropdownViaClick(testDropdownMenu);
+            assertDropdownIsOpen(testDropdownMenu);
+
+            AddStep("hover item 3", () => InputManager.MoveMouseTo(testDropdownMenu.Menu.Children[3]));
+
+            AddStep("user scroll down by 1", () => InputManager.ScrollVerticalBy(-1));
+            AddUntilStep("item 6 is hovered", () => testDropdownMenu.Menu.Children[6].IsHovered);
+
+            AddStep("user scroll up by 1", () => InputManager.ScrollVerticalBy(1));
+            AddUntilStep("item 3 is hovered", () => testDropdownMenu.Menu.Children[3].IsHovered);
+
+            AddStep("close dropdown", () => InputManager.Key(Key.Escape));
+        }
+
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>
         {
             InputManager.MoveMouseTo(dropdown.Header);

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -410,12 +410,13 @@ namespace osu.Framework.Graphics.UserInterface
             /// Preselects an item from this <see cref="DropdownMenu"/>.
             /// </summary>
             /// <param name="item">The item to select.</param>
-            protected void PreselectItem(MenuItem item)
+            /// <param name="scrollToItem">Whether to scroll to the preselected item.</param>
+            protected void PreselectItem(MenuItem item, bool scrollToItem = true)
             {
                 Children.OfType<DrawableDropdownMenuItem>().ForEach(c =>
                 {
                     c.IsPreSelected = compareItemEquality(item, c.Item);
-                    if (c.IsPreSelected)
+                    if (c.IsPreSelected && scrollToItem)
                         ContentContainer.ScrollIntoView(c);
                 });
             }
@@ -436,7 +437,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             public abstract partial class DrawableDropdownMenuItem : DrawableMenuItem
             {
-                public event Action<DropdownMenuItem<T>> PreselectionRequested;
+                public event Action<DropdownMenuItem<T>, bool> PreselectionRequested;
 
                 protected DrawableDropdownMenuItem(MenuItem item)
                     : base(item)
@@ -521,7 +522,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 protected override bool OnHover(HoverEvent e)
                 {
-                    PreselectionRequested?.Invoke(Item as DropdownMenuItem<T>);
+                    PreselectionRequested?.Invoke(Item as DropdownMenuItem<T>, false);
                     return base.OnHover(e);
                 }
             }


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/9442

When an item that is out of view gets hovered, `ScrollIntoView` will override the user scroll.

Before:
![h3BGy8jh0T](https://user-images.githubusercontent.com/35318437/222686543-d18b4497-294f-4858-b60a-f332dc2c7857.gif)

After:
![JjkSE7Ltyc](https://user-images.githubusercontent.com/35318437/222686193-4ef76ff3-6c79-4fea-8fa7-06125a265b2c.gif)
