### PR TITLE
Allow displays with no display modes

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
+++ b/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
@@ -161,7 +161,7 @@ namespace osu.Framework.Tests.Visual.Platform
                         RelativeSizeAxes = Axes.Both,
                         Text = $"{display.Name}\n"
                                + $"{display.Bounds.Width}x{display.Bounds.Height}\n"
-                               + $"Mode: {modeName(display.DisplayModes.First())}",
+                               + $"Mode: {modeName(display.DisplayModes.FirstOrDefault())}",
                         Padding = new MarginPadding(50),
                     }
                 }

--- a/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs
@@ -344,12 +344,14 @@ namespace osu.Framework.Platform
 
             int numModes = SDL.SDL_GetNumDisplayModes(displayIndex);
 
-            if (numModes <= 0)
+            if (numModes < 0)
             {
                 Logger.Log($"Failed to get display modes for display at index ({displayIndex}) ({rect.w}x{rect.h}). SDL Error: {SDL.SDL_GetError()} ({numModes})");
                 display = null;
                 return false;
             }
+
+            if (numModes == 0) Logger.Log($"Display at index ({displayIndex}) ({rect.w}x{rect.h}) has no display modes. Fullscreen might not work.");
 
             var displayModes = Enumerable.Range(0, numModes)
                                          .Select(modeIndex =>


### PR DESCRIPTION
Should help with https://github.com/ppy/osu/discussions/20481#discussioncomment-5200475.

Since displays can have no display modes on Android (and possibly on iOS), this shouldn't cause problems for consumers.
Not sure that this will fix the initial issue; I would expect it to fail at [`getClosestDisplayMode`](https://github.com/ppy/osu-framework/blob/8edb95303aef78b553c3f78d26702e77586f9905/osu.Framework/Platform/SDL2DesktopWindow_Windowing.cs#L778) or at least log some errors (when using fullscreen).