### PR TITLE
Improve `IpcChannel<T>` to enable two-way communication

### DIFF
--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -135,6 +135,13 @@ namespace osu.Framework.Platform
             return ipcProvider.SendMessageAsync(message);
         }
 
+        public override Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message)
+        {
+            ensureIPCReady();
+
+            return ipcProvider.SendMessageWithResponseAsync(message);
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             ipcProvider?.Dispose();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -136,6 +136,8 @@ namespace osu.Framework.Platform
 
         public virtual Task SendMessageAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
 
+        public virtual Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
+
         /// <summary>
         /// Requests that a file be opened externally with an associated application, if available.
         /// </summary>

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -19,5 +19,12 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <param name="ipcMessage">The message to send.</param>
         Task SendMessageAsync(IpcMessage ipcMessage);
+
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <returns>The response from the server.</returns>
+        public Task<IpcMessage?> SendMessageWithResponseAsync(IpcMessage message);
     }
 }

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 
@@ -14,7 +12,7 @@ namespace osu.Framework.Platform
         /// Invoked when a message is received by this IPC server.
         /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
         /// </summary>
-        event Func<IpcMessage, IpcMessage> MessageReceived;
+        event Func<IpcMessage, IpcMessage?>? MessageReceived;
 
         /// <summary>
         /// Send a message to the IPC server.

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace osu.Framework.Platform
 {
     public class IpcChannel<T> : IDisposable
+        where T : class
     {
         private readonly IIpcHost host;
         public event Func<T, IpcMessage?>? MessageReceived;

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -18,11 +18,23 @@ namespace osu.Framework.Platform
             this.host.MessageReceived += handleMessage;
         }
 
-        public Task SendMessageAsync(T message) => host.SendMessageAsync(new IpcMessage
+        public Task SendMessageAsync(T message) => host.SendMessageAsync(makeMessage(message));
+
+        public async Task<T?> SendMessageWithResponseAsync(T message)
+        {
+            var response = await host.SendMessageWithResponseAsync(makeMessage(message)).ConfigureAwait(false);
+
+            if (response == null || response.Type != typeof(T).AssemblyQualifiedName)
+                return null;
+
+            return (T)response.Value;
+        }
+
+        private IpcMessage makeMessage(T message) => new IpcMessage
         {
             Type = typeof(T).AssemblyQualifiedName,
             Value = message,
-        });
+        };
 
         private IpcMessage? handleMessage(IpcMessage message)
         {

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Platform
         where T : class
     {
         private readonly IIpcHost host;
-        public event Func<T, IpcMessage?>? MessageReceived;
+        public event Func<T, T?>? MessageReceived;
 
         public IpcChannel(IIpcHost host)
         {
@@ -41,7 +41,12 @@ namespace osu.Framework.Platform
             if (message.Type != typeof(T).AssemblyQualifiedName)
                 return null;
 
-            return MessageReceived?.Invoke((T)message.Value);
+            var response = MessageReceived?.Invoke((T)message.Value);
+
+            if (response == null)
+                return null;
+
+            return makeMessage(response);
         }
 
         public void Dispose()

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 
@@ -11,7 +9,7 @@ namespace osu.Framework.Platform
     public class IpcChannel<T> : IDisposable
     {
         private readonly IIpcHost host;
-        public event Func<T, IpcMessage> MessageReceived;
+        public event Func<T, IpcMessage?>? MessageReceived;
 
         public IpcChannel(IIpcHost host)
         {
@@ -25,7 +23,7 @@ namespace osu.Framework.Platform
             Value = message,
         });
 
-        private IpcMessage handleMessage(IpcMessage message)
+        private IpcMessage? handleMessage(IpcMessage message)
         {
             if (message.Type != typeof(T).AssemblyQualifiedName)
                 return null;


### PR DESCRIPTION
- required for https://github.com/ppy/osu/pull/22793#issuecomment-1455164188

This PR adds
```cs
public async Task<T?> SendMessageWithResponseAsync(T message)
```
and changes
```diff
-public event Func<T, IpcMessage> MessageReceived;
+public event Func<T, T?>? MessageReceived;
```

Enabling two-way communication using `IpcChannel<T>`.

This is also an RFC because I've noticed that `event Func<T, TResult> MessageReceived` is used throughout IPC handling. This is a problem since multicast delegates (easily possible if two channels are bound to the same host) don't mix well with return values.

For `IpcChannel<T>` making the `public Func<T, T?>? MessageReceived` a regular property could work.

But [`TcpIpcProvider`](https://github.com/ppy/osu-framework/blob/ba1385330cc501f34937e08257e586c84e35d772/osu.Framework/Platform/TcpIpcProvider.cs#L108) and [`GameHost`](https://github.com/ppy/osu-framework/blob/956fbc3c159d31af24de4e1cd9d8da1865f3d46e/osu.Framework/Platform/GameHost.cs#L135) will need special handling (via `GetInvocationList()`). Using the value from the first delegate that returns non-null seems amicable since one message should be handled by only one `IpcChannel<T>`.