### PR TITLE
Fix `Quad.Contains` sometimes failing due to floating point precision issues

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkQuad.cs
+++ b/osu.Framework.Benchmarks/BenchmarkQuad.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics.Primitives;
+using osuTK;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkQuad
+    {
+        private Quad quad;
+
+        [Params(10, 100, 1000)]
+        public int NumPoints;
+
+        private Vector2[] points;
+        private bool[] results;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            quad = new Quad(
+                new Vector2(3, 0),
+                new Vector2(5, 1),
+                new Vector2(0, 5),
+                new Vector2(7, 7)
+            );
+
+            points = new Vector2[NumPoints];
+            results = new bool[NumPoints];
+
+            var random = new Random(20230307);
+            for (int i = 0; i < NumPoints; ++i)
+                points[i] = new Vector2(random.Next(0, 10), random.Next(0, 10));
+        }
+
+        [Benchmark]
+        public void Contains()
+        {
+            for (int i = 0; i < NumPoints; ++i)
+                results[i] = quad.Contains(points[i]);
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkQuad.cs
+++ b/osu.Framework.Benchmarks/BenchmarkQuad.cs
@@ -16,8 +16,8 @@ namespace osu.Framework.Benchmarks
         [Params(10, 100, 1000)]
         public int NumPoints;
 
-        private Vector2[] points;
-        private bool[] results;
+        private Vector2[] points = null!;
+        private bool[] results = null!;
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -23,6 +23,13 @@ namespace osu.Framework.Tests.Primitives
                 new Vector2(1679.6332f, 695.51416f),
                 new Vector2(1513.5333f, 861.614f),
                 new Vector2(1679.6332f, 861.614f)
+            ),
+            // Arbitrary convex quad
+            new Quad(
+                new Vector2(3, 0),
+                new Vector2(5, 1),
+                new Vector2(0, 5),
+                new Vector2(7, 7)
             )
         };
 

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -18,13 +18,12 @@ namespace osu.Framework.Tests.Primitives
         {
             new Quad(0, 0, 10, 10),
             // Test potential precision edge cases using the precise centre point.
-            // TODO: currently failing, needs fix.
-            // new Quad(
-            //     new Vector2(1513.5333f, 695.51416f),
-            //     new Vector2(1679.6332f, 695.51416f),
-            //     new Vector2(1513.5333f, 861.614f),
-            //     new Vector2(1679.6332f, 861.614f)
-            // )
+            new Quad(
+                new Vector2(1513.5333f, 695.51416f),
+                new Vector2(1679.6332f, 695.51416f),
+                new Vector2(1513.5333f, 861.614f),
+                new Vector2(1679.6332f, 861.614f)
+            )
         };
 
         [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -65,9 +65,10 @@ namespace osu.Framework.Tests.Primitives
             Assert.That(quad.Contains(quad.BottomRight + new Vector2(0, 1)), Is.False);
             Assert.That(quad.Contains(quad.BottomRight + new Vector2(1)), Is.False);
 
-            Assert.That(quad.Contains(quad.Centre + new Vector2(quad.Width / 2, 0)), Is.True);
-            Assert.That(quad.Contains(quad.Centre + new Vector2(quad.Height / 2, 0)), Is.True);
-            Assert.That(quad.Contains(quad.Centre + quad.Size / 2), Is.True);
+            Assert.That(quad.Contains((quad.TopLeft + quad.TopRight) / 2), Is.True);
+            Assert.That(quad.Contains((quad.BottomLeft + quad.BottomRight) / 2), Is.True);
+            Assert.That(quad.Contains((quad.TopLeft + quad.BottomLeft) / 2), Is.True);
+            Assert.That(quad.Contains((quad.TopRight + quad.BottomRight) / 2), Is.True);
         }
 
         private class AreaTestData

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -107,6 +107,20 @@ namespace osu.Framework.Graphics.Primitives
 
         public ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in TopLeft), 4);
 
+        /// <summary>
+        /// Checks whether <paramref name="pos"/> is inside of this quad.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This method assumes a convex quad. The convexity of the quad is not checked.
+        /// </para>
+        /// <para>
+        /// The method works by checking whether the point lies on the same side of all four sides of the quad.
+        /// Note that the quad vertices are *not* using the standard Cartesian coordinates, but rather a Y-inverted version of them
+        /// (as in higher Y is *down*),
+        /// which is why the sign of the perpendicular dot product is opposite to what would be normally expected on the Cartesian plane.
+        /// </para>
+        /// </remarks>
         public bool Contains(Vector2 pos) =>
             Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft) <= 0
             && Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft) <= 0

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -108,8 +108,10 @@ namespace osu.Framework.Graphics.Primitives
         public ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in TopLeft), 4);
 
         public bool Contains(Vector2 pos) =>
-            new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||
-            new Triangle(TopLeft, TopRight, BottomLeft).Contains(pos);
+            Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft) <= 0
+            && Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft) <= 0
+            && Vector2.PerpDot(TopRight - BottomRight, pos - BottomRight) <= 0
+            && Vector2.PerpDot(TopLeft - TopRight, pos - TopRight) <= 0;
 
         /// <summary>
         /// Computes the area of this <see cref="Quad"/>.


### PR DESCRIPTION
Closes #5669.

I will pre-empt this by saying that I am only *mostly* confident of this fix, so please be on the look-out if you don't like anything here. It took me the better part of an hour to convince myself that this works due to reasons I will elaborate on below.

To the point: In order to avoid the issue demonstrated by the test in #5668, a different way of computing whether a given point is inside of the quad is used. Namely, this method uses the perpendicular dot product, which has the property of

$$ \textbf{a}^\perp \cdot \textbf{b} = |\textbf{a}| |\textbf{b}| \sin \theta $$

wherein $\theta$ is the angle between the vectors $\textbf{a}$ and $\textbf{b}$.[^1] In particular, this means that because the sine of an angle is positive in the range [0, 180deg], and negative in the range [-180deg, 0], it allows to distinguish which side of the half-plane defined by the direction of vector $\textbf{a}$ the vector $\textbf{b}$ lies. On the Cartesian plane, it will be positive if $\textbf{b}$ is "on the left of" or "counterclockwise" to $\textbf{a}$, zero if they are collinear, and negative otherwise.

Assuming `Quad` is convex (which can be done, as it inherits `IConvexPolygon` - and notably, the previous implementation also silently assumed convexity, because in the general case you can't just arbitrarily slice the quad into two tris if it's not convex), we can say that a point lies within the quad if it lies on the same side of four half-planes defined by the quad's sides (by which I mean, for every side, we can divide the plane using a line going through both ends of the segment, and take the half-plane where the quad's interior is). Due to this we can therefore check whether for every vertex of the quad, the sign of the perp dot product between the vector which starts at the current vertex and ends at the next vertex (going in counterclockwise order), and the vector which starts at the current vertex and ends at the point being tested by `Contains()`, is the same - if it is, then the tested point is inside of the quad.

Now this is the part where this gets confusing: On the Cartesian plane, the sign we want would be *positive* (or zero, as zero means collinearity). But because computer graphics are hell and somebody somewhere decided that when drawing to the screen Y should be *down* and not up and that is what `Quad` abides by, the signs need to flip. So for our test here we use zero or less.

Interestingly, I have managed to produce a benchmark (included in the diff) which happens to show that this method is faster:

### Before

|   Method | NumPoints |        Mean |     Error |    StdDev | Allocated |
|--------- |---------- |------------:|----------:|----------:|----------:|
| Contains |        10 |    274.5 ns |   1.10 ns |   1.03 ns |         - |
| Contains |       100 |  2,903.4 ns |   3.65 ns |   3.41 ns |         - |
| Contains |      1000 | 29,330.9 ns | 297.09 ns | 263.36 ns |         - |

### After

|   Method | NumPoints |        Mean |     Error |    StdDev | Allocated |
|--------- |---------- |------------:|----------:|----------:|----------:|
| Contains |        10 |    62.32 ns |  0.726 ns |  0.679 ns |         - |
| Contains |       100 |   573.51 ns |  3.283 ns |  2.742 ns |         - |
| Contains |      1000 | 5,937.07 ns | 62.791 ns | 52.433 ns |         - |

but this is very likely highly dependent on data. The new method will be likely faster for rejections (as checking half-planes may allow to reject a point faster) but slower for hits (as all four half-planes must be examined), which is probably the correct access pattern to optimise for anyways?

As for testing, I did some using the draw visualiser but admittedly not much. I have checked that this diff passes game-side tests which is something extra I suppose?

[^1]: https://mathworld.wolfram.com/PerpDotProduct.html