### PR TITLE
Remove xmldoc references to private methods

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -482,7 +482,7 @@ namespace osu.Framework.Tests.Localisation
         }
 
         /// <summary>
-        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in <see cref="LocalisationManager.onLocaleChanged"/>.
+        /// Tests a possible edge case where both the old and new locales could be invalid in the 'revert to previous value' logic in LocalisationManager.onLocaleChanged.
         /// </summary>
         [Test]
         public void TestInvalidLocaleToInvalid()

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -342,7 +342,7 @@ namespace osu.Framework.Tests.Text
         }
 
         /// <summary>
-        /// Tests that baseline alignment adjustments are done correctly on a builder which has <see cref="TextBuilder.useFontSizeAsHeight"/> disabled,
+        /// Tests that baseline alignment adjustments are done correctly on a builder which has TextBuilder.useFontSizeAsHeight disabled,
         /// and only affect the line the new character was placed on.
         /// </summary>
         [Test]
@@ -469,7 +469,7 @@ namespace osu.Framework.Tests.Text
         }
 
         /// <summary>
-        /// Tests that removing a character behaves correctly on a builder which has <see cref="TextBuilder.useFontSizeAsHeight"/> disabled.
+        /// Tests that removing a character behaves correctly on a builder which has TextBuilder.useFontSizeAsHeight disabled.
         /// </summary>
         [Test]
         public void TestRemoveCharacterWhenNotUsingFontSizeAsHeight()
@@ -636,7 +636,7 @@ namespace osu.Framework.Tests.Text
         }
 
         /// <summary>
-        /// Retrieves the baseline of a glyph when <see cref="TextBuilder.useFontSizeAsHeight"/> is turned off.
+        /// Retrieves the baseline of a glyph when TextBuilder.useFontSizeAsHeight is turned off.
         /// </summary>
         /// <param name="glyph">The glyph to return the trimmed baseline for.</param>
         private float getTrimmedBaseline(ITexturedCharacterGlyph glyph) => glyph.Baseline - glyph.YOffset;


### PR DESCRIPTION
These have been causing warnings on android CI for a while now that we've just been ignoring. I'd consider looking into why they are only failing there, but to be honest it doesn't really make much sense to reference private methods in the first place like this, so let's just remove them and call it a day.

See https://github.com/ppy/osu-framework/actions/runs/4383176901 for an example.