### PR TITLE
Fix UBOs not being initialised when data is default

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
@@ -29,6 +29,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             size = Marshal.SizeOf(default(TData));
 
             GL.GenBuffers(1, out uboId);
+
+            // Initialise the buffer with the default data.
+            setData(ref data);
         }
 
         public TData Data
@@ -39,12 +42,17 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 if (value.Equals(data))
                     return;
 
-                data = value;
-
-                GL.BindBuffer(BufferTarget.UniformBuffer, uboId);
-                GL.BufferData(BufferTarget.UniformBuffer, size, ref value, BufferUsageHint.DynamicDraw);
-                GL.BindBuffer(BufferTarget.UniformBuffer, 0);
+                setData(ref value);
             }
+        }
+
+        private void setData(ref TData data)
+        {
+            this.data = data;
+
+            GL.BindBuffer(BufferTarget.UniformBuffer, uboId);
+            GL.BufferData(BufferTarget.UniformBuffer, size, ref data, BufferUsageHint.DynamicDraw);
+            GL.BindBuffer(BufferTarget.UniformBuffer, 0);
         }
 
         #region Disposal


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/5674

When setting `Data`, if the value is `default(T)` then the equality comparer will exit early. But it turns out that macOS (maybe M1 specific) needs the call to `GL.BufferData()` to initialise the buffer's memory.

I don't know if this will also affect the Veldrid implementation, since we can't currently run that with OpenGL on macOS.