### PR TITLE
Fix `Quad.Contains()` failing for zero-sized drawables

### DIFF
--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using NUnit.Framework;
 using osu.Framework.Extensions.MatrixExtensions;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Framework.Tests.Primitives
@@ -30,6 +31,13 @@ namespace osu.Framework.Tests.Primitives
                 new Vector2(5, 1),
                 new Vector2(0, 5),
                 new Vector2(7, 7)
+            ),
+            // Very small quad
+            new Quad(
+                new Vector2(-Precision.FLOAT_EPSILON, -Precision.FLOAT_EPSILON),
+                new Vector2(Precision.FLOAT_EPSILON, -Precision.FLOAT_EPSILON),
+                new Vector2(-Precision.FLOAT_EPSILON, Precision.FLOAT_EPSILON),
+                new Vector2(Precision.FLOAT_EPSILON, Precision.FLOAT_EPSILON)
             )
         };
 
@@ -69,6 +77,49 @@ namespace osu.Framework.Tests.Primitives
             Assert.That(quad.Contains((quad.BottomLeft + quad.BottomRight) / 2), Is.True);
             Assert.That(quad.Contains((quad.TopLeft + quad.BottomLeft) / 2), Is.True);
             Assert.That(quad.Contains((quad.TopRight + quad.BottomRight) / 2), Is.True);
+        }
+
+        [Test]
+        public void TestContains_ZeroHeightQuad()
+        {
+            var quad = new Quad(-2, 0, 4, 0);
+
+            Assert.That(quad.Contains(new Vector2(-5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(-5, 5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, 5)), Is.False);
+
+            Assert.That(quad.Contains(new Vector2(-2, 0)), Is.True);
+            Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
+            Assert.That(quad.Contains(new Vector2(2, 0)), Is.True);
+        }
+
+        [Test]
+        public void TestContains_ZeroWidthQuad()
+        {
+            var quad = new Quad(0, -2, 0, 4);
+
+            Assert.That(quad.Contains(new Vector2(-5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(-5, 5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, 5)), Is.False);
+
+            Assert.That(quad.Contains(new Vector2(0, -2)), Is.True);
+            Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
+            Assert.That(quad.Contains(new Vector2(0, 2)), Is.True);
+        }
+
+        [Test]
+        public void TestContains_ZeroSizedQuad()
+        {
+            var quad = new Quad(0, 0, 0, 0);
+
+            Assert.That(quad.Contains(new Vector2(-5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(-5, 5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, -5)), Is.False);
+            Assert.That(quad.Contains(new Vector2(5, 5)), Is.False);
+
+            Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
         }
 
         private class AreaTestData

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -121,11 +121,16 @@ namespace osu.Framework.Graphics.Primitives
         /// which is why the sign of the perpendicular dot product is opposite to what would be normally expected on the Cartesian plane.
         /// </para>
         /// </remarks>
-        public bool Contains(Vector2 pos) =>
-            Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft) <= 0
-            && Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft) <= 0
-            && Vector2.PerpDot(TopRight - BottomRight, pos - BottomRight) <= 0
-            && Vector2.PerpDot(TopLeft - TopRight, pos - TopRight) <= 0;
+        public bool Contains(Vector2 pos)
+        {
+            if (Width == 0 && Height == 0)
+                return pos == TopLeft;
+
+            return Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft) <= 0
+                   && Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft) <= 0
+                   && Vector2.PerpDot(TopRight - BottomRight, pos - BottomRight) <= 0
+                   && Vector2.PerpDot(TopLeft - TopRight, pos - TopRight) <= 0;
+        }
 
         /// <summary>
         /// Computes the area of this <see cref="Quad"/>.


### PR DESCRIPTION
As reported [on discord](https://discord.com/channels/188630481301012481/188630652340404224/1085495571202183208). Regressed in #5670.

Test coverage added to cover this case and a few others that did not end up needing targeted fixes; the fix pretty much targets the zero-sized case directly.

# Benchmarking results

## Before

|   Method | NumPoints |        Mean |      Error |     StdDev | Allocated |
|--------- |---------- |------------:|-----------:|-----------:|----------:|
| Contains |        10 |    64.12 ns |   1.296 ns |   2.056 ns |         - |
| Contains |       100 |   580.51 ns |  11.631 ns |  20.674 ns |         - |
| Contains |      1000 | 5,989.39 ns | 118.540 ns | 188.017 ns |         - |

## After

|   Method | NumPoints |        Mean |     Error |     StdDev | Allocated |
|--------- |---------- |------------:|----------:|-----------:|----------:|
| Contains |        10 |    73.32 ns |  1.353 ns |   1.661 ns |         - |
| Contains |       100 |   673.57 ns |  9.624 ns |   7.514 ns |         - |
| Contains |      1000 | 6,975.66 ns | 92.932 ns | 114.129 ns |         - |

tl;dr: About a 16% performance cost, although this implementation is still [better than the previous](https://github.com/ppy/osu-framework/pull/5670#issue-1614424916).