### PR TITLE
Fix masking info not reset on new frame

### DIFF
--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -211,6 +211,7 @@ namespace osu.Framework.Graphics.Rendering
 
             currentActiveBatch = null;
             CurrentBlendingParameters = new BlendingParameters();
+            currentMaskingInfo = default;
 
             foreach (var b in batchResetList)
                 b.ResetCounters();


### PR DESCRIPTION
Noticed this when working on some unrelated changes. Because this is not reset, a subsequent call to `setMaskingInfo` exits early on the precondition:

https://github.com/ppy/osu-framework/blob/b87b7545ee89a073a244635e1b39ad4d3e6ba75d/osu.Framework/Graphics/Rendering/Renderer.cs#L609-L614