### PR TITLE
Fix local uniform buffers not always bound on draw

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -113,14 +113,12 @@ namespace osu.Framework.Graphics
                 SharedData.DrawVersion = GetDrawVersion();
             }
 
-            var shader = TextureShader;
-
-            shader.Bind();
+            BindTextureShader(renderer);
 
             base.Draw(renderer);
             DrawContents(renderer);
 
-            shader.Unbind();
+            UnbindTextureShader(renderer);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Sprites/BufferedContainerView.cs
+++ b/osu.Framework/Graphics/Sprites/BufferedContainerView.cs
@@ -139,9 +139,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (shared?.MainBuffer?.Texture.Available != true || shared.DrawVersion == -1)
                     return;
 
-                var shader = TextureShader;
-
-                shader.Bind();
+                BindTextureShader(renderer);
 
                 if (sourceEffectPlacement == EffectPlacement.InFront)
                     drawMainBuffer(renderer);
@@ -151,7 +149,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (sourceEffectPlacement == EffectPlacement.Behind)
                     drawMainBuffer(renderer);
 
-                shader.Unbind();
+                UnbindTextureShader(renderer);
             }
 
             private void drawMainBuffer(IRenderer renderer)

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -83,13 +83,11 @@ namespace osu.Framework.Graphics.Sprites
             if (Texture?.Available != true)
                 return;
 
-            var shader = TextureShader;
-
-            shader.Bind();
+            BindTextureShader(renderer);
 
             Blit(renderer);
 
-            shader.Unbind();
+            UnbindTextureShader(renderer);
         }
 
         protected override void DrawOpaqueInterior(IRenderer renderer)
@@ -99,11 +97,11 @@ namespace osu.Framework.Graphics.Sprites
             if (Texture?.Available != true)
                 return;
 
-            TextureShader.Bind();
+            BindTextureShader(renderer);
 
             BlitOpaqueInterior(renderer);
 
-            TextureShader.Unbind();
+            UnbindTextureShader(renderer);
         }
 
         protected internal override bool CanDrawOpaqueInterior => Texture?.Available == true && Texture.Opacity == Opacity.Opaque && hasOpaqueInterior;

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -50,9 +50,7 @@ namespace osu.Framework.Graphics.Sprites
             {
                 base.Draw(renderer);
 
-                var shader = TextureShader;
-
-                shader.Bind();
+                BindTextureShader(renderer);
 
                 var avgColour = (Color4)DrawColourInfo.Colour.AverageColour;
                 float shadowAlpha = MathF.Pow(Math.Max(Math.Max(avgColour.R, avgColour.G), avgColour.B), 2);
@@ -80,7 +78,7 @@ namespace osu.Framework.Graphics.Sprites
                     renderer.DrawQuad(parts[i].Texture, parts[i].DrawQuad, DrawColourInfo.Colour, inflationPercentage: parts[i].InflationPercentage);
                 }
 
-                shader.Unbind();
+                UnbindTextureShader(renderer);
             }
         }
 

--- a/osu.Framework/Graphics/TexturedShaderDrawNode.cs
+++ b/osu.Framework/Graphics/TexturedShaderDrawNode.cs
@@ -3,13 +3,14 @@
 
 #nullable disable
 
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 
 namespace osu.Framework.Graphics
 {
     public abstract class TexturedShaderDrawNode : DrawNode
     {
-        protected IShader TextureShader { get; private set; }
+        private IShader textureShader;
 
         protected new ITexturedShaderDrawable Source => (ITexturedShaderDrawable)base.Source;
 
@@ -22,7 +23,29 @@ namespace osu.Framework.Graphics
         {
             base.ApplyState();
 
-            TextureShader = Source.TextureShader;
+            textureShader = Source.TextureShader;
+        }
+
+        /// <summary>
+        /// Binds the <see cref="IShader"/> used for rendering the texture.
+        /// </summary>
+        /// <param name="renderer">The renderer to use for setting up uniform resources.</param>
+        protected void BindTextureShader(IRenderer renderer)
+        {
+            textureShader.Bind();
+
+            BindUniformResources(textureShader, renderer);
+        }
+
+        protected void UnbindTextureShader(IRenderer renderer) => textureShader.Unbind();
+
+        /// <summary>
+        /// Binds uniform resources against the provided shader.
+        /// </summary>
+        /// <param name="shader">The shader to bind uniform resources against.</param>
+        /// <param name="renderer">The renderer to use for setting up uniform resources.</param>
+        protected virtual void BindUniformResources(IShader shader, IRenderer renderer)
+        {
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/CircularBlob.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularBlob.cs
@@ -129,6 +129,13 @@ namespace osu.Framework.Graphics.UserInterface
                 if (innerRadius == 0)
                     return;
 
+                base.Blit(renderer);
+            }
+
+            protected override void BindUniformResources(IShader shader, IRenderer renderer)
+            {
+                base.BindUniformResources(shader, renderer);
+
                 parametersBuffer ??= renderer.CreateUniformBuffer<CircularBlobParameters>();
                 parametersBuffer.Data = new CircularBlobParameters
                 {
@@ -139,9 +146,7 @@ namespace osu.Framework.Graphics.UserInterface
                     NoisePosition = noisePosition,
                 };
 
-                TextureShader.BindUniformBlock("m_CircularBlobParameters", parametersBuffer);
-
-                base.Blit(renderer);
+                shader.BindUniformBlock("m_CircularBlobParameters", parametersBuffer);
             }
 
             protected internal override bool CanDrawOpaqueInterior => false;

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -122,6 +122,13 @@ namespace osu.Framework.Graphics.UserInterface
                 if (innerRadius == 0 || (!roundedCaps && progress == 0))
                     return;
 
+                base.Blit(renderer);
+            }
+
+            protected override void BindUniformResources(IShader shader, IRenderer renderer)
+            {
+                base.BindUniformResources(shader, renderer);
+
                 parametersBuffer ??= renderer.CreateUniformBuffer<CircularProgressParameters>();
                 parametersBuffer.Data = new CircularProgressParameters
                 {
@@ -131,9 +138,7 @@ namespace osu.Framework.Graphics.UserInterface
                     RoundedCaps = roundedCaps,
                 };
 
-                TextureShader.BindUniformBlock("m_CircularProgressParameters", parametersBuffer);
-
-                base.Blit(renderer);
+                shader.BindUniformBlock("m_CircularProgressParameters", parametersBuffer);
             }
 
             protected internal override bool CanDrawOpaqueInterior => false;

--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
@@ -259,12 +259,14 @@ namespace osu.Framework.Graphics.UserInterface
 
                     private IUniformBuffer<HueData> hueDataBuffer;
 
-                    protected override void Blit(IRenderer renderer)
+                    protected override void BindUniformResources(IShader shader, IRenderer renderer)
                     {
+                        base.BindUniformResources(shader, renderer);
+
                         hueDataBuffer ??= renderer.CreateUniformBuffer<HueData>();
                         hueDataBuffer.Data = hueDataBuffer.Data with { Hue = hue };
-                        TextureShader.BindUniformBlock("m_HueData", hueDataBuffer);
-                        base.Blit(renderer);
+
+                        shader.BindUniformBlock("m_HueData", hueDataBuffer);
                     }
 
                     protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/Video/VideoSpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Video/VideoSpriteDrawNode.cs
@@ -6,6 +6,7 @@
 using System.Runtime.InteropServices;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
 
 namespace osu.Framework.Graphics.Video
@@ -22,15 +23,14 @@ namespace osu.Framework.Graphics.Video
 
         private IUniformBuffer<YuvData> yuvDataBuffer;
 
-        public override void Draw(IRenderer renderer)
+        protected override void BindUniformResources(IShader shader, IRenderer renderer)
         {
+            base.BindUniformResources(shader, renderer);
+
             yuvDataBuffer ??= renderer.CreateUniformBuffer<YuvData>();
             yuvDataBuffer.Data = new YuvData { YuvCoeff = video.ConversionMatrix };
 
-            var shader = TextureShader;
             shader.BindUniformBlock("m_yuvData", yuvDataBuffer);
-
-            base.Draw(renderer);
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
This caused Metal to crash when loading a colour picker, due to the UBO not being bound in the front-to-back pass. Rather than duplicating code there, I've refactored the API to force UBOs to always be bound whenever the `DrawNode` wishes to bind the shader.

`DrawNode`s that bind other shaders will have to manually bind UBOs themselves. One alternative direction I had was to completely mark `IShader.Bind/Unbind` internal and re-define the methods in `DrawNode` instead, along with logic to store uniform blocks in the shader in order to be bound on `DrawNode.BindShader`.

# vNext
## `TexturedShaderDrawNode.TextureShader` is made private

This is partially done to force consumers into binding uniform blocks in the newly defined `TexturedShaderDrawNode.BindUniformResources` method, such that uniform blocks are always bound whenever the corresponding shader is used for drawing in the framework.

For binding/unbinding shaders, use `TexturedShaderDrawNode.BindTextureShader`/`TexturedShaderDrawNode.UnbindTextureShader` instead.