### PR TITLE
Allow renderer choice to be stored in user configuration (and add automatic fallbacks)

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Platform;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
+    [Ignore("This test cannot be run in headless mode (a renderer is required).")]
     public partial class TestSceneRenderer : FrameworkTestScene
     {
         [Resolved]

--- a/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Visual.Platform
+{
+    public partial class TestSceneRenderer : FrameworkTestScene
+    {
+        [Resolved]
+        private GameHost host { get; set; } = null!;
+
+        [Resolved]
+        private FrameworkConfigManager config { get; set; } = null!;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Add(new SpriteText
+            {
+                Text = $"Renderer: {host.ResolvedRenderer} ({host.Renderer.GetType().Name} / {host.Window.GraphicsSurface.Type})",
+                Font = FrameworkFont.Regular.With(size: 24),
+            });
+
+            Add(new BasicDropdown<RendererType>
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Current = config.GetBindable<RendererType>(FrameworkSetting.Renderer),
+                Items = host.GetValidRenderersForCurrentPlatform(),
+                Width = 200f,
+            });
+        });
+    }
+}

--- a/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -32,8 +33,8 @@ namespace osu.Framework.Tests.Visual.Platform
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
+                Items = host.GetPreferredRenderersForCurrentPlatform().OrderBy(t => t),
                 Current = config.GetBindable<RendererType>(FrameworkSetting.Renderer),
-                Items = host.GetValidRenderersForCurrentPlatform(),
                 Width = 200f,
             });
         });

--- a/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.iOS
             this.gameView = gameView;
         }
 
-        protected override IRenderer CreateRenderer() => new IOSGLRenderer(gameView);
+        protected override IRenderer CreateGLRenderer() => new IOSGLRenderer(gameView);
 
         protected override void SetupForRun()
         {

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -39,6 +39,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
             SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
+            SetDefault(FrameworkSetting.Renderer, Renderer.Automatic);
             SetDefault(FrameworkSetting.ShowUnicode, false);
             SetDefault(FrameworkSetting.Locale, string.Empty);
 
@@ -90,6 +91,7 @@ namespace osu.Framework.Configuration
 
         SizeFullscreen,
 
+        Renderer,
         WindowMode,
         ConfineMouseMode,
         FrameSync,

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
             SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
-            SetDefault(FrameworkSetting.Renderer, Renderer.Automatic);
+            SetDefault(FrameworkSetting.Renderer, RendererType.Automatic);
             SetDefault(FrameworkSetting.ShowUnicode, false);
             SetDefault(FrameworkSetting.Locale, string.Empty);
 

--- a/osu.Framework/Configuration/Renderer.cs
+++ b/osu.Framework/Configuration/Renderer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Framework.Configuration
+{
+    public enum Renderer
+    {
+        [Description("Automatic")]
+        Automatic,
+
+        [Description("Metal")]
+        Metal,
+
+        [Description("Vulkan")]
+        Vulkan,
+
+        [Description("Direct3D 11")]
+        Direct3D11,
+
+        [Description("OpenGL")]
+        OpenGL,
+
+        [Description("OpenGL (Legacy)")]
+        Legacy,
+    }
+}

--- a/osu.Framework/Configuration/Renderer.cs
+++ b/osu.Framework/Configuration/Renderer.cs
@@ -23,6 +23,6 @@ namespace osu.Framework.Configuration
         OpenGL,
 
         [Description("OpenGL (Legacy)")]
-        Legacy,
+        OpenGLLegacy,
     }
 }

--- a/osu.Framework/Configuration/RendererType.cs
+++ b/osu.Framework/Configuration/RendererType.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace osu.Framework.Configuration
 {
-    public enum Renderer
+    public enum RendererType
     {
         [Description("Automatic")]
         Automatic,

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -888,13 +888,26 @@ namespace osu.Framework.Platform
 
         protected void SetupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)
         {
+            switch (renderer)
+            {
+                case "veldrid":
+                    SetupRendererAndWindow(new VeldridRenderer(), surfaceType);
+                    break;
+
+                default:
+                case "gl":
+                    SetupRendererAndWindow(CreateGLRenderer(), surfaceType);
+                    break;
+            }
+        }
+
+        protected void SetupRendererAndWindow(IRenderer renderer, GraphicsSurfaceType surfaceType)
+        {
             Logger.Log($"🖼️ Attempting initialisation using renderer: {renderer} surface: {surfaceType}");
 
             try
             {
-                Renderer = renderer == "veldrid"
-                    ? new VeldridRenderer()
-                    : CreateGLRenderer();
+                Renderer = renderer;
 
                 // Prepare window
                 Window = CreateWindow(surfaceType);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -803,10 +803,34 @@ namespace osu.Framework.Platform
         /// <summary>
         /// All valid <see cref="RendererType"/>s for the current platform.
         /// </summary>
-        public IEnumerable<RendererType> GetValidRenderersForCurrentPlatform() =>
-            GetPreferredRenderersForCurrentPlatform()
-                .Append(RendererType.OpenGL)
-                .Append(RendererType.OpenGLLegacy);
+        public IEnumerable<RendererType> GetValidRenderersForCurrentPlatform()
+        {
+            yield return RendererType.Automatic;
+
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    yield return RendererType.Direct3D11;
+                    yield return RendererType.Vulkan;
+
+                    break;
+
+                case RuntimeInfo.Platform.Linux:
+                case RuntimeInfo.Platform.Android:
+                    yield return RendererType.Vulkan;
+
+                    break;
+
+                case RuntimeInfo.Platform.macOS:
+                case RuntimeInfo.Platform.iOS:
+                    yield return RendererType.Metal;
+
+                    break;
+            }
+
+            yield return RendererType.OpenGL;
+            yield return RendererType.OpenGLLegacy;
+        }
 
         /// <summary>
         /// All preferred <see cref="RendererType"/>s for the current platform.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -889,7 +889,6 @@ namespace osu.Framework.Platform
 
             // fallback to legacy renderer. this is basically guaranteed to support all platforms.
             SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
-            Config.SetValue(FrameworkSetting.Renderer, RendererType.OpenGLLegacy);
         }
 
         protected void SetupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -708,6 +708,8 @@ namespace osu.Framework.Platform
 
                 chooseAndSetupRenderer();
 
+                initialiseInputHandlers();
+
                 // Prepare renderer (requires config).
                 Dependencies.CacheAs(Renderer);
 
@@ -884,8 +886,6 @@ namespace osu.Framework.Platform
 
                 // Prepare window
                 Window = CreateWindow(surfaceType);
-
-                initialiseInputHandlers();
 
                 if (Window != null)
                 {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -23,6 +23,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Development;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.TypeExtensions;
@@ -865,7 +866,7 @@ namespace osu.Framework.Platform
                 }
             }
 
-            Logger.Log($"🖼️ Renderer fallback order: [ {string.Join(", ", attemptSurfaceTypes.Select(e => e.ToString()).Append("Legacy"))} ]");
+            Logger.Log($"🖼️ Renderer fallback order: [ {string.Join(", ", attemptSurfaceTypes.Select(e => e.GetDescription()).Append("OpenGL (Legacy)"))} ]");
 
             foreach (var attemptSurfaceType in attemptSurfaceTypes)
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1326,14 +1326,9 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Construct all input handlers for this host. The order here decides the priority given to handlers, with the earliest occurring having higher priority.
         /// </summary>
-        protected abstract IEnumerable<InputHandler>
-            CreateAvailableInputHandlers();
+        protected abstract IEnumerable<InputHandler> CreateAvailableInputHandlers();
 
-        public ImmutableArray<InputHandler> AvailableInputHandlers
-        {
-            get;
-            private set;
-        }
+        public ImmutableArray<InputHandler> AvailableInputHandlers { get; private set; }
 
         protected virtual TextInputSource CreateTextInput() => new TextInputSource();
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -850,7 +850,6 @@ namespace osu.Framework.Platform
             Logger.Log($"🖼️ Configuration renderer choice: {configRenderer}");
 
             // Attempt to initialise various veldrid surface types (and legacy GL).
-            // If legacy GL was requested we can skip this and fallback to the final logic below.
             var rendererTypes = GetPreferredRenderersForCurrentPlatform().ToList();
 
             // Move user's preference to the start of the attempts.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -905,27 +905,25 @@ namespace osu.Framework.Platform
         {
             Logger.Log($"🖼️ Initialising \"{renderer.GetType().ReadableName().Replace("Renderer", "")}\" renderer with \"{surfaceType}\" surface");
 
+            Renderer = renderer;
+
+            // Prepare window
+            Window = CreateWindow(surfaceType);
+
+            if (Window == null)
+            {
+                Logger.Log("🖼️ Renderer could not be initialised, no window exists.");
+                return;
+            }
+
+            Window.SetupWindow(Config);
+
             try
             {
-                Renderer = renderer;
+                Window.Create();
+                Window.Title = $@"osu!framework (running ""{Name}"")";
 
-                // Prepare window
-                Window = CreateWindow(surfaceType);
-
-                if (Window != null)
-                {
-                    Window.SetupWindow(Config);
-
-                    Window.Create();
-                    Window.Title = $@"osu!framework (running ""{Name}"")";
-
-                    Renderer.Initialise(Window.GraphicsSurface);
-
-                    currentDisplayMode = Window.CurrentDisplayMode.GetBoundCopy();
-                    currentDisplayMode.BindValueChanged(_ => updateFrameSyncMode());
-
-                    IsActive.BindTo(Window.IsActive);
-                }
+                Renderer.Initialise(Window.GraphicsSurface);
 
                 Logger.Log("🖼️ Renderer initialised!");
             }
@@ -936,8 +934,15 @@ namespace osu.Framework.Platform
 
                 Window?.Close();
                 Window = null;
+
+                Renderer = null;
                 throw;
             }
+
+            currentDisplayMode = Window.CurrentDisplayMode.GetBoundCopy();
+            currentDisplayMode.BindValueChanged(_ => updateFrameSyncMode());
+
+            IsActive.BindTo(Window.IsActive);
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -832,7 +832,7 @@ namespace osu.Framework.Platform
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.OpenGL);
                     break;
 
-                case Configuration.Renderer.Legacy:
+                case Configuration.Renderer.OpenGLLegacy:
                     attemptOperatingSystemSpecificFallbacks = false;
                     break;
             }
@@ -883,7 +883,7 @@ namespace osu.Framework.Platform
 
             // fallback to legacy renderer. this is basically guaranteed to support all platforms.
             setupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
-            Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.Legacy);
+            Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.OpenGLLegacy);
         }
 
         private void setupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -853,11 +853,11 @@ namespace osu.Framework.Platform
             // If legacy GL was requested we can skip this and fallback to the final logic below.
             var rendererTypes = GetPreferredRenderersForCurrentPlatform().ToList();
 
-            Logger.Log($"🖼️ Renderer fallback order: [ {string.Join(", ", rendererTypes.Select(e => e.GetDescription()))} ]");
-
             // Move user's preference to the start of the attempts.
             rendererTypes.Remove(configRenderer.Value);
             rendererTypes.Insert(0, configRenderer.Value);
+
+            Logger.Log($"🖼️ Renderer fallback order: [ {string.Join(", ", rendererTypes.Select(e => e.GetDescription()))} ]");
 
             foreach (RendererType type in rendererTypes)
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -749,7 +749,16 @@ namespace osu.Framework.Platform
                             break;
                     }
 
-                    setupRendererAndWindow(renderer, surfaceType);
+                    try
+                    {
+                        setupRendererAndWindow(renderer, surfaceType);
+                    }
+                    catch
+                    {
+                        // fallback to legacy renderer.
+                        setupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
+                        Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.Legacy);
+                    }
                 }
 
                 // Prepare renderer (requires config).

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -326,19 +326,7 @@ namespace osu.Framework.Platform
             };
         }
 
-        protected virtual IRenderer CreateRenderer()
-        {
-            switch (FrameworkEnvironment.PreferredGraphicsRenderer)
-            {
-                case "veldrid":
-                    return new VeldridRenderer();
-
-                default:
-                case "gl":
-                case "opengl":
-                    return new GLRenderer();
-            }
-        }
+        protected virtual IRenderer CreateGLRenderer() => new GLRenderer();
 
         /// <summary>
         /// Performs a GC collection and frees all framework caches.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -251,7 +251,7 @@ namespace osu.Framework.Platform
         public InputThread InputThread { get; private set; }
         public AudioThread AudioThread { get; private set; }
 
-        private double maximumUpdateHz;
+        private double maximumUpdateHz = GameThread.DEFAULT_ACTIVE_HZ;
 
         /// <summary>
         /// The target number of update frames per second when the game window is active.
@@ -265,7 +265,7 @@ namespace osu.Framework.Platform
             set => threadRunner.MaximumUpdateHz = UpdateThread.ActiveHz = maximumUpdateHz = value;
         }
 
-        private double maximumDrawHz;
+        private double maximumDrawHz = GameThread.DEFAULT_ACTIVE_HZ;
 
         /// <summary>
         /// The target number of draw frames per second when the game window is active.
@@ -284,7 +284,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private double maximumInactiveHz;
+        private double maximumInactiveHz = GameThread.DEFAULT_INACTIVE_HZ;
 
         /// <summary>
         /// The target number of updates per second when the game window is inactive.
@@ -298,7 +298,7 @@ namespace osu.Framework.Platform
             get => maximumInactiveHz;
             set
             {
-                maximumInactiveHz = threadRunner.MaximumInactiveHz = UpdateThread.InactiveHz = value;
+                threadRunner.MaximumInactiveHz = UpdateThread.InactiveHz = maximumInactiveHz = value;
                 if (DrawThread != null)
                     DrawThread.InactiveHz = maximumInactiveHz;
             }
@@ -724,7 +724,7 @@ namespace osu.Framework.Platform
 
                 RegisterThread(DrawThread = new DrawThread(DrawFrame, this, $"{Renderer.GetType().ReadableName().Replace("Renderer", "")} / {(Window?.GraphicsSurface.Type.ToString() ?? "headless")}")
                 {
-                    ActiveHz = maximumDrawHz,
+                    ActiveHz = MaximumDrawHz,
                     InactiveHz = MaximumInactiveHz,
                 });
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -861,6 +861,8 @@ namespace osu.Framework.Platform
 
                     break;
             }
+
+            yield return RendererType.OpenGLLegacy;
         }
 
         protected virtual void ChooseAndSetupRenderer()
@@ -895,6 +897,10 @@ namespace osu.Framework.Platform
                 foreach (RendererType type in rendererTypes)
                 {
                     if (type == RendererType.Automatic)
+                        continue;
+
+                    // Handled below as final non-veldrid fallback.
+                    if (type == RendererType.OpenGLLegacy)
                         continue;
 
                     try

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -903,7 +903,7 @@ namespace osu.Framework.Platform
 
         protected void SetupRendererAndWindow(IRenderer renderer, GraphicsSurfaceType surfaceType)
         {
-            Logger.Log($"🖼️ Attempting initialisation using renderer: {renderer} surface: {surfaceType}");
+            Logger.Log($"🖼️ Initialising \"{renderer.GetType().ReadableName().Replace("Renderer", "")}\" renderer with \"{surfaceType}\" surface");
 
             try
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -934,6 +934,7 @@ namespace osu.Framework.Platform
                 Logger.Log(e.ToString());
 
                 Window?.Close();
+                Window?.Dispose();
                 Window = null;
 
                 Renderer = null;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -798,6 +798,9 @@ namespace osu.Framework.Platform
         /// <summary>
         /// The renderer which the game host is currently running with.
         /// </summary>
+        /// <remarks>
+        /// This is similar to <see cref="IGraphicsSurface.Type"/> except that this is expressed as a <see cref="RendererType"/> rather than a <see cref="GraphicsSurfaceType"/>.
+        /// </remarks>
         public RendererType ResolvedRenderer { get; private set; }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -951,10 +951,9 @@ namespace osu.Framework.Platform
                 return;
             }
 
-            Window.SetupWindow(Config);
-
             try
             {
+                Window.SetupWindow(Config);
                 Window.Create();
                 Window.Title = $@"osu!framework (running ""{Name}"")";
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -908,6 +908,9 @@ namespace osu.Framework.Platform
             {
                 Logger.Log("🖼️ Renderer initialisation failed with:");
                 Logger.Log(e.ToString());
+
+                Window?.Close();
+                Window = null;
                 throw;
             }
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -811,28 +811,28 @@ namespace osu.Framework.Platform
             List<GraphicsSurfaceType> attemptSurfaceTypes = new List<GraphicsSurfaceType>();
             bool attemptOperatingSystemSpecificFallbacks = true;
 
-            var configRenderer = Config.Get<Configuration.Renderer>(FrameworkSetting.Renderer);
+            var configRenderer = Config.Get<RendererType>(FrameworkSetting.Renderer);
             Logger.Log($"🖼️ Configuration renderer choice: {configRenderer}");
 
             switch (configRenderer)
             {
-                case Configuration.Renderer.Metal:
+                case RendererType.Metal:
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.Metal);
                     break;
 
-                case Configuration.Renderer.Vulkan:
+                case RendererType.Vulkan:
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.Vulkan);
                     break;
 
-                case Configuration.Renderer.Direct3D11:
+                case RendererType.Direct3D11:
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.Direct3D11);
                     break;
 
-                case Configuration.Renderer.OpenGL:
+                case RendererType.OpenGL:
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.OpenGL);
                     break;
 
-                case Configuration.Renderer.OpenGLLegacy:
+                case RendererType.OpenGLLegacy:
                     attemptOperatingSystemSpecificFallbacks = false;
                     break;
             }
@@ -877,13 +877,13 @@ namespace osu.Framework.Platform
                 catch
                 {
                     // If we fail, assume the user may have had a custom setting and switch it back to automatic.
-                    Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.Automatic);
+                    Config.SetValue(FrameworkSetting.Renderer, RendererType.Automatic);
                 }
             }
 
             // fallback to legacy renderer. this is basically guaranteed to support all platforms.
             SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
-            Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.OpenGLLegacy);
+            Config.SetValue(FrameworkSetting.Renderer, RendererType.OpenGLLegacy);
         }
 
         protected void SetupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -812,10 +812,10 @@ namespace osu.Framework.Platform
             List<GraphicsSurfaceType> attemptSurfaceTypes = new List<GraphicsSurfaceType>();
             bool attemptOperatingSystemSpecificFallbacks = true;
 
-            var configRenderer = Config.Get<RendererType>(FrameworkSetting.Renderer);
+            var configRenderer = Config.GetBindable<RendererType>(FrameworkSetting.Renderer);
             Logger.Log($"🖼️ Configuration renderer choice: {configRenderer}");
 
-            switch (configRenderer)
+            switch (configRenderer.Value)
             {
                 case RendererType.Metal:
                     attemptSurfaceTypes.Add(GraphicsSurfaceType.Metal);
@@ -877,8 +877,13 @@ namespace osu.Framework.Platform
                 }
                 catch
                 {
-                    // If we fail, assume the user may have had a custom setting and switch it back to automatic.
-                    Config.SetValue(FrameworkSetting.Renderer, RendererType.Automatic);
+                    if (configRenderer.Value != RendererType.Automatic)
+                    {
+                        // If we fail, assume the user may have had a custom setting and switch it back to automatic.
+                        Logger.Log($"The selected renderer ({configRenderer.Value.GetDescription()}) failed to initialise. Renderer selection has been reverted to automatic.",
+                            level: LogLevel.Important);
+                        configRenderer.Value = RendererType.Automatic;
+                    }
                 }
             }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -820,14 +820,14 @@ namespace osu.Framework.Platform
             switch (RuntimeInfo.OS)
             {
                 case RuntimeInfo.Platform.Windows:
-                    yield return RendererType.Vulkan;
+                    // yield return RendererType.Vulkan;
                     yield return RendererType.Direct3D11;
 
                     break;
 
                 case RuntimeInfo.Platform.Linux:
                 case RuntimeInfo.Platform.Android:
-                    yield return RendererType.Vulkan;
+                    // yield return RendererType.Vulkan;
 
                     break;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -714,7 +714,7 @@ namespace osu.Framework.Platform
 
                 SetupConfig(game.GetFrameworkConfigDefaults() ?? new Dictionary<FrameworkSetting, object>());
 
-                chooseAndSetupRenderer();
+                ChooseAndSetupRenderer();
 
                 initialiseInputHandlers();
 
@@ -794,7 +794,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void chooseAndSetupRenderer()
+        protected virtual void ChooseAndSetupRenderer()
         {
             // Always give preference to environment variables.
             if (FrameworkEnvironment.PreferredGraphicsSurface != null || FrameworkEnvironment.PreferredGraphicsRenderer != null)
@@ -802,7 +802,7 @@ namespace osu.Framework.Platform
                 Logger.Log("🖼️ Using environment variables for renderer and surface selection.", level: LogLevel.Important);
 
                 // And allow this to hard fail with no fallbacks.
-                setupRendererAndWindow(
+                SetupRendererAndWindow(
                     FrameworkEnvironment.PreferredGraphicsRenderer ?? "veldrid",
                     FrameworkEnvironment.PreferredGraphicsSurface ?? GraphicsSurfaceType.OpenGL);
                 return;
@@ -871,7 +871,7 @@ namespace osu.Framework.Platform
             {
                 try
                 {
-                    setupRendererAndWindow("veldrid", attemptSurfaceType);
+                    SetupRendererAndWindow("veldrid", attemptSurfaceType);
                     return;
                 }
                 catch
@@ -882,11 +882,11 @@ namespace osu.Framework.Platform
             }
 
             // fallback to legacy renderer. this is basically guaranteed to support all platforms.
-            setupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
+            SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
             Config.SetValue(FrameworkSetting.Renderer, Configuration.Renderer.OpenGLLegacy);
         }
 
-        private void setupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)
+        protected void SetupRendererAndWindow(string renderer, GraphicsSurfaceType surfaceType)
         {
             Logger.Log($"🖼️ Attempting initialisation using renderer: {renderer} surface: {surfaceType}");
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -850,19 +850,19 @@ namespace osu.Framework.Platform
             Logger.Log($"🖼️ Configuration renderer choice: {configRenderer}");
 
             // Attempt to initialise various veldrid surface types (and legacy GL).
-            var rendererTypes = GetPreferredRenderersForCurrentPlatform().ToList();
+            var rendererTypes = GetPreferredRenderersForCurrentPlatform().Where(r => r != RendererType.Automatic).ToList();
 
             // Move user's preference to the start of the attempts.
-            rendererTypes.Remove(configRenderer.Value);
-            rendererTypes.Insert(0, configRenderer.Value);
+            if (!configRenderer.IsDefault)
+            {
+                rendererTypes.Remove(configRenderer.Value);
+                rendererTypes.Insert(0, configRenderer.Value);
+            }
 
             Logger.Log($"🖼️ Renderer fallback order: [ {string.Join(", ", rendererTypes.Select(e => e.GetDescription()))} ]");
 
             foreach (RendererType type in rendererTypes)
             {
-                if (type == RendererType.Automatic)
-                    continue;
-
                 try
                 {
                     if (type == RendererType.OpenGLLegacy)

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -46,6 +46,8 @@ namespace osu.Framework.Platform
             this.realtime = realtime;
         }
 
+        protected override void ChooseAndSetupRenderer() => SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
+
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             defaultOverrides[FrameworkSetting.AudioDevice] = "No sound";

--- a/osu.Framework/Platform/OsuTKGameHost.cs
+++ b/osu.Framework/Platform/OsuTKGameHost.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Platform
             toolkit = Toolkit.Init();
         }
 
-        protected override IRenderer CreateRenderer() => new GLRenderer();
+        protected override IRenderer CreateGLRenderer() => new GLRenderer();
 
         protected override void Dispose(bool disposing)
         {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -303,7 +303,11 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Forcefully closes the window.
         /// </summary>
-        public void Close() => ScheduleCommand(() => Exists = false);
+        public void Close() => ScheduleCommand(() =>
+        {
+            SDL.SDL_DestroyWindow(SDLWindowHandle);
+            Exists = false;
+        });
 
         public void Raise() => ScheduleCommand(() =>
         {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -282,11 +282,6 @@ namespace osu.Framework.Platform
             }
 
             Exited?.Invoke();
-
-            if (SDLWindowHandle != IntPtr.Zero)
-                SDL.SDL_DestroyWindow(SDLWindowHandle);
-
-            SDL.SDL_Quit();
         }
 
         private bool firstDraw = true;
@@ -303,11 +298,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Forcefully closes the window.
         /// </summary>
-        public void Close() => ScheduleCommand(() =>
-        {
-            SDL.SDL_DestroyWindow(SDLWindowHandle);
-            Exists = false;
-        });
+        public void Close() => ScheduleCommand(() => Exists = false);
 
         public void Raise() => ScheduleCommand(() =>
         {
@@ -534,6 +525,10 @@ namespace osu.Framework.Platform
 
         public void Dispose()
         {
+            if (SDLWindowHandle != IntPtr.Zero)
+                SDL.SDL_DestroyWindow(SDLWindowHandle);
+
+            SDL.SDL_Quit();
         }
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -282,6 +282,9 @@ namespace osu.Framework.Platform
             }
 
             Exited?.Invoke();
+
+            Close();
+            SDL.SDL_Quit();
         }
 
         private bool firstDraw = true;
@@ -298,7 +301,16 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Forcefully closes the window.
         /// </summary>
-        public void Close() => ScheduleCommand(() => Exists = false);
+        public void Close() => ScheduleCommand(() =>
+        {
+            Exists = false;
+
+            if (SDLWindowHandle != IntPtr.Zero)
+            {
+                SDL.SDL_DestroyWindow(SDLWindowHandle);
+                SDLWindowHandle = IntPtr.Zero;
+            }
+        });
 
         public void Raise() => ScheduleCommand(() =>
         {
@@ -525,9 +537,7 @@ namespace osu.Framework.Platform
 
         public void Dispose()
         {
-            if (SDLWindowHandle != IntPtr.Zero)
-                SDL.SDL_DestroyWindow(SDLWindowHandle);
-
+            Close();
             SDL.SDL_Quit();
         }
     }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -65,13 +65,7 @@ namespace osu.Framework.Platform.Windows
                        .Concat(new InputHandler[] { new WindowsMouseHandler() });
         }
 
-        protected override IRenderer CreateRenderer()
-        {
-            if (FrameworkEnvironment.PreferredGraphicsRenderer != null || FrameworkEnvironment.PreferredGraphicsSurface != null)
-                return base.CreateRenderer();
-
-            return new WindowsGLRenderer(this);
-        }
+        protected override IRenderer CreateGLRenderer() => new WindowsGLRenderer(this);
 
         protected override void SetupForRun()
         {


### PR DESCRIPTION
RFC

The goal here is to provide both renderer fallback logic, but also expose the renderer to the user in a way they can interact with it from game settings (or via config file for recovery, should that ever be required).

Example with user set configuration that is invalid:

```csharp
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼 Configuration renderer choice: Vulkan
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼️ Renderer fallback order: [ Vulkan, Metal, OpenGLLegacy ]
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼️ Attempting initialisation using renderer: veldrid surface: Vulkan
[runtime] 2023-03-16 10:45:09 [verbose]: Updated display mode to desktop resolution: 2560x1440@144, SDL_PIXELFORMAT_ARGB8888
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼️ Renderer initialisation failed with:
[runtime] 2023-03-16 10:45:09 [verbose]: System.TypeInitializationException: The type initializer for 'Vulkan.VulkanNative' threw an exception.
[runtime] 2023-03-16 10:45:09 [verbose]: ---> System.InvalidOperationException: Could not load libvulkan.dylib
[runtime] 2023-03-16 10:45:09 [verbose]: at Vulkan.NativeLibrary..ctor(String libraryName)
[runtime] 2023-03-16 10:45:09 [verbose]: at Vulkan.NativeLibrary.UnixNativeLibrary..ctor(String libraryName)
[runtime] 2023-03-16 10:45:09 [verbose]: at Vulkan.NativeLibrary.Load(String libraryName)
[runtime] 2023-03-16 10:45:09 [verbose]: at Vulkan.VulkanNative.LoadNativeLibrary()
[runtime] 2023-03-16 10:45:09 [verbose]: at Vulkan.VulkanNative..cctor()
[runtime] 2023-03-16 10:45:09 [verbose]: --- End of inner exception stack trace ---
[runtime] 2023-03-16 10:45:09 [verbose]: at Veldrid.Vk.VulkanUtil.EnumerateInstanceLayers()
[runtime] 2023-03-16 10:45:09 [verbose]: at Veldrid.Vk.VkGraphicsDevice.CreateInstance(Boolean debug, VulkanDeviceOptions options)
[runtime] 2023-03-16 10:45:09 [verbose]: at Veldrid.Vk.VkGraphicsDevice..ctor(GraphicsDeviceOptions options, Nullable`1 scDesc, VulkanDeviceOptions vkOptions)
[runtime] 2023-03-16 10:45:09 [verbose]: at Veldrid.Vk.VkGraphicsDevice..ctor(GraphicsDeviceOptions options, Nullable`1 scDesc)
[runtime] 2023-03-16 10:45:09 [verbose]: at Veldrid.GraphicsDevice.CreateVulkan(GraphicsDeviceOptions options, SwapchainDescription swapchainDescription)
[runtime] 2023-03-16 10:45:09 [verbose]: at osu.Framework.Graphics.Veldrid.VeldridRenderer.Initialise(IGraphicsSurface graphicsSurface) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs:line 146
[runtime] 2023-03-16 10:45:09 [verbose]: at osu.Framework.Graphics.Rendering.Renderer.osu.Framework.Graphics.Rendering.IRenderer.Initialise(IGraphicsSurface graphicsSurface) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Rendering/Renderer.cs:line 171
[runtime] 2023-03-16 10:45:09 [verbose]: at osu.Framework.Platform.GameHost.setupRendererAndWindow(String renderer, GraphicsSurfaceType surfaceType) in /Users/dean/Projects/osu-framework/osu.Framework/Platform/GameHost.cs:line 897
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼️ Attempting initialisation using renderer: veldrid surface: Metal
[runtime] 2023-03-16 10:45:09 [verbose]: Updated display mode to desktop resolution: 2560x1440@144, SDL_PIXELFORMAT_ARGB8888
[runtime] 2023-03-16 10:45:09 [verbose]: Metal Initialized
[runtime] 2023-03-16 10:45:09 [verbose]: Metal Feature Set: macOS GPU family 2 (v1)
[runtime] 2023-03-16 10:45:09 [verbose]: 🖼️ Renderer initialised!
```

Legacy example:

```csharp
[runtime] 2023-03-16 10:45:45 [verbose]: 🖼 Configuration renderer choice: OpenGLLegacy
[runtime] 2023-03-16 10:45:45 [verbose]: 🖼️ Renderer fallback order: [ OpenGLLegacy ]
[runtime] 2023-03-16 10:45:45 [verbose]: 🖼️ Attempting initialisation using renderer: gl surface: OpenGL
[runtime] 2023-03-16 10:45:45 [verbose]: Updated display mode to desktop resolution: 2560x1440@144, SDL_PIXELFORMAT_ARGB8888
[runtime] 2023-03-16 10:45:45 [verbose]: GL Initialized
[runtime] 2023-03-16 10:45:45 [verbose]: GL Version:                 4.1 ATI-4.9.51
[runtime] 2023-03-16 10:45:45 [verbose]: GL Renderer:                AMD Radeon Pro 580X OpenGL Engine
[runtime] 2023-03-16 10:45:45 [verbose]: GL Shader Language version: 4.10
[runtime] 2023-03-16 10:45:45 [verbose]: GL Vendor:                  ATI Technologies Inc.
[runtime] 2023-03-16 10:45:45 [verbose]: GL Extensions:              GL_ARB_blend_func_extended GL_ARB_draw_buffers_blend GL_ARB_draw_indirect GL_ARB_ES2_compatibility GL_ARB_explicit_attrib_location GL_ARB_gpu_shader_fp64 GL_ARB_gpu_shader5 GL_ARB_instanced_arrays GL_ARB_internalformat_query GL_ARB_occlusion_query2 GL_ARB_sample_shading GL_ARB_sampler_objects GL_ARB_separate_shader_objects GL_ARB_shader_bit_encoding GL_ARB_shader_subroutine GL_ARB_shading_language_include GL_ARB_tessellation_shader GL_ARB_texture_buffer_object_rgb32 GL_ARB_texture_cube_map_array GL_ARB_texture_gather GL_ARB_texture_query_lod GL_ARB_texture_rgb10_a2ui GL_ARB_texture_storage GL_ARB_texture_swizzle GL_ARB_timer_query GL_ARB_transform_feedback2 GL_ARB_transform_feedback3 GL_ARB_vertex_attrib_64bit GL_ARB_vertex_type_2_10_10_10_rev GL_ARB_viewport_array GL_EXT_debug_label GL_EXT_debug_marker GL_EXT_depth_bounds_test GL_EXT_texture_compression_s3tc GL_EXT_texture_filter_anisotropic GL_EXT_texture_mirror_clamp GL_EXT_texture_sRGB_decode GL_APPLE_client_storage GL_APPLE_container_object_shareable GL_APPLE_flush_render GL_APPLE_object_purgeable GL_APPLE_rgb_422 GL_APPLE_row_bytes GL_APPLE_texture_range GL_ATI_texture_mirror_once GL_NV_texture_barrier
[runtime] 2023-03-16 10:45:45 [verbose]: 🖼️ Renderer initialised!

```