### PR TITLE
Fix Metal performance with a separate command list for buffer updates

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 if (value.Equals(data))
                     return;
 
+                renderer.FlushCurrentBatch(FlushBatchSource.SetUniform);
+
                 setData(ref value);
             }
         }

--- a/osu.Framework/Graphics/Rendering/IUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/IUniformBuffer.cs
@@ -17,6 +17,9 @@ namespace osu.Framework.Graphics.Rendering
     public interface IUniformBuffer<TData> : IUniformBuffer
         where TData : unmanaged, IEquatable<TData>
     {
+        /// <summary>
+        /// The data contained by this <see cref="IUniformBuffer{TData}"/>.
+        /// </summary>
         TData Data { get; set; }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
@@ -14,8 +14,8 @@ namespace osu.Framework.Graphics.Veldrid.Batches
     {
         private readonly PrimitiveTopology type;
 
-        public VeldridLinearBatch(VeldridRenderer renderer, int size, int maxBuffers, PrimitiveTopology type)
-            : base(renderer, size, maxBuffers)
+        public VeldridLinearBatch(VeldridRenderer renderer, int size, PrimitiveTopology type)
+            : base(renderer, size)
         {
             this.type = type;
         }

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
@@ -11,8 +11,8 @@ namespace osu.Framework.Graphics.Veldrid.Batches
     internal class VeldridQuadBatch<T> : VeldridVertexBatch<T>
         where T : unmanaged, IEquatable<T>, IVertex
     {
-        public VeldridQuadBatch(VeldridRenderer renderer, int size, int maxBuffers)
-            : base(renderer, size, maxBuffers)
+        public VeldridQuadBatch(VeldridRenderer renderer, int size)
+            : base(renderer, size)
         {
             if (size > VeldridQuadBuffer<T>.MAX_QUADS)
                 throw new OverflowException($"Attempted to initialise a {nameof(VeldridQuadBuffer<T>)} with more than {nameof(VeldridQuadBuffer<T>)}.{nameof(VeldridQuadBuffer<T>.MAX_QUADS)} quads ({VeldridQuadBuffer<T>.MAX_QUADS}).");

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
@@ -27,15 +27,13 @@ namespace osu.Framework.Graphics.Veldrid.Batches
         private int currentVertexIndex;
 
         private readonly VeldridRenderer renderer;
-        private readonly int maxBuffers;
 
         private VeldridVertexBuffer<T> currentVertexBuffer => VertexBuffers[currentBufferIndex];
 
-        protected VeldridVertexBatch(VeldridRenderer renderer, int bufferSize, int maxBuffers)
+        protected VeldridVertexBatch(VeldridRenderer renderer, int bufferSize)
         {
             Size = bufferSize;
             this.renderer = renderer;
-            this.maxBuffers = maxBuffers;
 
             AddAction = Add;
         }
@@ -117,8 +115,7 @@ namespace osu.Framework.Graphics.Veldrid.Batches
             int count = currentVertexIndex;
 
             // When using multiple buffers we advance to the next one with every draw to prevent contention on the same buffer with future vertex updates.
-            //TODO: let us know if we exceed and roll over to zero here.
-            currentBufferIndex = (currentBufferIndex + 1) % maxBuffers;
+            currentBufferIndex++;
             currentVertexIndex = 0;
             changeBeginIndex = -1;
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 for (ushort i = 0; i < amountVertices; i++)
                     indices[i] = i;
 
-                renderer.Commands.UpdateBuffer(renderer.SharedLinearIndex.Buffer, 0, indices);
+                renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedLinearIndex.Buffer, 0, indices);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                     indices[j + 5] = (ushort)(i + 1);
                 }
 
-                renderer.Commands.UpdateBuffer(renderer.SharedQuadIndex.Buffer, 0, indices);
+                renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedQuadIndex.Buffer, 0, indices);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
@@ -45,7 +45,10 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             get => pendingData ?? currentStorage.Data;
             set
             {
-                // Immediately flush the current draw call, since we'll be changing the contents of this UBO.
+                if (value.Equals(Data))
+                    return;
+
+                // Flush the current draw call since the contents of the buffer will change.
                 renderer.FlushCurrentBatch(FlushBatchSource.SetUniform);
 
                 pendingData = value;
@@ -63,12 +66,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             if (pendingData is not TData pending)
                 return;
 
-            // The storage should only be advanced once if matching data is set twice in a row in a single frame.
-            if (pending.Equals(currentStorage.Data))
-            {
-                pendingData = null;
-                return;
-            }
+            pendingData = null;
 
             // Register this UBO to be reset in the next frame, but only once per frame.
             if (currentStorageIndex == 0)
@@ -81,15 +79,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             {
                 // If the new storage previously existed, then it may already contain the data.
                 if (pending.Equals(currentStorage.Data))
-                {
-                    pendingData = null;
                     return;
-                }
             }
 
             // Upload the data.
             currentStorage.Data = pending;
-            pendingData = null;
 
             FrameStatistics.Increment(StatisticsCounterType.UniformUpl);
         }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
@@ -34,13 +34,15 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             get => storages[currentStorageIndex].Data;
             set
             {
-                renderer.TrackUniformBufferForReset(this);
+                renderer.FlushCurrentBatch(FlushBatchSource.SetUniform);
 
                 ++currentStorageIndex;
                 while (currentStorageIndex >= storages.Count)
                     storages.Add(new VeldridUniformBufferStorage<TData>(renderer));
 
                 storages[currentStorageIndex].Data = value;
+
+                renderer.RegisterUniformBufferForReset(this);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
@@ -10,9 +10,16 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 {
     internal interface IVeldridUniformBuffer : IDisposable
     {
+        /// <summary>
+        /// Gets the <see cref="ResourceSet"/> containing the buffer attached to the given layout.
+        /// </summary>
+        /// <param name="layout">The <see cref="ResourceLayout"/> which the buffer should be attached to.</param>
         ResourceSet GetResourceSet(ResourceLayout layout);
 
-        void Reset();
+        /// <summary>
+        /// Resets this <see cref="IVeldridUniformBuffer"/>, bringing it to the initial state.
+        /// </summary>
+        void ResetCounters();
     }
 
     internal class VeldridUniformBuffer<TData> : IUniformBuffer<TData>, IVeldridUniformBuffer
@@ -48,7 +55,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public ResourceSet GetResourceSet(ResourceLayout layout) => storages[currentStorageIndex].GetResourceSet(layout);
 
-        public void Reset()
+        public void ResetCounters()
         {
             currentStorageIndex = 0;
         }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers
+{
+    internal class VeldridUniformBufferStorage<TData>
+        where TData : unmanaged, IEquatable<TData>
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly DeviceBuffer buffer;
+
+        private ResourceSet? set;
+        private TData data;
+
+        public VeldridUniformBufferStorage(VeldridRenderer renderer)
+        {
+            this.renderer = renderer;
+            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)Marshal.SizeOf(default(TData)), BufferUsage.UniformBuffer));
+        }
+
+        public TData Data
+        {
+            get => data;
+            set
+            {
+                if (value.Equals(data))
+                    return;
+
+                data = value;
+
+                renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, ref data);
+            }
+        }
+
+        public ResourceSet GetResourceSet(ResourceLayout layout) => set ??= renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+
+        public void Dispose()
+        {
+            buffer.Dispose();
+            set?.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Platform;
 using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
@@ -12,6 +13,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
     {
         private readonly VeldridRenderer renderer;
         private readonly DeviceBuffer buffer;
+        private readonly NativeMemoryTracker.NativeMemoryLease memoryLease;
 
         private ResourceSet? set;
         private TData data;
@@ -19,7 +21,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public VeldridUniformBufferStorage(VeldridRenderer renderer)
         {
             this.renderer = renderer;
+
             buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)Marshal.SizeOf(default(TData)), BufferUsage.UniformBuffer));
+            memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
         }
 
         public TData Data
@@ -27,11 +31,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             get => data;
             set
             {
-                if (value.Equals(data))
-                    return;
-
                 data = value;
-
                 renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, ref data);
             }
         }
@@ -41,6 +41,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public void Dispose()
         {
             buffer.Dispose();
+            memoryLease.Dispose();
             set?.Dispose();
         }
     }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 Initialise();
 
             int countVertices = endIndex - startIndex;
-            renderer.Commands.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
+            renderer.BufferUpdateCommands.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
 
             FrameStatistics.Add(StatisticsCounterType.VerticesUpl, countVertices);
         }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -44,6 +44,7 @@ namespace osu.Framework.Graphics.Veldrid
         public ResourceFactory Factory => Device.ResourceFactory;
 
         public CommandList Commands { get; private set; } = null!;
+        public CommandList BufferUpdateCommands { get; private set; } = null!;
 
         public VeldridIndexData SharedLinearIndex { get; }
         public VeldridIndexData SharedQuadIndex { get; }
@@ -161,6 +162,7 @@ namespace osu.Framework.Graphics.Veldrid
             MaxTextureSize = maxTextureSize;
 
             Commands = Factory.CreateCommandList();
+            BufferUpdateCommands = Factory.CreateCommandList();
 
             pipeline.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }
@@ -176,6 +178,7 @@ namespace osu.Framework.Graphics.Veldrid
             }
 
             Commands.Begin();
+            BufferUpdateCommands.Begin();
 
             base.BeginFrame(windowSize);
         }
@@ -183,6 +186,9 @@ namespace osu.Framework.Graphics.Veldrid
         protected internal override void FinishFrame()
         {
             base.FinishFrame();
+
+            BufferUpdateCommands.End();
+            Device.SubmitCommands(BufferUpdateCommands);
 
             Commands.End();
             Device.SubmitCommands(Commands);

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -179,7 +179,7 @@ namespace osu.Framework.Graphics.Veldrid
             }
 
             foreach (var ubo in uniformBufferResetList)
-                ubo.Reset();
+                ubo.ResetCounters();
             uniformBufferResetList.Clear();
 
             Commands.Begin();

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -473,7 +473,7 @@ namespace osu.Framework.Graphics.Veldrid
         {
         }
 
-        public void TrackUniformBufferForReset(IVeldridUniformBuffer buffer)
+        public void RegisterUniformBufferForReset(IVeldridUniformBuffer buffer)
         {
             uniformBufferResetList.Add(buffer);
         }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -49,6 +49,7 @@ namespace osu.Framework.Graphics.Veldrid
         public VeldridIndexData SharedLinearIndex { get; }
         public VeldridIndexData SharedQuadIndex { get; }
 
+        private readonly List<IVeldridUniformBuffer> uniformBufferResetList = new List<IVeldridUniformBuffer>();
         private readonly Dictionary<int, VeldridTextureResources> boundTextureUnits = new Dictionary<int, VeldridTextureResources>();
         private readonly Dictionary<string, IVeldridUniformBuffer> boundUniformBuffers = new Dictionary<string, IVeldridUniformBuffer>();
         private IGraphicsSurface graphicsSurface = null!;
@@ -176,6 +177,10 @@ namespace osu.Framework.Graphics.Veldrid
                 Device.ResizeMainWindow((uint)windowSize.X, (uint)windowSize.Y);
                 currentSize = windowSize;
             }
+
+            foreach (var ubo in uniformBufferResetList)
+                ubo.Reset();
+            uniformBufferResetList.Clear();
 
             Commands.Begin();
             BufferUpdateCommands.Begin();
@@ -466,6 +471,11 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected override void SetUniformImplementation<T>(IUniformWithValue<T> uniform)
         {
+        }
+
+        public void TrackUniformBufferForReset(IVeldridUniformBuffer buffer)
+        {
+            uniformBufferResetList.Add(buffer);
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -437,10 +437,16 @@ namespace osu.Framework.Graphics.Veldrid
             => new VeldridFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
 
         protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, Rendering.PrimitiveTopology primitiveType)
-            => new VeldridLinearBatch<TVertex>(this, size, maxBuffers, primitiveType.ToPrimitiveTopology());
+        {
+            // maxBuffers is ignored because batches are not allowed to wrap around in Veldrid.
+            return new VeldridLinearBatch<TVertex>(this, size, primitiveType.ToPrimitiveTopology());
+        }
 
         protected override IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers)
-            => new VeldridQuadBatch<TVertex>(this, size, maxBuffers);
+        {
+            // maxBuffers is ignored because batches are not allowed to wrap around in Veldrid.
+            return new VeldridQuadBatch<TVertex>(this, size);
+        }
 
         protected override IUniformBuffer<TData> CreateUniformBuffer<TData>()
             => new VeldridUniformBuffer<TData>(this);

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -77,6 +77,7 @@ namespace osu.Framework.Statistics
         ShaderBinds,
         VerticesDraw,
         VerticesUpl,
+        UniformUpl,
         Pixels,
 
         TasksRun,

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -59,6 +59,7 @@ namespace osu.Framework.Threading
             StatisticsCounterType.ShaderBinds,
             StatisticsCounterType.VerticesDraw,
             StatisticsCounterType.VerticesUpl,
+            StatisticsCounterType.UniformUpl,
             StatisticsCounterType.Pixels,
         };
     }


### PR DESCRIPTION
Veldrid's `CommandList` corresponds to a [`MTLCommandBuffer`](https://developer.apple.com/documentation/metal/mtlcommandbuffer) in Metal.

To write to a `MTLCommandBuffer`, you use command encoders. There are two particular encoders which are relevant for us:
1. A [`MTLRenderCommandEncoder`](https://developer.apple.com/documentation/metal/mtlrendercommandencoder) which allows us to render things - set viewports, call `DrawIndexed`, etc.
2. A [`MTLBlitCommandEncoder`](https://developer.apple.com/documentation/metal/mtlblitcommandencoder), which, for our purposes, allows us to upload data into VBOs/UBOs.

By interleaving VBO/UBO updates, we are essentially pausing and resuming the render pass, which is causing a huge amount (~9GB/frame at song select) of GPU memory traffic at song select. The Metal debugger warns us that we should be coalescing these encoders to resolve the issue.

To do so, I've split out VBO/UBO updates into their own isolated command list. Importantly, this means that we must not overwrite buffers during the render pass so VBOs no longer respect the `maxBuffers` parameter and UBOs now also contain multiple "storage" units.

This PR makes Metal outperform GL and Veldrid-GL.