### PR TITLE
Fix Veldrid framebuffers leaking GPU memory

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 {
     internal class VeldridFrameBuffer : IFrameBuffer
     {
-        public osu.Framework.Graphics.Textures.Texture Texture { get; private set; }
+        public osu.Framework.Graphics.Textures.Texture Texture { get; }
 
         public Framebuffer Framebuffer { get; private set; }
 
@@ -24,7 +24,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly SamplerFilter filteringMode;
         private readonly PixelFormat? depthFormat;
 
-        private VeldridTexture colourTarget;
+        private readonly VeldridTexture colourTarget;
         private Texture? depthTarget;
 
         private Vector2 size = Vector2.One;
@@ -58,21 +58,21 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             this.filteringMode = filteringMode;
             depthFormat = formats?[0];
 
+            colourTarget = new FrameBufferTexture(renderer, filteringMode);
+            Texture = renderer.CreateFrameBufferTexture(colourTarget);
+
             recreateResources();
         }
 
-        [MemberNotNull(nameof(Framebuffer), nameof(colourTarget), nameof(Texture))]
+        [MemberNotNull(nameof(Framebuffer))]
         private void recreateResources()
         {
             // The texture is created once and resized internally, so it should not be deleted.
             DeleteResources(false);
 
-            colourTarget ??= new FrameBufferTexture(renderer, filteringMode);
-            Texture ??= renderer.CreateFrameBufferTexture(colourTarget);
-
             if (depthFormat is PixelFormat depth)
             {
-                TextureDescription depthDescription = TextureDescription.Texture2D((uint)colourTarget.Width, (uint)colourTarget.Height, 1, 1, depth, TextureUsage.DepthStencil);
+                var depthDescription = TextureDescription.Texture2D((uint)colourTarget.Width, (uint)colourTarget.Height, 1, 1, depth, TextureUsage.DepthStencil);
                 depthTarget = renderer.Factory.CreateTexture(ref depthDescription);
             }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Textures;
 using osuTK;
 using Veldrid;
+using Texture = Veldrid.Texture;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
 {
@@ -24,7 +25,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly PixelFormat? depthFormat;
 
         private VeldridTexture colourTarget;
-        private global::Veldrid.Texture? depthTarget;
+        private Texture? depthTarget;
 
         private Vector2 size = Vector2.One;
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -21,7 +21,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public Framebuffer Framebuffer { get; private set; }
 
         private readonly VeldridRenderer renderer;
-        private readonly SamplerFilter filteringMode;
         private readonly PixelFormat? depthFormat;
 
         private readonly VeldridTexture colourTarget;
@@ -55,7 +54,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 throw new ArgumentException("Veldrid framebuffer cannot contain more than one depth target.");
 
             this.renderer = renderer;
-            this.filteringMode = filteringMode;
+
             depthFormat = formats?[0];
 
             colourTarget = new FrameBufferTexture(renderer, filteringMode);

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -403,6 +403,12 @@ namespace osu.Framework.Graphics.Veldrid
         }
 
         /// <summary>
+        /// Checks whether the given frame buffer is currently bound.
+        /// </summary>
+        /// <param name="frameBuffer">The frame buffer to check.</param>
+        public bool IsFrameBufferBound(IFrameBuffer frameBuffer) => FrameBuffer == frameBuffer;
+
+        /// <summary>
         /// Deletes a frame buffer.
         /// </summary>
         /// <param name="frameBuffer">The frame buffer to delete.</param>
@@ -411,7 +417,7 @@ namespace osu.Framework.Graphics.Veldrid
             while (FrameBuffer == frameBuffer)
                 UnbindFrameBuffer(frameBuffer);
 
-            frameBuffer.Framebuffer.Dispose();
+            frameBuffer.DeleteResources(true);
         }
 
         private readonly Dictionary<GraphicsPipelineDescription, Pipeline> pipelineCache = new Dictionary<GraphicsPipelineDescription, Pipeline>();


### PR DESCRIPTION
I noticed this when entering and exiting song select, which would retain about 100MB VRAM every time.

Unlike with GL, resizing Veldrid FBOs requires them to be recreated. This PR is a three part fix:
- It was recreating them but not disposing the old ones. 
- It was not disposing the depth texture, which would likely have exacerbated this issue during gameplay (sliders).
- It was not rebinding the FBO upon such recreation. ~~I'm still evaluating whether this was the cause of other brokenness I was seeing.~~ (it is not)

The changes are hard to read since this is practically a total refactoring of the flow of this class.