### PR TITLE
Fix possible division by 0 in SpriteText

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -527,7 +527,9 @@ namespace osu.Framework.Graphics.Sprites
                 screenSpaceCharactersBacking.Add(new ScreenSpaceCharacterPart
                 {
                     DrawQuad = ToScreenSpace(character.DrawRectangle.Inflate(inflationAmount)),
-                    InflationPercentage = Vector2.Divide(inflationAmount, character.DrawRectangle.Size),
+                    InflationPercentage = new Vector2(
+                        character.DrawRectangle.Size.X == 0 ? 0 : inflationAmount.X / character.DrawRectangle.Size.X,
+                        character.DrawRectangle.Size.Y == 0 ? 0 : inflationAmount.Y / character.DrawRectangle.Size.Y),
                     Texture = character.Texture
                 });
             }


### PR DESCRIPTION
I'm very deep into debugging D3D right now and noticed this coming up potentially causing unnecessary & invalid vertex uploads.