### PR TITLE
Fix draw thread unnecessarily marking GL context as current

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -103,6 +103,9 @@ namespace osu.Framework.Graphics.OpenGL
             lastBoundBuffers.AsSpan().Clear();
             lastBoundVertexArray = 0;
 
+            // Seems to be required on some drivers as the context is lost from the draw thread.
+            MakeCurrent();
+
             GL.UseProgram(0);
 
             base.BeginFrame(windowSize);

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -28,8 +28,6 @@ namespace osu.Framework.Threading
 
             if (window != null)
             {
-                host.Renderer.MakeCurrent();
-
                 host.Renderer.BeginFrame(new Vector2(window.ClientSize.Width, window.ClientSize.Height));
                 host.Renderer.FinishFrame();
             }
@@ -40,16 +38,13 @@ namespace osu.Framework.Threading
             base.MakeCurrent();
 
             ThreadSafety.IsDrawThread = true;
-
-            if (host.Renderer.IsInitialised)
-                // Seems to be required on some drivers as the context is lost from the draw thread.
-                host.Renderer.MakeCurrent();
         }
 
         protected sealed override void OnSuspended()
         {
             base.OnSuspended();
 
+            // if we've acquired the GL context before in this thread, make sure to release it before suspension.
             if (host.Renderer.IsInitialised)
                 host.Renderer.ClearCurrent();
         }


### PR DESCRIPTION
- Closes #5688 

I'll preface this by saying this only affects Veldrid/OpenGL, so this doesn't need immediate attention at all and can be left for another release if preferred.

`MakeCurrent` calls are supposed to happen internally within the renderer whenever it's expecting to execute GL commands. In Veldrid, all GL commands are executed in a separate thread, therefore calling `MakeCurrent` here is unnecessary and will fail due to being acquired in the Veldrid thread.

I've kept the `ClearCurrent` call though since I'm not entirely sure of a better place for it that exists on `GLRenderer`, and I'm slightly skeptical of doing it in `FinishFrame`.