### PR TITLE
Fix D3D VBOs sometimes initialised with junk data

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             vboId = GL.GenBuffer();
             GL.BindBuffer(BufferTarget.ArrayBuffer, vboId);
-            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)size, IntPtr.Zero, usage);
+            GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)size, ref getMemory().Span[0], usage);
 
             GLVertexUtils<DepthWrappingVertex<T>>.SetAttributes();
         }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -69,10 +69,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             ThreadSafety.EnsureDrawThread();
 
-            var description = new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage);
-            buffer = renderer.Factory.CreateBuffer(description);
-
+            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage));
             memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
+
+            // Ensure the device buffer is initialised to 0.
+            Update();
         }
 
         ~VeldridVertexBuffer()


### PR DESCRIPTION
I noticed that every once in a while certain vertices would get incorrect data.

Furthermore this would always occur on vertices that were 0-initialised, which is _always_ the case with exactly one vertex in FBOs since the FtB pass doesn't do anything there (depth = 0). That explains why the issues I was seeing was always when `BufferedContainer` + blur were involved (e.g. backgrounds, in-gameplay break overlay arrows, song select leaderboard glows).

This makes it so that we always perform one buffer update with 0-initialised data when initialising a VBO. In `GLRenderer` we are relying on `glBufferData` to both initialise the storage for us _and_ clean out the driver/GPU buffer, so this was just missed in the port to Veldrid.