### PR TITLE
Fix Android CI workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Restore .NET workloads
-        run: dotnet workload restore
+        run: dotnet workload install android
 
       - name: Compile
         run: dotnet build -c Debug osu-framework.Android.slnf


### PR DESCRIPTION
Successful run: https://github.com/Susko3/osu-framework/actions/runs/4472707773/jobs/7859184672

The same tactic is used in [`osu`](https://github.com/ppy/osu/blob/88700c85fd22a74750fcdac223b661c7774e22f9/.github/workflows/ci.yml#L117) repo.