### PR TITLE
Add a finaliser to Veldrid UBOs

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         public void Dispose()
         {
-            Dispose(true);
+            renderer.ScheduleDisposal(v => v.Dispose(true), this);
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBuffer.cs
@@ -44,10 +44,28 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public ResourceSet GetResourceSet(ResourceLayout layout) => set ??= renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
 
+        ~VeldridUniformBuffer()
+        {
+            renderer.ScheduleDisposal(v => v.Dispose(false), this);
+        }
+
         public void Dispose()
         {
+            renderer.ScheduleDisposal(v => v.Dispose(true), this);
+            GC.SuppressFinalize(this);
+        }
+
+        protected bool IsDisposed { get; private set; }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+                return;
+
             buffer.Dispose();
             set?.Dispose();
+
+            IsDisposed = true;
         }
     }
 }


### PR DESCRIPTION
This doesn't fix any issue, it's just a preventative measure that is mostly the same implementation as `VeldridVertexBuffer`.