### PR TITLE
Enable Mono Interpreter on iOS

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -1,6 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <!-- Mono Interpreter resolves many AOT issues occuring on runtime,
+         and will be enabled by default on .NET 8+: https://github.com/dotnet/maui/issues/13019 -->
+    <UseInterpreter>true</UseInterpreter>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
     <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
          It only warns about not copying the library to the app bundle to save space,


### PR DESCRIPTION
This makes iOS development less PITA in multiple ways:
 - Works around https://github.com/xamarin/xamarin-macios/issues/17708 which is encountered very frequently during work sessions.
 - Fixes SDL P/Invokes oddly throwing `DllNotFoundException` despite a resolver already being attached.
 - Decreases build time immensely.