### PR TITLE
Add workaround for incorrect SRGB conversion inside `BufferedContainer`s on android

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -71,7 +71,12 @@ namespace osu.Framework.Graphics.OpenGL
 
             GL.Disable(EnableCap.StencilTest);
             GL.Enable(EnableCap.Blend);
-            GL.Disable((EnableCap)36281); // GL_FRAMEBUFFER_SRGB
+
+            // For whatever reason, changing this value breaks colour rendering inside BufferedContainers only on android.
+            // We're going to eventually have to figure out why this is the case, but for now this workaround fixes the issue very locally.
+            // See https://github.com/ppy/osu-framework/issues/5694.
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Android)
+                GL.Disable((EnableCap)36281); // GL_FRAMEBUFFER_SRGB
 
             Logger.Log($@"GL Initialized
                         GL Version:                 {GL.GetString(StringName.Version)}


### PR DESCRIPTION
See https://github.com/ppy/osu-framework/issues/5694.

Not closing the issue because I don't see this as a permanent fix. That said, maybe it won't be required if we switch to veldrid GL and it works there? Not even testing that at this point because I just want to ensure we can get the next release out on android without everything toppling over.

Tested on my only test device to work as expected.