### PR TITLE
Fix namespace warnings in iOS / android test projects

### DIFF
--- a/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj.DotSettings
+++ b/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">HINT</s:String>
+</wpf:ResourceDictionary>

--- a/osu.Framework.Tests.iOS/osu.Framework.Tests.iOS.csproj.DotSettings
+++ b/osu.Framework.Tests.iOS/osu.Framework.Tests.iOS.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">HINT</s:String>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
Fixes:

![JetBrains Rider-EAP 2023-03-24 at 07 53 01](https://user-images.githubusercontent.com/191335/227458962-41740f69-425c-4898-89ac-f26b578f90e8.png)

Caused by files being included from a directory which causes namespace checks to fail.