### PR TITLE
Build debug symbol packages in deploy workflow

### DIFF
--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -55,13 +55,15 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Pack (Framework)
-        run: dotnet pack -c Release osu.Framework /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: dotnet pack -c Release osu.Framework /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: osu-framework
-          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+          path: |
+            ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+            ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.snupkg
 
       - name: Publish packages to nuget.org
         run: dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
In theory, this should deal with #5695.

Admittedly I haven't tested this end-to-end because it's a little tedious to do so (would have to change default branch on my fork to use these changes, add a secret to push to nuget, change the package IDs around, tag, trigger the workflow...) But, if the docs [from nuget](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#creating-a-symbol-package) and the [`upload-artifact` action](https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions) are to be trusted, this _should_ work? I can go and do the full flow test described above if that is considered a requirement.

Note that I haven't changed the final push command, because [docs claim the symbols package should be automatically detected](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package). If it turns out they're not, then we can always try adding another push command for the `snupkg`s specifically.