### PR TITLE
Fix blur direction changing between renderer surfaces

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Graphics.Containers
 
                 using (BindFrameBuffer(target))
                 {
-                    float radians = -MathUtils.DegreesToRadians(blurRotation);
+                    float radians = MathUtils.DegreesToRadians(blurRotation);
 
                     blurParametersBuffer.Data = blurParametersBuffer.Data with
                     {

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             this.renderer = renderer;
             FrameBuffer = GL.GenFramebuffer();
 
-            Texture = renderer.CreateFrameBufferTexture(glTexture = new FrameBufferTexture(renderer, filteringMode));
+            Texture = renderer.CreateTexture(glTexture = new FrameBufferTexture(renderer, filteringMode));
 
             renderer.BindFrameBuffer(this);
 

--- a/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
+++ b/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
@@ -36,6 +36,7 @@ namespace osu.Framework.Graphics.Rendering
 
         public UniformBool IsDepthRangeZeroToOne;
         public UniformBool IsClipSpaceYInverted;
-        private readonly UniformPadding8 pad4;
+        public UniformBool IsUvOriginTopLeft;
+        private readonly UniformPadding4 pad4;
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -189,7 +189,8 @@ namespace osu.Framework.Graphics.Rendering
             globalUniformBuffer.Data = globalUniformBuffer.Data with
             {
                 IsDepthRangeZeroToOne = IsDepthRangeZeroToOne,
-                IsClipSpaceYInverted = IsClipSpaceYInverted
+                IsClipSpaceYInverted = IsClipSpaceYInverted,
+                IsUvOriginTopLeft = IsUvOriginTopLeft
             };
 
             Debug.Assert(defaultQuadBatch != null);
@@ -1071,14 +1072,6 @@ namespace osu.Framework.Graphics.Rendering
         internal Texture CreateTexture(INativeTexture nativeTexture, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
             => registerTexture(new Texture(nativeTexture, wrapModeS, wrapModeT));
 
-        /// <summary>
-        /// Creates a special <see cref="Texture"/> which responds to any UV-coordinate space requirements for use in framebuffers.
-        /// </summary>
-        /// <param name="nativeTexture">The framebuffer's native texture.</param>
-        /// <returns>The <see cref="Texture"/>.</returns>
-        internal Texture CreateFrameBufferTexture(INativeTexture nativeTexture)
-            => registerTexture(new ClipSpaceAdjustedTexture(nativeTexture, WrapMode.None, WrapMode.None));
-
         private Texture registerTexture(Texture texture)
         {
             allTextures.Add(texture);
@@ -1238,37 +1231,6 @@ namespace osu.Framework.Graphics.Rendering
         }
 
         Texture[] IRenderer.GetAllTextures() => allTextures.ToArray();
-
-        #endregion
-
-        #region Utils
-
-        /// <summary>
-        /// A special <see cref="Texture"/> which applies adjustments necessary for the current renderer
-        /// to ensure that (0, 0) is the top-left texel of the texture.
-        /// </summary>
-        /// <remarks>
-        /// This is used for framebuffers where the texture can't be pre-adjusted from the time of creation.
-        /// </remarks>
-        private class ClipSpaceAdjustedTexture : Texture
-        {
-            public ClipSpaceAdjustedTexture(INativeTexture nativeTexture, WrapMode wrapModeS, WrapMode wrapModeT)
-                : base(nativeTexture, wrapModeS, wrapModeT)
-            {
-            }
-
-            public ClipSpaceAdjustedTexture(Texture parent, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
-                : base(parent, wrapModeS, wrapModeT)
-            {
-            }
-
-            public override RectangleF GetTextureRect(RectangleF? area = null)
-            {
-                return base.NativeTexture.Renderer.IsUvOriginTopLeft
-                    ? base.GetTextureRect(area)
-                    : base.GetTextureRect(area).Inflate(new Vector2(0, -1));
-            }
-        }
 
         #endregion
     }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             depthFormat = formats?[0];
 
             colourTarget = new FrameBufferTexture(renderer, filteringMode);
-            Texture = renderer.CreateFrameBufferTexture(colourTarget);
+            Texture = renderer.CreateTexture(colourTarget);
 
             recreateResources();
         }

--- a/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
@@ -35,4 +35,7 @@ layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
 
     // Whether the clip space ranges from -1 (top) to 1 (bottom). If false, the clip space ranges from -1 (bottom) to 1 (top).
     bool g_IsClipSpaceYInverted;
+
+    // Whether the texture coordinates begin in the top-left of the texture. If false, (0, 0) is the bottom-left texel of the texture.
+    bool g_IsUvOriginTopLeft;
 };

--- a/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Output.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Output.h
@@ -14,6 +14,11 @@ void main()
     if (g_IsDepthRangeZeroToOne)
         gl_Position.z = gl_Position.z / 2.0 + 0.5;
 
-    if (g_IsClipSpaceYInverted)
+    // When the device's texture coordinates are inverted, and when we are outputting to a framebuffer,
+    // we should ensure that the framebuffer output is also inverted so that it's treated as a normal texture
+    // later on in the frame.
+    bool requiresFramebufferInvert = !g_BackbufferDraw && !g_IsUvOriginTopLeft;
+
+    if (g_IsClipSpaceYInverted || requiresFramebufferInvert)
         gl_Position.y = -gl_Position.y;
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/5701

The core of the issue is that in OpenGL textures are inverted with the bottom-left texel being (0,0). Historically, we've always been rendering to FBOs such that their output is stored as if the top-left texel was (0,0), and then we had some logic to invert the FBO's texture when it was used for drawing.

So this is a two part fix:
1. Making FBOs rendered to as expected by the surface. For OpenGL if you view them in RenderDoc, they'll now be inverted. This makes all surfaces render the same way.
2. Removing the custom inversion logic for the blur direction. This only existed because the DrawNode assumed our incorrect rendering of FBOs. This makes the blur direction clockwise once again as expected.

@bdach Please double check that this fixes the issue.