### PR TITLE
Fix opening external links on Android

### DIFF
--- a/SampleGame.Android/AndroidManifest.xml
+++ b/SampleGame.Android/AndroidManifest.xml
@@ -2,16 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="SampleGame.Android" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application />
-	<queries>
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<category android:name="android.intent.category.BROWSABLE" />
-			<data android:scheme="https" />
-		</intent>
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<category android:name="android.intent.category.BROWSABLE" />
-			<data android:scheme="mailto" />
-		</intent>
-	</queries>
 </manifest>

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -18,6 +18,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Midi;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using Uri = Android.Net.Uri;
 
@@ -79,12 +80,18 @@ namespace osu.Framework.Android
             if (!url.CheckIsValidUrl())
                 throw new ArgumentException("The provided URL must be one of either http://, https:// or mailto: protocols.", nameof(url));
 
-            if (gameView.Activity.PackageManager == null) return;
-
             using (var intent = new Intent(Intent.ActionView, Uri.Parse(url)))
             {
-                if (intent.ResolveActivity(gameView.Activity.PackageManager) != null)
+                // Recommended way to open URLs on Android 11+
+                // https://developer.android.com/training/package-visibility/use-cases#open-urls-browser-or-other-app
+                try
+                {
                     gameView.Activity.StartActivity(intent);
+                }
+                catch (ActivityNotFoundException e)
+                {
+                    Logger.Error(e, $"Failed to start intent: {intent}");
+                }
             }
         }
 

--- a/osu.Framework.Tests.Android/AndroidManifest.xml
+++ b/osu.Framework.Tests.Android/AndroidManifest.xml
@@ -2,16 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="osu.Framework.Tests.Android" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
 	<application android:label="osu!framework test" />
-	<queries>
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<category android:name="android.intent.category.BROWSABLE" />
-			<data android:scheme="https" />
-		</intent>
-		<intent>
-			<action android:name="android.intent.action.VIEW" />
-			<category android:name="android.intent.category.BROWSABLE" />
-			<data android:scheme="mailto" />
-		</intent>
-	</queries>
 </manifest>

--- a/osu.Framework.Tests/Visual/Platform/TestSceneExternalLinks.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneExternalLinks.cs
@@ -45,6 +45,18 @@ namespace osu.Framework.Tests.Visual.Platform
                         Size = new Vector2(150, 30),
                         Text = "Open bad link",
                     },
+                    new BasicButton
+                    {
+                        Action = () => host.OpenUrlExternally("https://github.com/ppy/osu-framework"),
+                        Size = new Vector2(150, 30),
+                        Text = "Open github link",
+                    },
+                    new BasicButton
+                    {
+                        Action = () => host.OpenUrlExternally("https://twitter.com/osugame"),
+                        Size = new Vector2(150, 30),
+                        Text = "Open twitter link",
+                    },
                 }
             };
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/22993
- Alternative to https://github.com/ppy/osu/pull/23005
- Somewhat reverts #5666 

This PR follows the [guidelines](https://developer.android.com/training/package-visibility/use-cases#open-urls-browser-or-other-app) for apps targeting Android 11+.

The links added in the tests only fail if they are opened in their respective app (not the default web browser).

- https://github.com/ppy/osu/pull/22790 should be reverted after this is merged