### PR TITLE
Fix gamma blending in new renderers

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
@@ -105,21 +105,22 @@ namespace osu.Framework.Graphics.OpenGL.Batches
 
         public int Draw()
         {
-            if (currentVertexIndex == 0)
+            int count = currentVertexIndex;
+            currentVertexIndex = 0;
+
+            if (count == 0)
                 return 0;
 
             GLVertexBuffer<T> vertexBuffer = currentVertexBuffer;
             if (changeBeginIndex >= 0)
                 vertexBuffer.UpdateRange(changeBeginIndex, changeEndIndex);
 
-            vertexBuffer.DrawRange(0, currentVertexIndex);
-
-            int count = currentVertexIndex;
+            vertexBuffer.DrawRange(0, count);
 
             // When using multiple buffers we advance to the next one with every draw to prevent contention on the same buffer with future vertex updates.
             //TODO: let us know if we exceed and roll over to zero here.
             currentBufferIndex = (currentBufferIndex + 1) % maxBuffers;
-            currentVertexIndex = 0;
+            count = 0;
             changeBeginIndex = -1;
 
             FrameStatistics.Increment(StatisticsCounterType.DrawCalls);

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
@@ -126,6 +126,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private class FrameBufferTexture : GLTexture
         {
+            public override bool IsFrameBufferTexture => true;
+
             public FrameBufferTexture(GLRenderer renderer, All filteringMode = All.Linear)
                 : base(renderer, 1, 1, true, filteringMode)
             {

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
@@ -131,8 +131,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         {
             Bind(true);
 
-            int countVertices = endIndex - startIndex;
-            GL.DrawElements(Type, ToElements(countVertices), DrawElementsType.UnsignedShort, (IntPtr)(ToElementIndex(startIndex) * sizeof(ushort)));
+            Renderer.DrawVertices(Type, ToElementIndex(startIndex), ToElements(endIndex - startIndex));
         }
 
         public void Update()

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -50,8 +50,6 @@ namespace osu.Framework.Graphics.OpenGL
 
         private int backbufferFramebuffer;
 
-        protected override bool GammaCorrection => base.GammaCorrection || !IsEmbedded;
-
         private readonly int[] lastBoundBuffers = new int[2];
 
         private bool? lastBlendingEnabledState;

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -264,6 +264,9 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
                 if (programID != -1)
                     DeleteProgram(this);
+
+                foreach (var buf in textureAuxDataBuffers)
+                    buf.Dispose();
             }
         }
 

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
@@ -59,7 +59,8 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
             // After this transformation, the g_GlobalUniforms block is placed in set 0 and all other user blocks begin from 1.
             // The difference in implementation here (compared to above) is intentional, as uniform blocks must be consistent between the shader stages, so they can't be easily appended.
             for (int i = 0; i < shaderCodes.Count; i++)
-                shaderCodes[i] = uniform_pattern.Replace(shaderCodes[i], match => $"{match.Groups[1].Value}set = {int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture) + 1}{match.Groups[3].Value}");
+                shaderCodes[i] = uniform_pattern.Replace(shaderCodes[i],
+                    match => $"{match.Groups[1].Value}set = {int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture) + 1}{match.Groups[3].Value}");
         }
 
         private string loadFile(byte[] bytes, bool mainFile)
@@ -115,6 +116,12 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
                 {
                     string internalIncludes = loadFile(manager.LoadRaw("Internal/sh_Compatibility.h"), false) + "\n";
                     internalIncludes += loadFile(manager.LoadRaw("Internal/sh_GlobalUniforms.h"), false) + "\n";
+
+                    if (Type == ShaderType.VertexShader)
+                        internalIncludes += loadFile(manager.LoadRaw("Internal/sh_Vertex_Utils.h"), false) + "\n";
+                    else
+                        internalIncludes += loadFile(manager.LoadRaw("Internal/sh_Fragment_Utils.h"), false) + "\n";
+
                     code = internalIncludes + code;
 
                     if (Type == ShaderType.VertexShader)

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -221,6 +221,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// </summary>
         public bool IsQueuedForUpload { get; set; }
 
+        public virtual bool IsFrameBufferTexture => false;
+
         private bool tryGetNextUpload(out ITextureUpload upload)
         {
             lock (uploadQueue)

--- a/osu.Framework/Graphics/Rendering/AuxTextureData.cs
+++ b/osu.Framework/Graphics/Rendering/AuxTextureData.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Shaders.Types;
+
+namespace osu.Framework.Graphics.Rendering
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public record struct AuxTextureData
+    {
+        public UniformBool IsFrameBufferTexture;
+        private readonly UniformPadding12 pad1;
+    }
+}

--- a/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
+++ b/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
@@ -10,9 +10,10 @@ namespace osu.Framework.Graphics.Rendering
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public record struct GlobalUniformData
     {
-        public UniformBool GammaCorrection;
         public UniformBool BackbufferDraw;
-        private readonly UniformPadding8 pad1;
+        public UniformBool IsDepthRangeZeroToOne;
+        public UniformBool IsClipSpaceYInverted;
+        public UniformBool IsUvOriginTopLeft;
 
         public UniformMatrix4 ProjMatrix;
         public UniformMatrix3 ToMaskingSpace;
@@ -33,10 +34,5 @@ namespace osu.Framework.Graphics.Rendering
         public UniformFloat InnerCornerRadius;
         public UniformInt WrapModeS;
         public UniformInt WrapModeT;
-
-        public UniformBool IsDepthRangeZeroToOne;
-        public UniformBool IsClipSpaceYInverted;
-        public UniformBool IsUvOriginTopLeft;
-        private readonly UniformPadding4 pad4;
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -69,12 +69,6 @@ namespace osu.Framework.Graphics.Rendering
         public bool UsingBackbuffer => frameBufferStack.Count == 0;
         public Texture WhitePixel => whitePixel.Value;
 
-        /// <summary>
-        /// Whether this renderer should apply gamma correction (toSRGB/toLinear) functions in fragment shaders.
-        /// By default, this is only applied to the main framebuffer (i.e. "backbuffer").
-        /// </summary>
-        protected virtual bool GammaCorrection => UsingBackbuffer;
-
         public bool IsInitialised { get; private set; }
 
         protected ClearInfo CurrentClearInfo { get; private set; }
@@ -942,8 +936,7 @@ namespace osu.Framework.Graphics.Rendering
 
             globalUniformBuffer!.Data = globalUniformBuffer.Data with
             {
-                BackbufferDraw = UsingBackbuffer,
-                GammaCorrection = GammaCorrection,
+                BackbufferDraw = UsingBackbuffer
             };
 
             FrameBuffer = frameBuffer;

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -135,6 +135,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             protected override TextureUsage Usages => base.Usages | TextureUsage.RenderTarget;
 
+            protected override bool IsFrameBufferTexture => true;
+
             public FrameBufferTexture(VeldridRenderer renderer, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
                 : base(renderer, 1, 1, true, filteringMode)
             {

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
@@ -169,34 +169,11 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
                     if (layout.Elements.Any(e => e.Kind == ResourceKind.TextureReadOnly || e.Kind == ResourceKind.TextureReadWrite))
                     {
-                        // Todo: We should enforce that a texture set contains both a texture and a sampler.
-                        var textureElement = layout.Elements.First(e => e.Kind == ResourceKind.TextureReadOnly || e.Kind == ResourceKind.TextureReadWrite);
-                        var samplerElement = layout.Elements.First(e => e.Kind == ResourceKind.Sampler);
-
-                        textureLayouts.Add(new VeldridUniformLayout(
-                            set,
-                            renderer.Factory.CreateResourceLayout(
-                                new ResourceLayoutDescription(
-                                    new ResourceLayoutElementDescription(
-                                        textureElement.Name,
-                                        ResourceKind.TextureReadOnly,
-                                        ShaderStages.Fragment),
-                                    new ResourceLayoutElementDescription(
-                                        samplerElement.Name,
-                                        ResourceKind.Sampler,
-                                        ShaderStages.Fragment)))));
+                        bool hasAuxData = layout.Elements.Any(e => e.Kind == ResourceKind.UniformBuffer);
+                        textureLayouts.Add(new VeldridTextureUniformLayout(set, renderer.Factory.CreateResourceLayout(layout), hasAuxData));
                     }
                     else if (layout.Elements[0].Kind == ResourceKind.UniformBuffer)
-                    {
-                        uniformLayouts[layout.Elements[0].Name] = new VeldridUniformLayout(
-                            set,
-                            renderer.Factory.CreateResourceLayout(
-                                new ResourceLayoutDescription(
-                                    new ResourceLayoutElementDescription(
-                                        layout.Elements[0].Name,
-                                        ResourceKind.UniformBuffer,
-                                        ShaderStages.Fragment | ShaderStages.Vertex))));
-                    }
+                        uniformLayouts[layout.Elements[0].Name] = new VeldridUniformLayout(set, renderer.Factory.CreateResourceLayout(layout));
                 }
             }
             catch (SpirvCompilationException e)

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
@@ -107,6 +107,12 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                 {
                     string internalIncludes = loadFile(manager.LoadRaw("Internal/sh_Compatibility.h"), false) + "\n";
                     internalIncludes += loadFile(manager.LoadRaw("Internal/sh_GlobalUniforms.h"), false) + "\n";
+
+                    if (Type == ShaderPartType.Vertex)
+                        internalIncludes += loadFile(manager.LoadRaw("Internal/sh_Vertex_Utils.h"), false) + "\n";
+                    else
+                        internalIncludes += loadFile(manager.LoadRaw("Internal/sh_Fragment_Utils.h"), false) + "\n";
+
                     code = internalIncludes + code;
 
                     if (Type == ShaderPartType.Vertex)

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridTextureUniformLayout.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridTextureUniformLayout.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Shaders
+{
+    internal class VeldridTextureUniformLayout : VeldridUniformLayout
+    {
+        public readonly bool HasAuxData;
+
+        public VeldridTextureUniformLayout(int set, ResourceLayout layout, bool hasAuxData)
+            : base(set, layout)
+        {
+            HasAuxData = hasAuxData;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -321,8 +321,10 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 sampler = Renderer.Factory.CreateSampler(ref samplerDescription);
             }
 
-            resources = new VeldridTextureResources(texture, sampler);
+            resources = new VeldridTextureResources(texture, sampler, IsFrameBufferTexture);
         }
+
+        protected virtual bool IsFrameBufferTexture => false;
 
         private unsafe void initialiseLevel(Texture texture, int level, int width, int height)
         {

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Veldrid.Shaders;
 using Veldrid;
@@ -63,13 +64,6 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             Sampler.Dispose();
             auxDataBuffer?.Dispose();
             set?.Dispose();
-        }
-
-        [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        private record struct AuxTextureData
-        {
-            public UniformBool IsFrameBufferTexture;
-            private readonly UniformPadding12 pad1;
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
@@ -58,7 +58,8 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                             MinimumLod = 0,
                             MaximumLod = IRenderer.MAX_MIPMAP_LEVELS,
                             MaximumAnisotropy = 0,
-                        })
+                        }),
+                        false
                     );
 
                     textureSize += countPixels;

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -41,8 +41,6 @@ namespace osu.Framework.Graphics.Veldrid
             set => Device.AllowTearing = value;
         }
 
-        protected override bool GammaCorrection => true;
-
         public override bool IsDepthRangeZeroToOne => Device.IsDepthRangeZeroToOne;
         public override bool IsUvOriginTopLeft => Device.IsUvOriginTopLeft;
         public override bool IsClipSpaceYInverted => Device.IsClipSpaceYInverted;

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -41,6 +41,8 @@ namespace osu.Framework.Graphics.Veldrid
             set => Device.AllowTearing = value;
         }
 
+        protected override bool GammaCorrection => true;
+
         public override bool IsDepthRangeZeroToOne => Device.IsDepthRangeZeroToOne;
         public override bool IsUvOriginTopLeft => Device.IsUvOriginTopLeft;
         public override bool IsClipSpaceYInverted => Device.IsClipSpaceYInverted;
@@ -420,10 +422,10 @@ namespace osu.Framework.Graphics.Veldrid
             foreach (var (unit, texture) in boundTextureUnits)
             {
                 var layout = veldridShader.GetTextureLayout(unit);
-                if (layout == null)
+                if (layout is not VeldridTextureUniformLayout textureLayout)
                     continue;
 
-                Commands.SetGraphicsResourceSet((uint)layout.Set, texture.GetResourceSet(this, layout.Layout));
+                Commands.SetGraphicsResourceSet((uint)layout.Set, texture.GetResourceSet(this, textureLayout));
             }
 
             // Activate uniform buffer resources.

--- a/osu.Framework/Resources/Shaders/Internal/sh_Compatibility.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Compatibility.h
@@ -2,3 +2,31 @@
 
 #version 450
 #extension GL_ARB_uniform_buffer_object : enable
+#define GAMMA 2.4
+
+lowp float toLinear(lowp float color)
+{
+    return color <= 0.04045 ? (color / 12.92) : pow((color + 0.055) / 1.055, GAMMA);
+}
+
+lowp vec4 toLinear(lowp vec4 colour)
+{
+    return vec4(toLinear(colour.r), toLinear(colour.g), toLinear(colour.b), colour.a);
+}
+
+lowp float toSRGB(lowp float color)
+{
+    return color < 0.0031308 ? (12.92 * color) : (1.055 * pow(color, 1.0 / GAMMA) - 0.055);
+}
+
+lowp vec4 toSRGB(lowp vec4 colour)
+{
+    return vec4(toSRGB(colour.r), toSRGB(colour.g), toSRGB(colour.b), colour.a);
+    // The following implementation using mix and step may be faster, but stackoverflow indicates it is in fact a lot slower on some GPUs.
+    //return vec4(mix(colour.rgb * 12.92, 1.055 * pow(colour.rgb, vec3(1.0 / GAMMA)) - vec3(0.055), step(0.0031308, colour.rgb)), colour.a);
+}
+
+struct AuxTextureData
+{
+    bool IsFrameBufferTexture;
+};

--- a/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
@@ -1,0 +1,25 @@
+vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coord, float lodBias)
+{
+    vec4 col = texture(sampler2D(tex, samp), coord);
+
+    if (auxData.IsFrameBufferTexture)
+        col = toLinear(col);
+
+    return col;
+}
+
+vec4 sampleTexture(texture2D tex, sampler samp, vec2 coord, float lodBias)
+{
+    AuxTextureData auxData;
+    return sampleTexture(tex, samp, auxData, coord, lodBias);
+}
+
+vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coord)
+{
+    return sampleTexture(tex, samp, auxData, coord, 0.0);
+}
+
+vec4 sampleTexture(texture2D tex, sampler samp, vec2 coord)
+{
+    return sampleTexture(tex, samp, coord, 0.0);
+}

--- a/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
@@ -1,6 +1,6 @@
 vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coord, float lodBias)
 {
-    vec4 col = texture(sampler2D(tex, samp), coord);
+    vec4 col = texture(sampler2D(tex, samp), coord, lodBias);
 
     if (auxData.IsFrameBufferTexture)
         col = toLinear(col);

--- a/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Fragment_Utils.h
@@ -11,6 +11,8 @@ vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coo
 vec4 sampleTexture(texture2D tex, sampler samp, vec2 coord, float lodBias)
 {
     AuxTextureData auxData;
+    auxData.IsFrameBufferTexture = false;
+
     return sampleTexture(tex, samp, auxData, coord, lodBias);
 }
 

--- a/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
@@ -2,10 +2,18 @@
 
 layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
 {
-    bool g_GammaCorrection;
-
     // Whether the backbuffer is currently being drawn to.
     bool g_BackbufferDraw;
+
+    // Whether the depth values range from 0 to 1. If false, depth values range from -1 to 1.
+    // OpenGL uses [-1, 1], Vulkan/D3D/MTL all use [0, 1].
+    bool g_IsDepthRangeZeroToOne;
+
+    // Whether the clip space ranges from -1 (top) to 1 (bottom). If false, the clip space ranges from -1 (bottom) to 1 (top).
+    bool g_IsClipSpaceYInverted;
+
+    // Whether the texture coordinates begin in the top-left of the texture. If false, (0, 0) is the bottom-left texel of the texture.
+    bool g_IsUvOriginTopLeft;
 
     mat4 g_ProjMatrix;
     mat3 g_ToMaskingSpace;
@@ -28,14 +36,4 @@ layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
     // 3 -> Repeat
     int g_WrapModeS;
     int g_WrapModeT;
-
-    // Whether the depth values range from 0 to 1. If false, depth values range from -1 to 1.
-    // OpenGL uses [-1, 1], Vulkan/D3D/MTL all use [0, 1].
-    bool g_IsDepthRangeZeroToOne;
-
-    // Whether the clip space ranges from -1 (top) to 1 (bottom). If false, the clip space ranges from -1 (bottom) to 1 (top).
-    bool g_IsClipSpaceYInverted;
-
-    // Whether the texture coordinates begin in the top-left of the texture. If false, (0, 0) is the bottom-left texel of the texture.
-    bool g_IsUvOriginTopLeft;
 };

--- a/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Utils.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Utils.h
@@ -11,5 +11,7 @@ vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coo
 vec4 sampleTexture(texture2D tex, sampler samp, vec2 coord)
 {
     AuxTextureData auxData;
+    auxData.IsFrameBufferTexture = false;
+
     return sampleTexture(tex, samp, auxData, coord);
 }

--- a/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Utils.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Utils.h
@@ -1,0 +1,15 @@
+vec4 sampleTexture(texture2D tex, sampler samp, AuxTextureData auxData, vec2 coord)
+{
+    vec4 col = texture(sampler2D(tex, samp), coord);
+
+    if (auxData.IsFrameBufferTexture)
+        col = toLinear(col);
+
+    return col;
+}
+
+vec4 sampleTexture(texture2D tex, sampler samp, vec2 coord)
+{
+    AuxTextureData auxData;
+    return sampleTexture(tex, samp, auxData, coord);
+}

--- a/osu.Framework/Resources/Shaders/sh_Blur.fs
+++ b/osu.Framework/Resources/Shaders/sh_Blur.fs
@@ -14,6 +14,10 @@ layout(std140, set = 0, binding = 0) uniform m_BlurParameters
 
 layout(set = 1, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 1, binding = 1) uniform lowp sampler m_Sampler;
+layout(std140, set = 1, binding = 2) uniform m_TextureAuxData
+{
+    AuxTextureData m_TextureData;
+};
 
 layout(location = 0) out vec4 o_Colour;
 
@@ -25,7 +29,7 @@ mediump float computeGauss(in mediump float x, in mediump float sigma)
 lowp vec4 blur(int radius, highp vec2 direction, mediump vec2 texCoord, mediump vec2 texSize, mediump float sigma)
 {
 	mediump float factor = computeGauss(0.0, sigma);
-	mediump vec4 sum = texture(sampler2D(m_Texture, m_Sampler), texCoord) * factor;
+	mediump vec4 sum = sampleTexture(m_Texture, m_Sampler, m_TextureData, texCoord) * factor;
 
 	mediump float totalFactor = factor;
 
@@ -34,8 +38,8 @@ lowp vec4 blur(int radius, highp vec2 direction, mediump vec2 texCoord, mediump 
 		mediump float x = float(i) - 0.5;
 		factor = computeGauss(x, sigma) * 2.0;
 		totalFactor += 2.0 * factor;
-		sum += texture(sampler2D(m_Texture, m_Sampler), texCoord + direction * x / texSize) * factor;
-		sum += texture(sampler2D(m_Texture, m_Sampler), texCoord - direction * x / texSize) * factor;
+		sum += sampleTexture(m_Texture, m_Sampler, m_TextureData, texCoord + direction * x / texSize) * factor;
+		sum += sampleTexture(m_Texture, m_Sampler, m_TextureData, texCoord - direction * x / texSize) * factor;
 		if (i >= radius)
 			break;
 	}

--- a/osu.Framework/Resources/Shaders/sh_Blur.fs
+++ b/osu.Framework/Resources/Shaders/sh_Blur.fs
@@ -14,10 +14,7 @@ layout(std140, set = 0, binding = 0) uniform m_BlurParameters
 
 layout(set = 1, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 1, binding = 1) uniform lowp sampler m_Sampler;
-layout(std140, set = 1, binding = 2) uniform m_TextureAuxData
-{
-    AuxTextureData m_TextureData;
-};
+layout(std140, set = 1, binding = 2) uniform AuxData { AuxTextureData m_TextureData; };
 
 layout(location = 0) out vec4 o_Colour;
 

--- a/osu.Framework/Resources/Shaders/sh_Texture.fs
+++ b/osu.Framework/Resources/Shaders/sh_Texture.fs
@@ -6,11 +6,15 @@ layout(location = 2) in mediump vec2 v_TexCoord;
 
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
+layout(std140, set = 0, binding = 2) uniform m_TextureAuxData
+{
+    AuxTextureData m_TextureData;
+};
 
 layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
 {
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
-    o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
+    o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, m_TextureData, -0.9), wrappedCoord);
 }

--- a/osu.Framework/Resources/Shaders/sh_Texture.fs
+++ b/osu.Framework/Resources/Shaders/sh_Texture.fs
@@ -6,14 +6,11 @@ layout(location = 2) in mediump vec2 v_TexCoord;
 
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
 layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
-layout(std140, set = 0, binding = 2) uniform m_TextureAuxData
-{
-    AuxTextureData m_TextureData;
-};
+layout(std140, set = 0, binding = 2) uniform AuxData { AuxTextureData m_TextureData; };
 
 layout(location = 0) out vec4 o_Colour;
 
-void main(void) 
+void main(void)
 {
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, m_TextureData, -0.9), wrappedCoord);

--- a/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
+++ b/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
@@ -31,5 +31,7 @@ vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, samp
 vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, sampler wrapSampler, float lodBias)
 {
     AuxTextureData auxData;
+    auxData.IsFrameBufferTexture = false;
+
     return wrappedSampler(wrappedCoord, texRect, wrapTexture, wrapSampler, auxData, lodBias);
 }

--- a/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
+++ b/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
@@ -17,11 +17,19 @@ vec2 wrap(vec2 texCoord, vec4 texRect)
     return vec2(wrap(texCoord.x, g_WrapModeS, texRect[0], texRect[2]), wrap(texCoord.y, g_WrapModeT, texRect[1], texRect[3]));
 }
 
-vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, sampler wrapSampler, float lodBias)
+vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, sampler wrapSampler, AuxTextureData auxData, float lodBias)
 {
     if (g_WrapModeS == 2 && (wrappedCoord.x < texRect[0] || wrappedCoord.x > texRect[2]) ||
         g_WrapModeT == 2 && (wrappedCoord.y < texRect[1] || wrappedCoord.y > texRect[3]))
+    {
         return vec4(0.0);
+    }
 
-    return texture(sampler2D(wrapTexture, wrapSampler), wrappedCoord, lodBias);
+    return sampleTexture(wrapTexture, wrapSampler, auxData, wrappedCoord, lodBias);
+}
+
+vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, sampler wrapSampler, float lodBias)
+{
+    AuxTextureData auxData;
+    return wrappedSampler(wrappedCoord, texRect, wrapTexture, wrapSampler, auxData, lodBias);
 }

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -1,28 +1,4 @@
-﻿#define GAMMA 2.4
-
-lowp float toLinear(lowp float color)
-{
-    return color <= 0.04045 ? (color / 12.92) : pow((color + 0.055) / 1.055, GAMMA);
-}
-
-lowp vec4 toLinear(lowp vec4 colour)
-{
-    return g_GammaCorrection ? vec4(toLinear(colour.r), toLinear(colour.g), toLinear(colour.b), colour.a) : colour;
-}
-
-lowp float toSRGB(lowp float color)
-{
-    return color < 0.0031308 ? (12.92 * color) : (1.055 * pow(color, 1.0 / GAMMA) - 0.055);
-}
-
-lowp vec4 toSRGB(lowp vec4 colour)
-{
-    return g_GammaCorrection ? vec4(toSRGB(colour.r), toSRGB(colour.g), toSRGB(colour.b), colour.a) : colour;
-    // The following implementation using mix and step may be faster, but stackoverflow indicates it is in fact a lot slower on some GPUs.
-    //return vec4(mix(colour.rgb * 12.92, 1.055 * pow(colour.rgb, vec3(1.0 / GAMMA)) - vec3(0.055), step(0.0031308, colour.rgb)), colour.a);
-}
-
-// perform alpha compositing of two colour components.
+﻿// perform alpha compositing of two colour components.
 // see http://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha.html
 lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
 {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/22990

I'm going to let this one simmer for a bit and gather review comments.

When rendering to FBOs, every Veldrid-based renderer enables the equivalent of [`GL_FRAMEBUFFER_SRGB`](https://www.khronos.org/opengl/wiki/Framebuffer). This flag cannot be disabled on some renderers, and so I've also made our `GLRenderer` also enable it for FBOs.

How this flag works is hard to explain, but I'll try. The rendering process is as follows:

1. The shader _always_ operates in linear colour space. In order to do so, it makes two important decisions:
    1. It assumes that the colours output by the fragment shader are _already_ in linear space.
    2. It converts whatever colour's in the render target ("destination") to linear space.
2. Those two colours are blended.
3. The resultant colour is converted to sRGB and stored into the destination.

For us, the goal is to blend in sRGB colour space ([reading material](https://bottosson.github.io/posts/colorwrong/)). This is the "incorrect" way, but is the way that browsers and most image editing applications work.

By setting the `g_GammaCorrection` uniform to `true`, the fragment shader is made to always output sRGB colours. This is one step of the way there, and as a result the flag has been removed in this PR.

The second step, is a little bit confusing. To be able to blend in sRGB, the destination colour the shader reads must be sRGB post-its-conversion. The only way to do this is for the destination colour to be `(sRGB)^2`. This is done implicitly for us, as step (3) from the above, but has the annoying implication that if we bind a framebuffer as a texture, then it will also be in sRGB colour space for us!

The solution I've come up with is to have the flag `IsFrameBufferTexture` be passed along-side textures to shaders, which when `true` causes the shader to invoke one additional `toLinear()`. This is facilitated by the  `sampleTexture()` helper method which supports this additional argument.

The following shader changes are required to do gamma correction properly (to our specifications):
```diff
  #include "sh_Utils.h"
  #include "sh_Masking.h"
  #include "sh_TextureWrapping.h"

  layout(location = 2) in mediump vec2 v_TexCoord;

  layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
  layout(set = 0, binding = 1) uniform lowp sampler m_Sampler;
+ layout(std140, set = 0, binding = 2) uniform AuxData { AuxTextureData m_TextureData; };

 layout(location = 0) out vec4 o_Colour;

 void main(void)
 {
-    o_Colour = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord);
+    o_Colour = sampleTexture(m_Texture, m_Sampler, m_TextureData, v_TexCoord);
 }
```