### PR TITLE
Change `SupportedWindowModes` to non-bindable

### DIFF
--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Android
             SafeAreaPadding.BindTo(view.SafeAreaPadding);
         }
 
-        protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]
+        protected override IEnumerable<WindowMode> SupportedWindowModes => new[]
         {
             Configuration.WindowMode.Fullscreen,
         };

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Android
             SafeAreaPadding.BindTo(view.SafeAreaPadding);
         }
 
-        protected override IEnumerable<WindowMode> SupportedWindowModes => new[]
+        public override IEnumerable<WindowMode> SupportedWindowModes => new[]
         {
             Configuration.WindowMode.Fullscreen,
         };

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// The <see cref="WindowMode"/>s supported by this <see cref="IWindow"/> implementation.
         /// </summary>
-        IBindableList<WindowMode> SupportedWindowModes { get; }
+        IEnumerable<WindowMode> SupportedWindowModes { get; }
 
         /// <summary>
         /// Provides a <see cref="Bindable{WindowMode}"/> that manages the current window mode.

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -150,8 +150,6 @@ namespace osu.Framework.Platform
             MouseEnter += (_, _) => cursorInWindow.Value = true;
             MouseLeave += (_, _) => cursorInWindow.Value = false;
 
-            supportedWindowModes.AddRange(DefaultSupportedWindowModes);
-
             UpdateFrame += (_, _) => UpdateFrameScheduler.Update();
 
             graphicsSurface = new OsuTKGraphicsSurface(this);
@@ -257,9 +255,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual BindableSafeArea SafeAreaPadding { get; } = new BindableSafeArea();
 
-        private readonly BindableList<WindowMode> supportedWindowModes = new BindableList<WindowMode>();
-
-        public IBindableList<WindowMode> SupportedWindowModes => supportedWindowModes;
+        public IEnumerable<WindowMode> SupportedWindowModes => DefaultSupportedWindowModes;
 
         public virtual WindowMode DefaultWindowMode => SupportedWindowModes.First();
 

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -255,11 +255,9 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual BindableSafeArea SafeAreaPadding { get; } = new BindableSafeArea();
 
-        public IEnumerable<WindowMode> SupportedWindowModes => DefaultSupportedWindowModes;
+        public abstract IEnumerable<WindowMode> SupportedWindowModes { get; }
 
         public virtual WindowMode DefaultWindowMode => SupportedWindowModes.First();
-
-        protected abstract IEnumerable<WindowMode> DefaultSupportedWindowModes { get; }
 
         public virtual VSyncMode VSync { get; set; }
 

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -189,7 +189,6 @@ namespace osu.Framework.Platform
             SDL.SDL_LogSetOutputFunction(logOutputDelegate = logOutput, IntPtr.Zero);
 
             graphicsSurface = new SDL2GraphicsSurface(this, surfaceType);
-            SupportedWindowModes = new BindableList<WindowMode>(DefaultSupportedWindowModes);
 
             CursorStateBindable.ValueChanged += evt =>
             {

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -135,7 +135,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Returns the window modes that the platform should support by default.
         /// </summary>
-        protected virtual IEnumerable<WindowMode> DefaultSupportedWindowModes
+        public virtual IEnumerable<WindowMode> SupportedWindowModes
         {
             get
             {
@@ -222,8 +222,6 @@ namespace osu.Framework.Platform
         private readonly BindableBool cursorInWindow = new BindableBool();
 
         public IBindable<bool> CursorInWindow => cursorInWindow;
-
-        public IEnumerable<WindowMode> SupportedWindowModes { get; }
 
         private bool visible;
 

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -132,9 +132,7 @@ namespace osu.Framework.Platform
 
         public WindowMode DefaultWindowMode => RuntimeInfo.IsMobile ? Configuration.WindowMode.Fullscreen : Configuration.WindowMode.Windowed;
 
-        /// <summary>
-        /// Returns the window modes that the platform should support by default.
-        /// </summary>
+        /// <inheritdoc />
         public virtual IEnumerable<WindowMode> SupportedWindowModes
         {
             get

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Platform
 
         public IBindable<bool> CursorInWindow => cursorInWindow;
 
-        public IBindableList<WindowMode> SupportedWindowModes { get; }
+        public IEnumerable<WindowMode> SupportedWindowModes { get; }
 
         private bool visible;
 


### PR DESCRIPTION
# Breaking changes

## `IWindow.SupportedWindowModes` type changed from `IBindableList<WindowMode>` to `IEnumerable<WindowMode>`

The property being bindable had mostly no use, as generally the list of supported modes will not change while the game is running, so there is no benefit to having it bindable.

Consumers that are broken by this change (due to using the property in bindable flow) can safely enumerate `SupportedWindowModes` at initialisation time without having to worry about the returned set of modes ever changing during game operation.