### PR TITLE
Fix Veldrid failing to initialise on Wayland

### DIFF
--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -119,7 +119,7 @@ namespace osu.Framework.Platform
                         return wmInfo.info.uikit.window;
 
                     case SDL.SDL_SYSWM_TYPE.SDL_SYSWM_WAYLAND:
-                        return wmInfo.info.wl.shell_surface;
+                        return wmInfo.info.wl.surface;
 
                     case SDL.SDL_SYSWM_TYPE.SDL_SYSWM_ANDROID:
                         return wmInfo.info.android.window;


### PR DESCRIPTION
wl_shell_surface is a part of wl_shell, which is a deprecated protocol and isn't supported by the majority of compositors today

I'm not sure why commit 37a3331473d37c9c895df746d94f379b28f90008 made this mistake (maybe SDL2 documentation wasn't clear about wl_shell?)

This mistake wasn't really relevant until recently, when Veldrid renderer started using this variable for creating a Wayland surface on Vulkan (which was always empty and so ended up crashing Mesa's Wayland Vulkan WSI code when creating a swapchain)

This change fixes Vulkan renderer crashes when SDL is using the Wayland video driver (I personally tested this on a debug build of osu! and it works)