### PR TITLE
Fix `Quad.Contains()` not working with clockwise-oriented quads

### DIFF
--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -122,6 +122,47 @@ namespace osu.Framework.Tests.Primitives
             Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
         }
 
+        [Test]
+        public void TestFromNegativeSizedRectangle()
+        {
+            var rectangle = new RectangleF(-5, 5, 10, -10);
+            var quad = Quad.FromRectangle(rectangle);
+
+            Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
+
+            Assert.That(quad.Contains(new Vector2(-5, -5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(-5, 5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(5, -5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(5, 5)), Is.True);
+
+            Assert.That(quad.Contains(new Vector2(-15, -15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(-15, 15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(15, -15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(15, 15)), Is.False);
+        }
+
+        [Test]
+        public void TestFlippedQuad()
+        {
+            var quad = new Quad(-5, -5, 10, 10);
+            quad *= new Matrix3(
+                -1, 0, 0,
+                0, 1, 0,
+                0, 0, 1);
+
+            Assert.That(quad.Contains(new Vector2(0, 0)), Is.True);
+
+            Assert.That(quad.Contains(new Vector2(-5, -5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(-5, 5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(5, -5)), Is.True);
+            Assert.That(quad.Contains(new Vector2(5, 5)), Is.True);
+
+            Assert.That(quad.Contains(new Vector2(-15, -15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(-15, 15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(15, -15)), Is.False);
+            Assert.That(quad.Contains(new Vector2(15, 15)), Is.False);
+        }
+
         private class AreaTestData
         {
             public static IEnumerable TestCases

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -113,6 +113,7 @@ namespace osu.Framework.Graphics.Primitives
         /// <remarks>
         /// <para>
         /// This method assumes a convex quad. The convexity of the quad is not checked.
+        /// Vertices of the quad as returned by <see cref="GetVertices"/> must be arranged either in clockwise or counter-clockwise order.
         /// </para>
         /// <para>
         /// The method works by checking whether the point lies on the same side of all four sides of the quad.
@@ -126,10 +127,38 @@ namespace osu.Framework.Graphics.Primitives
             if (Width == 0 && Height == 0)
                 return pos == TopLeft;
 
-            return Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft) <= 0
-                   && Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft) <= 0
-                   && Vector2.PerpDot(TopRight - BottomRight, pos - BottomRight) <= 0
-                   && Vector2.PerpDot(TopLeft - TopRight, pos - TopRight) <= 0;
+            // to check if the point is inside the quad, we will calculate on which side of each quad segment the tested point is using the sign of the perp dot product.
+            // note that the order in which we walk the segments matters - it must be clockwise or counterclockwise.
+            // in theory quads should always be CCW (see note at top of class), but this is not necessarily true after applying negative horizontal or vertical scale.
+            // if the signs all match (all positive or negative), then the point is inside of the quad.
+            // a zero perp dot anywhere means that the point lies on one of the lines going through one of the quad sides, so zeroes are treated like positive values.
+
+            // we test if two perp dots have matching signs by multiplying them and testing against 0.
+            // if the result is positive, both perp dots were nonzero and had matching signs => don't reject point.
+            // if the result is zero, one (or both) perp dots was zero, so the point may lie on the quad boundary => don't reject point.
+            // if the result is negative, both perp dots were nonzero and had different signs => reject point.
+
+            // note that we don't generally care about overflows there as long as the sign is right.
+            // however, NaN values may come from Infinity - Infinity subtractions in `Vector2.PerpDot`.
+            // there's not much good left to be done in such cases, so we err on the side of caution and reject points that generate any NaNs on sight.
+
+            float perpDot1 = Vector2.PerpDot(BottomLeft - TopLeft, pos - TopLeft);
+            if (float.IsNaN(perpDot1))
+                return false;
+
+            float perpDot2 = Vector2.PerpDot(BottomRight - BottomLeft, pos - BottomLeft);
+            if (float.IsNaN(perpDot2) || perpDot1 * perpDot2 < 0)
+                return false;
+
+            float perpDot3 = Vector2.PerpDot(TopRight - BottomRight, pos - BottomRight);
+            if (float.IsNaN(perpDot3) || perpDot1 * perpDot3 < 0 || perpDot2 * perpDot3 < 0)
+                return false;
+
+            float perpDot4 = Vector2.PerpDot(TopLeft - TopRight, pos - TopRight);
+            if (float.IsNaN(perpDot4) || perpDot1 * perpDot4 < 0 || perpDot2 * perpDot4 < 0 || perpDot3 * perpDot4 < 0)
+                return false;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23042

Hopefully the last one of these... I'll let the diff do most of the talking here, as I added a huge explanatory inline comment to attempt to explain what is going on in the new implementation. Scrutiny is however both warranted and welcome.

## Benchmarking

### Before

|   Method | NumPoints |        Mean |     Error |    StdDev | Allocated |
|--------- |---------- |------------:|----------:|----------:|----------:|
| Contains |        10 |    72.03 ns |  1.437 ns |  2.479 ns |         - |
| Contains |       100 |   661.56 ns |  9.191 ns |  8.147 ns |         - |
| Contains |      1000 | 6,723.38 ns | 33.804 ns | 28.228 ns |         - |

### After

|   Method | NumPoints |        Mean |      Error |     StdDev | Allocated |
|--------- |---------- |------------:|-----------:|-----------:|----------:|
| Contains |        10 |    78.49 ns |   1.575 ns |   2.632 ns |         - |
| Contains |       100 |   736.67 ns |  12.492 ns |  16.676 ns |         - |
| Contains |      1000 | 7,688.50 ns | 152.251 ns | 203.250 ns |         - |

Ever so slightly slower, but not by much.