### PR TITLE
Fix Veldrid OpenGL not working on iOS and bring back as valid

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
@@ -127,11 +127,11 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                     Array.Empty<byte>(),
                     renderer.Factory.BackendType == GraphicsBackend.Metal ? "main0" : "main");
 
-                // GLSL cross compile is always performed for reflection, even though the cross-compiled shaders aren't used under Vulkan.
+                // GLSL cross compile is always performed for reflection, even though the cross-compiled shaders aren't used under other backends.
                 VertexFragmentCompilationResult crossCompileResult = SpirvCompilation.CompileVertexFragment(
                     Encoding.UTF8.GetBytes(vertex.GetRawText()),
                     Encoding.UTF8.GetBytes(fragment.GetRawText()),
-                    CrossCompileTarget.GLSL);
+                    RuntimeInfo.IsMobile ? CrossCompileTarget.ESSL : CrossCompileTarget.GLSL);
 
                 if (renderer.SurfaceType == GraphicsSurfaceType.Vulkan)
                 {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Development;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
@@ -20,6 +21,7 @@ using osuTK;
 using SixLabors.ImageSharp.PixelFormats;
 using Veldrid;
 using Veldrid.OpenGL;
+using Veldrid.OpenGLBinding;
 using PixelFormat = Veldrid.PixelFormat;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
@@ -153,8 +155,7 @@ namespace osu.Framework.Graphics.Veldrid
             {
                 case GraphicsSurfaceType.OpenGL:
                     var openGLGraphics = (IOpenGLGraphicsSurface)graphicsSurface;
-
-                    Device = GraphicsDevice.CreateOpenGL(options, new OpenGLPlatformInfo(
+                    var openGLInfo = new OpenGLPlatformInfo(
                         openGLContextHandle: openGLGraphics.WindowContext,
                         getProcAddress: openGLGraphics.GetProcAddress,
                         makeCurrent: openGLGraphics.MakeCurrent,
@@ -162,8 +163,11 @@ namespace osu.Framework.Graphics.Veldrid
                         clearCurrentContext: openGLGraphics.ClearCurrent,
                         deleteContext: openGLGraphics.DeleteContext,
                         swapBuffers: openGLGraphics.SwapBuffers,
-                        setSyncToVerticalBlank: v => openGLGraphics.VerticalSync = v), swapchain.Width, swapchain.Height);
+                        setSyncToVerticalBlank: v => openGLGraphics.VerticalSync = v,
+                        setSwapchainFramebuffer: () => OpenGLNative.glBindFramebuffer(FramebufferTarget.Framebuffer, (uint)openGLGraphics.BackbufferFramebuffer.AsNonNull()),
+                        null);
 
+                    Device = GraphicsDevice.CreateOpenGL(options, openGLInfo, swapchain.Width, swapchain.Height);
                     Device.LogOpenGL(out maxTextureSize);
                     break;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -837,16 +837,15 @@ namespace osu.Framework.Platform
             }
 
             // See https://github.com/ppy/osu/issues/23003
-            // See https://github.com/ppy/osu/issues/22978
             if (RuntimeInfo.OS != RuntimeInfo.Platform.iOS)
             {
                 // Non-veldrid "known-to-work".
                 yield return RendererType.OpenGLLegacy;
-
-                // Other available renderers should also be returned (to make this method usable as "all available renderers for current platform"),
-                // but will never be preferred as OpenGLLegacy will always work.
-                yield return RendererType.OpenGL;
             }
+
+            // Other available renderers should also be returned (to make this method usable as "all available renderers for current platform"),
+            // but will never be preferred as OpenGLLegacy will always work.
+            yield return RendererType.OpenGL;
 
             if (!RuntimeInfo.IsApple) yield return RendererType.Vulkan;
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/22978

I didn't intend on spending much time on this one, but I realised the cause was too simple that it's better to fix as a fallback rather than leaving it broken for later.

Interestingly, the [`Path` rendering issue](https://github.com/ppy/osu/issues/23003) doesn't actually occur with Veldrid OpenGL, so the cause of that one may very well lie within the `GLRenderer` implementation (potentially a specific GL call that isn't supported on iOS).