### PR TITLE
Add Veldrid screenshot support

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -342,7 +342,7 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.Disable(EnableCap.StencilTest);
         }
 
-        public override Image<Rgba32> TakeScreenshot()
+        protected internal override Image<Rgba32> TakeScreenshot()
         {
             var size = ((IGraphicsSurface)openGLSurface).GetDrawableSize();
             var data = MemoryAllocator.Default.Allocate<Rgba32>(size.Width * size.Height);

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -176,8 +176,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
 
         public void ScheduleDisposal<T>(Action<T> disposalAction, T target) => disposalAction(target);
 
-        public Image<Rgba32> TakeScreenshot()
-            => new Image<Rgba32>(1366, 768);
+        Image<Rgba32> IRenderer.TakeScreenshot() => new Image<Rgba32>(1366, 768);
 
         IShaderPart IRenderer.CreateShaderPart(ShaderManager manager, string name, byte[]? rawData, ShaderPartType partType)
             => new DummyShaderPart();

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -9,7 +9,9 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osuTK;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Graphics.Rendering.Dummy
 {
@@ -173,6 +175,9 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public void ScheduleExpensiveOperation(ScheduledDelegate operation) => operation.RunTask();
 
         public void ScheduleDisposal<T>(Action<T> disposalAction, T target) => disposalAction(target);
+
+        public Image<Rgba32> TakeScreenshot()
+            => new Image<Rgba32>(1366, 768);
 
         IShaderPart IRenderer.CreateShaderPart(ShaderManager manager, string name, byte[]? rawData, ShaderPartType partType)
             => new DummyShaderPart();

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -331,7 +331,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// Returns an image containing the current content of the backbuffer, i.e. takes a screenshot.
         /// </summary>
-        Image<Rgba32> TakeScreenshot();
+        protected internal Image<Rgba32> TakeScreenshot();
 
         /// <summary>
         /// Creates a new <see cref="IShaderPart"/>.

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
+using SixLabors.ImageSharp;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -326,6 +327,11 @@ namespace osu.Framework.Graphics.Rendering
         /// <param name="disposalAction">The disposal action.</param>
         /// <param name="target">The target to be disposed.</param>
         void ScheduleDisposal<T>(Action<T> disposalAction, T target);
+
+        /// <summary>
+        /// Returns an image containing the current content of the backbuffer, i.e. takes a screenshot.
+        /// </summary>
+        Image<Rgba32> TakeScreenshot();
 
         /// <summary>
         /// Creates a new <see cref="IShaderPart"/>.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -312,7 +312,10 @@ namespace osu.Framework.Graphics.Rendering
                 disposalAction.Invoke(target);
         }
 
-        public abstract Image<Rgba32> TakeScreenshot();
+        /// <summary>
+        /// Returns an image containing the current content of the backbuffer, i.e. takes a screenshot.
+        /// </summary>
+        protected internal abstract Image<Rgba32> TakeScreenshot();
 
         /// <summary>
         /// Sets the current draw depth.
@@ -1104,6 +1107,7 @@ namespace osu.Framework.Graphics.Rendering
         void IRenderer.SetDrawDepth(float drawDepth) => SetDrawDepth(drawDepth);
         void IRenderer.PushQuadBatch(IVertexBatch<TexturedVertex2D> quadBatch) => PushQuadBatch(quadBatch);
         void IRenderer.PopQuadBatch() => PopQuadBatch();
+        Image<Rgba32> IRenderer.TakeScreenshot() => TakeScreenshot();
         IShaderPart IRenderer.CreateShaderPart(ShaderManager manager, string name, byte[]? rawData, ShaderPartType partType) => CreateShaderPart(manager, name, rawData, partType);
         IShader IRenderer.CreateShader(string name, IShaderPart[] parts) => CreateShader(name, parts, globalUniformBuffer!);
 

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -22,7 +22,9 @@ using osu.Framework.Threading;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -309,6 +311,8 @@ namespace osu.Framework.Graphics.Rendering
             else
                 disposalAction.Invoke(target);
         }
+
+        public abstract Image<Rgba32> TakeScreenshot();
 
         /// <summary>
         /// Sets the current draw depth.

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -500,7 +500,10 @@ namespace osu.Framework.Graphics.Veldrid
 
                 default:
                 {
-                    using var staging = Factory.CreateTexture(TextureDescription.Texture2D(texture.Width, texture.Height, 1, 1, texture.Format, TextureUsage.Staging));
+                    uint width = texture.Width;
+                    uint height = texture.Height;
+
+                    using var staging = Factory.CreateTexture(TextureDescription.Texture2D(width, height, 1, 1, texture.Format, TextureUsage.Staging));
                     using var commands = Factory.CreateCommandList();
                     using var fence = Factory.CreateFence(false);
 
@@ -513,10 +516,17 @@ namespace osu.Framework.Graphics.Veldrid
                     var resource = Device.Map(staging, MapMode.Read);
                     var span = new Span<Bgra32>(resource.Data.ToPointer(), (int)(resource.SizeInBytes / Marshal.SizeOf<Bgra32>()));
 
-                    using var image = Image.LoadPixelData<Bgra32>(span, (int)staging.Width, (int)staging.Height);
+                    // on some backends (Direct3D11, in particular), the staging resource data may contain padding at the end of each row for alignment,
+                    // which means that for the image width, we cannot use the framebuffer's width raw.
+                    using var image = Image.LoadPixelData<Bgra32>(span, (int)(resource.RowPitch / Marshal.SizeOf<Bgra32>()), (int)height);
 
                     if (!Device.IsUvOriginTopLeft)
                         image.Mutate(i => i.Flip(FlipMode.Vertical));
+
+                    // if the image width doesn't match the framebuffer, it means that we still have padding at the end of each row mentioned above to get rid of.
+                    // snip it to get a clean image.
+                    if (image.Width != width)
+                        image.Mutate(i => i.Crop((int)width, (int)height));
 
                     Device.Unmap(staging);
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
@@ -17,9 +18,13 @@ using osu.Framework.Graphics.Veldrid.Shaders;
 using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Statistics;
 using osuTK;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using Veldrid;
 using Veldrid.OpenGL;
+using Veldrid.OpenGLBinding;
+using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = Veldrid.PixelFormat;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
@@ -466,6 +471,58 @@ namespace osu.Framework.Graphics.Veldrid
             }
 
             return instance;
+        }
+
+        public override unsafe Image<Rgba32> TakeScreenshot()
+        {
+            var texture = Device.SwapchainFramebuffer.ColorTargets[0].Target;
+
+            switch (graphicsSurface.Type)
+            {
+                // Veldrid doesn't support copying content from a swapchain framebuffer texture on OpenGL.
+                // OpenGL already provides a method for reading pixels directly from the active framebuffer, so let's just use that for now.
+                case GraphicsSurfaceType.OpenGL:
+                {
+                    var pixelData = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<Rgba32>((int)(texture.Width * texture.Height));
+
+                    var info = Device.GetOpenGLInfo();
+
+                    info.ExecuteOnGLThread(() =>
+                    {
+                        fixed (Rgba32* data = pixelData.Memory.Span)
+                            OpenGLNative.glReadPixels(0, 0, texture.Width, texture.Height, GLPixelFormat.Rgba, GLPixelType.UnsignedByte, data);
+                    });
+
+                    var glImage = Image.LoadPixelData<Rgba32>(pixelData.Memory.Span, (int)texture.Width, (int)texture.Height);
+                    glImage.Mutate(i => i.Flip(FlipMode.Vertical));
+                    return glImage;
+                }
+
+                default:
+                {
+                    using var staging = Factory.CreateTexture(TextureDescription.Texture2D(texture.Width, texture.Height, 1, 1, texture.Format, TextureUsage.Staging));
+                    using var commands = Factory.CreateCommandList();
+                    using var fence = Factory.CreateFence(false);
+
+                    commands.Begin();
+                    commands.CopyTexture(texture, staging);
+                    commands.End();
+                    Device.SubmitCommands(commands, fence);
+                    Device.WaitForFence(fence);
+
+                    var resource = Device.Map(staging, MapMode.Read);
+                    var span = new Span<Bgra32>(resource.Data.ToPointer(), (int)(resource.SizeInBytes / Marshal.SizeOf<Bgra32>()));
+
+                    using var image = Image.LoadPixelData<Bgra32>(span, (int)staging.Width, (int)staging.Height);
+
+                    if (!Device.IsUvOriginTopLeft)
+                        image.Mutate(i => i.Flip(FlipMode.Vertical));
+
+                    Device.Unmap(staging);
+
+                    return image.CloneAs<Rgba32>();
+                }
+            }
         }
 
         protected override IShaderPart CreateShaderPart(ShaderManager manager, string name, byte[]? rawData, ShaderPartType partType)

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -473,7 +473,7 @@ namespace osu.Framework.Graphics.Veldrid
             return instance;
         }
 
-        public override unsafe Image<Rgba32> TakeScreenshot()
+        protected internal override unsafe Image<Rgba32> TakeScreenshot()
         {
             var texture = Device.SwapchainFramebuffer.ColorTargets[0].Target;
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.2-ge26e1137e5" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.2-g4640e52628" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gc5e8498253" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/22959
- [x] Depends on https://github.com/mellinoe/veldrid/pull/493 (rebased in https://github.com/ppy/veldrid/pull/7)
- [x] Depends on https://github.com/mellinoe/veldrid/pull/494

As per the issue thread, this follows a simple approach of reading backbuffer pixels by copying the swapchain texture to a staging buffer and mapping it for CPU read.

Tested to work on OpenGL, D3D11, and Metal. Vulkan may require further changes against Veldrid according to [an old PR that's achieving similar to what my PRs above achieve](https://github.com/mellinoe/veldrid/pull/363).