### PR TITLE
Update veldrid again to fix direct x crash

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.2-g4640e52628" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.2-g0ec05acb9b" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gc5e8498253" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
See https://github.com/ppy/veldrid/commit/0ec05acb9b7ed04649f57ef979548bcfb5797694 (diff applied from discord discussion).