### PR TITLE
Fix non-legacy OpenGL sometimes flickering/freezing

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -167,11 +167,7 @@ namespace osu.Framework.Graphics.Veldrid
                         deleteContext: openGLGraphics.DeleteContext,
                         swapBuffers: openGLGraphics.SwapBuffers,
                         setSyncToVerticalBlank: v => openGLGraphics.VerticalSync = v,
-                        setSwapchainFramebuffer: () =>
-                        {
-                            if (openGLGraphics.BackbufferFramebuffer != null)
-                                OpenGLNative.glBindFramebuffer(FramebufferTarget.Framebuffer, (uint)openGLGraphics.BackbufferFramebuffer);
-                        },
+                        setSwapchainFramebuffer: () => OpenGLNative.glBindFramebuffer(FramebufferTarget.Framebuffer, (uint)(openGLGraphics.BackbufferFramebuffer ?? 0)),
                         null);
 
                     Device = GraphicsDevice.CreateOpenGL(options, openGLInfo, swapchain.Width, swapchain.Height);


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/issues/23088, can't test it right now.

When `setSwapchainFramebuffer` is non-null, Veldrid will always use it without falling back to `glBindFramebuffer(0)`. Therefore we should fall back to binding to framebuffer 0 ourselves rather than returning without binding anything.