### PR TITLE
Improve performance of video texture uploads

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -331,7 +331,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             Commands.CopyTexture(
                 staging, 0, 0, 0, 0, 0,
-                texture, (uint)x, (uint)y, 0, 0, 0, (uint)width, (uint)height, 1, 1);
+                texture, (uint)x, (uint)y, 0, (uint)level, 0, (uint)width, (uint)height, 1, 1);
         }
 
         protected override void SetShaderImplementation(IShader shader)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/22970

It's not the most that can be done, because Veldrid doesn't expose interfaces to do this sort of alignment, and although it seems possible in at least D3D, it's something I don't want to do unless absolutely necessary. This is already between 1-2 magnitudes faster for me, just in this one block nevermind GL execution time which is hard to profile.

I want confirmation that this fixes the issue before merge, though.

Also would be good to test this on mobile platforms.