### PR TITLE
Improve texture shader performance on fragments away from corners

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -110,15 +110,17 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	highp float borderStart = 1.0 + fadeStart - g_BorderThickness;
 	lowp float colourWeight = min(borderStart - dist, 1.0);
 
+	lowp vec4 contentColour = v_Colour * texel;
+
+	if (colourWeight == 1.0)
+		return vec4(contentColour.rgb, contentColour.a * alphaFactor);
+
 	lowp vec4 borderColour = getBorderColour();
 
 	if (colourWeight <= 0.0)
-	{
 		return vec4(borderColour.rgb, borderColour.a * alphaFactor);
-	}
 
-	lowp vec4 dest = vec4(v_Colour.rgb, v_Colour.a * alphaFactor) * texel;
-	lowp vec4 src = vec4(borderColour.rgb, borderColour.a * (1.0 - colourWeight));
-
-	return blend(src, dest);
+	contentColour.a *= alphaFactor;
+	borderColour.a *= 1.0 - colourWeight;
+	return blend(borderColour, contentColour);
 }


### PR DESCRIPTION
Computing the border colour is a bit of an expensive operation, and on vertices with a high number of fragments, could lead to a reduction in performance.

When the "colour weight" is equal to one, the border colour is completely ignored. So I've let it early-return with the texel colour before computing the border colour if so. I've also renamed the locals to better describe them rather than the generic `dest`/`src` names. 

Profiling on Metal with Xcode's instrument tools shows ~25% gain, as can be seen below:
| Before | After |
|--------|-------|
| ![CleanShot 2023-04-08 at 08 58 46](https://user-images.githubusercontent.com/22781491/230706220-82d6b213-dddc-484e-a071-cf88448c0156.png) | ![CleanShot 2023-04-08 at 08 54 59](https://user-images.githubusercontent.com/22781491/230706229-82349d06-f292-4914-91d1-bbf7c593385c.png) |

Testing with:
```diff
diff --git a/SampleGame/SampleGameGame.cs b/SampleGame/SampleGameGame.cs
index df0e0a91e..2cfff2a32 100644
--- a/SampleGame/SampleGameGame.cs
+++ b/SampleGame/SampleGameGame.cs
@@ -7,29 +7,35 @@
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 
 namespace SampleGame
 {
     public partial class SampleGameGame : Game
     {
-        private Box box = null!;
+        private Container box = null!;
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(box = new Box
+            Add(box = new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(150, 150),
-                Colour = Color4.Tomato
+                Size = new Vector2(1000, 1000),
+                Colour = Color4.Tomato,
+                CornerRadius = 75f,
+                MaskingSmoothness = 3f,
+                BorderThickness = 20f,
+                BorderColour = Color4.Lime,
+                Masking = true,
+                Child = new Box { RelativeSizeAxes = Axes.Both },
             });
         }
 
         protected override void Update()
         {
             base.Update();
-            box.Rotation += (float)Time.Elapsed / 10;

```
