### PR TITLE
Fix incorrect VBO start index

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -131,7 +131,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             Bind();
 
             int countVertices = endIndex - startIndex;
-            renderer.DrawVertices(Type, ToElementIndex(startIndex) * sizeof(ushort), ToElements(countVertices));
+            renderer.DrawVertices(Type, ToElementIndex(startIndex), ToElements(countVertices));
 
             Unbind();
         }


### PR DESCRIPTION
This only came up due to further performance investigations that attempt to fill VBOs instead, which requires non-zero `startIndex`. The value is pinned to zero in all current use cases, so this doesn't have any immediate effects.