### PR TITLE
Refactor Veldrid VBO storages to speed up data upload commands on Metal

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -15,13 +15,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         where T : unmanaged, IEquatable<T>, IVertex
     {
         private readonly VeldridRenderer renderer;
-        private readonly int amountVertices;
 
         internal VeldridLinearBuffer(VeldridRenderer renderer, int amountVertices, PrimitiveTopology type, BufferUsage usage)
             : base(renderer, amountVertices, usage)
         {
             this.renderer = renderer;
-            this.amountVertices = amountVertices;
             Type = type;
 
             if (amountVertices > renderer.SharedLinearIndex.Capacity)

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -23,11 +23,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             this.renderer = renderer;
             this.amountVertices = amountVertices;
             Type = type;
-        }
-
-        protected override void Initialise()
-        {
-            base.Initialise();
 
             if (amountVertices > renderer.SharedLinearIndex.Capacity)
             {

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -30,11 +30,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             this.renderer = renderer;
             amountIndices = amountQuads * indices_per_quad;
             Debug.Assert(amountIndices <= ushort.MaxValue);
-        }
-
-        protected override void Initialise()
-        {
-            base.Initialise();
 
             if (amountIndices > renderer.SharedQuadIndex.Capacity)
             {

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -2,15 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Vertices;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
-using SixLabors.ImageSharp.Memory;
 using Veldrid;
 using BufferUsage = Veldrid.BufferUsage;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
@@ -23,20 +22,40 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         protected static readonly int STRIDE = VeldridVertexUtils<DepthWrappingVertex<T>>.STRIDE;
 
         private readonly VeldridRenderer renderer;
-        private readonly BufferUsage usage;
+        private readonly DeviceBuffer buffer;
 
-        private Memory<DepthWrappingVertex<T>> vertexMemory;
-        private IMemoryOwner<DepthWrappingVertex<T>>? memoryOwner;
-        private NativeMemoryTracker.NativeMemoryLease? memoryLease;
+        private readonly DeviceBuffer stagingBuffer;
+        private readonly MappedResource stagingResource;
 
-        private DeviceBuffer? buffer;
+        // todo: need MemoryManager<T> for unmanaged resources to use Memory<T> instead of a pointer and make this safe.
+        private readonly unsafe DepthWrappingVertex<T>* memory;
+        private readonly NativeMemoryTracker.NativeMemoryLease memoryLease;
 
-        protected VeldridVertexBuffer(VeldridRenderer renderer, int amountVertices, BufferUsage usage)
+        public ulong LastUseResetId { get; private set; }
+
+        public bool InUse => LastUseResetId > 0;
+
+        /// <summary>
+        /// Gets the number of vertices in this <see cref="VeldridVertexBuffer{T}"/>.
+        /// </summary>
+        public int Size { get; }
+
+        protected abstract PrimitiveTopology Type { get; }
+
+        protected unsafe VeldridVertexBuffer(VeldridRenderer renderer, int amountVertices, BufferUsage usage)
         {
             this.renderer = renderer;
-            this.usage = usage;
 
             Size = amountVertices;
+
+            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage));
+            stagingBuffer = renderer.Factory.CreateBuffer(new BufferDescription(buffer.SizeInBytes, BufferUsage.Staging));
+            stagingResource = renderer.Device.Map(stagingBuffer, MapMode.ReadWrite);
+
+            memory = (DepthWrappingVertex<T>*)stagingResource.Data.ToPointer();
+            memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
+
+            Unsafe.InitBlock(memory, 0, buffer.SizeInBytes);
         }
 
         /// <summary>
@@ -45,9 +64,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// <param name="vertexIndex">The index of the vertex.</param>
         /// <param name="vertex">The vertex.</param>
         /// <returns>Whether the vertex changed.</returns>
-        public bool SetVertex(int vertexIndex, T vertex)
+        public unsafe bool SetVertex(int vertexIndex, T vertex)
         {
-            ref var currentVertex = ref getMemory().Span[vertexIndex];
+            ref var currentVertex = ref memory[vertexIndex];
 
             bool isNewVertex = !currentVertex.Vertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != renderer.BackbufferDrawDepth;
 
@@ -57,55 +76,10 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             return isNewVertex;
         }
 
-        /// <summary>
-        /// Gets the number of vertices in this <see cref="VeldridVertexBuffer{T}"/>.
-        /// </summary>
-        public int Size { get; }
-
-        /// <summary>
-        /// Initialises this <see cref="VeldridVertexBuffer{T}"/>. Guaranteed to be run on the draw thread.
-        /// </summary>
-        protected virtual void Initialise()
-        {
-            ThreadSafety.EnsureDrawThread();
-
-            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage));
-            memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
-
-            // Ensure the device buffer is initialised to 0.
-            Update();
-        }
-
-        ~VeldridVertexBuffer()
-        {
-            renderer.ScheduleDisposal(v => v.Dispose(false), this);
-        }
-
-        public void Dispose()
-        {
-            renderer.ScheduleDisposal(v => v.Dispose(true), this);
-            GC.SuppressFinalize(this);
-        }
-
-        protected bool IsDisposed { get; private set; }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (IsDisposed)
-                return;
-
-            ((IVertexBuffer)this).Free();
-
-            IsDisposed = true;
-        }
-
         public virtual void Bind()
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not bind disposed vertex buffers.");
-
-            if (buffer == null)
-                Initialise();
 
             Debug.Assert(buffer != null);
             renderer.BindVertexBuffer(buffer, VeldridVertexUtils<DepthWrappingVertex<T>>.Layout);
@@ -114,12 +88,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public virtual void Unbind()
         {
         }
-
-        protected virtual int ToElements(int vertices) => vertices;
-
-        protected virtual int ToElementIndex(int vertexIndex) => vertexIndex;
-
-        protected abstract PrimitiveTopology Type { get; }
 
         public void Draw()
         {
@@ -143,49 +111,47 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public void UpdateRange(int startIndex, int endIndex)
         {
-            if (buffer == null)
-                Initialise();
-
             int countVertices = endIndex - startIndex;
-            renderer.BufferUpdateCommands.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
+            renderer.BufferUpdateCommands.CopyBuffer(stagingBuffer, (uint)(startIndex * STRIDE), buffer, (uint)(startIndex * STRIDE), (uint)(countVertices * STRIDE));
 
             FrameStatistics.Add(StatisticsCounterType.VerticesUpl, countVertices);
         }
 
-        private ref Memory<DepthWrappingVertex<T>> getMemory()
-        {
-            ThreadSafety.EnsureDrawThread();
+        protected virtual int ToElements(int vertices) => vertices;
 
-            if (!InUse)
-            {
-                memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<DepthWrappingVertex<T>>(Size, AllocationOptions.Clean);
-                vertexMemory = memoryOwner.Memory;
-
-                renderer.RegisterVertexBufferUse(this);
-            }
-
-            LastUseResetId = renderer.ResetId;
-
-            return ref vertexMemory;
-        }
-
-        public ulong LastUseResetId { get; private set; }
-
-        public bool InUse => LastUseResetId > 0;
+        protected virtual int ToElementIndex(int vertexIndex) => vertexIndex;
 
         public void Free()
         {
-            memoryLease?.Dispose();
-            memoryLease = null;
+            renderer.Device.Unmap(stagingResource.Resource);
 
-            buffer?.Dispose();
-            buffer = null;
-
-            memoryOwner?.Dispose();
-            memoryOwner = null;
-            vertexMemory = Memory<DepthWrappingVertex<T>>.Empty;
-
+            memoryLease.Dispose();
+            buffer.Dispose();
+            stagingBuffer.Dispose();
             LastUseResetId = 0;
+        }
+
+        ~VeldridVertexBuffer()
+        {
+            renderer.ScheduleDisposal(v => v.Dispose(false), this);
+        }
+
+        public void Dispose()
+        {
+            renderer.ScheduleDisposal(v => v.Dispose(true), this);
+            GC.SuppressFinalize(this);
+        }
+
+        protected bool IsDisposed { get; private set; }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (IsDisposed)
+                return;
+
+            ((IVertexBuffer)this).Free();
+
+            IsDisposed = true;
         }
     }
 }


### PR DESCRIPTION
Initially, the VBO implementation was a straight-up copy pasta from `GLRenderer` and it was working well for the most part. Now, upon profiling on Metal, it turns out that every call to `Commands.UpdateBuffer` fires up a staging buffer (from a pool now) and calls `MTLBuffer.contents` which has some overhead when used in a hot path.

One way to avoid the frequent calls to `contents` would be to store a staging buffer and use `Commands.CopyBuffer` instead, which directly encodes a [`copy`](https://developer.apple.com/documentation/metal/mtlblitcommandencoder/1400767-copy) command without extra API calls.

Now, using `UpdateBuffer` on the staging buffer alone still won't avoid the overhead of `contents`, so I've mapped it to CPU using `Device.Map` (which is essentially just returning `contents`) and used the pointer directly for uploading vertices.

I've also removed the memory storage allocated with ImageSharp in favour of the staging buffer.

I had considered removing the staging buffer and directly mapping the vertex buffer itself since it's always created with "shared" storage mode, but that violates Veldrid's public API and even when bypassing that, it doesn't really add any more gains compared to the approach done here.