### PR TITLE
Avoid enumerable/enumerator allocation when fetching texture resources on Veldrid

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -158,15 +158,15 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         #endregion
 
-        private readonly VeldridTextureResources[] resourcesArray = new VeldridTextureResources[1];
+        private readonly VeldridTextureResources?[] resourcesArray = new VeldridTextureResources?[1];
 
-        private VeldridTextureResources resources
+        private VeldridTextureResources? resources
         {
             get => resourcesArray[0];
             set => resourcesArray[0] = value;
         }
 
-        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => resourcesArray;
+        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => (VeldridTextureResources[])resourcesArray;
 
         public void FlushUploads()
         {

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -166,7 +166,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             set => resourcesArray[0] = value;
         }
 
-        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => (VeldridTextureResources[])resourcesArray;
+        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => resourcesArray!;
 
         public void FlushUploads()
         {

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -158,7 +158,15 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         #endregion
 
-        private VeldridTextureResources? resources;
+        private readonly VeldridTextureResources[] resourcesArray = new VeldridTextureResources[1];
+
+        private VeldridTextureResources resources
+        {
+            get => resourcesArray[0];
+            set => resourcesArray[0] = value;
+        }
+
+        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => resourcesArray;
 
         public void FlushUploads()
         {
@@ -192,12 +200,6 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 BindCount++;
 
             return true;
-        }
-
-        public virtual IEnumerable<VeldridTextureResources> GetResourceList()
-        {
-            if (resources != null)
-                yield return resources;
         }
 
         public bool Upload()

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             }
         }
 
-        public override IEnumerable<VeldridTextureResources> GetResourceList() => resourceList.AsNonNull();
+        public override IReadOnlyList<VeldridTextureResources> GetResourceList() => resourceList.AsNonNull();
 
         #region Disposal
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -268,8 +268,10 @@ namespace osu.Framework.Graphics.Veldrid
             if (texture is not VeldridTexture veldridTexture)
                 return false;
 
-            foreach (var res in veldridTexture.GetResourceList())
-                boundTextureUnits[unit++] = res;
+            var resources = veldridTexture.GetResourceList();
+
+            for (int i = 0; i < resources.Count; i++)
+                boundTextureUnits[unit++] = resources[i];
 
             return true;
         }


### PR DESCRIPTION
Before:

![CleanShot 2023-04-15 at 14 17 55](https://user-images.githubusercontent.com/22781491/232210782-b1cc2516-d262-4381-b4e1-693a703ca50a.png)

After:

![CleanShot 2023-04-15 at 14 22 28](https://user-images.githubusercontent.com/22781491/232211344-39323024-8e4a-4728-9cc3-b2fbdf924c76.png)
