### PR TITLE
Upload Veldrid VBOs directly rather than using a command list

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -147,7 +147,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 Initialise();
 
             int countVertices = endIndex - startIndex;
-            renderer.BufferUpdateCommands.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
+            renderer.Device.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
 
             FrameStatistics.Add(StatisticsCounterType.VerticesUpl, countVertices);
         }


### PR DESCRIPTION
- Alternative to / closes #5740 

On Metal, encoding a buffer copy command comes with an overhead, and that overhead becomes noticeable on frequently updated buffers (aka "dynamic").

Since we update our vertex buffers pretty much every single frame, it's wiser to update them directly from the CPU rather than encoding a copy command every time.

In addition, since we're updating vertex buffers directly from the CPU, we must ensure it shouldn't be read from the GPU. Simple triple-buffering logic should help with that, but note that it increases the memory usage to triple times its original size in return (maybe double-buffering is better?).

If the memory usage here turns out to have taken a bad turn, then this PR can be ignored for the time being (potentially wait for https://github.com/ppy/osu-framework/pull/5109).

Before:

![CleanShot 2023-04-15 at 18 10 05](https://user-images.githubusercontent.com/22781491/232233663-e009bfa6-cd00-459a-86c8-d306f18c8ac2.png)

After:

![CleanShot 2023-04-15 at 18 10 01](https://user-images.githubusercontent.com/22781491/232233674-9b68267a-7878-4f6d-9bf3-eb8ee948b3cf.png)
