### PR TITLE
Move FBO content population to a separate pass and enable "memoryless" storage mode on Metal

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -34,10 +34,11 @@ namespace osu.Framework.Graphics
 
         protected RectangleF DrawRectangle { get; private set; }
 
+        protected Vector2 FrameBufferSize { get; private set; }
+
         private Color4 backgroundColour;
         private RectangleF screenSpaceDrawRectangle;
         private Vector2 frameBufferScale;
-        private Vector2 frameBufferSize;
         private IDrawable rootNodeCached;
 
         public BufferedDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData)
@@ -58,9 +59,9 @@ namespace osu.Framework.Graphics
 
             clipDrawRectangle();
 
-            frameBufferSize = new Vector2(MathF.Ceiling(screenSpaceDrawRectangle.Width * frameBufferScale.X), MathF.Ceiling(screenSpaceDrawRectangle.Height * frameBufferScale.Y));
+            FrameBufferSize = new Vector2(MathF.Ceiling(screenSpaceDrawRectangle.Width * frameBufferScale.X), MathF.Ceiling(screenSpaceDrawRectangle.Height * frameBufferScale.Y));
             DrawRectangle = SharedData.PixelSnapping
-                ? new RectangleF(screenSpaceDrawRectangle.X, screenSpaceDrawRectangle.Y, frameBufferSize.X, frameBufferSize.Y)
+                ? new RectangleF(screenSpaceDrawRectangle.X, screenSpaceDrawRectangle.Y, FrameBufferSize.X, FrameBufferSize.Y)
                 : screenSpaceDrawRectangle;
 
             Child.ApplyState();
@@ -83,36 +84,6 @@ namespace osu.Framework.Graphics
 
         public sealed override void Draw(IRenderer renderer)
         {
-            if (!SharedData.IsInitialised)
-                SharedData.Initialise(renderer);
-
-            if (RequiresRedraw)
-            {
-                FrameStatistics.Increment(StatisticsCounterType.FBORedraw);
-
-                SharedData.ResetCurrentEffectBuffer();
-
-                using (establishFrameBufferViewport(renderer))
-                {
-                    // Fill the frame buffer with drawn children
-                    using (BindFrameBuffer(SharedData.MainBuffer))
-                    {
-                        // We need to draw children as if they were zero-based to the top-left of the texture.
-                        // We can do this by adding a translation component to our (orthogonal) projection matrix.
-                        renderer.PushOrtho(screenSpaceDrawRectangle);
-                        renderer.Clear(new ClearInfo(backgroundColour));
-
-                        Child.Draw(renderer);
-
-                        renderer.PopOrtho();
-                    }
-
-                    PopulateContents(renderer);
-                }
-
-                SharedData.DrawVersion = GetDrawVersion();
-            }
-
             BindTextureShader(renderer);
 
             base.Draw(renderer);
@@ -121,12 +92,53 @@ namespace osu.Framework.Graphics
             UnbindTextureShader(renderer);
         }
 
+        protected override void PopulateFrameBuffers(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer)
+        {
+            base.PopulateFrameBuffers(renderer, bindFrameBuffer);
+
+            if (!RequiresRedraw)
+                return;
+
+            if (!SharedData.IsInitialised)
+                SharedData.Initialise(renderer);
+
+            SharedData.ResetCurrentEffectBuffer();
+
+            FrameStatistics.Increment(StatisticsCounterType.FBORedraw);
+
+            // If there are any nested buffered draw nodes, make sure they're populated before beginning to draw them to this frame buffer.
+            Child.PopulateFrameBuffers(renderer);
+
+            // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
+            SharedData.MainBuffer.Size = FrameBufferSize;
+
+            using (establishFrameBufferViewport(renderer))
+            {
+                // Fill the frame buffer with drawn children
+                using (bindFrameBuffer(SharedData.MainBuffer))
+                {
+                    // We need to draw children as if they were zero-based to the top-left of the texture.
+                    // We can do this by adding a translation component to our (orthogonal) projection matrix.
+                    renderer.PushOrtho(screenSpaceDrawRectangle);
+                    renderer.Clear(new ClearInfo(backgroundColour));
+
+                    Child.Draw(renderer);
+
+                    renderer.PopOrtho();
+                }
+
+                PopulateContents(renderer, bindFrameBuffer);
+            }
+
+            SharedData.DrawVersion = GetDrawVersion();
+        }
+
         /// <summary>
-        /// Populates the contents of the effect buffers of <see cref="SharedData"/>.
-        /// This is invoked after <see cref="Child"/> has been rendered to the main buffer.
+        /// Populates the contents of the <see cref="SharedData"/>.
         /// </summary>
-        /// <param name="renderer"></param>
-        protected virtual void PopulateContents(IRenderer renderer)
+        /// <param name="renderer">The renderer to populate the frame buffer with.</param>
+        /// <param name="bindFrameBuffer">The function for binding <see cref="IFrameBuffer"/>s with the renderer. For optimal performance, <see cref="IFrameBuffer"/>s should only be bound once during the frame.</param>
+        protected virtual void PopulateContents(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer)
         {
         }
 
@@ -139,28 +151,13 @@ namespace osu.Framework.Graphics
             renderer.DrawFrameBuffer(SharedData.MainBuffer, DrawRectangle, DrawColourInfo.Colour);
         }
 
-        /// <summary>
-        /// Binds and initialises an <see cref="IFrameBuffer"/> if required.
-        /// </summary>
-        /// <param name="frameBuffer">The <see cref="IFrameBuffer"/> to bind.</param>
-        /// <returns>A token that must be disposed upon finishing use of <paramref name="frameBuffer"/>.</returns>
-        protected IDisposable BindFrameBuffer(IFrameBuffer frameBuffer)
-        {
-            // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
-            frameBuffer.Size = frameBufferSize;
-
-            frameBuffer.Bind();
-
-            return new ValueInvokeOnDisposal<IFrameBuffer>(frameBuffer, b => b.Unbind());
-        }
-
         private IDisposable establishFrameBufferViewport(IRenderer renderer)
         {
             // Disable masking for generating the frame buffer since masking will be re-applied
             // when actually drawing later on anyways. This allows more information to be captured
             // in the frame buffer and helps with cached buffers being re-used.
-            RectangleI screenSpaceMaskingRect = new RectangleI((int)Math.Floor(screenSpaceDrawRectangle.X), (int)Math.Floor(screenSpaceDrawRectangle.Y), (int)frameBufferSize.X + 1,
-                (int)frameBufferSize.Y + 1);
+            RectangleI screenSpaceMaskingRect = new RectangleI((int)Math.Floor(screenSpaceDrawRectangle.X), (int)Math.Floor(screenSpaceDrawRectangle.Y), (int)FrameBufferSize.X + 1,
+                (int)FrameBufferSize.Y + 1);
 
             renderer.PushMaskingInfo(new MaskingInfo
             {
@@ -172,8 +169,8 @@ namespace osu.Framework.Graphics
             }, true);
 
             // Match viewport to FrameBuffer such that we don't draw unnecessary pixels.
-            renderer.PushViewport(new RectangleI(0, 0, (int)frameBufferSize.X, (int)frameBufferSize.Y));
-            renderer.PushScissor(new RectangleI(0, 0, (int)frameBufferSize.X, (int)frameBufferSize.Y));
+            renderer.PushViewport(new RectangleI(0, 0, (int)FrameBufferSize.X, (int)FrameBufferSize.Y));
+            renderer.PushScissor(new RectangleI(0, 0, (int)FrameBufferSize.X, (int)FrameBufferSize.Y));
             renderer.PushScissorOffset(screenSpaceMaskingRect.Location);
 
             return new ValueInvokeOnDisposal<(BufferedDrawNode node, IRenderer renderer)>((this, renderer), tup => tup.node.returnViewport(tup.renderer));

--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -74,16 +75,16 @@ namespace osu.Framework.Graphics.Containers
 
             protected override long GetDrawVersion() => updateVersion;
 
-            protected override void PopulateContents(IRenderer renderer)
+            protected override void PopulateContents(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer)
             {
-                base.PopulateContents(renderer);
+                base.PopulateContents(renderer, bindFrameBuffer);
 
                 if (blurRadius.X > 0 || blurRadius.Y > 0)
                 {
                     renderer.PushScissorState(false);
 
-                    if (blurRadius.X > 0) drawBlurredFrameBuffer(renderer, blurRadius.X, blurSigma.X, blurRotation);
-                    if (blurRadius.Y > 0) drawBlurredFrameBuffer(renderer, blurRadius.Y, blurSigma.Y, blurRotation + 90);
+                    if (blurRadius.X > 0) drawBlurredFrameBuffer(renderer, bindFrameBuffer, blurRadius.X, blurSigma.X, blurRotation);
+                    if (blurRadius.Y > 0) drawBlurredFrameBuffer(renderer, bindFrameBuffer, blurRadius.Y, blurSigma.Y, blurRotation + 90);
 
                     renderer.PopScissorState();
                 }
@@ -108,7 +109,7 @@ namespace osu.Framework.Graphics.Containers
             private IUniformBuffer<BlurParameters> blurParametersBuffer;
             private IVertexBatch<BlurVertex> blurQuadBatch;
 
-            private void drawBlurredFrameBuffer(IRenderer renderer, int kernelRadius, float sigma, float blurRotation)
+            private void drawBlurredFrameBuffer(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer, int kernelRadius, float sigma, float blurRotation)
             {
                 blurParametersBuffer ??= renderer.CreateUniformBuffer<BlurParameters>();
                 blurQuadBatch ??= renderer.CreateQuadBatch<BlurVertex>(1, 1);
@@ -118,7 +119,9 @@ namespace osu.Framework.Graphics.Containers
 
                 renderer.SetBlend(BlendingParameters.None);
 
-                using (BindFrameBuffer(target))
+                target.Size = FrameBufferSize;
+
+                using (bindFrameBuffer(target))
                 {
                     float radians = MathUtils.DegreesToRadians(blurRotation);
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -10,6 +10,7 @@ using osuTK;
 using osu.Framework.Graphics.Colour;
 using System;
 using System.Runtime.CompilerServices;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -256,6 +257,17 @@ namespace osu.Framework.Graphics.Containers
                     if (quadBatch != null)
                         renderer.PopQuadBatch();
                 }
+            }
+
+            protected override void PopulateFrameBuffers(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer)
+            {
+                if (Children != null)
+                {
+                    for (int i = 0; i < Children.Count; i++)
+                        Children[i].PopulateFrameBuffers(renderer);
+                }
+
+                base.PopulateFrameBuffers(renderer, bindFrameBuffer);
             }
 
             protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Rendering;
 
 namespace osu.Framework.Graphics
@@ -128,6 +129,28 @@ namespace osu.Framework.Graphics
         protected virtual void DrawOpaqueInterior(IRenderer renderer)
         {
             renderer.SetDrawDepth(drawDepth);
+        }
+
+        /// <summary>
+        /// Populates all <see cref="IFrameBuffer"/>s belonging to this <see cref="DrawNode"/> with content.
+        /// </summary>
+        /// <param name="renderer">The renderer to populate frame buffers with.</param>
+        public void PopulateFrameBuffers(IRenderer renderer) => PopulateFrameBuffers(renderer, bindFrameBuffer);
+
+        /// <summary>
+        /// Populates all <see cref="IFrameBuffer"/>s belonging to this <see cref="DrawNode"/> with content.
+        /// </summary>
+        /// <param name="renderer">The renderer to populate frame buffers with.</param>
+        /// <param name="bindFrameBuffer">The function for binding <see cref="IFrameBuffer"/>s with the renderer. For optimal performance, <see cref="IFrameBuffer"/>s should only be bound once during the frame.</param>
+        protected virtual void PopulateFrameBuffers(IRenderer renderer, Func<IFrameBuffer, ValueInvokeOnDisposal<IFrameBuffer>> bindFrameBuffer)
+        {
+        }
+
+        private static ValueInvokeOnDisposal<IFrameBuffer> bindFrameBuffer(IFrameBuffer frameBuffer)
+        {
+            frameBuffer.Bind();
+
+            return new ValueInvokeOnDisposal<IFrameBuffer>(frameBuffer, b => b.Unbind());
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// Binds the framebuffer.
         /// <para>Does not clear the buffer or reset the viewport/ortho.</para>
         /// </summary>
-        public void Bind()
+        void IFrameBuffer.Bind()
         {
             renderer.BindFrameBuffer(this);
 
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// <summary>
         /// Unbinds the framebuffer.
         /// </summary>
-        public void Unbind()
+        void IFrameBuffer.Unbind()
         {
             // See: https://community.arm.com/developer/tools-software/graphics/b/blog/posts/mali-performance-2-how-to-correctly-handle-framebuffers
             // Unbinding renderbuffers causes an invalidation of the relevant attachment of this framebuffer on embedded devices, causing the renderbuffers to remain transient.

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -239,7 +239,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <param name="frameBuffer">The frame buffer to delete.</param>
         public void DeleteFrameBuffer(IFrameBuffer frameBuffer)
         {
-            while (FrameBuffer == frameBuffer)
+            if (FrameBuffer == frameBuffer)
                 UnbindFrameBuffer(frameBuffer);
 
             ScheduleDisposal(GL.DeleteFramebuffer, ((GLFrameBuffer)frameBuffer).FrameBuffer);

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyFrameBuffer.cs
@@ -29,11 +29,11 @@ namespace osu.Framework.Graphics.Rendering.Dummy
             Texture = new Texture(new DummyNativeTexture(renderer), WrapMode.None, WrapMode.None);
         }
 
-        public void Bind()
+        void IFrameBuffer.Bind()
         {
         }
 
-        public void Unbind()
+        void IFrameBuffer.Unbind()
         {
         }
 

--- a/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
@@ -23,11 +23,11 @@ namespace osu.Framework.Graphics.Rendering
         /// Binds the framebuffer.
         /// <para>Does not clear the buffer or reset the viewport/ortho.</para>
         /// </summary>
-        void Bind();
+        protected internal void Bind();
 
         /// <summary>
         /// Unbinds the framebuffer.
         /// </summary>
-        void Unbind();
+        protected internal void Unbind();
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -68,7 +68,7 @@ namespace osu.Framework.Graphics.Rendering
         public WrapMode CurrentWrapModeT { get; private set; }
         public bool IsMaskingActive => maskingStack.Count > 1;
         public float BackbufferDrawDepth { get; private set; }
-        public bool UsingBackbuffer => frameBufferStack.Count == 0;
+        public bool UsingBackbuffer => FrameBuffer == null;
         public Texture WhitePixel => whitePixel.Value;
 
         public bool IsInitialised { get; private set; }
@@ -113,7 +113,6 @@ namespace osu.Framework.Graphics.Rendering
         private readonly Stack<DepthInfo> depthStack = new Stack<DepthInfo>();
         private readonly Stack<StencilInfo> stencilStack = new Stack<StencilInfo>();
         private readonly Stack<Vector2I> scissorOffsetStack = new Stack<Vector2I>();
-        private readonly Stack<IFrameBuffer> frameBufferStack = new Stack<IFrameBuffer>();
         private readonly Stack<IShader> shaderStack = new Stack<IShader>();
         private readonly Stack<bool> scissorStateStack = new Stack<bool>();
 
@@ -222,7 +221,6 @@ namespace osu.Framework.Graphics.Rendering
             projectionMatrixStack.Clear();
             maskingStack.Clear();
             scissorRectStack.Clear();
-            frameBufferStack.Clear();
             depthStack.Clear();
             stencilStack.Clear();
             scissorStateStack.Clear();
@@ -927,17 +925,21 @@ namespace osu.Framework.Graphics.Rendering
 
         public void BindFrameBuffer(IFrameBuffer frameBuffer)
         {
-            frameBufferStack.Push(frameBuffer);
+            if (FrameBuffer != null)
+            {
+                throw new InvalidOperationException("Attempting to bind a frame buffer while another one is still bound."
+                                                    + "Binding the same frame buffer more than once per frame may result in unexpected behaviour.");
+            }
+
             setFrameBuffer(frameBuffer);
         }
 
         public void UnbindFrameBuffer(IFrameBuffer frameBuffer)
         {
             if (FrameBuffer != frameBuffer)
-                return;
+                throw new InvalidOperationException("Attempting to unbind a frame buffer that is not bound currently.");
 
-            frameBufferStack.Pop();
-            setFrameBuffer(frameBufferStack.TryPeek(out var lastFramebuffer) ? lastFramebuffer : null);
+            setFrameBuffer(null);
         }
 
         private void setFrameBuffer(IFrameBuffer? frameBuffer, bool force = false)
@@ -948,10 +950,9 @@ namespace osu.Framework.Graphics.Rendering
             FlushCurrentBatch(FlushBatchSource.SetFrameBuffer);
 
             SetFrameBufferImplementation(frameBuffer);
+            FrameBuffer = frameBuffer;
 
             globalUniformBuffer!.Data = globalUniformBuffer.Data with { BackbufferDraw = UsingBackbuffer };
-
-            FrameBuffer = frameBuffer;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -86,8 +86,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             // Check if we need to rebind this framebuffer as a result of recreating it.
             if (renderer.IsFrameBufferBound(this))
             {
-                Unbind();
-                Bind();
+                renderer.UnbindFrameBuffer(this);
+                renderer.BindFrameBuffer(this);
             }
         }
 
@@ -106,8 +106,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             depthTarget?.Dispose();
         }
 
-        public void Bind() => renderer.BindFrameBuffer(this);
-        public void Unbind() => renderer.UnbindFrameBuffer(this);
+        void IFrameBuffer.Bind() => renderer.BindFrameBuffer(this);
+        void IFrameBuffer.Unbind() => renderer.UnbindFrameBuffer(this);
 
         ~VeldridFrameBuffer()
         {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -186,7 +186,7 @@ namespace osu.Framework.Graphics.Veldrid
                     break;
 
                 case GraphicsSurfaceType.Metal:
-                    Device = GraphicsDevice.CreateMetal(options, swapchain);
+                    Device = GraphicsDevice.CreateMetal(options, swapchain, new MetalDeviceOptions { PreferMemorylessDepthTargets = true });
                     Device.LogMetal(out maxTextureSize);
                     break;
             }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -481,7 +481,7 @@ namespace osu.Framework.Graphics.Veldrid
         /// <param name="frameBuffer">The frame buffer to delete.</param>
         public void DeleteFrameBuffer(VeldridFrameBuffer frameBuffer)
         {
-            while (FrameBuffer == frameBuffer)
+            if (FrameBuffer == frameBuffer)
                 UnbindFrameBuffer(frameBuffer);
 
             frameBuffer.DeleteResources(true);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -492,6 +492,9 @@ namespace osu.Framework.Platform
                 using (drawMonitor.BeginCollecting(PerformanceCollectionType.DrawReset))
                     Renderer.BeginFrame(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
 
+                // Frame buffers pass
+                buffer.Object.PopulateFrameBuffers(Renderer);
+
                 if (!bypassFrontToBackPass.Value)
                 {
                     depthValue.Reset();


### PR DESCRIPTION
I'll preface this by mentioning that I don't seem to notice that much of a gain on my phone, but I'm PR'ing this anyway as it saves GPU memory bandwidth according to Xcode.

Until now, we've always been switching between framebuffers in the middle of a render pass, which was pretty much fine with OpenGL. But with Metal, switching a framebuffer requires ending the current render pass and beginning a new one, therefore unnecessarily increasing the number of render passes in a frame, potentially along with the bandwidth of loading and storing framebuffer attachments from/to tile memory.

This PR moves away any logic that involves binding a framebuffer to a separate pass that occurs before the main render pass, and enables using ["memoryless" storage mode](https://developer.apple.com/documentation/metal/mtlstoragemode/memoryless) for depth/stencil attachments on Metal (only affects Apple GPUs), therefore saving the bandwidth of unnecessarily storing depth/stencil content into system memory (which we were forced to do previously because `BufferedDrawNode`s were interrupting the main render pass, making the backbuffer lose its depth content and break depth testing).

## vNext
### `IFrameBuffer.Bind`/`BufferedDrawNode.BindFramebuffer` is no longer available

For optimal performance, `IFrameBuffer`s should not be bound anywhere freely. Instead, we've defined a new render pass specific for populating frame buffers with content.

The new render pass iterates through `DrawNode.PopulateFrameBuffers()`. Consumers should override the method for binding frame buffers and populating them.