### PR TITLE
Disable "memoryless" storage mode for now and fix potential mipmap generation crash

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -250,15 +250,19 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 } while (mergeFound);
 
                 // Mipmap generation using the merged upload regions follows
-                using var frameBuffer = new GLFrameBuffer(Renderer, this);
-
+                IFrameBuffer previousFrameBuffer = Renderer.FrameBuffer;
                 BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
+
+                if (previousFrameBuffer != null)
+                    Renderer.UnbindFrameBuffer(previousFrameBuffer);
 
                 // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
                 Renderer.SetBlend(BlendingParameters.None);
                 Renderer.PushDepthInfo(new DepthInfo(false, false));
                 Renderer.PushStencilInfo(new StencilInfo(false));
                 Renderer.PushScissorState(false);
+
+                using var frameBuffer = new GLFrameBuffer(Renderer, this);
 
                 Renderer.BindFrameBuffer(frameBuffer);
 
@@ -333,6 +337,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Renderer.SetBlend(previousBlendingParameters);
 
                 Renderer.UnbindFrameBuffer(frameBuffer);
+
+                if (previousFrameBuffer != null)
+                    Renderer.BindFrameBuffer(previousFrameBuffer);
 
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, 0);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, IRenderer.MAX_MIPMAP_LEVELS);

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -87,7 +87,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The current framebuffer, or null if the backbuffer is used.
         /// </summary>
-        protected IFrameBuffer? FrameBuffer { get; private set; }
+        protected internal IFrameBuffer? FrameBuffer { get; private set; }
 
         /// <summary>
         /// The current shader, or null if no shader is currently bound.

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -260,7 +260,13 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 } while (mergeFound);
 
                 // Mipmap generation using the merged upload regions follows
+                IFrameBuffer? previousFrameBuffer = Renderer.FrameBuffer;
                 BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
+
+                // todo: this won't work once we use memoryless storage mode on metal, in which unbinding a framebuffer makes its lose its depth/stencil content.
+                // this should probably be moved into a separate command list or otherwise once that's required.
+                if (previousFrameBuffer != null)
+                    Renderer.UnbindFrameBuffer(previousFrameBuffer);
 
                 // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
                 Renderer.SetBlend(BlendingParameters.None);
@@ -356,6 +362,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 Renderer.PopDepthInfo();
 
                 Renderer.SetBlend(previousBlendingParameters);
+
+                if (previousFrameBuffer != null)
+                    Renderer.BindFrameBuffer(previousFrameBuffer);
             }
 
             // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -187,7 +187,7 @@ namespace osu.Framework.Graphics.Veldrid
                     break;
 
                 case GraphicsSurfaceType.Metal:
-                    Device = GraphicsDevice.CreateMetal(options, swapchain, new MetalDeviceOptions { PreferMemorylessDepthTargets = true });
+                    Device = GraphicsDevice.CreateMetal(options, swapchain);
                     Device.LogMetal(out maxTextureSize);
                     break;
             }


### PR DESCRIPTION
As per https://github.com/ppy/osu-framework/pull/5745#issuecomment-1511063628, this disables back "memoryless" storage mode for the time being.

In addition, this also handles a [noticed edge case](https://github.com/ppy/osu-framework/pull/5745#issuecomment-1511053877) of textures generating mipmap levels in the middle of a render pass. Since we're no longer using "memoryless" storage mode, we can safely unbind the previous framebuffer without its depth/stencil content being lost.

