### PR TITLE
Add multi-stage ShaderManager caching

### DIFF
--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Tests.Shaders
         {
             AddStep("setup manager", () =>
             {
-                manager = new TestShaderManager(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
+                manager = new ShaderManager(new TestGLRenderer(), new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
                 shader = (GLShader)manager.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
                 shaderRef = new WeakReference<IShader>(shader);
 
@@ -58,15 +58,10 @@ namespace osu.Framework.Tests.Shaders
             });
         }
 
-        private class TestShaderManager : ShaderManager
+        private class TestGLRenderer : GLRenderer
         {
-            public TestShaderManager(IResourceStore<byte[]> store)
-                : base(new GLRenderer(), store)
-            {
-            }
-
-            internal override IShader CreateShader(IRenderer renderer, string name, params IShaderPart[] parts)
-                => new TestGLShader((GLRenderer)renderer, name, parts.Cast<GLShaderPart>().ToArray());
+            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray());
 
             private class TestGLShader : GLShader
             {

--- a/osu.Framework.Tests/Shaders/TestShaderLoading.cs
+++ b/osu.Framework.Tests/Shaders/TestShaderLoading.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Tests.Shaders
         [Test]
         public void TestFetchNonExistentShader()
         {
-            var manager = new TestShaderManager(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
+            var manager = new ShaderManager(new TestGLRenderer(), new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
 
             // fetch non-existent shader throws an arbitrary exception type.
             // not sure this is the best way to have things (other stores return null instead), but is what it is for now so let's ensure we don't change behaviour.
@@ -29,7 +29,7 @@ namespace osu.Framework.Tests.Shaders
         {
             IShader lookup1;
 
-            var manager = new TestShaderManager(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
+            var manager = new ShaderManager(new TestGLRenderer(), new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
 
             // fetch existent shader.
             Assert.That(lookup1 = manager.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE), Is.Not.Null);
@@ -38,15 +38,10 @@ namespace osu.Framework.Tests.Shaders
             Assert.That(manager.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE), Is.SameAs(lookup1));
         }
 
-        private class TestShaderManager : ShaderManager
+        private class TestGLRenderer : GLRenderer
         {
-            public TestShaderManager(IResourceStore<byte[]> store)
-                : base(new GLRenderer(), store)
-            {
-            }
-
-            internal override IShader CreateShader(IRenderer renderer, string name, params IShaderPart[] parts)
-                => new TestGLShader((GLRenderer)renderer, name, parts.Cast<GLShaderPart>().ToArray());
+            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray());
 
             private class TestGLShader : GLShader
             {

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
                         //                        if (File.Exists(includeName))
                         //                            rawData = File.ReadAllBytes(includeName);
                         //#endif
-                        code += loadFile(store.LoadRaw(includeName), false) + '\n';
+                        code += loadFile(store.GetRawData(includeName), false) + '\n';
                     }
                     else
                         code += line + '\n';
@@ -113,13 +113,13 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
                 if (mainFile)
                 {
-                    string internalIncludes = loadFile(store.LoadRaw("Internal/sh_Compatibility.h"), false) + "\n";
-                    internalIncludes += loadFile(store.LoadRaw("Internal/sh_GlobalUniforms.h"), false) + "\n";
+                    string internalIncludes = loadFile(store.GetRawData("Internal/sh_Compatibility.h"), false) + "\n";
+                    internalIncludes += loadFile(store.GetRawData("Internal/sh_GlobalUniforms.h"), false) + "\n";
                     code = internalIncludes + code;
 
                     if (Type == ShaderType.VertexShader)
                     {
-                        string backbufferCode = loadFile(store.LoadRaw("Internal/sh_Vertex_Output.h"), false);
+                        string backbufferCode = loadFile(store.GetRawData("Internal/sh_Vertex_Output.h"), false);
 
                         if (!string.IsNullOrEmpty(backbufferCode))
                         {

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -1054,8 +1054,8 @@ namespace osu.Framework.Graphics.Rendering
 
             mipmapShader = CreateShader("mipmap", new[]
             {
-                CreateShaderPart(store, "mipmap.vs", store.LoadRaw("sh_mipmap.vs"), ShaderPartType.Vertex),
-                CreateShaderPart(store, "mipmap.fs", store.LoadRaw("sh_mipmap.fs"), ShaderPartType.Fragment),
+                CreateShaderPart(store, "mipmap.vs", store.GetRawData("sh_mipmap.vs"), ShaderPartType.Vertex),
+                CreateShaderPart(store, "mipmap.fs", store.GetRawData("sh_mipmap.fs"), ShaderPartType.Fragment),
             }, globalUniformBuffer.AsNonNull());
 
             return mipmapShader;
@@ -1285,7 +1285,7 @@ namespace osu.Framework.Graphics.Rendering
                 this.store = store;
             }
 
-            public byte[]? LoadRaw(string name) => store.Get(name);
+            public byte[]? GetRawData(string fileName) => store.Get(fileName);
         }
     }
 }

--- a/osu.Framework/Graphics/Shaders/IShaderStore.cs
+++ b/osu.Framework/Graphics/Shaders/IShaderStore.cs
@@ -5,6 +5,6 @@ namespace osu.Framework.Graphics.Shaders
 {
     public interface IShaderStore
     {
-        byte[]? LoadRaw(string name);
+        byte[]? GetRawData(string fileName);
     }
 }

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -29,54 +29,63 @@ namespace osu.Framework.Graphics.Shaders
         }
 
         /// <summary>
-        /// Retrieves raw shader data from the store.
-        /// Use <see cref="Load"/> to retrieve a usable <see cref="IShader"/> instead.
-        /// </summary>
-        /// <param name="name">The shader name.</param>
-        public virtual byte[] LoadRaw(string name)
-        {
-            byte[]? bytes = store.Get(name);
-
-            if (bytes == null) throw new FileNotFoundException("Shader file could not be found", name);
-
-            return bytes;
-        }
-
-        /// <summary>
         /// Retrieves a usable <see cref="IShader"/> given the vertex and fragment shaders.
         /// </summary>
         /// <param name="vertex">The vertex shader name.</param>
         /// <param name="fragment">The fragment shader name.</param>
-        public virtual IShader Load(string vertex, string fragment)
+        public IShader Load(string vertex, string fragment)
         {
-            var tuple = (vertex, fragment);
+            IShader? cached = GetCachedShader(vertex, fragment);
+            if (cached != null)
+                return cached;
 
-            if (shaderCache.TryGetValue(tuple, out IShader? shader))
-                return shader;
-
-            return shaderCache[tuple] = CreateShader(
-                renderer,
+            return shaderCache[(vertex, fragment)] = renderer.CreateShader(
                 $"{vertex}/{fragment}",
-                createShaderPart(vertex, ShaderPartType.Vertex),
-                createShaderPart(fragment, ShaderPartType.Fragment));
+                new[]
+                {
+                    resolveShaderPart(vertex, ShaderPartType.Vertex),
+                    resolveShaderPart(fragment, ShaderPartType.Fragment)
+                });
         }
 
-        internal virtual IShader CreateShader(IRenderer renderer, string name, params IShaderPart[] parts) => renderer.CreateShader(name, parts);
+        /// <summary>
+        /// Attempts to retrieve an already-cached shader.
+        /// </summary>
+        /// <param name="vertex">The vertex shader name.</param>
+        /// <param name="fragment">The fragment shader name.</param>
+        /// <returns>A cached <see cref="IShader"/> instance, if existing.</returns>
+        public virtual IShader? GetCachedShader(string vertex, string fragment)
+            => shaderCache.TryGetValue((vertex, fragment), out IShader? shader) ? shader : null;
 
-        private IShaderPart createShaderPart(string name, ShaderPartType partType, bool bypassCache = false)
+        /// <summary>
+        /// Attempts to retrieve an already-cached shader part.
+        /// </summary>
+        /// <param name="name">The name of the shader part.</param>
+        /// <returns>A cached <see cref="IShaderPart"/> instance, if existing.</returns>
+        public virtual IShaderPart? GetCachedShaderPart(string name)
+            => partCache.TryGetValue(name, out IShaderPart? part) ? part : null;
+
+        /// <summary>
+        /// Attempts to retrieve the raw data for a shader file.
+        /// </summary>
+        /// <param name="fileName">The file name.</param>
+        /// <returns></returns>
+        public virtual byte[]? GetRawData(string fileName) => store.Get(fileName);
+
+        private IShaderPart resolveShaderPart(string name, ShaderPartType type)
         {
-            name = ensureValidName(name, partType);
+            name = ensureValidName(name, type);
 
-            if (!bypassCache && partCache.TryGetValue(name, out IShaderPart? part))
-                return part;
+            IShaderPart? cached = GetCachedShaderPart(name);
+            if (cached != null)
+                return cached;
 
-            byte[] rawData = LoadRaw(name);
+            byte[]? rawData = GetRawData(name);
 
-            part = renderer.CreateShaderPart(this, name, rawData, partType);
+            if (rawData == null)
+                throw new FileNotFoundException($"{type} shader part could not be found.", name);
 
-            //cache even on failure so we don't try and fail every time.
-            partCache[name] = part;
-            return part;
+            return partCache[name] = renderer.CreateShaderPart(this, name, rawData, type);
         }
 
         private string ensureValidName(string name, ShaderPartType partType)

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                         //                        if (File.Exists(includeName))
                         //                            rawData = File.ReadAllBytes(includeName);
                         //#endif
-                        code += loadFile(store.LoadRaw(includeName), false) + '\n';
+                        code += loadFile(store.GetRawData(includeName), false) + '\n';
                     }
                     else
                         code += line + '\n';
@@ -105,13 +105,13 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
                 if (mainFile)
                 {
-                    string internalIncludes = loadFile(store.LoadRaw("Internal/sh_Compatibility.h"), false) + "\n";
-                    internalIncludes += loadFile(store.LoadRaw("Internal/sh_GlobalUniforms.h"), false) + "\n";
+                    string internalIncludes = loadFile(store.GetRawData("Internal/sh_Compatibility.h"), false) + "\n";
+                    internalIncludes += loadFile(store.GetRawData("Internal/sh_GlobalUniforms.h"), false) + "\n";
                     code = internalIncludes + code;
 
                     if (Type == ShaderPartType.Vertex)
                     {
-                        string backbufferCode = loadFile(store.LoadRaw("Internal/sh_Vertex_Output.h"), false);
+                        string backbufferCode = loadFile(store.GetRawData("Internal/sh_Vertex_Output.h"), false);
 
                         if (!string.IsNullOrEmpty(backbufferCode))
                         {


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu-framework/pull/5739

This aims to resolve three issues:
1. Separation - when a ruleset only contains one part and references an o!f shader part lookup (e.g. the `Texture2D` vertex shader).
   * This resolves the same issue as the PR above.
2. Fallback - If a ruleset doesn't contain the requested shader (e.g. every sprite requesting `Texture2D/Texture`).
   * This removes the hack added in https://github.com/ppy/osu/pull/23111 .
3. Isolation - If two rulesets define and request shaders with the same name.
   * This will both help out in the future with multi-spectator, and prevent rulesets polluting the global `ShaderManager` that could lead to weird behaviour. The above PR didn't achieve this.