### PR TITLE
Fix legacy OpenGL initialising texture mipmap levels with invalid dimensions

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -431,12 +431,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     int height = internalHeight;
 
                     for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
-                    {
-                        width = MathUtils.DivideRoundUp(width, 2);
-                        height = MathUtils.DivideRoundUp(height, 2);
-
-                        initializeLevel(level, width, height, upload.Format);
-                    }
+                        initializeLevel(level, Math.Max(width >> level, 1), Math.Max(height >> level, 1), upload.Format);
                 }
             }
 


### PR DESCRIPTION
Resolve legacy-gl issue pointed out in https://github.com/ppy/osu-framework/pull/5508#issuecomment-1511010255.

![image](https://user-images.githubusercontent.com/22781491/232666571-bc5a1dfa-df56-4b44-ab54-ce2ba6961341.png)

OpenGL requires accurate mipmap level dimensions in order for mipmapping to work, and the dimensions need to be a *rounded-down* division of the original size rather than rounded-up as in the original PR (which can be simplified to a bitwise right shift operation).
