### PR TITLE
Update `veldrid-spirv` native library with lower iOS deployment target

### DIFF
--- a/osu.Framework.iOS/runtimes/ios/native/veldrid-spirv.xcframework/ios-arm64/veldrid-spirv.framework/Info.plist
+++ b/osu.Framework.iOS/runtimes/ios/native/veldrid-spirv.xcframework/ios-arm64/veldrid-spirv.framework/Info.plist
@@ -43,7 +43,7 @@
 	<key>DTXcodeBuild</key>
 	<string>14C18</string>
 	<key>MinimumOSVersion</key>
-	<string>16.2</string>
+	<string>13.4</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>


### PR DESCRIPTION
- Resolves ppy/osu#23198

Recompiled on same branch but with a lower deployment target (13.4) in order to resolve https://github.com/ppy/osu/issues/23198. I've tried updating the simulator version as well but that didn't work for odd reason, so I've kept it as-is.