### PR TITLE
Fix touch feedback breaking Direct3D 11 exclusive/optimised fullscreen

### DIFF
--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -67,6 +67,16 @@ namespace osu.Framework.Platform.Windows.Native
 
         [DllImport("user32.dll", SetLastError = false)]
         public static extern long GetMessageExtraInfo();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern unsafe bool SetWindowFeedbackSetting(IntPtr hwnd, FeedbackType feedback, ulong flags, uint size, int* configuration);
+
+        public static unsafe void SetWindowFeedbackSetting(IntPtr hwnd, FeedbackType feedback, bool configuration)
+        {
+            int config = configuration ? 1 : 0; // mimics win32 BOOL type.
+            SetWindowFeedbackSetting(hwnd, feedback, 0, sizeof(int), &config);
+        }
     }
 
     /// <summary>
@@ -338,5 +348,20 @@ namespace osu.Framework.Platform.Windows.Native
         BarCode = 0x8C,
         Scale = 0x8D,
         MSR = 0x8E
+    }
+
+    public enum FeedbackType
+    {
+        TouchContactVisualization = 1,
+        PenBarrelVisualization = 2,
+        PenTap = 3,
+        PenDoubleTap = 4,
+        PenPressAndHold = 5,
+        PenRightTap = 6,
+        TouchTap = 7,
+        TouchDoubleTap = 8,
+        TouchPressAndHold = 9,
+        TouchRightTap = 10,
+        GesturePressAndTap = 11,
     }
 }

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -64,6 +64,10 @@ namespace osu.Framework.Platform.Windows
         {
             base.Create();
 
+            // disable all pen and touch feedback as this causes issues when running "optimised" fullscreen under Direct3D11.
+            foreach (var feedbackType in Enum.GetValues<FeedbackType>())
+                Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
+
             // enable window message events to use with `OnSDLEvent` below.
             SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);
         }


### PR DESCRIPTION
- Closes ppy/osu#23144

This PR simply disables touch feedback in the window using [`SetWindowFeedbackSetting`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowfeedbacksetting). This will disable feedback for touches that start in the window. Pen and gesture feedback is also disabled for good measure.

Since we draw our own cursor (and cursor trails in osu!), having this disabled (in all window modes and renderers) is desirable.

The [docs](https://learn.microsoft.com/en-us/windows/win32/input_feedback/input-feedback-configuration-portal) mention our use case:
> For example, default visual feedback settings might not be necessary, or desirable, in a game app because of interference or conflicts with the gameplay itself.
