### PR TITLE
Fix broken `AudioMixerVisualiser` layout

### DIFF
--- a/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         public AudioMixerVisualiser()
             : base("AudioMixer", "(Ctrl+F9 to toggle)")
         {
-            ScrollContent.Expire();
+            MainHorizontalContent.Clear();
             MainHorizontalContent.Add(new BasicScrollContainer(Direction.Horizontal)
             {
                 RelativeSizeAxes = Axes.Y,


### PR DESCRIPTION
Noticed this in passing, seems to have been caused by the changes to `ToolWindow` in #5254.

Before:
![Screen Shot 2023-04-21 at 14 15 04](https://user-images.githubusercontent.com/272140/233548551-13fea639-cbc5-4335-aaee-fe38137c4cc5.png)

After:
![Screen Shot 2023-04-21 at 14 15 19](https://user-images.githubusercontent.com/272140/233548571-48bc5a28-7759-4ecf-8f58-e45c6bdb693e.png)

.