### PR TITLE
Dispose VBOs created during mipmap generation

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -274,7 +274,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
 
                     // Generate quad buffer that will hold all the updated regions
-                    var quadBuffer = new GLQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsageHint.StreamDraw);
+                    using var quadBuffer = new GLQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsageHint.StreamDraw);
 
                     // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
                     for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -17,7 +17,7 @@ using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
 {
-    internal abstract class VeldridVertexBuffer<T> : IVertexBuffer
+    internal abstract class VeldridVertexBuffer<T> : IVertexBuffer, IDisposable
         where T : unmanaged, IEquatable<T>, IVertex
     {
         protected static readonly int STRIDE = VeldridVertexUtils<DepthWrappingVertex<T>>.STRIDE;

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -272,7 +272,8 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 Renderer.BindTexture(this);
                 Renderer.GetMipmapShader().Bind();
 
-                using var samplingTexture = Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)Width, (uint)Height, resources!.Texture.MipLevels, 1, resources!.Texture.Format, TextureUsage.Sampled));
+                using var samplingTexture =
+                    Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)Width, (uint)Height, resources!.Texture.MipLevels, 1, resources!.Texture.Format, TextureUsage.Sampled));
                 using var samplingResources = new VeldridTextureResources(samplingTexture, null);
 
                 while (uploadedRegions.Count > 0)
@@ -283,7 +284,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                     int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
 
                     // Generate quad buffer that will hold all the updated regions
-                    var quadBuffer = new VeldridQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsage.Dynamic);
+                    using var quadBuffer = new VeldridQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsage.Dynamic);
 
                     // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
                     for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)


### PR DESCRIPTION
I don't think this would've caused any problems because these are periodically free'd via

https://github.com/ppy/osu-framework/blob/7c5b248198ee8bfa6b65e56e710afc3a3af45f39/osu.Framework/Graphics/Rendering/Renderer.cs#L811-L823

