### PR TITLE
Fix texture mipmap sizes not calculated correctly

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -279,8 +279,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
                     for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
                     {
-                        width = MathUtils.DivideRoundUp(width, 2);
-                        height = MathUtils.DivideRoundUp(height, 2);
+                        width /= 2;
+                        height /= 2;
 
                         // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
                         for (int i = 0; i < count; ++i)

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -288,8 +288,8 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                     // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
                     for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
                     {
-                        width = MathUtils.DivideRoundUp(width, 2);
-                        height = MathUtils.DivideRoundUp(height, 2);
+                        width /= 2;
+                        height /= 2;
 
                         // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
                         for (int i = 0; i < count; ++i)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23311

Similar to https://github.com/ppy/osu-framework/pull/5750, mipmap levels sizes are not up-rounded when divided by 2. Doing so results in the texture potentially accessing a non-existent mipmap level due to incorrect size calculations (say 11x11 for example, up-rounded division results in 5 mipmap levels, while normal divsion results in 4 levels).