### PR TITLE
Implement texture mipmap generation via compute pipelines

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
@@ -31,9 +30,6 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         [Resolved]
         private Game game { get; set; } = null!;
-
-        [Resolved]
-        private TextureStore textures { get; set; } = null!;
 
         private FontStore fonts = null!;
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
@@ -4,12 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL;
@@ -36,7 +32,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private readonly List<string?> availableFontResources = new List<string?>();
 
-        private FontStore fonts = null!;
+        private FontStore? fonts;
 
         private double timeSpent;
 
@@ -123,7 +119,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         public void TestAddGradually()
         {
             int fetchedGlyphs = 0;
-            int? count = null;
+            int? count;
             ScheduledDelegate? glyphDelegate = null;
 
             AddStep("add gradually", () =>
@@ -202,6 +198,8 @@ namespace osu.Framework.Tests.Visual.Sprites
             host.Renderer.ScheduleExpensiveOperation(new ScheduledDelegate(() =>
             {
                 // ensure atlas texture is uploaded first before profiling mipmap generation.
+                Debug.Assert(fonts != null);
+
                 fonts.Atlas.AtlasTexture!.NativeTexture.Upload();
 
                 switch (host.Renderer)
@@ -226,6 +224,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private void uploadOpenGL(GLRenderer gl)
         {
+            Debug.Assert(fonts != null);
+
             double timeBefore = stopwatchClock.CurrentTime;
 
             fonts.Atlas.AtlasTexture!.NativeTexture.GenerateMipmaps();
@@ -236,6 +236,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private void uploadVeldrid(VeldridRenderer veldrid)
         {
+            Debug.Assert(fonts != null);
+
             double timeBefore = stopwatchClock.CurrentTime;
 
             veldrid.MipmapGenerationCommands.Begin();
@@ -296,6 +298,8 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             if (availableFontResources.Count == 0)
                 return;
+
+            Debug.Assert(fonts != null);
 
             fonts.Get(availableFontResources[0]);
             availableFontResources.RemoveAt(0);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
@@ -1,0 +1,226 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Framework.Timing;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public class TestSceneTextureMipmaps : FrameworkTestScene
+    {
+        [Resolved]
+        private GameHost host { get; set; } = null!;
+
+        [Resolved]
+        private Game game { get; set; } = null!;
+
+        [Resolved]
+        private TextureStore textures { get; set; } = null!;
+
+        private FontStore fonts = null!;
+
+        private double timeSpent;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            timeSpent = 0;
+
+            Scheduler.CancelDelayedTasks();
+
+            fonts?.Dispose();
+            fonts = new FontStore(host.Renderer, new GlyphStore(game.Resources, @"Fonts/FontAwesome5/FontAwesome-Solid", host.CreateTextureLoaderStore(game.Resources)), useAtlas: true);
+
+            // fetch any glyph for a texture atlas to be generated.
+            fonts.Get(fonts.GetAvailableResources().First());
+
+            Debug.Assert(fonts.Atlas.AtlasTexture != null);
+
+            Children = new[]
+            {
+                new FillFlowContainer
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Margin = new MarginPadding { Left = 15f, Top = 30f },
+                    Spacing = new Vector2(0f, 5f),
+                    Children = new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Text = "Mipmaps",
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new[]
+                            {
+                                new MipmapSprite(0)
+                                {
+                                    Texture = fonts.Atlas.AtlasTexture,
+                                    Size = new Vector2(512, 512),
+                                },
+                                new MipmapSprite(1)
+                                {
+                                    X = 512,
+                                    Texture = fonts.Atlas.AtlasTexture,
+                                    Size = new Vector2(256, 256),
+                                },
+                                new MipmapSprite(2)
+                                {
+                                    X = 512,
+                                    Y = 256,
+                                    Texture = fonts.Atlas.AtlasTexture,
+                                    Size = new Vector2(128, 128),
+                                },
+                                new MipmapSprite(3)
+                                {
+                                    X = 512,
+                                    Y = 384,
+                                    Texture = fonts.Atlas.AtlasTexture,
+                                    Size = new Vector2(64, 64),
+                                },
+                            }
+                        }
+                    },
+                }
+            };
+        });
+
+        [Test]
+        public void TestAddGradually()
+        {
+            int currentGlyphIndex = 1;
+            ScheduledDelegate? glyphDelegate = null;
+
+            AddStep("add gradually", () =>
+            {
+                glyphDelegate?.Cancel();
+                glyphDelegate = Scheduler.AddDelayed(() =>
+                {
+                    if (currentGlyphIndex == 500)
+                    {
+                        finish();
+                        return;
+                    }
+
+                    string? resource = fonts.GetAvailableResources().ElementAt(currentGlyphIndex++);
+                    fonts.Get(resource);
+
+                    upload();
+                }, 1, true);
+            });
+
+            AddStep("finish", finish);
+
+            void finish()
+            {
+                // ReSharper disable once AccessToModifiedClosure
+                glyphDelegate?.Cancel();
+                report($"Generating mipmaps spent {timeSpent / (currentGlyphIndex - 1):N3}ms on average");
+            }
+        }
+
+        [Test]
+        public void TestAddHalf()
+        {
+            AddStep("add half", () =>
+            {
+                foreach (string? resource in fonts.GetAvailableResources().Take(fonts.GetAvailableResources().Count() / 2))
+                    fonts.Get(resource);
+
+                upload();
+                report($"Generating mipmaps of final texture atlas spent {timeSpent:N3}ms");
+            });
+        }
+
+        [Test]
+        public void TestAddAll()
+        {
+            AddStep("add all", () =>
+            {
+                foreach (string? resource in fonts.GetAvailableResources())
+                    fonts.Get(resource);
+
+                upload();
+                report($"Generating mipmaps of final texture atlas spent {timeSpent:N3}ms");
+            });
+        }
+
+        private readonly StopwatchClock stopwatchClock = new StopwatchClock(true);
+
+        private void upload()
+        {
+            var tcs = new TaskCompletionSource();
+
+            host.DrawThread.Scheduler.Add(() =>
+            {
+                double timeBefore = stopwatchClock.CurrentTime;
+                fonts.Atlas.AtlasTexture!.NativeTexture.Upload(true);
+                timeSpent += stopwatchClock.CurrentTime - timeBefore;
+                tcs.SetResult();
+            });
+
+            tcs.Task.WaitSafely();
+        }
+
+        private SpriteText? reportText;
+
+        private void report(string message)
+        {
+            if (reportText != null)
+                Remove(reportText, true);
+
+            Add(reportText = new SpriteText
+            {
+                Position = new Vector2(15f, 5f),
+                Text = message
+            });
+        }
+
+        private class MipmapSprite : Sprite
+        {
+            private readonly int level;
+
+            public MipmapSprite(int level)
+            {
+                this.level = level;
+            }
+
+            protected override DrawNode CreateDrawNode() => new SingleMipmapSpriteDrawNode(this, level);
+
+            private class SingleMipmapSpriteDrawNode : SpriteDrawNode
+            {
+                private readonly int level;
+
+                public SingleMipmapSpriteDrawNode(Sprite source, int level)
+                    : base(source)
+                {
+                    this.level = level;
+                }
+
+                protected override void Blit(IRenderer renderer)
+                {
+                    Texture.MipLevel = level;
+                    base.Blit(renderer);
+                    renderer.FlushCurrentBatch(null);
+                    Texture.MipLevel = null;
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureMipmaps.cs
@@ -23,6 +23,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
+    [Ignore("This test cannot be run in headless mode (a renderer is required).")]
     public class TestSceneTextureMipmaps : FrameworkTestScene
     {
         [Resolved]

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -261,14 +261,14 @@ namespace osu.Framework.Graphics.OpenGL
             }
         }
 
-        public override void GenerateMipmaps(INativeTexture texture, params RectangleI[] regions)
+        public override void GenerateMipmaps(INativeTexture texture, List<RectangleI> regions)
         {
             var glTexture = (GLTexture)texture;
 
             if (supportsComputeMipmapGeneration)
                 generateMipmapsViaComputeShader(glTexture, regions);
             else
-                generateMipmapsViaFramebuffer(glTexture, regions); // todo: bad
+                generateMipmapsViaFramebuffer(glTexture, regions);
         }
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace osu.Framework.Graphics.OpenGL
             GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, IRenderer.MAX_MIPMAP_LEVELS);
         }
 
-        private void generateMipmapsViaFramebuffer(GLTexture texture, params RectangleI[] regions)
+        private void generateMipmapsViaFramebuffer(GLTexture texture, List<RectangleI> regions)
         {
             using var frameBuffer = new GLFrameBuffer(this, texture);
 
@@ -354,7 +354,7 @@ namespace osu.Framework.Graphics.OpenGL
             int height = texture.Height;
 
             // Generate quad buffer that will hold all the updated regions
-            var quadBuffer = new GLQuadBuffer<UncolouredVertex2D>(this, regions.Length, BufferUsageHint.StreamDraw);
+            var quadBuffer = new GLQuadBuffer<UncolouredVertex2D>(this, regions.Count, BufferUsageHint.StreamDraw);
 
             // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
             for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
@@ -363,7 +363,7 @@ namespace osu.Framework.Graphics.OpenGL
                 height = MathUtils.DivideRoundUp(height, 2);
 
                 // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
-                for (int i = 0; i < regions.Length; ++i)
+                for (int i = 0; i < regions.Count; ++i)
                 {
                     // Conservatively round the draw rectangles. Rounding to integer coords is required
                     // in order to ensure all the texels affected by linear interpolation are touched.

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -275,6 +275,8 @@ namespace osu.Framework.Graphics.OpenGL
             int width = texture.Width;
             int height = texture.Height;
 
+            GL.UseProgram(computeMipmapShader!.Value);
+
             for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 || (width > 1 || height > 1); level++)
             {
                 width = MathUtils.DivideRoundUp(width, 2);

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -277,7 +277,7 @@ namespace osu.Framework.Graphics.OpenGL
 
             GL.UseProgram(computeMipmapShader!.Value);
 
-            for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 || (width > 1 || height > 1); level++)
+            for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); level++)
             {
                 width = MathUtils.DivideRoundUp(width, 2);
                 height = MathUtils.DivideRoundUp(height, 2);

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -277,7 +277,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <remarks>
         /// This is specified in the compute shader as well for OpenGL backends.
         /// </remarks>
-        private static readonly Vector2I compute_mipmap_threads = new Vector2I(16, 16);
+        private static readonly Vector2I compute_mipmap_threads = new Vector2I(32, 32);
 
         private void generateMipmapsViaComputeShader(GLTexture texture, List<RectangleI> regions)
         {

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.OpenGL
                     computeMipmapShader = GL.CreateProgram();
                     GL.AttachShader(computeMipmapShader.Value, shader);
                     GL.LinkProgram(computeMipmapShader.Value);
-                    GL.GetProgram(shader, GetProgramParameterName.LinkStatus, out int linkResult);
+                    GL.GetProgram(computeMipmapShader.Value, GetProgramParameterName.LinkStatus, out int linkResult);
 
                     if (linkResult != 1)
                         throw new GLShader.PartCompilationFailedException("Failed to link mipmap shader", GL.GetShaderInfoLog(shader));

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -287,12 +287,14 @@ namespace osu.Framework.Graphics.OpenGL
                     osuTK.Graphics.ES31.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.ES31.BufferAccessArb.ReadOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
                     osuTK.Graphics.ES31.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.ES31.BufferAccessArb.WriteOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
                     osuTK.Graphics.ES31.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
+                    osuTK.Graphics.ES31.GL.MemoryBarrier(osuTK.Graphics.ES31.MemoryBarrierMask.TextureFetchBarrierBit | osuTK.Graphics.ES31.MemoryBarrierMask.TextureUpdateBarrierBit | osuTK.Graphics.ES31.MemoryBarrierMask.ShaderImageAccessBarrierBit);
                 }
                 else
                 {
                     osuTK.Graphics.OpenGL.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.OpenGL.TextureAccess.ReadOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
                     osuTK.Graphics.OpenGL.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.OpenGL.TextureAccess.WriteOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
                     osuTK.Graphics.OpenGL.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
+                    osuTK.Graphics.OpenGL.GL.MemoryBarrier(osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureFetchBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureUpdateBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.ShaderImageAccessBarrierBit);
                 }
             }
         }

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Veldrid;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -69,7 +70,7 @@ namespace osu.Framework.Graphics.OpenGL
         private int backbufferFramebuffer;
 
         private int? computeMipmapShader;
-        private GLUniformBuffer<MipmapGenerationParameters>? computeMipmapParametersBuffer;
+        private GLUniformBuffer<ComputeMipmapGenerationParameters>? computeMipmapParametersBuffer;
         private GLUniformBlock? computeMipmapParametersBlock;
 
         private bool supportsComputeMipmapGeneration;
@@ -140,7 +141,7 @@ namespace osu.Framework.Graphics.OpenGL
                         throw new GLShader.PartCompilationFailedException("Failed to link mipmap shader", GL.GetShaderInfoLog(shader));
 
                     computeMipmapParametersBlock = new GLUniformBlock(this, computeMipmapShader.Value, 0, 0);
-                    computeMipmapParametersBlock.Assign(computeMipmapParametersBuffer = new GLUniformBuffer<MipmapGenerationParameters>(this));
+                    computeMipmapParametersBlock.Assign(computeMipmapParametersBuffer = new GLUniformBuffer<ComputeMipmapGenerationParameters>(this));
                 }
                 else
                 {
@@ -306,9 +307,10 @@ namespace osu.Framework.Graphics.OpenGL
 
                 for (int i = 0; i < regions.Count; i++)
                 {
-                    computeMipmapParametersBuffer!.Data = new MipmapGenerationParameters
+                    computeMipmapParametersBuffer!.Data = new ComputeMipmapGenerationParameters
                     {
-                        Region = new Vector4(regions[i].X, regions[i].Y, regions[i].Width, regions[i].Height)
+                        Region = new Vector4(regions[i].X, regions[i].Y, regions[i].Width, regions[i].Height),
+                        InvocationWidth = width
                     };
 
                     if (IsEmbedded)
@@ -680,12 +682,5 @@ namespace osu.Framework.Graphics.OpenGL
             => new GLLinearBatch<TVertex>(this, size, maxBuffers, GLUtils.ToPrimitiveType(topology));
 
         protected override IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) => new GLQuadBatch<TVertex>(this, size, maxBuffers);
-
-        private record struct MipmapGenerationParameters
-        {
-            public UniformVector4 Region;
-            public UniformInt InvocationWidth;
-            private readonly UniformPadding12 _;
-        }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -277,22 +277,26 @@ namespace osu.Framework.Graphics.OpenGL
 
             GL.UseProgram(computeMipmapShader!.Value);
 
+            GL.ActiveTexture(TextureUnit.Texture0);
+            GL.BindTexture(TextureTarget.Texture2D, texture.TextureId);
+
             for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); level++)
             {
                 width = MathUtils.DivideRoundUp(width, 2);
                 height = MathUtils.DivideRoundUp(height, 2);
 
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, level - 1);
+                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, level - 1);
+
                 if (IsEmbedded)
                 {
-                    osuTK.Graphics.ES31.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.ES31.BufferAccessArb.ReadOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
-                    osuTK.Graphics.ES31.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.ES31.BufferAccessArb.WriteOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
+                    osuTK.Graphics.ES31.GL.BindImageTexture(2, texture.TextureId, level, false, 0, osuTK.Graphics.ES31.BufferAccessArb.WriteOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
                     osuTK.Graphics.ES31.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
                     osuTK.Graphics.ES31.GL.MemoryBarrier(osuTK.Graphics.ES31.MemoryBarrierMask.TextureFetchBarrierBit | osuTK.Graphics.ES31.MemoryBarrierMask.TextureUpdateBarrierBit | osuTK.Graphics.ES31.MemoryBarrierMask.ShaderImageAccessBarrierBit);
                 }
                 else
                 {
-                    osuTK.Graphics.OpenGL.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.OpenGL.TextureAccess.ReadOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
-                    osuTK.Graphics.OpenGL.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.OpenGL.TextureAccess.WriteOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
+                    osuTK.Graphics.OpenGL.GL.BindImageTexture(2, texture.TextureId, level, false, 0, osuTK.Graphics.OpenGL.TextureAccess.WriteOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
                     osuTK.Graphics.OpenGL.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
                     osuTK.Graphics.OpenGL.GL.MemoryBarrier(osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureFetchBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureUpdateBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.ShaderImageAccessBarrierBit);
                 }
@@ -301,6 +305,9 @@ namespace osu.Framework.Graphics.OpenGL
             // restore previous shader if there's one bound currently.
             if (Shader != null)
                 GL.UseProgram((GLShader)Shader);
+
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, 0);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, IRenderer.MAX_MIPMAP_LEVELS);
         }
 
         private void generateMipmapsViaFramebuffer(GLTexture texture, List<RectangleI>? regions)

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -29,13 +29,13 @@ using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Veldrid.SPIRV;
-using BufferAccessArb = osuTK.Graphics.ES31.BufferAccessArb;
 using FramebufferAttachment = osuTK.Graphics.ES30.FramebufferAttachment;
 using Image = SixLabors.ImageSharp.Image;
-using InternalFormat = osuTK.Graphics.ES31.InternalFormat;
 using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
 using PrimitiveTopology = osu.Framework.Graphics.Rendering.PrimitiveTopology;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
+
+// ReSharper disable BitwiseOperatorOnEnumWithoutFlags
 
 namespace osu.Framework.Graphics.OpenGL
 {

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -15,9 +15,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Graphics.Veldrid;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -130,7 +128,7 @@ namespace osu.Framework.Graphics.OpenGL
                     GL.GetShader(shader, ShaderParameter.CompileStatus, out int compileResult);
 
                     if (compileResult != 1)
-                        throw new InvalidOperationException($"Failed to compile mipmap shader: {GL.GetShaderInfoLog(shader)}");
+                        throw new InvalidOperationException($"Failed to compile compute mipmap shader: {GL.GetShaderInfoLog(shader)}");
 
                     computeMipmapShader = GL.CreateProgram();
                     GL.AttachShader(computeMipmapShader.Value, shader);
@@ -138,7 +136,7 @@ namespace osu.Framework.Graphics.OpenGL
                     GL.GetProgram(computeMipmapShader.Value, GetProgramParameterName.LinkStatus, out int linkResult);
 
                     if (linkResult != 1)
-                        throw new GLShader.PartCompilationFailedException("Failed to link mipmap shader", GL.GetShaderInfoLog(shader));
+                        throw new GLShader.PartCompilationFailedException("Failed to link compute mipmap shader", GL.GetShaderInfoLog(shader));
 
                     computeMipmapParametersBlock = new GLUniformBlock(this, computeMipmapShader.Value, 0, 0);
                     computeMipmapParametersBlock.Assign(computeMipmapParametersBuffer = new GLUniformBuffer<ComputeMipmapGenerationParameters>(this));

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -282,9 +282,18 @@ namespace osu.Framework.Graphics.OpenGL
                 width = MathUtils.DivideRoundUp(width, 2);
                 height = MathUtils.DivideRoundUp(height, 2);
 
-                osuTK.Graphics.ES31.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, BufferAccessArb.ReadOnly, InternalFormat.Rgba8);
-                osuTK.Graphics.ES31.GL.BindImageTexture(1, texture.TextureId, level, false, 0, BufferAccessArb.WriteOnly, InternalFormat.Rgba8);
-                osuTK.Graphics.ES31.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
+                if (IsEmbedded)
+                {
+                    osuTK.Graphics.ES31.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.ES31.BufferAccessArb.ReadOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
+                    osuTK.Graphics.ES31.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.ES31.BufferAccessArb.WriteOnly, osuTK.Graphics.ES31.InternalFormat.Rgba8);
+                    osuTK.Graphics.ES31.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
+                }
+                else
+                {
+                    osuTK.Graphics.OpenGL.GL.BindImageTexture(0, texture.TextureId, level - 1, false, 0, osuTK.Graphics.OpenGL.TextureAccess.ReadOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
+                    osuTK.Graphics.OpenGL.GL.BindImageTexture(1, texture.TextureId, level, false, 0, osuTK.Graphics.OpenGL.TextureAccess.WriteOnly, osuTK.Graphics.OpenGL.SizedInternalFormat.Rgba8);
+                    osuTK.Graphics.OpenGL.GL.DispatchCompute((uint)MathUtils.DivideRoundUp(width, compute_mipmap_threads.X), (uint)MathUtils.DivideRoundUp(height, compute_mipmap_threads.Y), 1);
+                }
             }
         }
 

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.OpenGL
         private bool? lastBlendingEnabledState;
         private int lastBoundVertexArray;
 
-        protected override void Initialise(IGraphicsSurface graphicsSurface)
+        protected override void InitialiseDevice(IGraphicsSurface graphicsSurface)
         {
             if (graphicsSurface.Type != GraphicsSurfaceType.OpenGL)
                 throw new InvalidOperationException($"{nameof(GLRenderer)} only supports OpenGL graphics surfaces.");

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -308,7 +308,7 @@ namespace osu.Framework.Graphics.OpenGL
                     computeMipmapParametersBuffer!.Data = new ComputeMipmapGenerationParameters
                     {
                         Region = new Vector4(regions[i].X, regions[i].Y, regions[i].Width, regions[i].Height),
-                        InvocationWidth = width
+                        OutputWidth = width
                     };
 
                     if (IsEmbedded)

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -297,6 +297,10 @@ namespace osu.Framework.Graphics.OpenGL
                     osuTK.Graphics.OpenGL.GL.MemoryBarrier(osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureFetchBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.TextureUpdateBarrierBit | osuTK.Graphics.OpenGL.MemoryBarrierFlags.ShaderImageAccessBarrierBit);
                 }
             }
+
+            // restore previous shader if there's one bound currently.
+            if (Shader != null)
+                GL.UseProgram((GLShader)Shader);
         }
 
         private void generateMipmapsViaFramebuffer(GLTexture texture, List<RectangleI>? regions)

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLUniformBlock.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLUniformBlock.cs
@@ -21,10 +21,10 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
         /// Creates a new uniform block.
         /// </summary>
         /// <param name="renderer">The renderer.</param>
-        /// <param name="shader">The shader.</param>
+        /// <param name="shader">The shader program.</param>
         /// <param name="index">The index (location) of this block in the GL shader.</param>
         /// <param name="binding">A unique index for this block to bound to in the GL program.</param>
-        public GLUniformBlock(GLRenderer renderer, GLShader shader, int index, int binding)
+        public GLUniformBlock(GLRenderer renderer, int shader, int index, int binding)
         {
             this.renderer = renderer;
             this.binding = binding;

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -268,6 +268,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 }
             }
 
+            // trim left rectangle from overlapping with right rectangle to avoid any unnecessary work.
+            if (leftRectangle is RectangleI left)
+                leftRectangle = new RectangleI(left.X, left.Y, left.Width - Math.Max(0, left.Right - rightRectangle.Left), left.Height);
+
             Renderer.GenerateMipmaps(this, leftRectangle != null
                 ? new List<RectangleI> { rightRectangle, leftRectangle.Value }
                 : new List<RectangleI> { rightRectangle });

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -268,10 +268,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 }
             }
 
-            if (leftRectangle != null)
-                Renderer.GenerateMipmaps(this, rightRectangle, leftRectangle.Value);
-            else
-                Renderer.GenerateMipmaps(this, rightRectangle);
+            Renderer.GenerateMipmaps(this, leftRectangle != null ? new List<RectangleI> { rightRectangle, leftRectangle.Value } : new List<RectangleI> { rightRectangle });
 
             // Uncomment the following block of code in order to compare the above with the OpenGL
             // reference mipmap generation GL.GenerateMipmap().

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -9,11 +9,8 @@ using osu.Framework.Development;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
-using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
-using osu.Framework.Utils;
-using osuTK;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
@@ -249,93 +246,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     }
                 } while (mergeFound);
 
-                // Mipmap generation using the merged upload regions follows
-                using var frameBuffer = new GLFrameBuffer(Renderer, this);
-
-                BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
-
-                // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
-                Renderer.SetBlend(BlendingParameters.None);
-                Renderer.PushDepthInfo(new DepthInfo(false, false));
-                Renderer.PushStencilInfo(new StencilInfo(false));
-                Renderer.PushScissorState(false);
-
-                Renderer.BindFrameBuffer(frameBuffer);
-
-                // Create render state for mipmap generation
-                Renderer.BindTexture(this);
-                Renderer.GetMipmapShader().Bind();
-
-                while (uploadedRegions.Count > 0)
-                {
-                    int width = internalWidth;
-                    int height = internalHeight;
-
-                    int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
-
-                    // Generate quad buffer that will hold all the updated regions
-                    var quadBuffer = new GLQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsageHint.StreamDraw);
-
-                    // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
-                    for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
-                    {
-                        width = MathUtils.DivideRoundUp(width, 2);
-                        height = MathUtils.DivideRoundUp(height, 2);
-
-                        // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
-                        for (int i = 0; i < count; ++i)
-                        {
-                            // Conservatively round the draw rectangles. Rounding to integer coords is required
-                            // in order to ensure all the texels affected by linear interpolation are touched.
-                            // We could skip the rounding & use a single vertex buffer for all levels if we had
-                            // conservative raster, but alas, that's only supported on NV and Intel.
-                            Vector2I topLeft = uploadedRegions[i].TopLeft;
-                            topLeft = new Vector2I(topLeft.X / 2, topLeft.Y / 2);
-                            Vector2I bottomRight = uploadedRegions[i].BottomRight;
-                            bottomRight = new Vector2I(MathUtils.DivideRoundUp(bottomRight.X, 2), MathUtils.DivideRoundUp(bottomRight.Y, 2));
-                            uploadedRegions[i] = new RectangleI(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
-
-                            // Normalize the draw rectangle into the unit square, which doubles as texture sampler coordinates.
-                            RectangleF r = (RectangleF)uploadedRegions[i] / new Vector2(width, height);
-
-                            quadBuffer.SetVertex(i * 4 + 0, new UncolouredVertex2D { Position = r.BottomLeft });
-                            quadBuffer.SetVertex(i * 4 + 1, new UncolouredVertex2D { Position = r.BottomRight });
-                            quadBuffer.SetVertex(i * 4 + 2, new UncolouredVertex2D { Position = r.TopRight });
-                            quadBuffer.SetVertex(i * 4 + 3, new UncolouredVertex2D { Position = r.TopLeft });
-                        }
-
-                        // Read the texture from 1 mip level higher...
-                        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, level - 1);
-                        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, level - 1);
-
-                        // ...than the one we're writing to via frame buffer.
-                        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget2d.Texture2D, TextureId, level);
-
-                        // Perform the actual mip level draw
-                        Renderer.PushViewport(new RectangleI(0, 0, width, height));
-
-                        quadBuffer.Update();
-                        quadBuffer.Draw();
-
-                        Renderer.PopViewport();
-                    }
-
-                    uploadedRegions.RemoveRange(0, count);
-                }
-
-                // Restore previous render state
-                Renderer.GetMipmapShader().Unbind();
-
-                Renderer.PopScissorState();
-                Renderer.PopStencilInfo();
-                Renderer.PopDepthInfo();
-
-                Renderer.SetBlend(previousBlendingParameters);
-
-                Renderer.UnbindFrameBuffer(frameBuffer);
-
-                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, 0);
-                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, IRenderer.MAX_MIPMAP_LEVELS);
+                Renderer.GenerateMipmaps(this, uploadedRegions);
             }
 
             // Uncomment the following block of code in order to compare the above with the OpenGL

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -191,7 +191,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        public unsafe bool Upload()
+        public unsafe bool Upload(bool forceMipmaps = false)
         {
             if (!Available)
                 return false;
@@ -216,7 +216,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             // This implementation is functionally equivalent to GL.GenerateMipmap(),
             // only that it is much more efficient if only small parts of the texture
             // have been updated.
-            if (uploadedRegions.Count != 0 && !manualMipmaps)
+            if (!manualMipmaps && (uploadedRegions.Count != 0 || forceMipmaps))
             {
                 // Merge overlapping upload regions to prevent redundant mipmap generation.
                 // i goes through the list left-to-right, j goes through it right-to-left
@@ -251,7 +251,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             // Uncomment the following block of code in order to compare the above with the OpenGL
             // reference mipmap generation GL.GenerateMipmap().
-            // if (uploadedRegions.Count != 0 && !manualMipmaps)
+            // if (!manualMipmaps && (uploadedRegions.Count != 0 || forceMipmap))
             // {
             //     GL.Hint(HintTarget.GenerateMipmapHint, HintMode.Nicest);
             //     GL.GenerateMipmap(TextureTarget.Texture2D);

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -268,7 +268,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 }
             }
 
-            Renderer.GenerateMipmaps(this, leftRectangle != null ? new List<RectangleI> { rightRectangle, leftRectangle.Value } : new List<RectangleI> { rightRectangle });
+            Renderer.GenerateMipmaps(this, leftRectangle != null
+                ? new List<RectangleI> { rightRectangle, leftRectangle.Value }
+                : new List<RectangleI> { rightRectangle });
 
             // Uncomment the following block of code in order to compare the above with the OpenGL
             // reference mipmap generation GL.GenerateMipmap().

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -53,6 +53,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             set
             {
                 mipLevel = value;
+
+                GL.BindTexture(TextureTarget.Texture2D, textureId);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinLod, mipLevel ?? 0);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLod, mipLevel ?? IRenderer.MAX_MIPMAP_LEVELS);
             }

--- a/osu.Framework/Graphics/Rendering/ComputeMipmapGenerationParameters.cs
+++ b/osu.Framework/Graphics/Rendering/ComputeMipmapGenerationParameters.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Rendering
     internal record struct ComputeMipmapGenerationParameters
     {
         public UniformVector4 Region;
-        public UniformInt InvocationWidth;
+        public UniformInt OutputWidth;
         private readonly UniformPadding12 pad1;
     }
 }

--- a/osu.Framework/Graphics/Rendering/ComputeMipmapGenerationParameters.cs
+++ b/osu.Framework/Graphics/Rendering/ComputeMipmapGenerationParameters.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Shaders.Types;
+
+namespace osu.Framework.Graphics.Rendering
+{
+    /// <summary>
+    /// Represents the parameters for the compute shader used in mipmap generation ("sh_mipmap.comp").
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal record struct ComputeMipmapGenerationParameters
+    {
+        public UniformVector4 Region;
+        public UniformInt InvocationWidth;
+        private readonly UniformPadding12 pad1;
+    }
+}

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
@@ -36,7 +36,9 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         {
         }
 
-        public bool Upload(bool forceMipmaps) => true;
+        public bool Upload() => true;
+
+        public bool GenerateMipmaps() => true;
 
         public bool Bind(int unit) => true;
 

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyNativeTexture.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         {
         }
 
-        public bool Upload() => true;
+        public bool Upload(bool forceMipmaps) => true;
 
         public bool Bind(int unit) => true;
 

--- a/osu.Framework/Graphics/Rendering/INativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/INativeTexture.cs
@@ -76,9 +76,14 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// Uploads this texture.
         /// </summary>
-        /// <param name="forceMipmaps">Whether mipmaps should be generated regardless of whether any uploads occurred. This is only used for testing mipmap performance.</param>
-        /// <returns>Whether any uploads occurred.</returns>
-        bool Upload(bool forceMipmaps = false);
+        // <returns>Whether any uploads occurred.</returns>
+        bool Upload();
+
+        /// <summary>
+        /// Generate mipmaps for the last uploaded regions of this texture.
+        /// </summary>
+        /// <returns>Whether any mipmap content was generated. False if the texture does not support automatic mipmap generation, or no data was uploaded at all.</returns>
+        bool GenerateMipmaps();
 
         /// <summary>
         /// The size of this texture in bytes.

--- a/osu.Framework/Graphics/Rendering/INativeTexture.cs
+++ b/osu.Framework/Graphics/Rendering/INativeTexture.cs
@@ -76,8 +76,9 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// Uploads this texture.
         /// </summary>
+        /// <param name="forceMipmaps">Whether mipmaps should be generated regardless of whether any uploads occurred. This is only used for testing mipmap performance.</param>
         /// <returns>Whether any uploads occurred.</returns>
-        bool Upload();
+        bool Upload(bool forceMipmaps = false);
 
         /// <summary>
         /// The size of this texture in bytes.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -928,7 +928,7 @@ namespace osu.Framework.Graphics.Rendering
         ///     A list of regions in the texture to generate partial mipmaps for, or null to generate full mipmaps.
         ///     This should only be considered as a hint the renderer to improve performance, and may be ignored by certain implementations.
         /// </param>
-        public abstract void GenerateMipmaps(INativeTexture texture, params RectangleI[] regions);
+        public abstract void GenerateMipmaps(INativeTexture texture, List<RectangleI> regions);
 
         /// <summary>
         /// Informs the graphics device to use the given texture for drawing.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -928,7 +928,7 @@ namespace osu.Framework.Graphics.Rendering
         ///     A list of regions in the texture to generate partial mipmaps for, or null to generate full mipmaps.
         ///     This should only be considered as a hint the renderer to improve performance, and may be ignored by certain implementations.
         /// </param>
-        public abstract void GenerateMipmaps(INativeTexture texture, List<RectangleI>? regions = null);
+        public abstract void GenerateMipmaps(INativeTexture texture, params RectangleI[] regions);
 
         /// <summary>
         /// Informs the graphics device to use the given texture for drawing.

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -23,7 +23,8 @@ namespace osu.Framework.Graphics.Textures
         internal const int WHITE_PIXEL_SIZE = 1;
 
         private readonly List<RectangleI> subTextureBounds = new List<RectangleI>();
-        private Texture? atlasTexture;
+
+        protected internal Texture? AtlasTexture { get; private set; }
 
         private readonly IRenderer renderer;
         private readonly int atlasWidth;
@@ -38,12 +39,12 @@ namespace osu.Framework.Graphics.Textures
         {
             get
             {
-                if (atlasTexture == null)
+                if (AtlasTexture == null)
                     Reset();
 
-                Debug.Assert(atlasTexture != null, "Atlas texture should not be null after Reset().");
+                Debug.Assert(AtlasTexture != null, "Atlas texture should not be null after Reset().");
 
-                return new TextureWhitePixel(atlasTexture);
+                return new TextureWhitePixel(AtlasTexture);
             }
         }
 
@@ -77,12 +78,12 @@ namespace osu.Framework.Graphics.Textures
 
                 // We pass PADDING/2 as opposed to PADDING such that the padded region of each individual texture
                 // occupies half of the padded space.
-                atlasTexture = new BackingAtlasTexture(renderer, atlasWidth, atlasHeight, manualMipmaps, filteringMode, PADDING / 2);
+                AtlasTexture = new BackingAtlasTexture(renderer, atlasWidth, atlasHeight, manualMipmaps, filteringMode, PADDING / 2);
 
                 RectangleI bounds = new RectangleI(0, 0, WHITE_PIXEL_SIZE, WHITE_PIXEL_SIZE);
                 subTextureBounds.Add(bounds);
 
-                using (var whiteTex = new TextureRegion(atlasTexture, bounds, WrapMode.Repeat, WrapMode.Repeat))
+                using (var whiteTex = new TextureRegion(AtlasTexture, bounds, WrapMode.Repeat, WrapMode.Repeat))
                     // Generate white padding as if the white texture was wrapped, even though it isn't
                     whiteTex.SetData(new TextureUpload(new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, whiteTex.Width, whiteTex.Height, new Rgba32(Vector4.One))));
 
@@ -106,12 +107,12 @@ namespace osu.Framework.Graphics.Textures
             lock (textureRetrievalLock)
             {
                 Vector2I position = findPosition(width, height);
-                Debug.Assert(atlasTexture != null, "Atlas texture should not be null after findPosition().");
+                Debug.Assert(AtlasTexture != null, "Atlas texture should not be null after findPosition().");
 
                 RectangleI bounds = new RectangleI(position.X, position.Y, width, height);
                 subTextureBounds.Add(bounds);
 
-                return new TextureRegion(atlasTexture, bounds, wrapModeS, wrapModeT);
+                return new TextureRegion(AtlasTexture, bounds, wrapModeS, wrapModeT);
             }
         }
 
@@ -143,7 +144,7 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>The position within the texture atlas to place the new texture.</returns>
         private Vector2I findPosition(int width, int height)
         {
-            if (atlasTexture == null)
+            if (AtlasTexture == null)
             {
                 Logger.Log($"TextureAtlas initialised ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Textures
         private readonly TextureFilteringMode filteringMode;
         private readonly bool manualMipmaps;
 
-        protected TextureAtlas Atlas;
+        protected internal TextureAtlas Atlas { get; protected set; }
 
         private const int max_atlas_size = 4096;
 

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -273,7 +273,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 }
             }
 
-            Renderer.GenerateMipmaps(this, leftRectangle != null ? new List<RectangleI> { rightRectangle, leftRectangle.Value } : new List<RectangleI> { rightRectangle });
+            Renderer.GenerateMipmaps(this, leftRectangle != null
+                ? new List<RectangleI> { rightRectangle, leftRectangle.Value }
+                : new List<RectangleI> { rightRectangle });
 
             // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().
             // if (!manualMipmaps && regions.Count != 0)

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -201,7 +201,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             return true;
         }
 
-        public bool Upload()
+        public bool Upload(bool forceMipmaps = false)
         {
             if (!Available)
                 return false;
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             // This implementation is functionally equivalent to CommandList.GenerateMipmaps(),
             // only that it is much more efficient if only small parts of the texture
             // have been updated.
-            if (uploadedRegions.Count != 0 && !manualMipmaps)
+            if (!manualMipmaps && (uploadedRegions.Count != 0 || forceMipmaps))
             {
                 // Merge overlapping upload regions to prevent redundant mipmap generation.
                 // i goes through the list left-to-right, j goes through it right-to-left
@@ -259,7 +259,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             }
 
             // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().
-            // if (uploadedRegions.Count != 0 && !manualMipmaps)
+            // if (!manualMipmaps && (uploadedRegions.Count != 0 || forceMipmap))
             // {
             //     Debug.Assert(resources != null);
             //     Renderer.Commands.GenerateMipmaps(resources.Texture);

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -273,6 +273,10 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 }
             }
 
+            // trim left rectangle from overlapping with right rectangle to avoid any unnecessary work.
+            if (leftRectangle is RectangleI left)
+                leftRectangle = new RectangleI(left.X, left.Y, left.Width - Math.Max(0, left.Right - rightRectangle.Left), left.Height);
+
             Renderer.GenerateMipmaps(this, leftRectangle != null
                 ? new List<RectangleI> { rightRectangle, leftRectangle.Value }
                 : new List<RectangleI> { rightRectangle });

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -15,7 +15,6 @@ using osu.Framework.Platform;
 using osuTK.Graphics;
 using SixLabors.ImageSharp.PixelFormats;
 using Veldrid;
-using PixelFormat = Veldrid.PixelFormat;
 using Texture = Veldrid.Texture;
 
 namespace osu.Framework.Graphics.Veldrid.Textures
@@ -274,10 +273,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 }
             }
 
-            if (leftRectangle != null)
-                Renderer.GenerateMipmaps(this, rightRectangle, leftRectangle.Value);
-            else
-                Renderer.GenerateMipmaps(this, rightRectangle);
+            Renderer.GenerateMipmaps(this, leftRectangle != null ? new List<RectangleI> { rightRectangle, leftRectangle.Value } : new List<RectangleI> { rightRectangle });
 
             // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().
             // if (!manualMipmaps && regions.Count != 0)

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         {
             get
             {
-                var usages = TextureUsage.Sampled;
+                var usages = TextureUsage.Sampled | TextureUsage.RenderTarget;
 
                 if (!manualMipmaps && Renderer.Device.Features.ComputeShader)
                     usages |= TextureUsage.Storage;

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -7,17 +7,13 @@ using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
-using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Platform;
-using osu.Framework.Utils;
-using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp.PixelFormats;
 using Veldrid;
 using PixelFormat = Veldrid.PixelFormat;
-using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using Texture = Veldrid.Texture;
 
 namespace osu.Framework.Graphics.Veldrid.Textures
@@ -63,10 +59,10 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         {
             get
             {
-                var usages = TextureUsage.Sampled | TextureUsage.RenderTarget;
+                var usages = TextureUsage.Sampled;
 
-                if (!manualMipmaps)
-                    usages |= TextureUsage.GenerateMipmaps;
+                if (!manualMipmaps && Renderer.Device.Features.ComputeShader)
+                    usages |= TextureUsage.Storage;
 
                 return usages;
             }
@@ -259,103 +255,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                     }
                 } while (mergeFound);
 
-                // Mipmap generation using the merged upload regions follows
-                BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
-
-                // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
-                Renderer.SetBlend(BlendingParameters.None);
-                Renderer.PushDepthInfo(new DepthInfo(false, false));
-                Renderer.PushStencilInfo(new StencilInfo(false));
-                Renderer.PushScissorState(false);
-
-                // Create render state for mipmap generation
-                Renderer.BindTexture(this);
-                Renderer.GetMipmapShader().Bind();
-
-                using var samplingTexture = Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)Width, (uint)Height, resources!.Texture.MipLevels, 1, resources!.Texture.Format, TextureUsage.Sampled));
-                using var samplingResources = new VeldridTextureResources(samplingTexture, null);
-
-                while (uploadedRegions.Count > 0)
-                {
-                    int width = Width;
-                    int height = Height;
-
-                    int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
-
-                    // Generate quad buffer that will hold all the updated regions
-                    var quadBuffer = new VeldridQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsage.Dynamic);
-
-                    // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
-                    for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
-                    {
-                        width = MathUtils.DivideRoundUp(width, 2);
-                        height = MathUtils.DivideRoundUp(height, 2);
-
-                        // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
-                        for (int i = 0; i < count; ++i)
-                        {
-                            // Conservatively round the draw rectangles. Rounding to integer coords is required
-                            // in order to ensure all the texels affected by linear interpolation are touched.
-                            // We could skip the rounding & use a single vertex buffer for all levels if we had
-                            // conservative raster, but alas, that's only supported on NV and Intel.
-                            Vector2I topLeft = uploadedRegions[i].TopLeft;
-                            topLeft = new Vector2I(topLeft.X / 2, topLeft.Y / 2);
-                            Vector2I bottomRight = uploadedRegions[i].BottomRight;
-                            bottomRight = new Vector2I(MathUtils.DivideRoundUp(bottomRight.X, 2), MathUtils.DivideRoundUp(bottomRight.Y, 2));
-                            uploadedRegions[i] = new RectangleI(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
-
-                            // Normalize the draw rectangle into the unit square, which doubles as texture sampler coordinates.
-                            RectangleF r = (RectangleF)uploadedRegions[i] / new Vector2(width, height);
-
-                            quadBuffer.SetVertex(i * 4 + 0, new UncolouredVertex2D { Position = r.BottomLeft });
-                            quadBuffer.SetVertex(i * 4 + 1, new UncolouredVertex2D { Position = r.BottomRight });
-                            quadBuffer.SetVertex(i * 4 + 2, new UncolouredVertex2D { Position = r.TopRight });
-                            quadBuffer.SetVertex(i * 4 + 3, new UncolouredVertex2D { Position = r.TopLeft });
-                        }
-
-                        // this intentionally runs a CopyTexture command on the render pass command list as it has to be executed after the previous level is rendered by the GPU.
-                        Renderer.Commands.CopyTexture(resources!.Texture, samplingTexture, (uint)level - 1, 0);
-
-                        // Read the texture from 1 mip level higher...
-                        samplingResources.Sampler = Renderer.Factory.CreateSampler(new SamplerDescription
-                        {
-                            AddressModeU = SamplerAddressMode.Clamp,
-                            AddressModeV = SamplerAddressMode.Clamp,
-                            AddressModeW = SamplerAddressMode.Clamp,
-                            Filter = filteringMode,
-                            MinimumLod = (uint)level - 1,
-                            MaximumLod = (uint)level - 1,
-                            MaximumAnisotropy = 0,
-                        });
-
-                        Renderer.BindTextureResource(samplingResources, 0);
-
-                        // ...than the one we're writing to via frame buffer.
-                        using (var frameBuffer = new VeldridFrameBuffer(Renderer, this, level))
-                        {
-                            Renderer.BindFrameBuffer(frameBuffer);
-                            Renderer.PushViewport(new RectangleI(0, 0, width, height));
-
-                            // Perform the actual mip level draw
-                            quadBuffer.Update();
-                            quadBuffer.Draw();
-
-                            Renderer.PopViewport();
-                            Renderer.UnbindFrameBuffer(frameBuffer);
-                        }
-                    }
-
-                    uploadedRegions.RemoveRange(0, count);
-                }
-
-                // Restore previous render state
-                Renderer.GetMipmapShader().Unbind();
-
-                Renderer.PopScissorState();
-                Renderer.PopStencilInfo();
-                Renderer.PopDepthInfo();
-
-                Renderer.SetBlend(previousBlendingParameters);
+                Renderer.GenerateMipmaps(this, uploadedRegions);
             }
 
             // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
@@ -12,6 +12,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
     internal class VeldridTextureResources : IDisposable
     {
         public readonly Texture Texture;
+        private readonly bool disposeResources;
 
         private Sampler? sampler;
 
@@ -30,10 +31,12 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         public ResourceSet? Set { get; private set; }
 
-        public VeldridTextureResources(Texture texture, Sampler? sampler)
+        public VeldridTextureResources(Texture texture, Sampler? sampler, bool disposeResources = true)
         {
             Texture = texture;
             Sampler = sampler;
+
+            this.disposeResources = disposeResources;
         }
 
         /// <summary>
@@ -52,8 +55,12 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         public void Dispose()
         {
-            Texture.Dispose();
-            Sampler?.Dispose();
+            if (disposeResources)
+            {
+                Texture.Dispose();
+                Sampler?.Dispose();
+            }
+
             Set?.Dispose();
         }
     }

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
@@ -58,7 +58,8 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                             MinimumLod = 0,
                             MaximumLod = IRenderer.MAX_MIPMAP_LEVELS,
                             MaximumAnisotropy = 0,
-                        })
+                        }),
+                        Renderer
                     );
 
                     textureSize += countPixels;

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -97,11 +97,11 @@ namespace osu.Framework.Graphics.Veldrid
         /// The number of threads in a thread group for the mipmap compute shader.
         /// </summary>
         /// <remarks>
-        /// On an M1 machine, setting any value that's higher than 1024 threads breaks mipmap generation, therefore.
+        /// This defines 1024 threads per thread group, which is the limit on Metal and Direct3D 11.
         /// This should always match with the values specified in the compute shader.
         /// todo: add validation logic at some point.
         /// </remarks>
-        private static readonly Vector2I compute_mipmap_threads = new Vector2I(16, 16);
+        private static readonly Vector2I compute_mipmap_threads = new Vector2I(32, 32);
 
         private readonly List<IVeldridUniformBuffer> uniformBufferResetList = new List<IVeldridUniformBuffer>();
         private readonly Dictionary<int, VeldridTextureResources> boundTextureUnits = new Dictionary<int, VeldridTextureResources>();

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -505,7 +505,7 @@ namespace osu.Framework.Graphics.Veldrid
                     computeMipmapParametersBuffer!.Data = new ComputeMipmapGenerationParameters
                     {
                         Region = new Vector4(regions[i].X, regions[i].Y, regions[i].Width, regions[i].Height),
-                        InvocationWidth = width,
+                        OutputWidth = width,
                     };
 
                     MipmapGenerationCommands.SetComputeResourceSet(1, computeMipmapParametersBuffer.GetResourceSet(computeMipmapBufferResourceLayout.AsNonNull()));

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.Veldrid
             SharedQuadIndex = new VeldridIndexData(this);
         }
 
-        protected override void Initialise(IGraphicsSurface graphicsSurface)
+        protected override void InitialiseDevice(IGraphicsSurface graphicsSurface)
         {
             // Veldrid must either be initialised on the main/"input" thread, or in a separate thread away from the draw thread at least.
             // Otherwise the window may not render anything on some platforms (macOS at least).
@@ -193,6 +193,11 @@ namespace osu.Framework.Graphics.Veldrid
             }
 
             MaxTextureSize = maxTextureSize;
+        }
+
+        protected override void SetupResources()
+        {
+            base.SetupResources();
 
             Commands = Factory.CreateCommandList();
             BufferUpdateCommands = Factory.CreateCommandList();

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Batches;
 using osu.Framework.Platform;
@@ -83,7 +82,7 @@ namespace osu.Framework.Graphics.Veldrid
         private Pipeline? computeMipmapPipeline;
         private ResourceLayout? computeMipmapTextureResourceLayout;
         private ResourceLayout? computeMipmapBufferResourceLayout;
-        private VeldridUniformBuffer<MipmapGenerationParameters>? computeMipmapParametersBuffer;
+        private VeldridUniformBuffer<ComputeMipmapGenerationParameters>? computeMipmapParametersBuffer;
 
         private bool supportsComputeMipmapGeneration =>
             // Requires GPU device to support compute shaders (not supported on old OpenGL versions).
@@ -274,7 +273,7 @@ namespace osu.Framework.Graphics.Veldrid
                         ThreadGroupSizeZ = 1,
                     });
 
-                    computeMipmapParametersBuffer = new VeldridUniformBuffer<MipmapGenerationParameters>(this);
+                    computeMipmapParametersBuffer = new VeldridUniformBuffer<ComputeMipmapGenerationParameters>(this);
                 }
                 else
                 {
@@ -476,7 +475,7 @@ namespace osu.Framework.Graphics.Veldrid
 
         private void generateMipmapsViaComputeShader(VeldridTexture texture, List<RectangleI> regions)
         {
-            computeMipmapParametersBuffer ??= new VeldridUniformBuffer<MipmapGenerationParameters>(this);
+            computeMipmapParametersBuffer ??= new VeldridUniformBuffer<ComputeMipmapGenerationParameters>(this);
 
             var textureResources = texture.GetResourceList().Single().AsNonNull();
 
@@ -503,7 +502,7 @@ namespace osu.Framework.Graphics.Veldrid
                     uint groupCountX = (uint)MathUtils.DivideRoundUp(regions[i].Width, compute_mipmap_threads.X);
                     uint groupCountY = (uint)MathUtils.DivideRoundUp(regions[i].Height, compute_mipmap_threads.Y);
 
-                    computeMipmapParametersBuffer!.Data = new MipmapGenerationParameters
+                    computeMipmapParametersBuffer!.Data = new ComputeMipmapGenerationParameters
                     {
                         Region = new Vector4(regions[i].X, regions[i].Y, regions[i].Width, regions[i].Height),
                         InvocationWidth = width,
@@ -878,13 +877,6 @@ namespace osu.Framework.Graphics.Veldrid
         public void RegisterUniformBufferForReset(IVeldridUniformBuffer buffer)
         {
             uniformBufferResetList.Add(buffer);
-        }
-
-        private record struct MipmapGenerationParameters
-        {
-            public UniformVector4 Region;
-            public UniformInt InvocationWidth;
-            private readonly UniformPadding12 _;
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -86,7 +86,8 @@ namespace osu.Framework.Graphics.Veldrid
         /// </summary>
         /// <remarks>
         /// On an M1 machine, setting any value that's higher than 1024 threads breaks mipmap generation, therefore.
-        /// This is specified in the compute shader as well for OpenGL backends.
+        /// This should always match with the values specified in the compute shader.
+        /// todo: add validation logic at some point.
         /// </remarks>
         private static readonly Vector2I compute_mipmap_threads = new Vector2I(16, 16);
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -489,7 +489,7 @@ namespace osu.Framework.Graphics.Veldrid
                 width = MathUtils.DivideRoundUp(width, 2);
                 height = MathUtils.DivideRoundUp(height, 2);
 
-                MipmapGenerationCommands.SetComputeResourceSet(0, textureResources.GetMipmapResourceSet(this, computeMipmapTextureResourceLayout.AsNonNull(), Device.LinearSampler, level));
+                MipmapGenerationCommands.SetComputeResourceSet(0, textureResources.GetMipmapResourceSet(this, computeMipmapTextureResourceLayout.AsNonNull(), level));
 
                 for (int i = 0; i < regions.Count; i++)
                 {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -438,7 +438,7 @@ namespace osu.Framework.Graphics.Veldrid
             int width = texture.Width;
             int height = texture.Height;
 
-            for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 || (width > 1 || height > 1); level++)
+            for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); level++)
             {
                 width = MathUtils.DivideRoundUp(width, 2);
                 height = MathUtils.DivideRoundUp(height, 2);

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -241,8 +241,7 @@ namespace osu.Framework.Graphics.Veldrid
 
                     computeMipmapTextureResourceLayout = Factory.CreateResourceLayout(new ResourceLayoutDescription(
                         new ResourceLayoutElementDescription("samplingTexture", ResourceKind.TextureReadOnly, ShaderStages.Compute),
-                        new ResourceLayoutElementDescription("targetTexture", ResourceKind.TextureReadWrite, ShaderStages.Compute),
-                        new ResourceLayoutElementDescription("sampler", ResourceKind.Sampler, ShaderStages.Compute)));
+                        new ResourceLayoutElementDescription("targetTexture", ResourceKind.TextureReadWrite, ShaderStages.Compute))); // todo: update to use SSBO type
 
                     computeMipmapBufferResourceLayout = Factory.CreateResourceLayout(new ResourceLayoutDescription(new ResourceLayoutElementDescription("parameters", ResourceKind.UniformBuffer, ShaderStages.Compute)));
 
@@ -452,7 +451,7 @@ namespace osu.Framework.Graphics.Veldrid
                 height = MathUtils.DivideRoundUp(height, 2);
 
                 using var targetTextureView = Factory.CreateTextureView(new TextureViewDescription(deviceTexture, (uint)level, 1, 0, 1));
-                using var textureResourceSet = Factory.CreateResourceSet(new ResourceSetDescription(computeMipmapTextureResourceLayout, deviceTexture, targetTextureView, Device.LinearSampler));
+                using var textureResourceSet = Factory.CreateResourceSet(new ResourceSetDescription(computeMipmapTextureResourceLayout, deviceTexture, targetTextureView));
 
                 int bufferIndex = level - 1;
 

--- a/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
+++ b/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
@@ -24,9 +24,9 @@ namespace osu.Framework.Platform.Windows
             this.host = host;
         }
 
-        protected override void Initialise(IGraphicsSurface graphicsSurface)
+        protected override void InitialiseDevice(IGraphicsSurface graphicsSurface)
         {
-            base.Initialise(graphicsSurface);
+            base.InitialiseDevice(graphicsSurface);
 
             WindowsWindow windowsWindow = (WindowsWindow)host.Window;
 

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -7,19 +7,15 @@ layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(set = 0, binding = 0) uniform texture2D inputTexture;
 layout(set = 0, binding = 1) uniform sampler inputSampler;
+layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 
+// normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
+// easiest way would be to supply it using a uniform buffer.
 #ifdef DIRECT3D11
-    // todo: there's so many fucked up shit to explain here.
-    layout(set = 0, binding = 2) writeonly buffer outputTexture { int outputTextureBuffer[]; };
-
     layout(set = 1, binding = 0) uniform parameters
     {
-        // normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
-        // easiest way would be to supply it using a uniform buffer.
         int invocationWidth;
     };
-#else
-    layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 #endif
 
 void main(void)
@@ -31,11 +27,5 @@ void main(void)
 #endif
 
     vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(gl_GlobalInvocationID.xy) + 0.5) / globalInvocationWidth);
-
-#ifdef DIRECT3D11
-    ivec4 byteColour = ivec4(colour * 255);
-    outputTextureBuffer[int(gl_GlobalInvocationID.y * invocationWidth + gl_GlobalInvocationID.x)] = byteColour.r + (byteColour.g << 8) + (byteColour.b << 16) + (byteColour.a << 24);
-#else
     imageStore(outputTexture, ivec2(gl_GlobalInvocationID), colour);
-#endif
 }

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -12,9 +12,7 @@ layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 layout(set = 1, binding = 0) uniform parameters
 {
     vec4 region;
-    // normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
-    // easiest way would be to supply it using a uniform buffer.
-    int invocationWidth;
+    int outputWidth;
 };
 
 void main(void)
@@ -23,6 +21,6 @@ void main(void)
         return;
 
     ivec2 texelCoord = ivec2(region.xy + gl_GlobalInvocationID.xy);
-    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(texelCoord) + 0.5) / invocationWidth);
+    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(texelCoord) + 0.5) / outputWidth);
     imageStore(outputTexture, texelCoord, colour);
 }

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -1,4 +1,5 @@
 #version 450
+#extension GL_EXT_samplerless_texture_functions : enable
 
 // On OpenGL backends, the thread group size is specified here in the compute shader.
 // On non-OpenGL backends, the thread group size is specified in Veldrid's compute pipeline description.
@@ -7,7 +8,6 @@ layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(set = 0, binding = 0) uniform texture2D samplingTexture;
 layout(set = 0, binding = 1) uniform writeonly image2D targetTexture;
-layout(set = 0, binding = 2) uniform sampler samplingSampler;
 
 layout(set = 1, binding = 0) uniform parameters
 {
@@ -17,10 +17,10 @@ layout(set = 1, binding = 0) uniform parameters
 void main(void)
 {
     vec4 colour =
-        (texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), samplingLevel) +
-         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), samplingLevel) +
-         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), samplingLevel) +
-         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), samplingLevel)) / 4;
+        (texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), samplingLevel) +
+         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), samplingLevel) +
+         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), samplingLevel) +
+         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), samplingLevel)) / 4;
 
     imageStore(targetTexture, ivec2(gl_GlobalInvocationID.xy), colour);
 }

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -1,5 +1,4 @@
 #version 450
-#extension GL_EXT_samplerless_texture_functions : enable
 
 // On OpenGL backends, the thread group size is specified here in the compute shader.
 // On non-OpenGL backends, the thread group size is specified in Veldrid's compute pipeline description.
@@ -7,32 +6,28 @@
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(set = 0, binding = 0) uniform texture2D inputTexture;
+layout(set = 0, binding = 1) uniform sampler inputSampler;
 
 #ifdef DIRECT3D11
     // todo: there's so many fucked up shit to explain here.
-    layout(set = 0, binding = 1) writeonly buffer outputTexture { int outputTextureBuffer[]; };
+    layout(set = 0, binding = 2) writeonly buffer outputTexture { int outputTextureBuffer[]; };
 #else
-    layout(set = 0, binding = 1, rgba8) writeonly uniform image2D outputTexture;
+    layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 #endif
 
 layout(set = 1, binding = 0) uniform parameters
 {
     int inputLevel;
-    int outputPitch;
+    int invocationWidth;
 };
 
 void main(void)
 {
-    // todo: use textureGather
-    vec4 colour =
-        (texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), inputLevel) +
-         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), inputLevel) +
-         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), inputLevel) +
-         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), inputLevel)) / 4;
+    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(gl_GlobalInvocationID.xy) + 0.5) / invocationWidth);
 
 #ifdef DIRECT3D11
     ivec4 byteColour = ivec4(colour * 255);
-    outputTextureBuffer[int(gl_GlobalInvocationID.y * outputPitch + gl_GlobalInvocationID.x)] = byteColour.r + (byteColour.g << 8) + (byteColour.b << 16) + (byteColour.a << 24);
+    outputTextureBuffer[int(gl_GlobalInvocationID.y * invocationWidth + gl_GlobalInvocationID.x)] = byteColour.r + (byteColour.g << 8) + (byteColour.b << 16) + (byteColour.a << 24);
 #else
     imageStore(outputTexture, ivec2(gl_GlobalInvocationID), colour);
 #endif

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -11,19 +11,26 @@ layout(set = 0, binding = 1) uniform sampler inputSampler;
 #ifdef DIRECT3D11
     // todo: there's so many fucked up shit to explain here.
     layout(set = 0, binding = 2) writeonly buffer outputTexture { int outputTextureBuffer[]; };
+
+    layout(set = 1, binding = 0) uniform parameters
+    {
+        // normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
+        // easiest way would be to supply it using a uniform buffer.
+        int invocationWidth;
+    };
 #else
     layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 #endif
 
-layout(set = 1, binding = 0) uniform parameters
-{
-    int inputLevel;
-    int invocationWidth;
-};
-
 void main(void)
 {
-    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(gl_GlobalInvocationID.xy) + 0.5) / invocationWidth);
+#ifdef DIRECT3D11
+    uint globalInvocationWidth = invocationWidth;
+#else
+    uint globalInvocationWidth = gl_WorkGroupSize.x * gl_NumWorkGroups.x;
+#endif
+
+    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(gl_GlobalInvocationID.xy) + 0.5) / globalInvocationWidth);
 
 #ifdef DIRECT3D11
     ivec4 byteColour = ivec4(colour * 255);

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -2,8 +2,8 @@
 
 // On OpenGL backends, the thread group size is specified here in the compute shader.
 // On non-OpenGL backends, the thread group size is specified in Veldrid's compute pipeline description.
-// This should always match with the values specified in the compute pipeline.
-layout(local_size_x = 16, local_size_y = 16) in;
+// This should always match with the constants defined in GLRenderer/VeldridRenderer.
+layout(local_size_x = 32, local_size_y = 32) in;
 
 layout(set = 0, binding = 0) uniform texture2D inputTexture;
 layout(set = 0, binding = 1) uniform sampler inputSampler;

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -2,7 +2,7 @@
 
 // On OpenGL backends, the thread group size is specified here in the compute shader.
 // On non-OpenGL backends, the thread group size is specified in Veldrid's compute pipeline description.
-// For consistent results, the size should match between here and GLRenderer/VeldridRenderer.compute_mipmap_threads.
+// This should always match with the values specified in the compute pipeline.
 layout(local_size_x = 16, local_size_y = 16) in;
 
 layout(set = 0, binding = 0) uniform texture2D inputTexture;

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -5,16 +5,22 @@
 // For consistent results, the size should match between here and GLRenderer/VeldridRenderer.compute_mipmap_threads.
 layout(local_size_x = 16, local_size_y = 16) in;
 
-layout(set = 0, binding = 0, rgba8) uniform readonly image2D samplingTexture;
-layout(set = 0, binding = 1, rgba8) uniform writeonly image2D targetTexture;
+layout(set = 0, binding = 0) uniform texture2D samplingTexture;
+layout(set = 0, binding = 1) uniform writeonly image2D targetTexture;
+layout(set = 0, binding = 2) uniform sampler samplingSampler;
+
+layout(set = 1, binding = 0) uniform parameters
+{
+    int samplingLevel;
+};
 
 void main(void)
 {
     vec4 colour =
-        (imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0))) +
-         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1))) +
-         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0))) +
-         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)))) / 4;
+        (texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), samplingLevel) +
+         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), samplingLevel) +
+         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), samplingLevel) +
+         texelFetch(sampler2D(samplingTexture, samplingSampler), ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), samplingLevel)) / 4;
 
     imageStore(targetTexture, ivec2(gl_GlobalInvocationID.xy), colour);
 }

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -9,23 +9,20 @@ layout(set = 0, binding = 0) uniform texture2D inputTexture;
 layout(set = 0, binding = 1) uniform sampler inputSampler;
 layout(set = 0, binding = 2, rgba8) writeonly uniform image2D outputTexture;
 
-// normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
-// easiest way would be to supply it using a uniform buffer.
-#ifdef DIRECT3D11
-    layout(set = 1, binding = 0) uniform parameters
-    {
-        int invocationWidth;
-    };
-#endif
+layout(set = 1, binding = 0) uniform parameters
+{
+    vec4 region;
+    // normally we would use gl_WorkGroupSize.x * gl_NumWorkGroups.x to get the width, but that's not supported in D3D11. 
+    // easiest way would be to supply it using a uniform buffer.
+    int invocationWidth;
+};
 
 void main(void)
 {
-#ifdef DIRECT3D11
-    uint globalInvocationWidth = invocationWidth;
-#else
-    uint globalInvocationWidth = gl_WorkGroupSize.x * gl_NumWorkGroups.x;
-#endif
+    if (gl_GlobalInvocationID.x >= region.z || gl_GlobalInvocationID.y >= region.w)
+        return;
 
-    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(gl_GlobalInvocationID.xy) + 0.5) / globalInvocationWidth);
-    imageStore(outputTexture, ivec2(gl_GlobalInvocationID), colour);
+    ivec2 texelCoord = ivec2(region.xy + gl_GlobalInvocationID.xy);
+    vec4 colour = texture(sampler2D(inputTexture, inputSampler), (vec2(texelCoord) + 0.5) / invocationWidth);
+    imageStore(outputTexture, texelCoord, colour);
 }

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -1,0 +1,20 @@
+#version 450
+
+// On OpenGL backends, the thread group size is specified here in the compute shader.
+// On non-OpenGL backends, the thread group size is specified in Veldrid's compute pipeline description.
+// For consistent results, the size should match between here and GLRenderer/VeldridRenderer.compute_mipmap_threads.
+layout(local_size_x = 16, local_size_y = 16) in;
+
+layout(set = 0, binding = 0, rgba8) uniform readonly image2D samplingTexture;
+layout(set = 0, binding = 1, rgba8) uniform writeonly image2D targetTexture;
+
+void main(void)
+{
+    vec4 colour =
+        (imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0))) +
+         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1))) +
+         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0))) +
+         imageLoad(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)))) / 4;
+
+    imageStore(targetTexture, ivec2(gl_GlobalInvocationID.xy), colour);
+}

--- a/osu.Framework/Resources/Shaders/sh_mipmap.comp
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.comp
@@ -6,21 +6,34 @@
 // For consistent results, the size should match between here and GLRenderer/VeldridRenderer.compute_mipmap_threads.
 layout(local_size_x = 16, local_size_y = 16) in;
 
-layout(set = 0, binding = 0) uniform texture2D samplingTexture;
-layout(set = 0, binding = 1) uniform writeonly image2D targetTexture;
+layout(set = 0, binding = 0) uniform texture2D inputTexture;
+
+#ifdef DIRECT3D11
+    // todo: there's so many fucked up shit to explain here.
+    layout(set = 0, binding = 1) writeonly buffer outputTexture { int outputTextureBuffer[]; };
+#else
+    layout(set = 0, binding = 1, rgba8) writeonly uniform image2D outputTexture;
+#endif
 
 layout(set = 1, binding = 0) uniform parameters
 {
-    int samplingLevel;
+    int inputLevel;
+    int outputPitch;
 };
 
 void main(void)
 {
+    // todo: use textureGather
     vec4 colour =
-        (texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), samplingLevel) +
-         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), samplingLevel) +
-         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), samplingLevel) +
-         texelFetch(samplingTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), samplingLevel)) / 4;
+        (texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 0)), inputLevel) +
+         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(0, 1)), inputLevel) +
+         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 0)), inputLevel) +
+         texelFetch(inputTexture, ivec2(gl_GlobalInvocationID.xy * 2 + uvec2(1, 1)), inputLevel)) / 4;
 
-    imageStore(targetTexture, ivec2(gl_GlobalInvocationID.xy), colour);
+#ifdef DIRECT3D11
+    ivec4 byteColour = ivec4(colour * 255);
+    outputTextureBuffer[int(gl_GlobalInvocationID.y * outputPitch + gl_GlobalInvocationID.x)] = byteColour.r + (byteColour.g << 8) + (byteColour.b << 16) + (byteColour.a << 24);
+#else
+    imageStore(outputTexture, ivec2(gl_GlobalInvocationID), colour);
+#endif
 }


### PR DESCRIPTION
- [ ] Depends on https://github.com/mellinoe/veldrid/pull/506
- [ ] Depends on https://github.com/ppy/veldrid/pull/15
- Should (resolve) https://github.com/ppy/osu/issues/23252
- Should (resolve) https://github.com/ppy/osu-framework/issues/5748

## Preface

Since https://github.com/ppy/osu-framework/pull/5508, custom mipmap generation was implemented to reduce the overhead in the case of uploading small textures to an atlas.

The implementation revolved around binding one level of a texture as a sampler and another level as a render target (FBO), and using `texture` to downsample the larger texture and store the result in the smaller texture.

This was pretty straightforward for OpenGL and Metal, but D3D11 and Vulkan weren't very supportive. Both of them don't seem to like the idea of binding the same texture as both an input and output of the shader.

That was worked around by allocating another texture to bind as the input for the shader, but that required preparing the texture content for each level, which means switching between encoders on Metal (and Veldrid's Vulkan implementation [doesn't handle that well?](https://github.com/ppy/osu-framework/issues/5748)).

## Compute-based mipmap generation

After exploring through compute shaders for the past week, I've came up with a simple implementation that avoids creating extra resources as much as possible.

The concept of it boils down to a compute shader accepting an input texture, a linear sampler, and a uniform buffer supplying the uploaded region. The compute shader downsamples from the texture according to the specified uploaded region and the current invocation ID, and stores the result in the output texture.

For Veldrid, this is implemented by splitting each texture into texture views in `VeldridTextureResources`, bind one view for sampling and another for output, and supply a re-usable uniform buffer with region data. 

For Legacy OpenGL, this is implemented similarly, but texture views aren't required as each texture resembles a sampler by itself, so the properties can be modified accordingly for each dispatch call without creating extra resources.

Compute shaders is shown to be supported by 80% of systems [according to this game](https://feedback.wildfiregames.com/gl/extensions/), but the rendering-based path still exists as a fall back for older hardware since it still behaves 10x better than driver implementation. It can be further improved by using texture views and caching VBOs, but I'm leaving it as-is in this PR.

## Better rectangle merging implementation

After writing a test scene for mipmap generation, it turns out there was a high overhead coming from the rectangle merging logic added in https://github.com/ppy/osu-framework/pull/5508.

The loop works well for a few overlapping regions, but can get very complex when queuing a high number of uploads at different regions.

The overhead can get as high as ~500ms, which is 100x higher than the overhead of mipmap generation itself.

After [discussing this on discord](https://discord.com/channels/188630481301012481/589331078574112768/1099936570796154971) with @smoogipoo, I've came up with a different implementation that follows the nature of texture atlases and produces as less rectangles as possible to simplify the mipmap generation process.

The implementation accepts all uploaded regions, and produces one or two rectangles, one covering all uploaded regions that are horizontally after the top-left uploaded region, and another rectangle covering all uploaded regions that are horizontally before the top-left uploaded region.

| Before | After |
|--------|-------|
| ![CleanShot 2023-04-26 at 16 04 00](https://user-images.githubusercontent.com/22781491/234583919-bb207d22-059e-40fa-a414-65aee2c94806.png) | ![CleanShot 2023-04-26 at 15 54 05](https://user-images.githubusercontent.com/22781491/234583980-b95816ca-1015-4ca1-813c-2964e04b817b.png) |

On master, mipmaps would be generated for every single uploaded data (including the paddings around the texture) as can be seen above, this resulted in too many vertices and unnecessary fills.

With the new implementation, all uploaded regions are formed into two rectangles to dispatch as many threads as possible without overlapping / unnecessary work.

The new implementation is also ~75x faster than the original logic, which should reduce stutters in osu! when starting gameplay, as there are a lot of textures getting added to the atlas at once.

---

As an aside, I have noticed both the computing and rendering implementations missing certain textures when testing with osu!, I'll leave this PR blocked from merge while I look into it.

Requires testing on all configurations below:
 - [ ] Windows (Legacy OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader`)
   - [ ] Rendering path
 - [ ] Windows (Veldrid OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader` and `GL_ARB_texture_view`)
   - [ ] Rendering path
 - [ ] Windows (Direct3D 11)
 - [ ] macOS (x64, Legacy OpenGL)
 - [ ] macOS (x64, Veldrid OpenGL)
 - [ ] macOS (x64, Metal)
 - [ ] macOS (M1, Legacy OpenGL)
 - [ ] macOS (M1, Veldrid OpenGL)
 - [ ] macOS (M1, Metal)
 - [ ] Linux (Legacy OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader`)
   - [ ] Rendering path
 - [ ] Linux (Veldrid OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader` and `GL_ARB_texture_view`)
   - [ ] Rendering path
 - [ ] Android (Legacy OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader`)
   - [ ] Rendering path
 - [ ] iOS (Legacy OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader`)
   - [ ] Rendering path
 - [ ] iOS (Veldrid OpenGL)
   - [ ] Computing path (requires `GL_ARB_compute_shader` and `GL_ARB_texture_view`)
   - [ ] Rendering path
 - [ ] iOS (Metal)

Optional configurations:
 - [ ] Windows (Vulkan) 
 - [ ] Linux (Vulkan)