### PR TITLE
Disable exclusive fullscreen detection on veldrid renderers for now

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
+++ b/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
@@ -57,6 +57,10 @@ namespace osu.Framework.Platform.Windows
             if (window.WindowState != WindowState.Fullscreen || !window.IsActive.Value || fullscreenCapability.Value != Windows.FullscreenCapability.Unknown)
                 return;
 
+            // This detection method was only ever tested / implemented with the legacy GL.
+            if (host.Renderer is not GLRenderer)
+                return;
+
             var cancellationSource = fullscreenCapabilityDetectionCancellationSource = new CancellationTokenSource();
             var cancellationToken = cancellationSource.Token;
 


### PR DESCRIPTION
As far as I know, this doesn't work correctly (based on discussion with @smoogipoo), but people are taking the message seriously and choosing a potentially sub-optimal renderer as a result:

![2023-04-28 17 17 21@2x](https://user-images.githubusercontent.com/191335/235094083-a95c793e-b539-4a92-b7d7-062db077037d.png)



@smoogipoo please confirm before merging.