### PR TITLE
Disable manual mipmap generation (and decrease atlas size again)

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -34,7 +34,13 @@ namespace osu.Framework.Graphics.Textures
 
         protected TextureAtlas Atlas;
 
-        private const int max_atlas_size = 4096;
+        /// <remarks>
+        /// While it would be beneficial to have this atlas size be higher (the ideal size seems to be somewhere in the ballpark of 4096),
+        /// built-in GL mipmapping performs poorly on atlases bigger than this maximum.
+        /// If the built-in GL mipmapping is replaced in the future (see custom generation logic in `{GL,Veldrid}Texture`),
+        /// then this limit can be increased to 4096 again.
+        /// </remarks>
+        private const int max_atlas_size = 1024;
 
         /// <summary>
         /// Decides at what resolution multiple this <see cref="TextureStore"/> is providing sprites at.

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -3,21 +3,18 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
-using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Platform;
-using osu.Framework.Utils;
-using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp.PixelFormats;
 using Veldrid;
 using PixelFormat = Veldrid.PixelFormat;
-using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using Texture = Veldrid.Texture;
 
 namespace osu.Framework.Graphics.Veldrid.Textures
@@ -225,145 +222,158 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 }
             }
 
+            #region Custom mipmap generation (disabled)
+
             // Generate mipmaps for just the updated regions of the texture.
             // This implementation is functionally equivalent to CommandList.GenerateMipmaps(),
             // only that it is much more efficient if only small parts of the texture
             // have been updated.
-            if (uploadedRegions.Count != 0 && !manualMipmaps)
-            {
-                // Merge overlapping upload regions to prevent redundant mipmap generation.
-                // i goes through the list left-to-right, j goes through it right-to-left
-                // until both indices meet somewhere in the middle.
-                // This algorithm needs multiple passes until no possible merges are found.
-                bool mergeFound;
 
-                do
-                {
-                    mergeFound = false;
+            // The implementation has been tried in a release, but the user reception has been mixed
+            // due to various issues on various platforms (most prominently android).
+            // As it's difficult to ascertain a reasonable heuristic as to when it should be safe to use this implementation,
+            // for now it is unconditionally disabled, and it can be revisited at a later date.
 
-                    for (int i = 0; i < uploadedRegions.Count; ++i)
-                    {
-                        RectangleI toMerge = uploadedRegions[i];
-
-                        for (int j = uploadedRegions.Count - 1; j > i; --j)
-                        {
-                            RectangleI mergeCandidate = uploadedRegions[j];
-
-                            if (!toMerge.Intersect(mergeCandidate).IsEmpty)
-                            {
-                                uploadedRegions[i] = toMerge = RectangleI.Union(toMerge, mergeCandidate);
-                                uploadedRegions.RemoveAt(j);
-                                mergeFound = true;
-                            }
-                        }
-                    }
-                } while (mergeFound);
-
-                // Mipmap generation using the merged upload regions follows
-                BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
-
-                // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
-                Renderer.SetBlend(BlendingParameters.None);
-                Renderer.PushDepthInfo(new DepthInfo(false, false));
-                Renderer.PushStencilInfo(new StencilInfo(false));
-                Renderer.PushScissorState(false);
-
-                // Create render state for mipmap generation
-                Renderer.BindTexture(this);
-                Renderer.GetMipmapShader().Bind();
-
-                using var samplingTexture = Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)Width, (uint)Height, resources!.Texture.MipLevels, 1, resources!.Texture.Format, TextureUsage.Sampled));
-                using var samplingResources = new VeldridTextureResources(samplingTexture, null);
-
-                while (uploadedRegions.Count > 0)
-                {
-                    int width = Width;
-                    int height = Height;
-
-                    int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
-
-                    // Generate quad buffer that will hold all the updated regions
-                    var quadBuffer = new VeldridQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsage.Dynamic);
-
-                    // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
-                    for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
-                    {
-                        width /= 2;
-                        height /= 2;
-
-                        // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
-                        for (int i = 0; i < count; ++i)
-                        {
-                            // Conservatively round the draw rectangles. Rounding to integer coords is required
-                            // in order to ensure all the texels affected by linear interpolation are touched.
-                            // We could skip the rounding & use a single vertex buffer for all levels if we had
-                            // conservative raster, but alas, that's only supported on NV and Intel.
-                            Vector2I topLeft = uploadedRegions[i].TopLeft;
-                            topLeft = new Vector2I(topLeft.X / 2, topLeft.Y / 2);
-                            Vector2I bottomRight = uploadedRegions[i].BottomRight;
-                            bottomRight = new Vector2I(MathUtils.DivideRoundUp(bottomRight.X, 2), MathUtils.DivideRoundUp(bottomRight.Y, 2));
-                            uploadedRegions[i] = new RectangleI(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
-
-                            // Normalize the draw rectangle into the unit square, which doubles as texture sampler coordinates.
-                            RectangleF r = (RectangleF)uploadedRegions[i] / new Vector2(width, height);
-
-                            quadBuffer.SetVertex(i * 4 + 0, new UncolouredVertex2D { Position = r.BottomLeft });
-                            quadBuffer.SetVertex(i * 4 + 1, new UncolouredVertex2D { Position = r.BottomRight });
-                            quadBuffer.SetVertex(i * 4 + 2, new UncolouredVertex2D { Position = r.TopRight });
-                            quadBuffer.SetVertex(i * 4 + 3, new UncolouredVertex2D { Position = r.TopLeft });
-                        }
-
-                        // this intentionally runs a CopyTexture command on the render pass command list as it has to be executed after the previous level is rendered by the GPU.
-                        Renderer.Commands.CopyTexture(resources!.Texture, samplingTexture, (uint)level - 1, 0);
-
-                        // Read the texture from 1 mip level higher...
-                        samplingResources.Sampler = Renderer.Factory.CreateSampler(new SamplerDescription
-                        {
-                            AddressModeU = SamplerAddressMode.Clamp,
-                            AddressModeV = SamplerAddressMode.Clamp,
-                            AddressModeW = SamplerAddressMode.Clamp,
-                            Filter = filteringMode,
-                            MinimumLod = (uint)level - 1,
-                            MaximumLod = (uint)level - 1,
-                            MaximumAnisotropy = 0,
-                        });
-
-                        Renderer.BindTextureResource(samplingResources, 0);
-
-                        // ...than the one we're writing to via frame buffer.
-                        using (var frameBuffer = new VeldridFrameBuffer(Renderer, this, level))
-                        {
-                            Renderer.BindFrameBuffer(frameBuffer);
-                            Renderer.PushViewport(new RectangleI(0, 0, width, height));
-
-                            // Perform the actual mip level draw
-                            quadBuffer.Update();
-                            quadBuffer.Draw();
-
-                            Renderer.PopViewport();
-                            Renderer.UnbindFrameBuffer(frameBuffer);
-                        }
-                    }
-
-                    uploadedRegions.RemoveRange(0, count);
-                }
-
-                // Restore previous render state
-                Renderer.GetMipmapShader().Unbind();
-
-                Renderer.PopScissorState();
-                Renderer.PopStencilInfo();
-                Renderer.PopDepthInfo();
-
-                Renderer.SetBlend(previousBlendingParameters);
-            }
-
-            // Uncomment the following block of code in order to compare the above with the renderer mipmap generation method CommandList.GenerateMipmaps().
             // if (uploadedRegions.Count != 0 && !manualMipmaps)
             // {
-            //     Debug.Assert(resources != null);
-            //     Renderer.Commands.GenerateMipmaps(resources.Texture);
+            //     // Merge overlapping upload regions to prevent redundant mipmap generation.
+            //     // i goes through the list left-to-right, j goes through it right-to-left
+            //     // until both indices meet somewhere in the middle.
+            //     // This algorithm needs multiple passes until no possible merges are found.
+            //     bool mergeFound;
+
+            //     do
+            //     {
+            //         mergeFound = false;
+
+            //         for (int i = 0; i < uploadedRegions.Count; ++i)
+            //         {
+            //             RectangleI toMerge = uploadedRegions[i];
+
+            //             for (int j = uploadedRegions.Count - 1; j > i; --j)
+            //             {
+            //                 RectangleI mergeCandidate = uploadedRegions[j];
+
+            //                 if (!toMerge.Intersect(mergeCandidate).IsEmpty)
+            //                 {
+            //                     uploadedRegions[i] = toMerge = RectangleI.Union(toMerge, mergeCandidate);
+            //                     uploadedRegions.RemoveAt(j);
+            //                     mergeFound = true;
+            //                 }
+            //             }
+            //         }
+            //     } while (mergeFound);
+
+            //     // Mipmap generation using the merged upload regions follows
+            //     BlendingParameters previousBlendingParameters = Renderer.CurrentBlendingParameters;
+
+            //     // Use a simple render state (no blending, masking, scissoring, stenciling, etc.)
+            //     Renderer.SetBlend(BlendingParameters.None);
+            //     Renderer.PushDepthInfo(new DepthInfo(false, false));
+            //     Renderer.PushStencilInfo(new StencilInfo(false));
+            //     Renderer.PushScissorState(false);
+
+            //     // Create render state for mipmap generation
+            //     Renderer.BindTexture(this);
+            //     Renderer.GetMipmapShader().Bind();
+
+            //     using var samplingTexture = Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)Width, (uint)Height, resources!.Texture.MipLevels, 1, resources!.Texture.Format, TextureUsage.Sampled));
+            //     using var samplingResources = new VeldridTextureResources(samplingTexture, null);
+
+            //     while (uploadedRegions.Count > 0)
+            //     {
+            //         int width = Width;
+            //         int height = Height;
+
+            //         int count = Math.Min(uploadedRegions.Count, IRenderer.MAX_QUADS);
+
+            //         // Generate quad buffer that will hold all the updated regions
+            //         var quadBuffer = new VeldridQuadBuffer<UncolouredVertex2D>(Renderer, count, BufferUsage.Dynamic);
+
+            //         // Compute mipmap by iteratively blitting coarser and coarser versions of the updated regions
+            //         for (int level = 1; level < IRenderer.MAX_MIPMAP_LEVELS + 1 && (width > 1 || height > 1); ++level)
+            //         {
+            //             width /= 2;
+            //             height /= 2;
+
+            //             // Fill quad buffer with downscaled (and conservatively rounded) draw rectangles
+            //             for (int i = 0; i < count; ++i)
+            //             {
+            //                 // Conservatively round the draw rectangles. Rounding to integer coords is required
+            //                 // in order to ensure all the texels affected by linear interpolation are touched.
+            //                 // We could skip the rounding & use a single vertex buffer for all levels if we had
+            //                 // conservative raster, but alas, that's only supported on NV and Intel.
+            //                 Vector2I topLeft = uploadedRegions[i].TopLeft;
+            //                 topLeft = new Vector2I(topLeft.X / 2, topLeft.Y / 2);
+            //                 Vector2I bottomRight = uploadedRegions[i].BottomRight;
+            //                 bottomRight = new Vector2I(MathUtils.DivideRoundUp(bottomRight.X, 2), MathUtils.DivideRoundUp(bottomRight.Y, 2));
+            //                 uploadedRegions[i] = new RectangleI(topLeft.X, topLeft.Y, bottomRight.X - topLeft.X, bottomRight.Y - topLeft.Y);
+
+            //                 // Normalize the draw rectangle into the unit square, which doubles as texture sampler coordinates.
+            //                 RectangleF r = (RectangleF)uploadedRegions[i] / new Vector2(width, height);
+
+            //                 quadBuffer.SetVertex(i * 4 + 0, new UncolouredVertex2D { Position = r.BottomLeft });
+            //                 quadBuffer.SetVertex(i * 4 + 1, new UncolouredVertex2D { Position = r.BottomRight });
+            //                 quadBuffer.SetVertex(i * 4 + 2, new UncolouredVertex2D { Position = r.TopRight });
+            //                 quadBuffer.SetVertex(i * 4 + 3, new UncolouredVertex2D { Position = r.TopLeft });
+            //             }
+
+            //             // this intentionally runs a CopyTexture command on the render pass command list as it has to be executed after the previous level is rendered by the GPU.
+            //             Renderer.Commands.CopyTexture(resources!.Texture, samplingTexture, (uint)level - 1, 0);
+
+            //             // Read the texture from 1 mip level higher...
+            //             samplingResources.Sampler = Renderer.Factory.CreateSampler(new SamplerDescription
+            //             {
+            //                 AddressModeU = SamplerAddressMode.Clamp,
+            //                 AddressModeV = SamplerAddressMode.Clamp,
+            //                 AddressModeW = SamplerAddressMode.Clamp,
+            //                 Filter = filteringMode,
+            //                 MinimumLod = (uint)level - 1,
+            //                 MaximumLod = (uint)level - 1,
+            //                 MaximumAnisotropy = 0,
+            //             });
+
+            //             Renderer.BindTextureResource(samplingResources, 0);
+
+            //             // ...than the one we're writing to via frame buffer.
+            //             using (var frameBuffer = new VeldridFrameBuffer(Renderer, this, level))
+            //             {
+            //                 Renderer.BindFrameBuffer(frameBuffer);
+            //                 Renderer.PushViewport(new RectangleI(0, 0, width, height));
+
+            //                 // Perform the actual mip level draw
+            //                 quadBuffer.Update();
+            //                 quadBuffer.Draw();
+
+            //                 Renderer.PopViewport();
+            //                 Renderer.UnbindFrameBuffer(frameBuffer);
+            //             }
+            //         }
+
+            //         uploadedRegions.RemoveRange(0, count);
+            //     }
+
+            //     // Restore previous render state
+            //     Renderer.GetMipmapShader().Unbind();
+
+            //     Renderer.PopScissorState();
+            //     Renderer.PopStencilInfo();
+            //     Renderer.PopDepthInfo();
+
+            //     Renderer.SetBlend(previousBlendingParameters);
             // }
+
+            #endregion
+
+            #region Veldrid-provided mipmap generation
+
+            if (uploadedRegions.Count != 0 && !manualMipmaps)
+            {
+                Debug.Assert(resources != null);
+                Renderer.Commands.GenerateMipmaps(resources.Texture);
+            }
+
+            #endregion
 
             return uploadedRegions.Count != 0;
         }


### PR DESCRIPTION
- Temporarily fixes https://github.com/ppy/osu/issues/23249
- Temporarily fixes https://github.com/ppy/osu/issues/23240 (as tested by @Joehuu)
- Temporarily fixes https://github.com/ppy/osu/issues/23318 (as tested by @Joehuu)
- Could possibly end up temporarily fixing some of the following (can't tell since I can't reproduce in the first place):
  - https://github.com/ppy/osu/issues/23285

As per [today's discussion in discord](https://discord.com/channels/188630481301012481/589331078574112768/1101851147570004030), this disables the meaningful changes made in #5508 to restore operation on configurations that have been negatively affected by the change (primarily appears to be mobile).

This is not a direct revert, and the goal was to keep the mipmap generation code in the tree, just in a disabled state, to permit revisiting the issue at a later date if necessary.

https://github.com/ppy/osu-framework/pull/5757 is a possible avenue for improvement in this stage, but it is currently not ready and @frenzibyte has no throughput to address the issues therein.