### PR TITLE
Remove reflection usage from `Interpolation` class

### DIFF
--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using System.Runtime.Serialization;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -377,26 +376,46 @@ namespace osu.Framework.Utils
 
             static GenericInterpolation()
             {
-                const string interpolation_method = nameof(GenericInterpolation<TEasing>.ValueAt);
-
-                var parameters = typeof(InterpolationFunc<TValue, TEasing>)
-                                 .GetMethod(nameof(InterpolationFunc<TValue, TEasing>.Invoke))
-                                 ?.GetParameters().Select(p => p.ParameterType).ToArray()
-                                 ?? Array.Empty<Type>();
-
-                var valueAtMethod = typeof(GenericInterpolation<TEasing>).GetMethod(interpolation_method, parameters);
-
-                if (valueAtMethod != null)
-                    FUNCTION = valueAtMethod.CreateDelegate<InterpolationFunc<TValue, TEasing>>();
-                else
-                {
-                    var typeRef = FormatterServices.GetSafeUninitializedObject(typeof(TValue)) as IInterpolable<TValue>;
-
-                    if (typeRef == null)
-                        throw new NotSupportedException($"Type {typeof(TValue)} has no interpolation function. Implement the interface {typeof(IInterpolable<TValue>)} interface on the object.");
-
+                if (typeof(TValue) == typeof(ColourInfo))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<ColourInfo, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(EdgeEffectParameters))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<EdgeEffectParameters, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(SRGBColour))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<SRGBColour, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(Color4))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<Color4, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(Colour4))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<Colour4, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(byte))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<byte, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(sbyte))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<sbyte, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(short))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<short, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(ushort))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<ushort, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(int))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<int, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(uint))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<uint, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(long))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<long, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(ulong))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<ulong, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(float))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<float, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(decimal))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<decimal, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(double))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<double, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(Vector2))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<Vector2, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (typeof(TValue) == typeof(RectangleF))
+                    FUNCTION = (InterpolationFunc<TValue, TEasing>)(object)(InterpolationFunc<RectangleF, TEasing>)GenericInterpolation<TEasing>.ValueAt;
+                else if (FormatterServices.GetSafeUninitializedObject(typeof(TValue)) is IInterpolable<TValue> typeRef)
                     FUNCTION = typeRef.ValueAt;
-                }
+                else
+                    throw new NotSupportedException($"Type {typeof(TValue)} has no interpolation function. Implement the interface {typeof(IInterpolable<TValue>)} interface on the object.");
             }
         }
     }


### PR DESCRIPTION
This is only intended to remove the reflection from the ctor, both to reduce memory footprint but also to be more AOT-friendly. There appears to be no difference in performance.

Before:

|                   Method |      Mean |     Error |    StdDev | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|
| InterpolateMarginPadding | 45.014 ns | 0.6000 ns | 0.5612 ns |         - |
|  InterpolateFloatGeneric |  8.282 ns | 0.1558 ns | 0.1382 ns |         - |
|         InterpolateFloat |  8.319 ns | 0.1909 ns | 0.2344 ns |         - |

After:

|                   Method |      Mean |     Error |    StdDev | Allocated |
|------------------------- |----------:|----------:|----------:|----------:|
| InterpolateMarginPadding | 45.721 ns | 0.3529 ns | 0.2947 ns |         - |
|  InterpolateFloatGeneric |  7.938 ns | 0.0656 ns | 0.0614 ns |         - |
|         InterpolateFloat |  6.279 ns | 0.1024 ns | 0.0855 ns |         - |