### PR TITLE
Move `ActiveCursor` initial population to ctor to allow safe non-null specification

### DIFF
--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Cursor
 {
     public partial class CursorContainer : VisibilityContainer, IRequireHighFrequencyMousePosition
     {
-        public Drawable? ActiveCursor { get; protected set; }
+        public Drawable ActiveCursor { get; protected set; }
 
         private TouchLongPressFeedback longPressFeedback = null!;
 
@@ -27,12 +27,14 @@ namespace osu.Framework.Graphics.Cursor
             RelativeSizeAxes = Axes.Both;
 
             State.Value = Visibility.Visible;
+
+            ActiveCursor = CreateCursor();
         }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            Add(ActiveCursor = CreateCursor());
+            Add(ActiveCursor);
             Add(longPressFeedback = CreateLongPressFeedback());
         }
 
@@ -63,8 +65,7 @@ namespace osu.Framework.Graphics.Cursor
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            if (ActiveCursor != null)
-                ActiveCursor.Position = e.MousePosition;
+            ActiveCursor.Position = e.MousePosition;
             return base.OnMouseMove(e);
         }
 

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Cursor
 {
     public partial class CursorContainer : VisibilityContainer, IRequireHighFrequencyMousePosition
     {
-        public Drawable ActiveCursor { get; protected set; } = null!;
+        public Drawable? ActiveCursor { get; protected set; }
 
         private TouchLongPressFeedback longPressFeedback = null!;
 
@@ -63,7 +63,8 @@ namespace osu.Framework.Graphics.Cursor
 
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            ActiveCursor.Position = e.MousePosition;
+            if (ActiveCursor != null)
+                ActiveCursor.Position = e.MousePosition;
             return base.OnMouseMove(e);
         }
 


### PR DESCRIPTION
See discussion at https://github.com/ppy/osu/pull/23394#issuecomment-1534999637