### PR TITLE
Disable relative-mode mouse by default on Linux

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using SDL2;
 using osu.Framework.Input;
+using osu.Framework.Input.Handlers;
+using osu.Framework.Input.Handlers.Mouse;
 
 namespace osu.Framework.Platform.Linux
 {
@@ -51,5 +54,19 @@ namespace osu.Framework.Platform.Linux
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new SDL2DesktopWindow(preferredSurface);
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new LinuxReadableKeyCombinationProvider();
+
+        protected override IEnumerable<InputHandler> CreateAvailableInputHandlers()
+        {
+            var handlers = base.CreateAvailableInputHandlers();
+
+            foreach (var h in handlers.OfType<MouseHandler>())
+            {
+                // There are several bugs we need to fix with Linux / SDL2 cursor handling before switching this on.
+                h.UseRelativeMode.Value = false;
+                h.UseRelativeMode.Default = false;
+            }
+
+            return handlers;
+        }
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -62,6 +62,7 @@ namespace osu.Framework.Platform.MacOS
             {
                 // There are several bugs we need to fix with macOS / SDL2 cursor handling before switching this on.
                 h.UseRelativeMode.Value = false;
+                h.UseRelativeMode.Default = false;
             }
 
             return handlers;


### PR DESCRIPTION
There are still edge cases on Linux where relative-mode isn't working correctly. One example is my NoMachine setup, which grabs the cursor but pins it to `(windowWidth, windowHeight)`.

The change to `Default` is intentional (for macOS also), otherwise the in-game options will show a non-default setting for the default value on these platforms.