### PR TITLE
Simplify UBO uploads

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
@@ -42,8 +42,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 if (value.Equals(data))
                     return;
 
-                renderer.FlushCurrentBatch(FlushBatchSource.SetUniform);
-
                 setData(ref value);
             }
         }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.Veldrid
         public VeldridIndexData SharedLinearIndex { get; }
         public VeldridIndexData SharedQuadIndex { get; }
 
-        private readonly List<IVeldridUniformBuffer> uniformBufferResetList = new List<IVeldridUniformBuffer>();
+        private readonly HashSet<IVeldridUniformBuffer> uniformBufferResetList = new HashSet<IVeldridUniformBuffer>();
         private readonly Dictionary<int, VeldridTextureResources> boundTextureUnits = new Dictionary<int, VeldridTextureResources>();
         private readonly Dictionary<string, IVeldridUniformBuffer> boundUniformBuffers = new Dictionary<string, IVeldridUniformBuffer>();
         private IGraphicsSurface graphicsSurface = null!;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/5770 and hopefully makes this code a lot more readable as to why it's doing things the way it is.

UBOs no longer flush when data is set, and are now flushed as part of the draw call. Considering the sequence of events:
```
1. VBO.Add(...)
2. UBO.Data = ...
3. VBO.Add(...)
4. UBO.Data = ...
5. VBO.Draw()
```
- Previously: Vertex 1 uses data 2, vertex 3 uses data 4.
- Now: Both vertices use data 4.

The global uniform buffer, which persists through multiple `DrawNode`s and needs special flush handling, is already covered by flushes in the various Renderer state change methods.

As a bonus, this removes the equality comparer from `Data_set()` which could _slightly_ improve performance where it's called multiple times before actually being uploaded (masking).