### PR TITLE
Update veldrid SPIRV with fix for older macOS versions

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
     <PackageReference Include="ppy.Veldrid" Version="4.9.3-gf1f8dc0432" />
-    <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gc5e8498253" />
+    <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />


### PR DESCRIPTION
Inclues https://github.com/ppy/veldrid-spirv/pull/1.