### PR TITLE
updating the dotnet command because -i is deprecated.

### DIFF
--- a/osu.Framework.Templates/README.md
+++ b/osu.Framework.Templates/README.md
@@ -7,7 +7,7 @@ Templates to use when starting off with osu!framework. Create a fully-testable, 
 ```bash
 # install (or update) template package.
 # this only needs to be done once
-dotnet new -i ppy.osu.Framework.Templates
+dotnet new install ppy.osu.Framework.Templates
 
 ## IMPORTANT: Do not use spaces or hyphens in your project name for the following commands.
 ## This does not play nice with the templating system.


### PR DESCRIPTION
for a pull request involving osu-framework and dotnet.

This is a very small tiny pull request. 
I ran the command as per the instruction to install the templates in the readme.md file and it gave me a warning because --install (which -i is the short for) is deprecated. 

[Learn more here](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new#description)

![image](https://github.com/ppy/osu-framework/assets/37085907/2404a1f2-d50b-4680-ba02-4b3b3ea836b9)

