### PR TITLE
Cache value of `VerticalSync` to avoid overhead retrieving from SDL2 each time

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
@@ -188,13 +188,26 @@ namespace osu.Framework.Platform.SDL2
             }
         }
 
+        // cache value locally as requesting from SDL is not free.
+        // it is assumed that we are the only thing changing vsync modes.
+        private bool? verticalSync = false;
+
         bool IOpenGLGraphicsSurface.VerticalSync
         {
-            get => SDL.SDL_GL_GetSwapInterval() != 0;
+            get
+            {
+                if (verticalSync != null)
+                    return verticalSync.Value;
+
+                return (verticalSync = SDL.SDL_GL_GetSwapInterval() != 0).Value;
+            }
             set
             {
                 if (RuntimeInfo.IsDesktop)
+                {
                     SDL.SDL_GL_SetSwapInterval(value ? 1 : 0);
+                    verticalSync = value;
+                }
             }
         }
 

--- a/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Platform.SDL2
 
         // cache value locally as requesting from SDL is not free.
         // it is assumed that we are the only thing changing vsync modes.
-        private bool? verticalSync = false;
+        private bool? verticalSync;
 
         bool IOpenGLGraphicsSurface.VerticalSync
         {


### PR DESCRIPTION
As seen by @smoogipoo 

![](https://cdn.discordapp.com/attachments/589331078574112768/1106511624686288946/image.png)

I can't repro on macOS but this should be a pretty low-risk change, and especially important since this is called at least once per frame for opengl renderers:

https://cdn.discordapp.com/attachments/589331078574112768/1106511624686288946/image.png