### PR TITLE
Reduce overhead induced by checking Bass CPU usage

### DIFF
--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -47,9 +47,12 @@ namespace osu.Framework.Threading
 
         private static readonly GlobalStatistic<double> cpu_usage = GlobalStatistics.Get<double>("Audio", "Bass CPU%");
 
+        private long frameCount;
+
         private void onNewFrame()
         {
-            cpu_usage.Value = Bass.CPUUsage;
+            if (frameCount++ % 1000 == 0)
+                cpu_usage.Value = Bass.CPUUsage;
 
             lock (managers)
             {


### PR DESCRIPTION
It's not the end of the world, but we're definitely querying too often.
![JetBrains Rider 2023-05-12 at 12 27 01](https://github.com/ppy/osu-framework/assets/191335/72ecf3f3-5d9d-4a33-ae67-38e8e71b742c)
