### PR TITLE
Fix D3D11 losing performance by constantly mapping/unmapping buffers

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using Veldrid;
-using BufferUsage = Veldrid.BufferUsage;
 
 namespace osu.Framework.Graphics.Veldrid.Batches
 {
@@ -20,6 +19,6 @@ namespace osu.Framework.Graphics.Veldrid.Batches
             this.type = type;
         }
 
-        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridLinearBuffer<T>(renderer, Size, type, BufferUsage.Dynamic);
+        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridLinearBuffer<T>(renderer, Size, type);
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers;
-using BufferUsage = Veldrid.BufferUsage;
 
 namespace osu.Framework.Graphics.Veldrid.Batches
 {
@@ -18,6 +17,6 @@ namespace osu.Framework.Graphics.Veldrid.Batches
                 throw new OverflowException($"Attempted to initialise a {nameof(VeldridQuadBuffer<T>)} with more than {nameof(VeldridQuadBuffer<T>)}.{nameof(VeldridQuadBuffer<T>.MAX_QUADS)} quads ({VeldridQuadBuffer<T>.MAX_QUADS}).");
         }
 
-        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridQuadBuffer<T>(renderer, Size, BufferUsage.Dynamic);
+        protected override VeldridVertexBuffer<T> CreateVertexBuffer(VeldridRenderer renderer) => new VeldridQuadBuffer<T>(renderer, Size);
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/IStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/IStagingBuffer.cs
@@ -20,6 +20,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
         uint Count { get; }
 
         /// <summary>
+        /// Any extra flags required for the target of a <see cref="CopyTo"/> operation.
+        /// </summary>
+        BufferUsage CopyTargetUsageFlags { get; }
+
+        /// <summary>
         /// The data contained in this buffer.
         /// </summary>
         Span<T> Data { get; }

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/IStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/IStagingBuffer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
+{
+    internal interface IStagingBuffer<T> : IDisposable
+        where T : unmanaged
+    {
+        /// <summary>
+        /// The total size of this buffer in bytes.
+        /// </summary>
+        uint SizeInBytes { get; }
+
+        /// <summary>
+        /// The number of elements in this buffer.
+        /// </summary>
+        uint Count { get; }
+
+        /// <summary>
+        /// The data contained in this buffer.
+        /// </summary>
+        Span<T> Data { get; }
+
+        /// <summary>
+        /// Copies data from this buffer into a <see cref="DeviceBuffer"/>.
+        /// </summary>
+        /// <param name="buffer">The target buffer.</param>
+        /// <param name="srcOffset">The offset into this buffer at which the copy should start.</param>
+        /// <param name="dstOffset">The offset into <paramref name="buffer"/> at which the copy should start.</param>
+        /// <param name="size">The number of elements to be copied.</param>
+        void CopyTo(DeviceBuffer buffer, uint srcOffset, uint dstOffset, uint size);
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/ManagedStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/ManagedStagingBuffer.cs
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Memory;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
+{
+    /// <summary>
+    /// A staging buffer that uses a buffer in managed memory as its storage medium.
+    /// </summary>
+    internal class ManagedStagingBuffer<T> : IStagingBuffer<T>
+        where T : unmanaged
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly Memory<T> vertexMemory;
+        private readonly IMemoryOwner<T> memoryOwner;
+
+        public ManagedStagingBuffer(VeldridRenderer renderer, uint count)
+        {
+            this.renderer = renderer;
+            Count = count;
+            SizeInBytes = (uint)(Unsafe.SizeOf<T>() * count);
+
+            memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<T>((int)Count, AllocationOptions.Clean);
+            vertexMemory = memoryOwner.Memory;
+        }
+
+        public uint SizeInBytes { get; }
+
+        public uint Count { get; }
+
+        public Span<T> Data => vertexMemory.Span;
+
+        public void CopyTo(DeviceBuffer buffer, uint srcOffset, uint dstOffset, uint count)
+        {
+            renderer.Device.UpdateBuffer(
+                buffer,
+                (uint)(dstOffset * Unsafe.SizeOf<T>()),
+                ref Data[(int)srcOffset],
+                (uint)(count * Unsafe.SizeOf<T>()));
+        }
+
+        public void Dispose()
+        {
+            memoryOwner.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/ManagedStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/ManagedStagingBuffer.cs
@@ -33,6 +33,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
 
         public uint Count { get; }
 
+        public BufferUsage CopyTargetUsageFlags => BufferUsage.Dynamic;
+
         public Span<T> Data => vertexMemory.Span;
 
         public void CopyTo(DeviceBuffer buffer, uint srcOffset, uint dstOffset, uint count)

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/PersistentStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/PersistentStagingBuffer.cs
@@ -34,6 +34,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
 
         public uint Count { get; }
 
+        public BufferUsage CopyTargetUsageFlags => 0;
+
         public Span<T> Data
         {
             get

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/PersistentStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/PersistentStagingBuffer.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.CompilerServices;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
+{
+    /// <summary>
+    /// A staging buffer that uses a persistently-mapped device buffer as its storage medium.
+    /// </summary>
+    internal class PersistentStagingBuffer<T> : IStagingBuffer<T>
+        where T : unmanaged
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly DeviceBuffer stagingBuffer;
+        private readonly MappedResource stagingBufferMap;
+
+        public PersistentStagingBuffer(VeldridRenderer renderer, uint count)
+        {
+            this.renderer = renderer;
+
+            Count = count;
+            SizeInBytes = (uint)(Unsafe.SizeOf<T>() * count);
+
+            stagingBuffer = renderer.Factory.CreateBuffer(new BufferDescription(SizeInBytes, BufferUsage.Staging));
+            stagingBufferMap = renderer.Device.Map(stagingBuffer, MapMode.ReadWrite);
+
+            Data.Clear();
+        }
+
+        public uint SizeInBytes { get; }
+
+        public uint Count { get; }
+
+        public Span<T> Data
+        {
+            get
+            {
+                unsafe
+                {
+                    return new Span<T>(stagingBufferMap.Data.ToPointer(), (int)Count);
+                }
+            }
+        }
+
+        public void CopyTo(DeviceBuffer buffer, uint srcOffset, uint dstOffset, uint size)
+        {
+            renderer.BufferUpdateCommands.CopyBuffer(
+                stagingBuffer,
+                (uint)(srcOffset * Unsafe.SizeOf<T>()),
+                buffer,
+                (uint)(dstOffset * Unsafe.SizeOf<T>()),
+                (uint)(size * Unsafe.SizeOf<T>()));
+        }
+
+        public void Dispose()
+        {
+            renderer.Device.Unmap(stagingBuffer);
+            stagingBuffer.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics.Rendering.Vertices;
 using Veldrid;
-using BufferUsage = Veldrid.BufferUsage;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
 {
@@ -17,8 +16,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly VeldridRenderer renderer;
         private readonly int amountVertices;
 
-        internal VeldridLinearBuffer(VeldridRenderer renderer, int amountVertices, PrimitiveTopology type, BufferUsage usage)
-            : base(renderer, amountVertices, usage)
+        internal VeldridLinearBuffer(VeldridRenderer renderer, int amountVertices, PrimitiveTopology type)
+            : base(renderer, amountVertices)
         {
             this.renderer = renderer;
             this.amountVertices = amountVertices;

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using Veldrid;
-using BufferUsage = Veldrid.BufferUsage;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
@@ -24,8 +23,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// </summary>
         public const int MAX_QUADS = ushort.MaxValue / indices_per_quad;
 
-        internal VeldridQuadBuffer(VeldridRenderer renderer, int amountQuads, BufferUsage usage)
-            : base(renderer, amountQuads * IRenderer.VERTICES_PER_QUAD, usage)
+        internal VeldridQuadBuffer(VeldridRenderer renderer, int amountQuads)
+            : base(renderer, amountQuads * IRenderer.VERTICES_PER_QUAD)
         {
             this.renderer = renderer;
             amountIndices = amountQuads * indices_per_quad;

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -64,7 +64,10 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             ThreadSafety.EnsureDrawThread();
 
-            gpuBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer));
+            getMemory();
+            Debug.Assert(stagingBuffer != null);
+
+            gpuBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | stagingBuffer.CopyTargetUsageFlags));
             memoryLease = NativeMemoryTracker.AddMemory(this, gpuBuffer.SizeInBytes);
 
             // Ensure the device buffer is initialised to 0.

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -180,9 +180,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             stagingBuffer?.Dispose();
             stagingBuffer = null;
 
-            stagingBuffer?.Dispose();
-            stagingBuffer = null;
-
             gpuBuffer?.Dispose();
             gpuBuffer = null;
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Buffers;
 using System.Diagnostics;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering;
@@ -10,7 +9,6 @@ using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Vertices;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
-using SixLabors.ImageSharp.Memory;
 using Veldrid;
 using BufferUsage = Veldrid.BufferUsage;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
@@ -25,11 +23,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly VeldridRenderer renderer;
         private readonly BufferUsage usage;
 
-        private Memory<DepthWrappingVertex<T>> vertexMemory;
-        private IMemoryOwner<DepthWrappingVertex<T>>? memoryOwner;
         private NativeMemoryTracker.NativeMemoryLease? memoryLease;
+        private DeviceBuffer? stagingBuffer;
+        private MappedResource stagingBufferMap;
 
-        private DeviceBuffer? buffer;
+        private DeviceBuffer? gpuBuffer;
 
         protected VeldridVertexBuffer(VeldridRenderer renderer, int amountVertices, BufferUsage usage)
         {
@@ -47,7 +45,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// <returns>Whether the vertex changed.</returns>
         public bool SetVertex(int vertexIndex, T vertex)
         {
-            ref var currentVertex = ref getMemory().Span[vertexIndex];
+            ref var currentVertex = ref getMemory()[vertexIndex];
 
             bool isNewVertex = !currentVertex.Vertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != renderer.BackbufferDrawDepth;
 
@@ -69,8 +67,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             ThreadSafety.EnsureDrawThread();
 
-            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer | usage));
-            memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
+            gpuBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.VertexBuffer));
+            memoryLease = NativeMemoryTracker.AddMemory(this, gpuBuffer.SizeInBytes);
 
             // Ensure the device buffer is initialised to 0.
             Update();
@@ -104,11 +102,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not bind disposed vertex buffers.");
 
-            if (buffer == null)
+            if (gpuBuffer == null)
                 Initialise();
 
-            Debug.Assert(buffer != null);
-            renderer.BindVertexBuffer(buffer, VeldridVertexUtils<DepthWrappingVertex<T>>.Layout);
+            Debug.Assert(gpuBuffer != null);
+            renderer.BindVertexBuffer(gpuBuffer, VeldridVertexUtils<DepthWrappingVertex<T>>.Layout);
         }
 
         public virtual void Unbind()
@@ -143,30 +141,35 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public void UpdateRange(int startIndex, int endIndex)
         {
-            if (buffer == null)
+            if (gpuBuffer == null)
                 Initialise();
 
             int countVertices = endIndex - startIndex;
-            renderer.Device.UpdateBuffer(buffer, (uint)(startIndex * STRIDE), ref getMemory().Span[startIndex], (uint)(countVertices * STRIDE));
+
+            // Todo: Using BufferUpdateCommands is temporary here for testing purposes. In the future, the device should have a CopyBuffer() method.
+            renderer.BufferUpdateCommands.CopyBuffer(stagingBuffer, (uint)(startIndex * STRIDE), gpuBuffer, (uint)(startIndex * STRIDE), (uint)(countVertices * STRIDE));
 
             FrameStatistics.Add(StatisticsCounterType.VerticesUpl, countVertices);
         }
 
-        private ref Memory<DepthWrappingVertex<T>> getMemory()
+        private Span<DepthWrappingVertex<T>> getMemory()
         {
-            ThreadSafety.EnsureDrawThread();
-
-            if (!InUse)
+            unsafe
             {
-                memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<DepthWrappingVertex<T>>(Size, AllocationOptions.Clean);
-                vertexMemory = memoryOwner.Memory;
+                ThreadSafety.EnsureDrawThread();
 
-                renderer.RegisterVertexBufferUse(this);
+                if (!InUse)
+                {
+                    stagingBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * STRIDE), BufferUsage.Staging));
+                    stagingBufferMap = renderer.Device.Map(stagingBuffer, MapMode.ReadWrite);
+
+                    renderer.RegisterVertexBufferUse(this);
+                }
+
+                LastUseResetId = renderer.ResetId;
+
+                return new Span<DepthWrappingVertex<T>>(stagingBufferMap.Data.ToPointer(), Size);
             }
-
-            LastUseResetId = renderer.ResetId;
-
-            return ref vertexMemory;
         }
 
         public ulong LastUseResetId { get; private set; }
@@ -178,12 +181,17 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             memoryLease?.Dispose();
             memoryLease = null;
 
-            buffer?.Dispose();
-            buffer = null;
+            if (stagingBuffer != null)
+            {
+                renderer.Device.Unmap(stagingBuffer);
+                stagingBufferMap = default;
+            }
 
-            memoryOwner?.Dispose();
-            memoryOwner = null;
-            vertexMemory = Memory<DepthWrappingVertex<T>>.Empty;
+            stagingBuffer?.Dispose();
+            stagingBuffer = null;
+
+            gpuBuffer?.Dispose();
+            gpuBuffer = null;
 
             LastUseResetId = 0;
         }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/5779

I've encapsulated the relevant logic in an `IStagingBuffer<T>`.
- Persistently-mapped buffers appear to work out-of-the-box on D3D11 and Vulkan, but not on OpenGL.
- Persistently-mapped buffers _may_ also work on MTL, either by grabbing the contained `IntPtr` of the device buffer and using the more optimal `renderer.Device.UpdateBuffer()`, _or_ by the way the class already works. This needs more testing, and I've chosen to not change MTL's behaviour here.
- Therefore, managed buffers are used for MTL, OpenGL, and OpenGL ES. There should be no behavioural changes on those platforms.

Tested:
- [x] D3D11
- [x] Vulkan (Linux)
- [x] Vulkan (Windows)
- [x] OpenGL (Linux)
- [x] OpenGL (Windows)
- [x] Metal