### PR TITLE
Revert changes to texture upload from manual mipmap generation pull

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using osu.Framework.Development;
 using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
@@ -428,6 +429,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         /// <summary>
         /// The maximum number of mip levels provided by an <see cref="ITextureUpload"/>.
         /// </summary>
+        /// <remarks>
+        /// This excludes automatic generation of mipmaps via the graphics backend.
+        /// </remarks>
         private int maximumUploadedLod;
 
         private Sampler createSampler()
@@ -453,7 +457,6 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         {
             Texture? texture = resources?.Texture;
             Sampler? sampler = resources?.Sampler;
-            bool newTexture = false;
 
             if (texture == null || texture.Width != Width || texture.Height != Height)
             {
@@ -461,32 +464,38 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
                 var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, PixelFormat.R8_G8_B8_A8_UNorm, Usages);
                 texture = Renderer.Factory.CreateTexture(ref textureDescription);
-                newTexture = true;
+
+                // todo: we may want to look into not having to allocate chunks of zero byte region for initialising textures
+                // similar to how OpenGL allows calling glTexImage2D with null data pointer.
+                initialiseLevel(texture, 0, Width, Height);
 
                 maximumUploadedLod = 0;
             }
 
             int lastMaximumUploadedLod = maximumUploadedLod;
 
-            if (!upload.Data.IsEmpty && upload.Level > maximumUploadedLod)
-                maximumUploadedLod = upload.Level;
-
-            if (sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
-                sampler = createSampler();
-
-            resources = new VeldridTextureResources(texture, sampler);
-
-            if (newTexture)
-            {
-                for (int i = 0; i < texture.MipLevels; i++)
-                    initialiseLevel(texture, i, Width >> i, Height >> i);
-            }
-
             if (!upload.Data.IsEmpty)
             {
+                // ensure all mip levels up to the target level are initialised.
+                if (upload.Level > maximumUploadedLod)
+                {
+                    for (int i = maximumUploadedLod + 1; i <= upload.Level; i++)
+                        initialiseLevel(texture, i, Width >> i, Height >> i);
+
+                    maximumUploadedLod = upload.Level;
+                }
+
                 Renderer.UpdateTexture(texture, upload.Bounds.X >> upload.Level, upload.Bounds.Y >> upload.Level, upload.Bounds.Width >> upload.Level, upload.Bounds.Height >> upload.Level,
                     upload.Level, upload.Data);
             }
+
+            if (sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
+            {
+                sampler?.Dispose();
+                sampler = createSampler();
+            }
+
+            resources = new VeldridTextureResources(texture, sampler);
         }
 
         private unsafe void initialiseLevel(Texture texture, int level, int width, int height)
@@ -502,7 +511,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         private Image<Rgba32> createBackingImage(int width, int height)
         {
             // it is faster to initialise without a background specification if transparent black is all that's required.
-            return new Image<Rgba32>(width, height);
+            return initialisationColour == default
+                ? new Image<Rgba32>(width, height)
+                : new Image<Rgba32>(width, height, new Rgba32(new Vector4(initialisationColour.R, initialisationColour.G, initialisationColour.B, initialisationColour.A)));
         }
 
         // todo: should this be limited to MAX_MIPMAP_LEVELS or was that constant supposed to be for automatic mipmap generation only?


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23466
- Closes https://github.com/ppy/osu/issues/23491
- Fixes https://github.com/ppy/osu/discussions/23503

There's not going to be much of an explanation in this one. The goal is to revert to a known-working state. I don't know why the old code would fail in the ways it did.

Part of it seems to be that initialising mip levels via framebuffers was deeply wrong somehow. The `glClear()` calls could lead to mip levels getting nuked (as in, cleared to transparent black) at some indeterminate point. If all of them got cleared, then there is no visual output. If only some of them got cleared, minimising a texture causes it to disappear (hilarious). If the mip level got cleared *during an upload of the zero level of a mipped atlas*, then some characters go missing.

But the other part of it is that `GLTexture` and `VeldridTexture` had structural changes applied that look essentially random to me and extremely difficult to make sense of as to which ones can work with automatic mipmaps. I'm referring to things like

https://github.com/ppy/osu-framework/blob/cb28262379e3c2abb9762f7433ed7c216c8479ec/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs#L442-L448

having size checks but

https://github.com/ppy/osu-framework/blob/cb28262379e3c2abb9762f7433ed7c216c8479ec/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs#L478-L482

not having zero-size checks. (How did this ever work?) Or the fact that `ITextureUpload.Level` is apparently always zero, but was used for what looks like *actual* checks in the old code, and the checks were since removed.

The optimal way to review this is probably via

```
$ git diff 2023.403.0 -- osu.Framework\Graphics\Veldrid\Textures\VeldridTexture.cs .\osu.Framework\Graphics\OpenGL\Textures\GLTexture.cs
```