### PR TITLE
Revert `Schedule` changes to `Dropdown`

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -6,14 +6,10 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
-using osu.Framework.Localisation;
-using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Input;
@@ -369,36 +365,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("close dropdown", () => InputManager.Key(Key.Escape));
         }
 
-        [Test]
-        public void TestReplaceItemsInItemSource()
-        {
-            AddStep("clear bindable list", () => bindableList.Clear());
-            toggleDropdownViaClick(bindableDropdown, "dropdown3");
-            AddAssert("no elements in bindable dropdown", () => !bindableDropdown.Items.Any());
-
-            AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
-            AddStep("select three", () => bindableDropdown.Current.Value = "three");
-
-            AddStep("remove and then add items to bindable", () =>
-            {
-                bindableList.Clear();
-                bindableList.AddRange(new[] { "four", "three" }.Select(s => new TestModel(s)));
-            });
-
-            AddAssert("current value still three", () => bindableDropdown.Current.Value.Identifier, () => Is.EqualTo("three"));
-        }
-
-        [Test]
-        public void TestAccessBdlInGenerateItemText()
-        {
-            AddStep("add dropdown that uses BDL", () => Add(new BdlDropdown
-            {
-                Width = 150,
-                Position = new Vector2(250, 350),
-                Items = new TestModel("test").Yield()
-            }));
-        }
-
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>
         {
             InputManager.MoveMouseTo(dropdown.Header);
@@ -437,17 +403,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             public int SelectedIndex => Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
             public int PreselectedIndex => Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
-        }
-
-        /// <summary>
-        /// Dropdown that will access <see cref="ResolvedAttribute"/> properties in <see cref="GenerateItemText"/>.
-        /// </summary>
-        private partial class BdlDropdown : TestDropdown
-        {
-            [Resolved]
-            private GameHost host { get; set; }
-
-            protected override LocalisableString GenerateItemText(TestModel item) => $"{host.Name}: {base.GenerateItemText(item)}";
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (boundItemSource != null)
                     throw new InvalidOperationException($"Cannot manually set {nameof(Items)} when an {nameof(ItemSource)} is bound.");
 
-                Scheduler.AddOnce(setItems, value);
+                setItems(value);
             }
         }
 
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.UserInterface
                     Menu.State = MenuState.Closed;
             };
 
-            ItemSource.CollectionChanged += (_, _) => Scheduler.AddOnce(setItems, ItemSource);
+            ItemSource.CollectionChanged += (_, _) => setItems(itemSource);
         }
 
         private void preselectionConfirmed(int selectedIndex)


### PR DESCRIPTION
This reverts changes from https://github.com/ppy/osu-framework/pull/5516, but also removed one extra `Scheduler.AddOnce` ensuring that `Items_Get` returns the same result as `Items_Set` in all cases.

Resolves performance concerns cited at https://github.com/ppy/osu-framework/pull/5516/files#r1042047938
Closes https://github.com/ppy/osu/issues/22573
Closes https://github.com/ppy/osu/issues/23537

I've tried to come up with a better approach but have not been able to yet. Let's restore sanity first and foremost.