### PR TITLE
Revert method group change in hot path

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -204,7 +204,9 @@ namespace osu.Framework.Input.Bindings
             {
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
                 // lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(KeyCombination.IsModifierKey));
+                // TODO: remove when we switch to .NET 7.
+                // ReSharper disable once ConvertClosureToMethodGroup
+                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
             }
 
             // we want to always handle bindings with more keys before bindings with less.


### PR DESCRIPTION
See discussion at https://github.com/ppy/osu-framework/pull/5793.

Inline comment already mentioned this.

Looks like we can remove this after switching to .NET 7 (https://github.com/dotnet/roslyn/issues/5835#issuecomment-1055790728). Heap allocations viewer plugin doesn't show this as an allocation already, for best or worst.