### PR TITLE
Show more information in frame statistic display

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Statistics;
 using osu.Framework.Timing;
 using osu.Framework.Utils;
-using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Performance
@@ -36,11 +35,10 @@ namespace osu.Framework.Graphics.Performance
                     Colour = Color4.Black,
                     Alpha = 0.75f
                 },
-                counter = new CounterText
+                counter = new SpriteText
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
-                    Spacing = new Vector2(-1, 0),
                     Text = @"...",
                 }
             });
@@ -102,16 +100,6 @@ namespace osu.Framework.Graphics.Performance
 
             counter.Text = $"{displayFps:0}fps ({rollingElapsed:0.00}ms ±{jitter:0.00}ms)"
                            + (clock.Throttling ? $"{(clock.MaximumUpdateHz > 0 && clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞"),4}hz" : string.Empty);
-        }
-
-        private partial class CounterText : SpriteText
-        {
-            public CounterText()
-            {
-                Font = FrameworkFont.Regular.With(fixedWidth: true);
-            }
-
-            protected override char[] FixedWidthExcludeCharacters { get; } = { ',', '.', ' ' };
         }
 
         public void NewFrame(FrameStatistics frame)

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Buffers;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Threading;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osuTK.Graphics;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance
@@ -18,7 +20,16 @@ namespace osu.Framework.Graphics.Performance
         [Resolved]
         private GameHost host { get; set; } = null!;
 
+        [Resolved]
+        private FrameworkConfigManager config { get; set; } = null!;
+
         private FrameStatisticsMode state;
+
+        private TextFlowContainer? infoText;
+
+        private Bindable<FrameSync> configFrameSync = null!;
+        private Bindable<ExecutionMode> configExecutionMode = null!;
+        private Bindable<WindowMode> configWindowMode = null!;
 
         public event Action<FrameStatisticsMode>? StateChanged;
 
@@ -46,7 +57,18 @@ namespace osu.Framework.Graphics.Performance
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            configFrameSync = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
+            configFrameSync.BindValueChanged(_ => updateInfoText());
+
+            configExecutionMode = config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode);
+            configExecutionMode.BindValueChanged(_ => updateInfoText());
+
+            configWindowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
+            configWindowMode.BindValueChanged(_ => updateInfoText());
+
             updateState();
+            updateInfoText();
         }
 
         private void updateState()
@@ -65,12 +87,15 @@ namespace osu.Framework.Graphics.Performance
 
                         var uploadPool = createUploadPool();
 
-                        Add(new SpriteText
+                        Add(infoText = new TextFlowContainer(cp => cp.Font = FrameworkFont.Condensed)
                         {
-                            Text = $"Renderer: {host.RendererInfo}",
                             Alpha = 0.75f,
                             Origin = Anchor.TopRight,
+                            TextAnchor = Anchor.TopRight,
+                            AutoSizeAxes = Axes.Both,
                         });
+
+                        updateInfoText();
 
                         foreach (GameThread t in host.Threads)
                             Add(new FrameStatisticsDisplay(t, uploadPool) { State = state });
@@ -84,6 +109,37 @@ namespace osu.Framework.Graphics.Performance
                 d.State = state;
 
             StateChanged?.Invoke(State);
+        }
+
+        private void updateInfoText()
+        {
+            if (infoText == null)
+                return;
+
+            infoText.Clear();
+
+            addHeader("Renderer:");
+            addValue(host.RendererInfo);
+
+            infoText.NewLine();
+
+            addHeader("Limiter:");
+            addValue(configFrameSync.ToString());
+            addHeader("Execution:");
+            addValue(configExecutionMode.ToString());
+            addHeader("Mode:");
+            addValue(configWindowMode.ToString());
+
+            void addHeader(string text) => infoText.AddText($"{text} ", cp =>
+            {
+                cp.Padding = new MarginPadding { Left = 5 };
+                cp.Colour = Color4.Gray;
+            });
+
+            void addValue(string text) => infoText.AddText(text, cp =>
+            {
+                cp.Font = cp.Font.With(weight: "Bold");
+            });
         }
 
         private ArrayPool<Rgba32> createUploadPool()


### PR DESCRIPTION
A result of smoogi not being able to tell which frame limiter is applied on high refresh monitors (where they all become 1000 Hz). Obviously this is a fault of the frame limiters, but fixing that is for another day.

I've also unapplied fixed width font display on the fps details since roboto is already fixed width for numbers. This improves the kerning of the non-numeric text.

| before | after |
| -- | -- |
|![osu Framework Tests 2023-05-18 at 07 48 02](https://github.com/ppy/osu-framework/assets/191335/a488fed9-9af9-4d4b-85f3-8613cb32cc04)|![osu Framework Tests 2023-05-18 at 07 47 05](https://github.com/ppy/osu-framework/assets/191335/23d3ad5d-a974-4bbf-ba5e-5cc1575f8359)|

