### PR TITLE
Use float for color space conversion

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
+++ b/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Graphics.Colour;
 using osuTK.Graphics;
@@ -10,24 +11,29 @@ namespace osu.Framework.Benchmarks
     [MemoryDiagnoser]
     public class BenchmarkColourInfo
     {
-        private ColourInfo colourInfo;
+        [ParamsSource(nameof(ColourParams))]
+        public ColourInfo Colour { get; set; }
 
-        [GlobalSetup]
-        public void GlobalSetup()
+        public IEnumerable<ColourInfo> ColourParams
         {
-            colourInfo = ColourInfo.SingleColour(Color4.Transparent);
+            get
+            {
+                yield return ColourInfo.SingleColour(Color4.Transparent);
+                yield return ColourInfo.SingleColour(Color4.Cyan);
+                yield return ColourInfo.SingleColour(Color4.DarkGray);
+            }
         }
 
         [Benchmark]
-        public SRGBColour ConvertToSRGBColour() => colourInfo;
+        public SRGBColour ConvertToSRGBColour() => Colour;
 
         [Benchmark]
-        public Color4 ConvertToColor4() => ((SRGBColour)colourInfo).Linear;
+        public Color4 ConvertToColor4() => ((SRGBColour)Colour).Linear;
 
         [Benchmark]
         public Color4 ExtractAndConvertToColor4()
         {
-            colourInfo.TryExtractSingleColour(out SRGBColour colour);
+            Colour.TryExtractSingleColour(out SRGBColour colour);
             return colour.Linear;
         }
     }

--- a/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
+++ b/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <!-- The following two are unused, but resolves warning MSB3277. -->

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneColours.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneColours.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Graphics
+{
+    public partial class TestSceneColours : FrameworkTestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            FillFlowContainer flow;
+
+            Child = new TooltipContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = flow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Full,
+                    Padding = new MarginPadding(10),
+                    Spacing = new Vector2(5)
+                }
+            };
+
+            var colours = typeof(Colour4).GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.GetProperty)
+                                         .Where(property => property.PropertyType == typeof(Colour4))
+                                         .Select(property => (property.Name, (Colour4)property.GetMethod!.Invoke(null, null)!));
+
+            flow.ChildrenEnumerable = colours.Select(colour => new ColourBox(colour.Name, colour.Item2));
+        }
+
+        private partial class ColourBox : Box, IHasTooltip
+        {
+            public ColourBox(string name, Colour4 colour)
+            {
+                Colour = colour;
+                Name = name;
+                Size = new Vector2(50);
+            }
+
+            public LocalisableString TooltipText => Name;
+        }
+    }
+}

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Extensions.Color4Extensions
         public const double GAMMA = 2.4;
 
         // ToLinear is quite a hot path in the game.
-        // MathF.Pow performs way faster than Math.Pow, how ever on Windows it lacks a short path for x == 1
+        // MathF.Pow performs way faster than Math.Pow, however on Windows it lacks a short path for x == 1
         // Given passing color == 1 (White or Transparent) is very common, a short path for 1 is added.
 
         public static double ToLinear(double color) => color == 1 ? 1 : color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, GAMMA);

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -11,9 +11,17 @@ namespace osu.Framework.Extensions.Color4Extensions
     {
         public const double GAMMA = 2.4;
 
-        public static double ToLinear(double color) => color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, GAMMA);
+        // ToLinear is quite a hot path in the game.
+        // MathF.Pow performs way faster than Math.Pow, how ever on Windows it lacks a short path for x == 1
+        // Given passing color == 1 (White or Transparent) is very common, a short path for 1 is added.
 
-        public static double ToSRGB(double color) => color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / GAMMA) - 0.055;
+        public static double ToLinear(double color) => color == 1 ? 1 : color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, GAMMA);
+
+        public static float ToLinear(float color) => color == 1 ? 1 : color <= 0.04045f ? color / 12.92f : MathF.Pow((color + 0.055f) / 1.055f, (float)GAMMA);
+
+        public static double ToSRGB(double color) => color == 1 ? 1 : color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / GAMMA) - 0.055;
+
+        public static float ToSRGB(float color) => color == 1 ? 1 : color < 0.0031308f ? 12.92f * color : 1.055f * MathF.Pow(color, 1.0f / (float)GAMMA) - 0.055f;
 
         public static Color4 Opacity(this Color4 color, float a) => new Color4(color.R, color.G, color.B, a);
 
@@ -21,16 +29,16 @@ namespace osu.Framework.Extensions.Color4Extensions
 
         public static Color4 ToLinear(this Color4 colour) =>
             new Color4(
-                (float)ToLinear(colour.R),
-                (float)ToLinear(colour.G),
-                (float)ToLinear(colour.B),
+                ToLinear(colour.R),
+                ToLinear(colour.G),
+                ToLinear(colour.B),
                 colour.A);
 
         public static Color4 ToSRGB(this Color4 colour) =>
             new Color4(
-                (float)ToSRGB(colour.R),
-                (float)ToSRGB(colour.G),
-                (float)ToSRGB(colour.B),
+                ToSRGB(colour.R),
+                ToSRGB(colour.G),
+                ToSRGB(colour.B),
                 colour.A);
 
         public static Color4 MultiplySRGB(Color4 first, Color4 second)

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -12,16 +12,40 @@ namespace osu.Framework.Extensions.Color4Extensions
         public const double GAMMA = 2.4;
 
         // ToLinear is quite a hot path in the game.
-        // MathF.Pow performs way faster than Math.Pow, however on Windows it lacks a short path for x == 1
-        // Given passing color == 1 (White or Transparent) is very common, a short path for 1 is added.
+        // MathF.Pow performs way faster than Math.Pow, however on Windows it lacks a fast path for x == 1.
+        // Given passing color == 1 (White or Transparent) is very common, a fast path for 1 is added.
 
-        public static double ToLinear(double color) => color == 1 ? 1 : color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, GAMMA);
+        public static double ToLinear(double color)
+        {
+            if (color == 1)
+                return 1;
 
-        public static float ToLinear(float color) => color == 1 ? 1 : color <= 0.04045f ? color / 12.92f : MathF.Pow((color + 0.055f) / 1.055f, (float)GAMMA);
+            return color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, GAMMA);
+        }
 
-        public static double ToSRGB(double color) => color == 1 ? 1 : color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / GAMMA) - 0.055;
+        public static float ToLinear(float color)
+        {
+            if (color == 1)
+                return 1;
 
-        public static float ToSRGB(float color) => color == 1 ? 1 : color < 0.0031308f ? 12.92f * color : 1.055f * MathF.Pow(color, 1.0f / (float)GAMMA) - 0.055f;
+            return color <= 0.04045f ? color / 12.92f : MathF.Pow((color + 0.055f) / 1.055f, (float)GAMMA);
+        }
+
+        public static double ToSRGB(double color)
+        {
+            if (color == 1)
+                return 1;
+
+            return color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / GAMMA) - 0.055;
+        }
+
+        public static float ToSRGB(float color)
+        {
+            if (color == 1)
+                return 1;
+
+            return color < 0.0031308f ? 12.92f * color : 1.055f * MathF.Pow(color, 1.0f / (float)GAMMA) - 0.055f;
+        }
 
         public static Color4 Opacity(this Color4 color, float a) => new Color4(color.R, color.G, color.B, a);
 

--- a/osu.Framework/Graphics/Colour4.cs
+++ b/osu.Framework/Graphics/Colour4.cs
@@ -230,13 +230,13 @@ namespace osu.Framework.Graphics
         /// Returns a new <see cref="Colour4"/> with an SRGB->Linear conversion applied
         /// to each of its chromatic components. Alpha is unchanged.
         /// </summary>
-        public Colour4 ToLinear() => new Colour4((float)toLinear(R), (float)toLinear(G), (float)toLinear(B), A);
+        public Colour4 ToLinear() => new Colour4(toLinear(R), toLinear(G), toLinear(B), A);
 
         /// <summary>
         /// Returns a new <see cref="Colour4"/> with a Linear->SRGB conversion applied
         /// to each of its chromatic components. Alpha is unchanged.
         /// </summary>
-        public Colour4 ToSRGB() => new Colour4((float)toSRGB(R), (float)toSRGB(G), (float)toSRGB(B), A);
+        public Colour4 ToSRGB() => new Colour4(toSRGB(R), toSRGB(G), toSRGB(B), A);
 
         /// <summary>
         /// Returns the <see cref="Colour4"/> as a 32-bit unsigned integer in the format RGBA.
@@ -552,9 +552,21 @@ namespace osu.Framework.Graphics
 
         private const double gamma = 2.4;
 
-        private static double toLinear(double color) => color <= 0.04045 ? color / 12.92 : Math.Pow((color + 0.055) / 1.055, gamma);
+        private static float toLinear(float color)
+        {
+            if (color == 1)
+                return 1;
 
-        private static double toSRGB(double color) => color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / gamma) - 0.055;
+            return color <= 0.04045f ? color / 12.92f : MathF.Pow((color + 0.055f) / 1.055f, (float)gamma);
+        }
+
+        private static float toSRGB(float color)
+        {
+            if (color == 1)
+                return 1;
+
+            return color < 0.0031308f ? 12.92f * color : 1.055f * MathF.Pow(color, 1.0f / (float)gamma) - 0.055f;
+        }
 
         #endregion
 


### PR DESCRIPTION
During profiling of watching autoplay, `Color4Extensions.ToLinear` appears to be the hottest function, with above 2% sampled count:
![image](https://github.com/ppy/osu-framework/assets/5644458/263bc3dd-a88e-4dea-a8ae-7d3ba80d1a2b)

When I first tried to use `MathF.Pow` instead of `Math.Pow`, the performance surprisingly regressed. Further investigation shows that when input `x` is 1, `Math.Pow` appears to use a shortcut while `MathF.Pow` doesn't. Breaking shows that about half of the calls are called with white color (R,G,B=1), it should be worth adding a short path for it.

I also added more colours to BenchmarkColourInfo to show the difference of colours.

### Benchmark results
##### Before
<details>

|                    Method |  Runtime |               Colour |       Mean |     Error |    StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
|-------------------------- |--------- |--------------------- |-----------:|----------:|----------:|------:|--------:|----------:|------------:|
|       **ConvertToSRGBColour** | **.NET 6.0** | **srgb:(...)ngle) [83]** |  **4.3220 ns** | **0.0594 ns** | **0.0556 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 | srgb:(...)ngle) [83] |  2.3678 ns | 0.0380 ns | 0.0355 ns |  0.55 |    0.01 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 | srgb:(...)ngle) [83] |  0.1217 ns | 0.0060 ns | 0.0056 ns |  0.03 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  9.5393 ns | 0.1174 ns | 0.1098 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  6.5509 ns | 0.0743 ns | 0.0695 ns |  0.69 |    0.01 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  3.8571 ns | 0.0303 ns | 0.0253 ns |  0.40 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  6.5958 ns | 0.1494 ns | 0.1534 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  6.2022 ns | 0.0917 ns | 0.0858 ns |  0.94 |    0.02 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  4.1279 ns | 0.0582 ns | 0.0544 ns |  0.63 |    0.02 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
|       **ConvertToSRGBColour** | **.NET 6.0** |  **srgb(...)gle) [134]** |  **4.5817 ns** | **0.0305 ns** | **0.0286 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 |  srgb(...)gle) [134] |  2.3007 ns | 0.0482 ns | 0.0451 ns |  0.50 |    0.01 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 |  srgb(...)gle) [134] |  0.1271 ns | 0.0109 ns | 0.0102 ns |  0.03 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 |  srgb(...)gle) [134] | 77.3689 ns | 0.4638 ns | 0.4339 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 |  srgb(...)gle) [134] | 72.9450 ns | 1.2184 ns | 1.1397 ns |  0.94 |    0.02 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 |  srgb(...)gle) [134] | 71.0124 ns | 0.3108 ns | 0.2907 ns |  0.92 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 |  srgb(...)gle) [134] | 74.4185 ns | 0.8906 ns | 0.8330 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 |  srgb(...)gle) [134] | 72.3401 ns | 0.6096 ns | 0.5404 ns |  0.97 |    0.01 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 |  srgb(...)gle) [134] | 72.4030 ns | 0.5260 ns | 0.4920 ns |  0.97 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
|       **ConvertToSRGBColour** | **.NET 6.0** | **srgb:(...)ngle) [83]** |  **4.4001 ns** | **0.0381 ns** | **0.0338 ns** | **1.000** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 | srgb:(...)ngle) [83] |  2.6235 ns | 0.0607 ns | 0.0567 ns | 0.596 |    0.01 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 | srgb:(...)ngle) [83] |  0.0198 ns | 0.0058 ns | 0.0054 ns | 0.005 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  8.8862 ns | 0.0636 ns | 0.0595 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  6.2204 ns | 0.1446 ns | 0.1776 ns |  0.70 |    0.02 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  4.0627 ns | 0.0673 ns | 0.0630 ns |  0.46 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] | 11.1009 ns | 0.0733 ns | 0.0686 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  6.0109 ns | 0.0962 ns | 0.0900 ns |  0.54 |    0.01 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  3.8176 ns | 0.0548 ns | 0.0513 ns |  0.34 |    0.01 |         - |          NA |

</details>

##### After

<details>

|                    Method |  Runtime |               Colour |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD | Allocated | Alloc Ratio |
|-------------------------- |--------- |--------------------- |-----------:|----------:|----------:|-----------:|------:|--------:|----------:|------------:|
|       **ConvertToSRGBColour** | **.NET 6.0** | **srgb:(...)ngle) [83]** |  **4.3103 ns** | **0.0337 ns** | **0.0315 ns** |  **4.3145 ns** |  **1.00** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 | srgb:(...)ngle) [83] |  2.3032 ns | 0.0525 ns | 0.0491 ns |  2.2980 ns |  0.53 |    0.01 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 | srgb:(...)ngle) [83] |  0.1097 ns | 0.0044 ns | 0.0041 ns |  0.1086 ns |  0.03 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  6.1932 ns | 0.0742 ns | 0.0658 ns |  6.1854 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  4.0631 ns | 0.0486 ns | 0.0455 ns |  4.0654 ns |  0.66 |    0.01 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  2.0859 ns | 0.0348 ns | 0.0325 ns |  2.0951 ns |  0.34 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  3.9531 ns | 0.0763 ns | 0.0714 ns |  3.9454 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  4.2549 ns | 0.0950 ns | 0.1017 ns |  4.2424 ns |  1.08 |    0.04 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  2.0745 ns | 0.0389 ns | 0.0364 ns |  2.0760 ns |  0.52 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
|       **ConvertToSRGBColour** | **.NET 6.0** |  **srgb(...)gle) [131]** | **13.7964 ns** | **0.1273 ns** | **0.1191 ns** | **13.7647 ns** | **1.000** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 |  srgb(...)gle) [131] |  2.2971 ns | 0.0628 ns | 0.0588 ns |  2.3061 ns | 0.167 |    0.00 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 |  srgb(...)gle) [131] |  0.1024 ns | 0.0040 ns | 0.0034 ns |  0.1028 ns | 0.007 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 |  srgb(...)gle) [131] | 19.8923 ns | 0.1208 ns | 0.1130 ns | 19.8987 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 |  srgb(...)gle) [131] | 17.8288 ns | 0.1791 ns | 0.1675 ns | 17.8221 ns |  0.90 |    0.01 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 |  srgb(...)gle) [131] | 16.7444 ns | 0.2497 ns | 0.2336 ns | 16.7257 ns |  0.84 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 |  srgb(...)gle) [131] | 19.1450 ns | 0.1276 ns | 0.1193 ns | 19.1703 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 |  srgb(...)gle) [131] | 17.6120 ns | 0.0586 ns | 0.0520 ns | 17.6177 ns |  0.92 |    0.01 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 |  srgb(...)gle) [131] | 18.0116 ns | 0.0752 ns | 0.0667 ns | 18.0112 ns |  0.94 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
|       **ConvertToSRGBColour** | **.NET 6.0** | **srgb:(...)ngle) [83]** |  **4.5987 ns** | **0.0419 ns** | **0.0392 ns** |  **4.5892 ns** | **1.000** |    **0.00** |         **-** |          **NA** |
|       ConvertToSRGBColour | .NET 7.0 | srgb:(...)ngle) [83] |  2.5273 ns | 0.0328 ns | 0.0307 ns |  2.5185 ns | 0.550 |    0.01 |         - |          NA |
|       ConvertToSRGBColour | .NET 8.0 | srgb:(...)ngle) [83] |  0.0083 ns | 0.0089 ns | 0.0083 ns |  0.0066 ns | 0.002 |    0.00 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
|           ConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  6.0760 ns | 0.0628 ns | 0.0587 ns |  6.0812 ns |  1.00 |    0.00 |         - |          NA |
|           ConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  3.8900 ns | 0.0412 ns | 0.0385 ns |  3.8954 ns |  0.64 |    0.01 |         - |          NA |
|           ConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  1.7777 ns | 0.0477 ns | 0.0446 ns |  1.7637 ns |  0.29 |    0.01 |         - |          NA |
|                           |          |                      |            |           |           |            |       |         |           |             |
| ExtractAndConvertToColor4 | .NET 6.0 | srgb:(...)ngle) [83] |  3.6950 ns | 0.0446 ns | 0.0417 ns |  3.6856 ns |  1.00 |    0.00 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 7.0 | srgb:(...)ngle) [83] |  4.1379 ns | 0.0489 ns | 0.0434 ns |  4.1446 ns |  1.12 |    0.02 |         - |          NA |
| ExtractAndConvertToColor4 | .NET 8.0 | srgb:(...)ngle) [83] |  1.7651 ns | 0.0167 ns | 0.0156 ns |  1.7629 ns |  0.48 |    0.01 |         - |          NA |

</details>

The difference of light color is significant. `Color4Extensions.ToLinear` is not in the top5 hot functions now.