### PR TITLE
Update SDL native libraries

### DIFF
--- a/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
+++ b/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="nunit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <!-- The following two are unused, but resolves warning MSB3277. -->
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.CodeDom" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 </Project>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,10 +32,10 @@
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenTabletDriver" Version="0.6.0.4" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.669-alpha" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
-    <PackageReference Include="ppy.SDL2-CS" Version="1.0.652-alpha" />
+    <PackageReference Include="ppy.SDL2-CS" Version="1.0.669-alpha" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2022.1222.1" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
Also bumps minor package versions because we can.

Incorporates https://github.com/libsdl-org/SDL/issues/6835, of note (but also thousands of other changes soo testing is probably best).

testing:

- [x] macOS
- [x] windows
- [x] linux