### PR TITLE
Force `FrameTimeDisplay` font choice to framework font

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -39,6 +39,7 @@ namespace osu.Framework.Graphics.Performance
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
+                    Font = FrameworkFont.Regular,
                     Text = @"...",
                 }
             });


### PR DESCRIPTION
After https://github.com/ppy/osu-framework/pull/5801/commits/c0979e9331bb4ab28f9db1fff1f72b223b764bc8, osu!-side FPS display went all weird as it was preferring an osu-provided font which does not support fixed-width display:

![osu! 2023-05-24 at 03 49 14](https://github.com/ppy/osu-framework/assets/191335/29dd5559-ac60-4250-ae2c-e00ff695057c)

We are already forcing the font choice almost everywhere else in this display, so let's call this an oversight.
