### PR TITLE
Avoid creating new `List<RectangleI>` when no texture uploads are required

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -66,6 +66,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         private int internalHeight;
         private bool manualMipmaps;
 
+        private readonly List<RectangleI> uploadedRegions = new List<RectangleI>();
+
         private readonly All filteringMode;
         private readonly Color4 initialisationColour;
 
@@ -199,10 +201,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             if (!Available)
                 return false;
 
+            uploadedRegions.Clear();
+
             // We should never run raw OGL calls on another thread than the main thread due to race conditions.
             ThreadSafety.EnsureDrawThread();
-
-            List<RectangleI> uploadedRegions = new List<RectangleI>();
 
             while (tryGetNextUpload(out ITextureUpload upload))
             {

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -51,6 +51,8 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         private readonly bool manualMipmaps;
 
+        private readonly List<RectangleI> uploadedRegions = new List<RectangleI>();
+
         private readonly SamplerFilter filteringMode;
         private readonly Color4 initialisationColour;
 
@@ -212,7 +214,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             // We should never run raw Veldrid calls on another thread than the draw thread due to race conditions.
             ThreadSafety.EnsureDrawThread();
 
-            List<RectangleI> uploadedRegions = new List<RectangleI>();
+            uploadedRegions.Clear();
 
             while (tryGetNextUpload(out ITextureUpload? upload))
             {


### PR DESCRIPTION
This was triggering on every texture *bind* operation. Oops.

Loading song select (from an already warmed up glyph cache):

| before | after |
| -- | -- |
|![JetBrains Rider 2023-05-24 at 04 01 46](https://github.com/ppy/osu-framework/assets/191335/b0255f16-0d1f-48c5-bc5c-e0a1b006430a) |![JetBrains Rider 2023-05-24 at 04 03 47](https://github.com/ppy/osu-framework/assets/191335/babbffb5-2ce3-4948-b489-8e03f561dfd8)| 
