### PR TITLE
Use `DummyRenderer` in `HeadlessGameHost`

### DIFF
--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public DummyRenderer()
         {
             maskingInfo = default;
-            WhitePixel = new Texture(new DummyNativeTexture(this), WrapMode.None, WrapMode.None);
+            WhitePixel = new TextureWhitePixel(new Texture(new DummyNativeTexture(this), WrapMode.None, WrapMode.None));
         }
 
         bool IRenderer.VerticalSync { get; set; } = true;

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
+using osu.Framework.Graphics.Rendering.Dummy;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Logging;
 using osu.Framework.Timing;
@@ -48,7 +49,7 @@ namespace osu.Framework.Platform
 
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => null;
 
-        protected override void ChooseAndSetupRenderer() => SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
+        protected override void ChooseAndSetupRenderer() => SetupRendererAndWindow(new DummyRenderer(), GraphicsSurfaceType.OpenGL);
 
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {


### PR DESCRIPTION
A significant amount of time is spent in tests on the `CompileGlslToSpirv()` method. It's quite hard to resolve because shaders are in stores, so it's not as simple as making things `static` unless by name-pairs which brings with it potential other side effects.

`HeadlessGameHost` does not draw anyway, so it doesn't sound like a stretch to use the `DummyRenderer`:

https://github.com/ppy/osu-framework/blob/5d72e48d64c98b483985f5b6a6888ad4c1dfbc33/osu.Framework/Platform/HeadlessGameHost.cs#L89-L92

(o!f UI tests) Before:

![image](https://github.com/ppy/osu-framework/assets/1329837/ec3580e2-4357-4635-ad0e-325d91840442)

(o!f UI tests) After:

![image](https://github.com/ppy/osu-framework/assets/1329837/ca274dc1-7c69-4c09-8358-f1ac0343ea68)

```
osu.Game.Tests `UserInterface` tests:

Before: 67s
After: 33.369s
```
```
osu.Game.Tests full:

Before: 14min
After: 8.5min
```
