### PR TITLE
Add Android to project templates

### DIFF
--- a/osu-framework.sln
+++ b/osu-framework.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29409.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework", "osu.Framework\osu.Framework.csproj", "{C76BF5B3-985E-4D39-95FE-97C9C879B83A}"
 EndProject
@@ -15,15 +15,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.NativeLibs", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.iOS", "osu.Framework.iOS\osu.Framework.iOS.csproj", "{BBC0D18F-8595-43A6-AE61-5BF36A072CCE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleGame.iOS", "SampleGame.iOS\SampleGame.iOS.csproj", "{529D5E2E-774A-4831-9C9E-59E3E8DFF155}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleGame.iOS", "SampleGame.iOS\SampleGame.iOS.csproj", "{529D5E2E-774A-4831-9C9E-59E3E8DFF155}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Tests.iOS", "osu.Framework.Tests.iOS\osu.Framework.Tests.iOS.csproj", "{D972753E-45FC-4B82-B017-34BDE485F1BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Tests.iOS", "osu.Framework.Tests.iOS\osu.Framework.Tests.iOS.csproj", "{D972753E-45FC-4B82-B017-34BDE485F1BB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Android", "osu.Framework.Android\osu.Framework.Android.csproj", "{4D112E30-462B-4264-B44D-53B61ABB185E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleGame.Android", "SampleGame.Android\SampleGame.Android.csproj", "{5A378BB7-11D6-4008-980E-A67507CD9969}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleGame.Android", "SampleGame.Android\SampleGame.Android.csproj", "{5A378BB7-11D6-4008-980E-A67507CD9969}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Tests.Android", "osu.Framework.Tests.Android\osu.Framework.Tests.Android.csproj", "{320089C6-A141-4D3E-BD5F-C4A6CE9E567B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Tests.Android", "osu.Framework.Tests.Android\osu.Framework.Tests.Android.csproj", "{320089C6-A141-4D3E-BD5F-C4A6CE9E567B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D29A2153-C171-457E-A147-720976BA430F}"
 	ProjectSection(SolutionItems) = preProject
@@ -37,39 +37,43 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		osu.Framework.iOS.props = osu.Framework.iOS.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Benchmarks", "osu.Framework.Benchmarks\osu.Framework.Benchmarks.csproj", "{F294C804-8AE2-4020-841A-AF0D97FBE80C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Benchmarks", "osu.Framework.Benchmarks\osu.Framework.Benchmarks.csproj", "{F294C804-8AE2-4020-841A-AF0D97FBE80C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Templates", "osu.Framework.Templates\osu.Framework.Templates.csproj", "{A95175BB-95D0-44B4-8B82-EABD166943DA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Templates", "osu.Framework.Templates\osu.Framework.Templates.csproj", "{A95175BB-95D0-44B4-8B82-EABD166943DA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Templates", "Templates", "{454655D7-6244-47A2-A379-3D019FBD6DD2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Game", "osu.Framework.Templates\templates\template-empty\TemplateGame.Game\TemplateGame.Game.csproj", "{6BEB95A6-0673-4AF5-892E-9146FF8B0948}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Game", "osu.Framework.Templates\templates\template-empty\TemplateGame.Game\TemplateGame.Game.csproj", "{6BEB95A6-0673-4AF5-892E-9146FF8B0948}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Game.Tests", "osu.Framework.Templates\templates\template-empty\TemplateGame.Game.Tests\TemplateGame.Game.Tests.csproj", "{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Game.Tests", "osu.Framework.Templates\templates\template-empty\TemplateGame.Game.Tests\TemplateGame.Game.Tests.csproj", "{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Resources", "osu.Framework.Templates\templates\template-empty\TemplateGame.Resources\TemplateGame.Resources.csproj", "{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Resources", "osu.Framework.Templates\templates\template-empty\TemplateGame.Resources\TemplateGame.Resources.csproj", "{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Desktop", "osu.Framework.Templates\templates\template-empty\TemplateGame.Desktop\TemplateGame.Desktop.csproj", "{55AB973D-ECA0-422B-B367-24BC47DA081B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Desktop", "osu.Framework.Templates\templates\template-empty\TemplateGame.Desktop\TemplateGame.Desktop.csproj", "{55AB973D-ECA0-422B-B367-24BC47DA081B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Empty", "Empty", "{5307589D-87A1-459B-BBD2-1077AA25EB1E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FlappyDon", "FlappyDon", "{139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Resources", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Resources\FlappyDon.Resources.csproj", "{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Resources", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Resources\FlappyDon.Resources.csproj", "{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Game", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Game\FlappyDon.Game.csproj", "{7809CB42-8FED-4BB7-8C68-7638357B94A6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Game", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Game\FlappyDon.Game.csproj", "{7809CB42-8FED-4BB7-8C68-7638357B94A6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Game.Tests", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Game.Tests\FlappyDon.Game.Tests.csproj", "{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Game.Tests", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Game.Tests\FlappyDon.Game.Tests.csproj", "{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Desktop", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Desktop\FlappyDon.Desktop.csproj", "{0309CF11-621A-4F23-8FBA-A583303A8531}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Desktop", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Desktop\FlappyDon.Desktop.csproj", "{0309CF11-621A-4F23-8FBA-A583303A8531}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.iOS", "osu.Framework.Templates\templates\template-empty\TemplateGame.iOS\TemplateGame.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.iOS", "osu.Framework.Templates\templates\template-empty\TemplateGame.iOS\TemplateGame.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.iOS", "osu.Framework.Templates\templates\template-flappy\FlappyDon.iOS\FlappyDon.iOS.csproj", "{48783186-230D-4048-A97A-E4F1DF43BF5C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.iOS", "osu.Framework.Templates\templates\template-flappy\FlappyDon.iOS\FlappyDon.iOS.csproj", "{48783186-230D-4048-A97A-E4F1DF43BF5C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.SourceGeneration", "osu.Framework.SourceGeneration\osu.Framework.SourceGeneration.csproj", "{BCFABDF9-AC1B-41B6-959E-04676F0C20F8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.SourceGeneration", "osu.Framework.SourceGeneration\osu.Framework.SourceGeneration.csproj", "{BCFABDF9-AC1B-41B6-959E-04676F0C20F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.SourceGeneration.Tests", "osu.Framework.SourceGeneration.Tests\osu.Framework.SourceGeneration.Tests.csproj", "{A0DDCF0A-A352-4CC6-8E6E-0E16CAA50CDD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.SourceGeneration.Tests", "osu.Framework.SourceGeneration.Tests\osu.Framework.SourceGeneration.Tests.csproj", "{A0DDCF0A-A352-4CC6-8E6E-0E16CAA50CDD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Android", "osu.Framework.Templates\templates\template-empty\TemplateGame.Android\TemplateGame.Android.csproj", "{7493F952-4ECF-45D6-B8E9-66427FD37DE2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Android", "osu.Framework.Templates\templates\template-flappy\FlappyDon.Android\FlappyDon.Android.csproj", "{40FF3ED6-828C-453D-98AC-79EA8D86124A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -153,7 +157,7 @@ Global
 		{BBC0D18F-8595-43A6-AE61-5BF36A072CCE}.Release|iPhone.Build.0 = Release|Any CPU
 		{BBC0D18F-8595-43A6-AE61-5BF36A072CCE}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{BBC0D18F-8595-43A6-AE61-5BF36A072CCE}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Debug|iPhone.Build.0 = Debug|iPhone
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -163,7 +167,7 @@ Global
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Release|iPhone.Build.0 = Release|iPhone
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{529D5E2E-774A-4831-9C9E-59E3E8DFF155}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{D972753E-45FC-4B82-B017-34BDE485F1BB}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{D972753E-45FC-4B82-B017-34BDE485F1BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D972753E-45FC-4B82-B017-34BDE485F1BB}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{D972753E-45FC-4B82-B017-34BDE485F1BB}.Debug|iPhone.Build.0 = Debug|iPhone
 		{D972753E-45FC-4B82-B017-34BDE485F1BB}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -225,26 +229,6 @@ Global
 		{A95175BB-95D0-44B4-8B82-EABD166943DA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A95175BB-95D0-44B4-8B82-EABD166943DA}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{A95175BB-95D0-44B4-8B82-EABD166943DA}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.Build.0 = Debug|iPhone
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.ActiveCfg = Release|iPhone
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.Build.0 = Release|iPhone
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhone.Build.0 = Debug|iPhone
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhone.ActiveCfg = Release|iPhone
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhone.Build.0 = Release|iPhone
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -257,6 +241,18 @@ Global
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Release|iPhone.Build.0 = Release|Any CPU
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhone.Build.0 = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -281,30 +277,6 @@ Global
 		{55AB973D-ECA0-422B-B367-24BC47DA081B}.Release|iPhone.Build.0 = Release|Any CPU
 		{55AB973D-ECA0-422B-B367-24BC47DA081B}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{55AB973D-ECA0-422B-B367-24BC47DA081B}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhone.Build.0 = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhone.Build.0 = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -317,18 +289,18 @@ Global
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Release|iPhone.Build.0 = Release|Any CPU
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhone.Build.0 = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhone.Build.0 = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7809CB42-8FED-4BB7-8C68-7638357B94A6}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -341,6 +313,38 @@ Global
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Release|iPhone.Build.0 = Release|Any CPU
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{9E4B69EE-34E6-47CF-8346-2A66D1714FCD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhone.Build.0 = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0309CF11-621A-4F23-8FBA-A583303A8531}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.Build.0 = Debug|iPhone
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.ActiveCfg = Release|iPhone
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.Build.0 = Release|iPhone
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhone.Build.0 = Debug|iPhone
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhone.ActiveCfg = Release|iPhone
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhone.Build.0 = Release|iPhone
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{48783186-230D-4048-A97A-E4F1DF43BF5C}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{BCFABDF9-AC1B-41B6-959E-04676F0C20F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BCFABDF9-AC1B-41B6-959E-04676F0C20F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCFABDF9-AC1B-41B6-959E-04676F0C20F8}.Debug|iPhone.ActiveCfg = Debug|Any CPU
@@ -365,20 +369,53 @@ Global
 		{A0DDCF0A-A352-4CC6-8E6E-0E16CAA50CDD}.Release|iPhone.Build.0 = Release|Any CPU
 		{A0DDCF0A-A352-4CC6-8E6E-0E16CAA50CDD}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{A0DDCF0A-A352-4CC6-8E6E-0E16CAA50CDD}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhone.Deploy.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhone.Build.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhone.Deploy.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhone.Deploy.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhone.Build.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhone.Deploy.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {27D12E10-E38E-4ECE-8DD1-77E8C387B2DD}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A95175BB-95D0-44B4-8B82-EABD166943DA} = {454655D7-6244-47A2-A379-3D019FBD6DD2}
-		{5307589D-87A1-459B-BBD2-1077AA25EB1E} = {454655D7-6244-47A2-A379-3D019FBD6DD2}
-		{55AB973D-ECA0-422B-B367-24BC47DA081B} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
 		{6BEB95A6-0673-4AF5-892E-9146FF8B0948} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
 		{FC0A9040-7BAF-4524-B398-8C7A1C7DDEE9} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
 		{6E3EBF71-8664-49D7-BD0D-2B21B3EEC540} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
+		{55AB973D-ECA0-422B-B367-24BC47DA081B} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
+		{5307589D-87A1-459B-BBD2-1077AA25EB1E} = {454655D7-6244-47A2-A379-3D019FBD6DD2}
 		{139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E} = {454655D7-6244-47A2-A379-3D019FBD6DD2}
 		{4C728441-4C3D-4AE4-9C0F-EA91E2C70965} = {139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}
 		{7809CB42-8FED-4BB7-8C68-7638357B94A6} = {139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}
@@ -386,5 +423,10 @@ Global
 		{0309CF11-621A-4F23-8FBA-A583303A8531} = {139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
 		{48783186-230D-4048-A97A-E4F1DF43BF5C} = {139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}
+		{7493F952-4ECF-45D6-B8E9-66427FD37DE2} = {5307589D-87A1-459B-BBD2-1077AA25EB1E}
+		{40FF3ED6-828C-453D-98AC-79EA8D86124A} = {139F6FAA-EF59-4ADC-A69B-33CA7D1C1D4E}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {27D12E10-E38E-4ECE-8DD1-77E8C387B2DD}
 	EndGlobalSection
 EndGlobal

--- a/osu.Framework.Templates/replace-references.sh
+++ b/osu.Framework.Templates/replace-references.sh
@@ -1,5 +1,6 @@
 game_projects=(./**/**/**/*.Game.csproj)
 ios_projects=(./**/**/**/*.iOS.csproj)
+android_projects=(./**/**/**/*.Android.csproj)
 
 cd "$(dirname "$0")"
 
@@ -16,3 +17,11 @@ do
 done
 
 sed -i '/osu.Framework.iOS.props/d' ./**/**/**/*.iOS.csproj
+
+for android_project in ${android_projects[@]}
+do
+    dotnet remove $android_project reference ../osu.Framework.Android/osu.Framework.Android.csproj
+    dotnet add $android_project package ppy.osu.Framework.Android -v $1 --no-restore
+done
+
+sed -i '/osu.Framework.Android.props/d' ./**/**/**/*.Android.csproj

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Android.slnf
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Android.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "TemplateGame.sln",
+    "projects": [
+      "TemplateGame.Game\\TemplateGame.Game.csproj",
+      "TemplateGame.Resources\\TemplateGame.Resources.csproj",
+      "TemplateGame.Android\\TemplateGame.Android.csproj"
+    ]
+  }
+}

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/AndroidManifest.xml
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="TemplateGame.Android" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
+	<application />
+</manifest>

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/TemplateGame.Android.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/TemplateGame.Android.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\..\osu.Framework.Android.props" />
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TemplateGame.Android</RootNamespace>
+    <AssemblyName>TemplateGame.Android</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TemplateGame.Game\TemplateGame.Game.csproj" />
+    <ProjectReference Include="..\TemplateGame.Resources\TemplateGame.Resources.csproj" />
+  </ItemGroup>
+  <ItemGroup Label="Package References">
+    <ProjectReference Include="..\..\..\..\osu.Framework.Android\osu.Framework.Android.csproj" />
+  </ItemGroup>
+</Project>

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/TemplateGameActivity.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Android/TemplateGameActivity.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.App;
+using osu.Framework.Android;
+using TemplateGame.Game;
+
+namespace TemplateGame.Android
+{
+    [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, Exported = true, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
+    public class TemplateGameActivity : AndroidGameActivity
+    {
+        protected override osu.Framework.Game CreateGame() => new TemplateGameGame();
+    }
+}

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.sln
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.sln
@@ -1,17 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29409.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Desktop", "TemplateGame.Desktop\TemplateGame.Desktop.csproj", "{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Desktop", "TemplateGame.Desktop\TemplateGame.Desktop.csproj", "{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.iOS", "TemplateGame.iOS\TemplateGame.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.iOS", "TemplateGame.iOS\TemplateGame.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Game", "TemplateGame.Game\TemplateGame.Game.csproj", "{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Game", "TemplateGame.Game\TemplateGame.Game.csproj", "{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}"
 EndProject
-Project("{9344BDBB-3E7F-41FC-A0DD-8665D75EE146}") = "TemplateGame.Game.Tests", "TemplateGame.Game.Tests\TemplateGame.Game.Tests.csproj", "{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Game.Tests", "TemplateGame.Game.Tests\TemplateGame.Game.Tests.csproj", "{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateGame.Resources", "TemplateGame.Resources\TemplateGame.Resources.csproj", "{31D3872C-3A4F-437E-9655-3EF58DD62F46}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Resources", "TemplateGame.Resources\TemplateGame.Resources.csproj", "{31D3872C-3A4F-437E-9655-3EF58DD62F46}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9AF9C164-2A9E-4958-BB12-0FEDC40F58EC}"
 	ProjectSection(SolutionItems) = preProject
@@ -20,59 +20,101 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		TemplateGame.sln.DotSettings = TemplateGame.sln.DotSettings
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TemplateGame.Android", "TemplateGame.Android\TemplateGame.Android.csproj", "{FB81CE95-F592-41F3-9B72-59C501BD2EF7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|iPhone = Debug|iPhone
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|Any CPU = Release|Any CPU
 		Release|iPhone = Release|iPhone
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhone.Build.0 = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.Build.0 = Debug|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.ActiveCfg = Release|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.Build.0 = Release|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhone.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhone.Build.0 = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhone.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhone.Deploy.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhone.Build.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhone.Deploy.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FB81CE95-F592-41F3-9B72-59C501BD2EF7}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E2397B24-B310-4DA5-84D8-2321C7BD7D68}
 	EndGlobalSection
 EndGlobal

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android.slnf
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "FlappyDon.sln",
+    "projects": [
+      "FlappyDon.Game\\FlappyDon.Game.csproj",
+      "FlappyDon.Resources\\FlappyDon.Resources.csproj",
+      "FlappyDon.Android\\FlappyDon.Android.csproj"
+    ]
+  }
+}

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/AndroidManifest.xml
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/AndroidManifest.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="TemplateGame.Android" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
+	<application />
+</manifest>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/FlappyDon.Android.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/FlappyDon.Android.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\..\osu.Framework.Android.props" />
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>FlappyDon.Android</RootNamespace>
+    <AssemblyName>FlappyDon.Android</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FlappyDon.Game\FlappyDon.Game.csproj" />
+    <ProjectReference Include="..\FlappyDon.Resources\FlappyDon.Resources.csproj" />
+  </ItemGroup>
+  <ItemGroup Label="Package References">
+    <ProjectReference Include="..\..\..\..\osu.Framework.Android\osu.Framework.Android.csproj" />
+  </ItemGroup>
+</Project>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/FlappyDonActivity.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Android/FlappyDonActivity.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.App;
+using FlappyDon.Game;
+using osu.Framework.Android;
+
+namespace FlappyDon.Android
+{
+    [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, Exported = true, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
+    public class FlappyDonActivity : AndroidGameActivity
+    {
+        protected override osu.Framework.Game CreateGame() => new FlappyDonGame();
+    }
+}

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.sln
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.sln
@@ -1,16 +1,17 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29409.12
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32811.315
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Desktop", "FlappyDon.Desktop\FlappyDon.Desktop.csproj", "{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Desktop", "FlappyDon.Desktop\FlappyDon.Desktop.csproj", "{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.iOS", "FlappyDon.iOS\FlappyDon.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.iOS", "FlappyDon.iOS\FlappyDon.iOS.csproj", "{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Game", "FlappyDon.Game\FlappyDon.Game.csproj", "{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Game", "FlappyDon.Game\FlappyDon.Game.csproj", "{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Game.Tests", "FlappyDon.Game.Tests\FlappyDon.Game.Tests.csproj", "{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Game.Tests", "FlappyDon.Game.Tests\FlappyDon.Game.Tests.csproj", "{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlappyDon.Resources", "FlappyDon.Resources\FlappyDon.Resources.csproj", "{31D3872C-3A4F-437E-9655-3EF58DD62F46}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Resources", "FlappyDon.Resources\FlappyDon.Resources.csproj", "{31D3872C-3A4F-437E-9655-3EF58DD62F46}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9AF9C164-2A9E-4958-BB12-0FEDC40F58EC}"
 	ProjectSection(SolutionItems) = preProject
@@ -19,59 +20,101 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		FlappyDon.sln.DotSettings = FlappyDon.sln.DotSettings
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlappyDon.Android", "FlappyDon.Android\FlappyDon.Android.csproj", "{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug|iPhone = Debug|iPhone
 		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|Any CPU = Release|Any CPU
 		Release|iPhone = Release|iPhone
 		Release|iPhoneSimulator = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhone.Build.0 = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{AEB3FC89-DC3E-4BC9-9EC7-03B72FC5D849}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhone.Build.0 = Debug|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|Any CPU.Deploy.0 = Release|Any CPU
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.ActiveCfg = Release|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhone.Build.0 = Release|iPhone
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{7AA1DB5D-78DB-4693-AE50-D6078F5A0CAB}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhone.Build.0 = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{1ADACD09-7BE3-46A1-AEAB-C41E78E8700F}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhone.Build.0 = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0A9CA1A5-5147-4AA8-9B9D-87178DE5A78D}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhone.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhone.Build.0 = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|Any CPU.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhone.Build.0 = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{31D3872C-3A4F-437E-9655-3EF58DD62F46}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhone.Deploy.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhone.Build.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhone.Deploy.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{B4C32F32-5916-4BE6-9756-5EDDBBA8C813}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6D4DD718-B436-4899-A1FE-1E002CE70580}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/5811. I have checked that the generated projects (Empty and FlappyDon) build fine (for Android and Desktop).

Note for the future: to generate projects using local templates, first run `./replace-references.sh 2023.521.0` (replace version if needed), then pack and install.