### PR TITLE
Fix not being able to parse empty string into nullable bindable

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -349,6 +349,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JIT/@EntryIndexedValue">JIT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LTRB/@EntryIndexedValue">LTRB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NRT/@EntryIndexedValue">NRT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NS/@EntryIndexedValue">NS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PM/@EntryIndexedValue">PM</s:String>

--- a/osu.Framework.Tests/Bindables/BindableEnumTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableEnumTest.cs
@@ -44,7 +44,6 @@ namespace osu.Framework.Tests.Bindables
 
         [TestCase(1.1f)]
         [TestCase("Not a value")]
-        [TestCase("")]
         public void TestUnparsaebles(object value)
         {
             var bindable = new Bindable<TestEnum>();
@@ -52,6 +51,19 @@ namespace osu.Framework.Tests.Bindables
 
             Assert.Throws<ArgumentException>(() => bindable.Parse(value));
             Assert.Throws<ArgumentException>(() => nullable.Parse(value));
+        }
+
+        [Test]
+        public void TestEmptyString()
+        {
+            var bindable = new Bindable<TestEnum>();
+            var nullable = new Bindable<TestEnum?>();
+
+            bindable.Parse(string.Empty);
+            nullable.Parse(string.Empty);
+
+            Assert.That(bindable.Value, Is.EqualTo(default(TestEnum)));
+            Assert.That(nullable.Value, Is.Null);
         }
 
         public enum TestEnum

--- a/osu.Framework.Tests/Bindables/BindableEnumTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableEnumTest.cs
@@ -59,10 +59,9 @@ namespace osu.Framework.Tests.Bindables
             var bindable = new Bindable<TestEnum>();
             var nullable = new Bindable<TestEnum?>();
 
-            bindable.Parse(string.Empty);
+            Assert.Throws<ArgumentException>(() => bindable.Parse(string.Empty));
             nullable.Parse(string.Empty);
 
-            Assert.That(bindable.Value, Is.EqualTo(default(TestEnum)));
             Assert.That(nullable.Value, Is.Null);
         }
 

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -195,7 +195,7 @@ namespace osu.Framework.Tests.Bindables
             bindable.Parse(string.Empty);
             Assert.That(bindable.Value, Is.Null);
         }
-#nullable restore
+#nullable disable
 
         [Test]
         public void TestParseNullIntoStringType()
@@ -245,7 +245,7 @@ namespace osu.Framework.Tests.Bindables
             bindable.Parse(string.Empty);
             Assert.That(bindable.Value, Is.Empty);
         }
-#nullable restore
+#nullable disable
 
         private static IEnumerable<object[]> getParsingConversionTests()
         {

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -215,7 +215,23 @@ namespace osu.Framework.Tests.Bindables
 
 #nullable enable
         [Test]
-        public void TestParseNullIntoNullableStringType()
+        public void TestParseNullIntoStringTypeWithNRT()
+        {
+            Bindable<string> bindable = new Bindable<string>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        [Test]
+        public void TestParseEmptyStringIntoStringTypeWithNRT()
+        {
+            Bindable<string> bindable = new Bindable<string>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Empty);
+        }
+
+        [Test]
+        public void TestParseNullIntoNullableStringTypeWithNRT()
         {
             Bindable<string?> bindable = new Bindable<string?>();
             bindable.Parse(null);
@@ -223,7 +239,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestParseEmptyStringIntoNullableStringType()
+        public void TestParseEmptyStringIntoNullableStringTypeWithNRT()
         {
             Bindable<string?> bindable = new Bindable<string?>();
             bindable.Parse(string.Empty);

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -107,6 +107,97 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(value, Is.EqualTo(output));
         }
 
+        // Bindable<int>.Parse(null)
+        [Test]
+        public void TestParseNullIntoValueType()
+        {
+            Bindable<int> bindable = new Bindable<int>();
+            Assert.That(() => bindable.Parse(null), Throws.ArgumentNullException);
+        }
+
+        // Bindable<int?>.Parse(null)
+        [Test]
+        public void TestParseNullIntoNullableValueType()
+        {
+            Bindable<int?> bindable = new Bindable<int?>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<int>.Parse(string.Empty)
+        [Test]
+        public void TestParseEmptyStringIntoValueType()
+        {
+            Bindable<int> bindable = new Bindable<int>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Zero);
+        }
+
+        // Bindable<int?>.Parse(string.Empty)
+        [Test]
+        public void TestParseEmptyStringIntoNullableValueType()
+        {
+            Bindable<int?> bindable = new Bindable<int?>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class>.Parse(null)
+        [Test]
+        public void TestParseNullIntoReferenceType()
+        {
+            Bindable<TestClass> bindable = new Bindable<TestClass>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class>.Parse(string.Empty)
+        [Test]
+        public void TestParseEmptyStringIntoReferenceType()
+        {
+            Bindable<TestClass> bindable = new Bindable<TestClass>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+#nullable enable
+        // Bindable<Class>.Parse(null) -- NRT
+        [Test]
+        public void TestParseNullIntoReferenceTypeWithNRT()
+        {
+            Bindable<TestClass> bindable = new Bindable<TestClass>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class?>.Parse(null) -- NRT
+        [Test]
+        public void TestParseNullIntoNullableReferenceTypeWithNRT()
+        {
+            Bindable<TestClass?> bindable = new Bindable<TestClass?>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class>.Parse(string.Empty) -- NRT
+        [Test]
+        public void TestParseEmptyStringIntoReferenceTypeWithNRT()
+        {
+            Bindable<TestClass> bindable = new Bindable<TestClass>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class?>.Parse(string.Empty) -- NRT
+        [Test]
+        public void TestParseEmptyStringIntoNullableReferenceTypeWithNRT()
+        {
+            Bindable<TestClass?> bindable = new Bindable<TestClass?>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Null);
+        }
+#nullable disable
+
         private static IEnumerable<object[]> getParsingConversionTests()
         {
             var testTypes = new[]
@@ -155,6 +246,10 @@ namespace osu.Framework.Tests.Bindables
                         yield return new[] { type, input, expectedOutput };
                 }
             }
+        }
+
+        private class TestClass
+        {
         }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -215,6 +215,14 @@ namespace osu.Framework.Tests.Bindables
 
 #nullable enable
         [Test]
+        public void TestParseNullIntoNullableStringType()
+        {
+            Bindable<string?> bindable = new Bindable<string?>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        [Test]
         public void TestParseEmptyStringIntoNullableStringType()
         {
             Bindable<string?> bindable = new Bindable<string?>();

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -115,6 +115,14 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(() => bindable.Parse(null), Throws.ArgumentNullException);
         }
 
+        // Bindable<int>.Parse(string.Empty)
+        [Test]
+        public void TestParseEmptyStringIntoValueType()
+        {
+            Bindable<int> bindable = new Bindable<int>();
+            Assert.Throws<FormatException>(() => bindable.Parse(string.Empty));
+        }
+
         // Bindable<int?>.Parse(null)
         [Test]
         public void TestParseNullIntoNullableValueType()
@@ -122,14 +130,6 @@ namespace osu.Framework.Tests.Bindables
             Bindable<int?> bindable = new Bindable<int?>();
             bindable.Parse(null);
             Assert.That(bindable.Value, Is.Null);
-        }
-
-        // Bindable<int>.Parse(string.Empty)
-        [Test]
-        public void TestParseEmptyStringIntoValueType()
-        {
-            Bindable<int> bindable = new Bindable<int>();
-            Assert.Throws<FormatException>(() => bindable.Parse(string.Empty));
         }
 
         // Bindable<int?>.Parse(string.Empty)
@@ -169,21 +169,21 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(bindable.Value, Is.Null);
         }
 
-        // Bindable<Class?>.Parse(null) -- NRT
-        [Test]
-        public void TestParseNullIntoNullableReferenceTypeWithNRT()
-        {
-            Bindable<TestClass?> bindable = new Bindable<TestClass?>();
-            bindable.Parse(null);
-            Assert.That(bindable.Value, Is.Null);
-        }
-
         // Bindable<Class>.Parse(string.Empty) -- NRT
         [Test]
         public void TestParseEmptyStringIntoReferenceTypeWithNRT()
         {
             Bindable<TestClass> bindable = new Bindable<TestClass>();
             bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        // Bindable<Class?>.Parse(null) -- NRT
+        [Test]
+        public void TestParseNullIntoNullableReferenceTypeWithNRT()
+        {
+            Bindable<TestClass?> bindable = new Bindable<TestClass?>();
+            bindable.Parse(null);
             Assert.That(bindable.Value, Is.Null);
         }
 

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -248,6 +248,7 @@ namespace osu.Framework.Tests.Bindables
             }
         }
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private class TestClass
         {
         }

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -129,8 +129,7 @@ namespace osu.Framework.Tests.Bindables
         public void TestParseEmptyStringIntoValueType()
         {
             Bindable<int> bindable = new Bindable<int>();
-            bindable.Parse(string.Empty);
-            Assert.That(bindable.Value, Is.Zero);
+            Assert.Throws<FormatException>(() => bindable.Parse(string.Empty));
         }
 
         // Bindable<int?>.Parse(string.Empty)
@@ -196,7 +195,33 @@ namespace osu.Framework.Tests.Bindables
             bindable.Parse(string.Empty);
             Assert.That(bindable.Value, Is.Null);
         }
-#nullable disable
+#nullable restore
+
+        [Test]
+        public void TestParseNullIntoStringType()
+        {
+            Bindable<string> bindable = new Bindable<string>();
+            bindable.Parse(null);
+            Assert.That(bindable.Value, Is.Null);
+        }
+
+        [Test]
+        public void TestParseEmptyStringIntoStringType()
+        {
+            Bindable<string> bindable = new Bindable<string>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Empty);
+        }
+
+#nullable enable
+        [Test]
+        public void TestParseEmptyStringIntoNullableStringType()
+        {
+            Bindable<string?> bindable = new Bindable<string?>();
+            bindable.Parse(string.Empty);
+            Assert.That(bindable.Value, Is.Empty);
+        }
+#nullable restore
 
         private static IEnumerable<object[]> getParsingConversionTests()
         {

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -249,7 +249,8 @@ namespace osu.Framework.Bindables
         {
             switch (input)
             {
-                // This also covers the case when the input is a string. Both `string.Empty` and `null` are valid values for this type.
+                // Of note, this covers the case when the input is a string and `T` is `string`.
+                // Both `string.Empty` and `null` are valid values for this type.
                 case T t:
                     Value = t;
                     break;

--- a/osu.Framework/Bindables/BindableBool.cs
+++ b/osu.Framework/Bindables/BindableBool.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Framework.Bindables
 {
     public class BindableBool : Bindable<bool>
@@ -10,8 +12,10 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override void Parse(object input)
+        public override void Parse(object? input)
         {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+
             if (input is "1")
                 Value = true;
             else if (input is "0")

--- a/osu.Framework/Bindables/BindableColour4.cs
+++ b/osu.Framework/Bindables/BindableColour4.cs
@@ -16,8 +16,10 @@ namespace osu.Framework.Bindables
         // 8-bit precision should probably be enough for serialization.
         public override string ToString(string format, IFormatProvider formatProvider) => Value.ToHex();
 
-        public override void Parse(object input)
+        public override void Parse(object? input)
         {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+
             switch (input)
             {
                 case string str:

--- a/osu.Framework/Bindables/BindableMarginPadding.cs
+++ b/osu.Framework/Bindables/BindableMarginPadding.cs
@@ -17,8 +17,10 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override void Parse(object input)
+        public override void Parse(object? input)
         {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+
             switch (input)
             {
                 case string str:

--- a/osu.Framework/Bindables/BindableSize.cs
+++ b/osu.Framework/Bindables/BindableSize.cs
@@ -21,8 +21,10 @@ namespace osu.Framework.Bindables
 
         public override string ToString(string format, IFormatProvider formatProvider) => ((FormattableString)$"{Value.Width}x{Value.Height}").ToString(formatProvider);
 
-        public override void Parse(object input)
+        public override void Parse(object? input)
         {
+            if (input == null) throw new ArgumentNullException(nameof(input));
+
             switch (input)
             {
                 case string str:


### PR DESCRIPTION
Previously:
![image](https://github.com/ppy/osu-framework/assets/1329837/5d93d3b1-ee3b-4763-a9bd-5c6a0c19de78)

My particular use case is I want to set a realm setting to `null`, but we currently store and retrieve them from the database as non-nullable strings. Not that having them stored as `null` would help (see `TestParseNullIntoNullableValueType` failure above).

Store: https://github.com/ppy/osu/blob/ba5f76fcc8b7e926310f22a6c5fc63bae19897fb/osu.Game/Rulesets/Configuration/RulesetConfigManager.cs#L72 (i.e. `Bindable<T>.ToString()` which returns `string.Empty` for a `null` value).

Retrieve: https://github.com/ppy/osu/blob/ba5f76fcc8b7e926310f22a6c5fc63bae19897fb/osu.Game/Configuration/RealmRulesetSetting.cs#L20-L21.

In summary:
```
Bindable<int>.Parse(null)               => ArgumentNullException()
Bindable<int>.Parse(string.Empty)       => FormatException()
Bindable<int?>.Parse(null)              => null
Bindable<int?>.Parse(string.Empty)      => null

Bindable<Class>.Parse(null)             => null (with and without NRT)
Bindable<Class>.Parse(string.Empty)     => null (with and without NRT)
Bindable<Class?>.Parse(null)            => null
Bindable<Class?>.Parse(string.Empty)    => null

Bindable<string>.Parse(null)            => null (with and without NRT)
Bindable<string>.Parse(string.Empty)    => string.Empty (with and without NRT)
Bindable<string?>.Parse(null)           => null
Bindable<string?>.Parse(string.Empty)   => string.Empty
```