### PR TITLE
Fix `WndProc` reporting too much elapsed time

### DIFF
--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -103,12 +103,17 @@ namespace osu.Framework.Statistics
         /// </summary>
         public InvokeOnDisposal BeginCollecting(PerformanceCollectionType type)
         {
+            // Consume time, regardless of whether we are using it at this point.
+            // If not, an `EndCollecting` call may end up reporting more time than actually passed between
+            // the Begin-End pair.
+            double time = consumeStopwatchElapsedTime();
+
             if (currentCollectionTypeStack.Count > 0)
             {
                 PerformanceCollectionType t = currentCollectionTypeStack.Peek();
 
                 currentFrame.CollectedTimes.TryAdd(t, 0);
-                currentFrame.CollectedTimes[t] += consumeStopwatchElapsedTime();
+                currentFrame.CollectedTimes[t] += time;
             }
 
             currentCollectionTypeStack.Push(type);


### PR DESCRIPTION
Well, no, potentially not just `WndProc` but other counters too. Basically if `BeginCollecting` is called with no items in the stack, it will not consume the stopwatch time, meaning the next `EndCollecting` call will also include all time passed since the *previous* `EndCollecting` call.

Ouch.

| before | after |
| -- | -- |
|![osu Framework Tests 2023-05-31 at 08 38 08](https://github.com/ppy/osu-framework/assets/191335/17b7816a-5924-4315-8187-b38deef938b7)|![osu Framework Tests 2023-05-31 at 08 37 49](https://github.com/ppy/osu-framework/assets/191335/7f0c0970-34d2-4621-9bf4-a2c1301a7e0d)| 