### PR TITLE
Improve iOS/iPadOS frame timings by using `CADisplayLink`

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -1,14 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
 using Foundation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Video;
 using osu.Framework.Input.Bindings;
@@ -66,7 +65,7 @@ namespace osu.Framework.iOS
 
             UIApplication.SharedApplication.InvokeOnMainThread(() =>
             {
-                NSUrl nsurl = NSUrl.FromString(url);
+                NSUrl nsurl = NSUrl.FromString(url).AsNonNull();
                 if (UIApplication.SharedApplication.CanOpenUrl(nsurl))
                     UIApplication.SharedApplication.OpenUrl(nsurl, new NSDictionary(), null);
             });

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -51,6 +51,14 @@ namespace osu.Framework.iOS
 
         protected override void RunMainLoop()
         {
+            // Delegate running the main loop to CADisplayLink.
+            //
+            // Note that this is most effective in single thread mode.
+            // .. In multi-threaded mode it will time the *input* thread to the callbacks. This is kinda silly,
+            // but users shouldn't be using multi-threaded mode in the first place. Disabling it completely on
+            // iOS may be a good forward direction if this ever comes up, as a user may see a potentially higher
+            // frame rate with multi-threaded mode turned on, but it is going to give them worse input latency
+            // and higher power usage.
             SDL.SDL_iPhoneSetEventPump(SDL.SDL_bool.SDL_FALSE);
             SDL.SDL_iPhoneSetAnimationCallback(SDLWindowHandle, 1, _ => RunFrame(), IntPtr.Zero);
         }

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using ObjCRuntime;
@@ -46,6 +47,12 @@ namespace osu.Framework.iOS
 
             window = Runtime.GetNSObject<UIWindow>(WindowHandle);
             updateSafeArea();
+        }
+
+        protected override void RunMainLoop()
+        {
+            SDL.SDL_iPhoneSetEventPump(SDL.SDL_bool.SDL_FALSE);
+            SDL.SDL_iPhoneSetAnimationCallback(SDLWindowHandle, 1, _ => RunFrame(), IntPtr.Zero);
         }
 
         private void updateSafeArea()

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -252,31 +252,49 @@ namespace osu.Framework.Platform
         {
             SDL.SDL_SetEventFilter(eventFilterDelegate = eventFilter, objectHandle.Handle);
 
+            RunMainLoop();
+        }
+
+        /// <summary>
+        /// Runs the main window loop.
+        /// </summary>
+        /// <remarks>
+        /// By default this will block and indefinitely call <see cref="RunFrame"/> as long as the window <see cref="Exists"/>.
+        /// Once the main loop finished running, cleanup logic will run.
+        ///
+        /// This may be overridden for special use cases, like mobile platforms which delegate execution of frames to the OS
+        /// and don't require any kind of exit logic to exist.
+        /// </remarks>
+        protected virtual void RunMainLoop()
+        {
             while (Exists)
-            {
-                commandScheduler.Update();
+                RunFrame();
 
-                if (!Exists)
-                    break;
-
-                if (pendingWindowState != null)
-                    updateAndFetchWindowSpecifics();
-
-                pollSDLEvents();
-
-                if (!cursorInWindow.Value)
-                    pollMouse();
-
-                EventScheduler.Update();
-
-                Update?.Invoke();
-            }
-
-            Exists = false;
             Exited?.Invoke();
-
             Close();
             SDL.SDL_Quit();
+        }
+
+        /// <summary>
+        /// Run a single frame.
+        /// </summary>
+        protected void RunFrame()
+        {
+            commandScheduler.Update();
+
+            if (!Exists)
+                return;
+
+            if (pendingWindowState != null)
+                updateAndFetchWindowSpecifics();
+
+            pollSDLEvents();
+
+            if (!cursorInWindow.Value)
+                pollMouse();
+
+            EventScheduler.Update();
+            Update?.Invoke();
         }
 
         /// <summary>


### PR DESCRIPTION
Alternative to and closes https://github.com/ppy/osu-framework/pull/5803 (the iOS portion – the macOS part is still
valid but only requires a veldrid version bump).

Testing at 2x limiter, 120hz display (iPad Pro 2018), release build local framework

| Header      | menu (contracted) | menu (expanded) | song select |
|-------------|-------------------|-----------------|-------------|
| `master`    | 120fps                 | 70fps               | 28fps           |
| this PR     | 120fps            | 80fps           | 28fps       |
| `master` gl | 120fps                 | 70fps               | 27fps           | 

Not much difference, but that's because we're still doing way too much work in draw. The main thing I want to show is that nothing regressed. Once we have more overhead this is only going to help more.

Of note, in a very simple framework visual test I *can* feel a reduction in input latency on this PR, similar to what I reported on macOS.