### PR TITLE
Update veldrid with macOS `CVDisplayLink` support

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gf1f8dc0432" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gd4340776eb" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
No changes required from our end as we are already calling the relevant `Renderer.WaitUntilNextFrameReady()` function. Veldrid side, this is now supported on desktop metal platforms.

Closes https://github.com/ppy/osu-framework/pull/5803 (separate PR so we can keep that one around for potential reference – it contains iOS changes).

In the future, we can improve this further by implementing `CVDisplayLink` in `MacOSWindow`, in a very similar way to https://github.com/ppy/osu-framework/pull/5820. Once this is merged and all has settled, I'll open an issue to track that. The benefits would be that the timings are slightly more precise as we are not using a semaphore. Higher effort though, as we will need to figure a better solution for multi-threaded mode.