### PR TITLE
Change Tablet AreaSize and AreaOffset to Bindable<Vector2?>

### DIFF
--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Configuration
 
                     // call `subscribe` with the type and bindable.
                     subscribeMethod.MakeGenericMethod(encapsulatedType)
-                                   .Invoke(this, new[] { property?.GetValue(handler) });
+                                   .Invoke(this, new[] { property.GetValue(handler) });
                 }
             }
         }

--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Configuration
 
                     // call `subscribe` with the type and bindable.
                     subscribeMethod.MakeGenericMethod(encapsulatedType)
-                                   .Invoke(this, new[] { property.GetValue(handler) });
+                                   .Invoke(this, new[] { property?.GetValue(handler) });
                 }
             }
         }

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -17,12 +17,12 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// <summary>
         /// The offset of the area which should be mapped to the game window.
         /// </summary>
-        Bindable<Vector2> AreaOffset { get; }
+        Bindable<Vector2?> AreaOffset { get; }
 
         /// <summary>
         /// The size of the area which should be mapped to the game window.
         /// </summary>
-        Bindable<Vector2> AreaSize { get; }
+        Bindable<Vector2?> AreaSize { get; }
 
         /// <summary>
         /// Information on the currently connected tablet device. May be null if no tablet is detected.
@@ -33,6 +33,26 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// The rotation of the tablet area in degrees.
         /// </summary>
         Bindable<float> Rotation { get; }
+
+        void updateAreaOffset(Vector2 areaOffset)
+        {
+            AreaOffset.Value = areaOffset;
+        }
+
+        void updateAreaSize(Vector2 areaSize)
+        {
+            AreaSize.Value = areaSize;
+        }
+
+        Vector2 getAreaOffset()
+        {
+            return AreaOffset.Value ?? Vector2.One * 50f;
+        }
+
+        Vector2 getAreaSize()
+        {
+            return AreaSize.Value ?? Vector2.One * 50f;
+        }
 
         BindableBool Enabled { get; }
     }

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -34,22 +34,22 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// </summary>
         Bindable<float> Rotation { get; }
 
-        void updateAreaOffset(Vector2 areaOffset)
+        void UpdateAreaOffset(Vector2 areaOffset)
         {
             AreaOffset.Value = areaOffset;
         }
 
-        void updateAreaSize(Vector2 areaSize)
+        void UpdateAreaSize(Vector2 areaSize)
         {
             AreaSize.Value = areaSize;
         }
 
-        Vector2 getAreaOffset()
+        Vector2 GetAreaOffset()
         {
             return AreaOffset.Value ?? Vector2.One * 50f;
         }
 
-        Vector2 getAreaSize()
+        Vector2 GetAreaSize()
         {
             return AreaSize.Value ?? Vector2.One * 50f;
         }

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -153,18 +153,17 @@ namespace osu.Framework.Input.Handlers.Tablet
             float inputHeight = digitizer.Height;
 
             AreaSize.Default = new Vector2(inputWidth, inputHeight);
-            //Force default value, Seems that somewhere Vector2? AreaSize.Value initializes to (0,0)
+            // Force default value, Seems that somewhere Vector2? AreaSize.Value initializes to (0,0)
             AreaSize.SetDefault();
-            // if it's clear the user has not configured the area, take the full area from the tablet that was just found.
+            // If the area hasn't been configured, take the full area from the tablet that was just found.
             if (AreaSize.Value == null)
                 AreaSize.SetDefault();
 
             AreaOffset.Default = new Vector2(inputWidth / 2, inputHeight / 2);
-            //Force default value, Seems that somewhere Vector2? AreaOffset.Value initializes to (0,0)
+            // Force default value, Seems that somewhere Vector2? AreaOffset.Value initializes to (0,0)
             AreaOffset.SetDefault();
 
             // likewise with the position, use the centre point if it has not been configured.
-            // it's safe to assume no user would set their centre point to 0,0 for now.
             if (AreaOffset.Value == null)
                 AreaOffset.SetDefault();
 

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -153,14 +153,14 @@ namespace osu.Framework.Input.Handlers.Tablet
             float inputHeight = digitizer.Height;
 
             AreaSize.Default = new Vector2(inputWidth, inputHeight);
-            //Force default value, Seems that somewhere Vector2? AreaSize.Value initializes to (0,0) 
+            //Force default value, Seems that somewhere Vector2? AreaSize.Value initializes to (0,0)
             AreaSize.SetDefault();
             // if it's clear the user has not configured the area, take the full area from the tablet that was just found.
             if (AreaSize.Value == null)
                 AreaSize.SetDefault();
 
             AreaOffset.Default = new Vector2(inputWidth / 2, inputHeight / 2);
-            //Force default value, Seems that somewhere Vector2? AreaOffset.Value initializes to (0,0) 
+            //Force default value, Seems that somewhere Vector2? AreaOffset.Value initializes to (0,0)
             AreaOffset.SetDefault();
 
             // likewise with the position, use the centre point if it has not been configured.
@@ -177,9 +177,9 @@ namespace osu.Framework.Input.Handlers.Tablet
                     // Set input area in millimeters
                     absoluteOutputMode.Input = new Area
                     {
-                        Width = AreaSize?.Value?.X ?? 0f,
-                        Height = AreaSize?.Value?.Y ?? 0f,
-                        Position = new System.Numerics.Vector2(AreaOffset?.Value?.X ?? 0f, AreaOffset?.Value?.Y ?? 0f),
+                        Width = AreaSize.Value?.X ?? 0f,
+                        Height = AreaSize.Value?.Y ?? 0f,
+                        Position = new System.Numerics.Vector2(AreaOffset.Value?.X ?? 0f, AreaOffset.Value?.Y ?? 0f),
                         Rotation = Rotation.Value
                     };
                     break;
@@ -196,7 +196,7 @@ namespace osu.Framework.Input.Handlers.Tablet
         {
             AreaSize.Value = areaSize;
         }
-        
+
         private Vector2 getAreaOffset()
         {
             return AreaOffset.Value ?? Vector2.One * 50f;

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -152,22 +152,23 @@ namespace osu.Framework.Input.Handlers.Tablet
             float inputWidth = digitizer.Width;
             float inputHeight = digitizer.Height;
 
-            AreaSize.Default = new Vector2(inputWidth, inputHeight);
+            Vector2 defaultSize = new Vector2(inputWidth, inputHeight);
+            AreaSize.Default = defaultSize;
             // Force default value, Seems that somewhere Vector2? AreaSize.Value initializes to (0,0)
-            AreaSize.SetDefault();
+            //AreaSize.SetDefault();
             // If the area hasn't been configured, take the full area from the tablet that was just found.
             if (AreaSize.Value == null)
                 AreaSize.SetDefault();
 
             AreaOffset.Default = new Vector2(inputWidth / 2, inputHeight / 2);
             // Force default value, Seems that somewhere Vector2? AreaOffset.Value initializes to (0,0)
-            AreaOffset.SetDefault();
+            //AreaOffset.SetDefault();
 
             // likewise with the position, use the centre point if it has not been configured.
             if (AreaOffset.Value == null)
                 AreaOffset.SetDefault();
 
-            tablet.Value = new TabletInfo(inputDevice.Properties.Name, AreaSize.Default ?? Vector2.Zero);
+            tablet.Value = new TabletInfo(inputDevice.Properties.Name, defaultSize);
 
             switch (inputDevice.OutputMode)
             {


### PR DESCRIPTION
For the edge case of `AreaOffset == 0,0` described here https://github.com/ppy/osu/pull/23628

There is one issue with this; somewhere along the way `.Value` gets initialized to `0,0` which means `if (AreaSize.Value == null)` and `if (AreaOffset.Value == null)` are never true.  I need some help figuring out what the cause could be (Are pull requests a good way to ask for help like this?)

For now, I'm forcing default values on restart regardless of user configuation. If you'd like I can commit the game side changes on that PR (or open a separate one), on which I have undone my changes and changed the bindable bindings to use callbacks instead.

BTW this is probably terrible, especially the null-coalescing spam as safeguards