### PR TITLE
Reduce invalidations of `childrenSizeDependencies` in edge cases

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1090,9 +1090,14 @@ namespace osu.Framework.Graphics.Containers
             // The invalidation still needs to occur as normal, since a derived CompositeDrawable may want to respond to children size invalidations.
             Invalidate(invalidation, InvalidationSource.Child);
 
-            // If all the changed axes were bypassed and an invalidation occurred, the children size dependencies can immediately be
-            // re-validated without a recomputation, as a recomputation would not change the auto-sized size.
-            if (wasValid && (axes & source.BypassAutoSizeAxes) == axes)
+            // Skip axes that are bypassed.
+            axes &= ~source.BypassAutoSizeAxes;
+
+            // Include only axes that this composite is autosizing for.
+            axes &= AutoSizeAxes;
+
+            // If no remaining axes remain, then children size dependencies can immediately be re-validated as the auto-sized size would not change.
+            if (wasValid && axes == Axes.None)
                 childrenSizeDependencies.Validate();
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -54,6 +54,9 @@ namespace osu.Framework.Graphics.Containers
             internalChildren = new SortedList<Drawable>(childComparer);
             aliveInternalChildren = new SortedList<Drawable>(childComparer);
 
+            // Validate initially. Done before the layout is added below to prevent a callback to this composite.
+            childrenSizeDependencies.Validate();
+
             AddLayout(childrenSizeDependencies);
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1780,7 +1780,12 @@ namespace osu.Framework.Graphics.Containers
                     throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
 
                 autoSizeAxes = value;
-                childrenSizeDependencies.Invalidate();
+
+                if (value == Axes.None)
+                    childrenSizeDependencies.Validate();
+                else
+                    childrenSizeDependencies.Invalidate();
+
                 OnSizingChanged();
             }
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1799,6 +1799,11 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         internal event Action OnAutoSize;
 
+        /// <summary>
+        /// Whether the <see cref="childrenSizeDependencies"/> layout is valid.
+        /// </summary>
+        internal bool ChildrenSizeDependenciesIsValid => childrenSizeDependencies.IsValid;
+
         private readonly LayoutValue childrenSizeDependencies = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.Presence, InvalidationSource.Child);
 
         public override float Width


### PR DESCRIPTION
Although this should not have much of an effect on performance, it has behavioural effects with [`RequiresChildrenUpdate`](https://github.com/ppy/osu-framework/blob/4f51459744d1f2e97692696b4c38a557d7c6e827/osu.Framework/Graphics/Containers/CompositeDrawable.cs#LL903C59-L903C59), that could needlessly trigger `Update`s on children when their parents are masked away.