### PR TITLE
Update Veldrid package to revert `CADisplayLink` implementation from veldrid-side

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gd4340776eb" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.3-g31346ea477" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/23792#discussioncomment-6111778

```
2023-06-08 05:38:37 [verbose]: 🖼️ Initialising "Veldrid" renderer with "Metal" surface
2023-06-08 05:38:37 [verbose]: Updated display mode to desktop resolution: 844x390@60, SDL_PIXELFORMAT_ABGR8888
2023-06-08 05:38:37 [verbose]: 🖼️ Renderer initialisation failed with:
2023-06-08 05:38:37 [verbose]: System.EntryPointNotFoundException: createDisplayLinkProxy
2023-06-08 05:38:37 [verbose]: at Veldrid.MetalBindings.CADisplayLinkProxy.InitWithCallback(IntPtr callback)
2023-06-08 05:38:37 [verbose]: at Veldrid.MTL.MTLCADisplayLink..ctor()
2023-06-08 05:38:37 [verbose]: at Veldrid.MTL.MTLGraphicsDevice..ctor(GraphicsDeviceOptions options, Nullable`1 swapchainDesc, MetalDeviceOptions metalOptions)
2023-06-08 05:38:37 [verbose]: at Veldrid.MTL.MTLGraphicsDevice..ctor(GraphicsDeviceOptions options, Nullable`1 swapchainDesc)
2023-06-08 05:38:37 [verbose]: at Veldrid.GraphicsDevice.CreateMetal(GraphicsDeviceOptions options, SwapchainDescription swapchainDescription)
2023-06-08 05:38:37 [verbose]: at osu.Framework.Graphics.Veldrid.VeldridRenderer.Initialise(IGraphicsSurface graphicsSurface)
2023-06-08 05:38:37 [verbose]: at osu.Framework.Graphics.Rendering.Renderer.osu.Framework.Graphics.Rendering.IRenderer.Initialise(IGraphicsSurface graphicsSurface)
2023-06-08 05:38:37 [verbose]: at osu.Framework.Platform.GameHost.SetupRendererAndWindow(IRenderer renderer, GraphicsSurfaceType surfaceType)
2023-06-08 05:38:37 [important]: The selected renderer (Metal) failed to initialise. Renderer selection has been reverted to automatic.
```

Latest Veldrid bump unintentionally included half-working changes on iOS. This bumps Veldrid again to a version that has those changes reverted. See [discord](https://discord.com/channels/188630481301012481/589331078574112768/1116252502568996925).