### PR TITLE
Add disk cache for shader compilations

### DIFF
--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -61,12 +61,12 @@ namespace osu.Framework.Tests.Shaders
         private class TestGLRenderer : GLRenderer
         {
             protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
-                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), compilationStore);
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), globalUniformBuffer, compilationStore);
 
             private class TestGLShader : GLShader
             {
-                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, ShaderCompilationStore compilationStore)
-                    : base(renderer, name, parts, null, compilationStore)
+                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+                    : base(renderer, name, parts, globalUniformBuffer, compilationStore)
                 {
                 }
 

--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -60,13 +60,13 @@ namespace osu.Framework.Tests.Shaders
 
         private class TestGLRenderer : GLRenderer
         {
-            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
-                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray());
+            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), compilationStore);
 
             private class TestGLShader : GLShader
             {
-                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts)
-                    : base(renderer, name, parts, null)
+                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, ShaderCompilationStore compilationStore)
+                    : base(renderer, name, parts, null, compilationStore)
                 {
                 }
 

--- a/osu.Framework.Tests/Shaders/TestShaderLoading.cs
+++ b/osu.Framework.Tests/Shaders/TestShaderLoading.cs
@@ -40,13 +40,13 @@ namespace osu.Framework.Tests.Shaders
 
         private class TestGLRenderer : GLRenderer
         {
-            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
-                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray());
+            protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), compilationStore);
 
             private class TestGLShader : GLShader
             {
-                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts)
-                    : base(renderer, name, parts, null)
+                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, ShaderCompilationStore compilationStore)
+                    : base(renderer, name, parts, null, compilationStore)
                 {
                 }
 

--- a/osu.Framework.Tests/Shaders/TestShaderLoading.cs
+++ b/osu.Framework.Tests/Shaders/TestShaderLoading.cs
@@ -41,12 +41,12 @@ namespace osu.Framework.Tests.Shaders
         private class TestGLRenderer : GLRenderer
         {
             protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
-                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), compilationStore);
+                => new TestGLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), globalUniformBuffer, compilationStore);
 
             private class TestGLShader : GLShader
             {
-                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, ShaderCompilationStore compilationStore)
-                    : base(renderer, name, parts, null, compilationStore)
+                internal TestGLShader(GLRenderer renderer, string name, GLShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+                    : base(renderer, name, parts, globalUniformBuffer, compilationStore)
                 {
                 }
 

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -376,8 +376,8 @@ namespace osu.Framework.Graphics.OpenGL
             return new GLShaderPart(this, name, rawData, glType, store);
         }
 
-        protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
-            => new GLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), globalUniformBuffer);
+        protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+            => new GLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), globalUniformBuffer, compilationStore);
 
         public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
         {

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
@@ -48,7 +47,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
             this.renderer = renderer;
             this.name = name;
             this.globalUniformBuffer = globalUniformBuffer;
-            this.parts = parts.Where(p => p != null).ToArray();
+            this.parts = parts;
 
             vertexPart = parts.Single(p => p.Type == ShaderType.VertexShader);
             fragmentPart = parts.Single(p => p.Type == ShaderType.FragmentShader);
@@ -225,15 +224,16 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!IsDisposed)
-            {
-                IsDisposed = true;
+            if (IsDisposed)
+                return;
 
-                shaderCompileDelegate?.Cancel();
+            IsDisposed = true;
 
-                if (programID != -1)
-                    DeleteProgram(this);
-            }
+            if (shaderCompileDelegate.IsNotNull())
+                shaderCompileDelegate.Cancel();
+
+            if (programID != -1)
+                DeleteProgram(this);
         }
 
         #endregion

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
@@ -123,10 +123,10 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
                         if (!string.IsNullOrEmpty(backbufferCode))
                         {
-                            string realMainName = "real_main_" + Guid.NewGuid().ToString("N");
+                            const string real_main_name = "__internal_real_main";
 
-                            backbufferCode = backbufferCode.Replace("{{ real_main }}", realMainName);
-                            code = Regex.Replace(code, @"void main\((.*)\)", $"void {realMainName}()") + backbufferCode + '\n';
+                            backbufferCode = backbufferCode.Replace("{{ real_main }}", real_main_name);
+                            code = Regex.Replace(code, @"void main\((.*)\)", $"void {real_main_name}()") + backbufferCode + '\n';
                         }
                     }
                 }

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -62,10 +60,10 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
                 shaderCodes[i] = uniform_pattern.Replace(shaderCodes[i], match => $"{match.Groups[1].Value}set = {int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture) + 1}{match.Groups[3].Value}");
         }
 
-        private string loadFile(byte[] bytes, bool mainFile)
+        private string loadFile(byte[]? bytes, bool mainFile)
         {
             if (bytes == null)
-                return null;
+                return string.Empty;
 
             using (MemoryStream ms = new MemoryStream(bytes))
             using (StreamReader sr = new StreamReader(ms))
@@ -74,7 +72,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
                 while (sr.Peek() != -1)
                 {
-                    string line = sr.ReadLine();
+                    string? line = sr.ReadLine();
 
                     if (string.IsNullOrEmpty(line))
                     {

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShaderPart.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
         private int partID = -1;
 
-        public GLShaderPart(IRenderer renderer, string name, byte[] data, ShaderType type, IShaderStore store)
+        public GLShaderPart(IRenderer renderer, string name, byte[]? data, ShaderType type, IShaderStore store)
         {
             this.renderer = renderer;
             this.store = store;

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -57,6 +57,8 @@ namespace osu.Framework.Graphics.Rendering.Dummy
 
         bool IRenderer.AllowTearing { get; set; }
 
+        Storage? IRenderer.CacheStorage { set { } }
+
         void IRenderer.Initialise(IGraphicsSurface graphicsSurface)
         {
             IsInitialised = true;

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -52,6 +52,11 @@ namespace osu.Framework.Graphics.Rendering
         protected internal bool AllowTearing { get; set; }
 
         /// <summary>
+        /// A <see cref="Storage"/> that can be used to cache objects.
+        /// </summary>
+        protected internal Storage? CacheStorage { set; }
+
+        /// <summary>
         /// The maximum allowed texture size.
         /// </summary>
         int MaxTextureSize { get; }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -44,6 +44,11 @@ namespace osu.Framework.Graphics.Rendering
         protected internal abstract bool VerticalSync { get; set; }
         protected internal abstract bool AllowTearing { get; set; }
 
+        protected internal Storage? CacheStorage
+        {
+            set => shaderCompilationStore.CacheStorage = value;
+        }
+
         public int MaxTextureSize { get; protected set; } = 4096; // default value is to allow roughly normal flow in cases we don't have graphics context, like headless CI.
 
         public int MaxTexturesUploadedPerFrame { get; set; } = 32;
@@ -93,6 +98,8 @@ namespace osu.Framework.Graphics.Rendering
         /// The current shader, or null if no shader is currently bound.
         /// </summary>
         protected IShader? Shader { get; private set; }
+
+        private readonly ShaderCompilationStore shaderCompilationStore = new ShaderCompilationStore();
 
         private readonly GlobalStatistic<int> statExpensiveOperationsQueued;
         private readonly GlobalStatistic<int> statTextureUploadsQueued;
@@ -1036,7 +1043,7 @@ namespace osu.Framework.Graphics.Rendering
         protected abstract IShaderPart CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType);
 
         /// <inheritdoc cref="IRenderer.CreateShader"/>
-        protected abstract IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer);
+        protected abstract IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore);
 
         private IShader? mipmapShader;
 
@@ -1056,7 +1063,7 @@ namespace osu.Framework.Graphics.Rendering
             {
                 CreateShaderPart(store, "mipmap.vs", store.GetRawData("sh_mipmap.vs"), ShaderPartType.Vertex),
                 CreateShaderPart(store, "mipmap.fs", store.GetRawData("sh_mipmap.fs"), ShaderPartType.Fragment),
-            }, globalUniformBuffer.AsNonNull());
+            }, globalUniformBuffer.AsNonNull(), shaderCompilationStore);
 
             return mipmapShader;
         }
@@ -1128,6 +1135,11 @@ namespace osu.Framework.Graphics.Rendering
             set => AllowTearing = value;
         }
 
+        Storage? IRenderer.CacheStorage
+        {
+            set => CacheStorage = value;
+        }
+
         IVertexBatch<TexturedVertex2D> IRenderer.DefaultQuadBatch => DefaultQuadBatch;
         void IRenderer.BeginFrame(Vector2 windowSize) => BeginFrame(windowSize);
         void IRenderer.FinishFrame() => FinishFrame();
@@ -1143,7 +1155,7 @@ namespace osu.Framework.Graphics.Rendering
         void IRenderer.PopQuadBatch() => PopQuadBatch();
         Image<Rgba32> IRenderer.TakeScreenshot() => TakeScreenshot();
         IShaderPart IRenderer.CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType) => CreateShaderPart(store, name, rawData, partType);
-        IShader IRenderer.CreateShader(string name, IShaderPart[] parts) => CreateShader(name, parts, globalUniformBuffer!);
+        IShader IRenderer.CreateShader(string name, IShaderPart[] parts) => CreateShader(name, parts, globalUniformBuffer!, shaderCompilationStore);
 
         IVertexBatch<TVertex> IRenderer.CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology)
         {

--- a/osu.Framework/Graphics/Shaders/ComputeProgramCompilation.cs
+++ b/osu.Framework/Graphics/Shaders/ComputeProgramCompilation.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Veldrid.SPIRV;
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public class ComputeProgramCompilation
+    {
+        /// <summary>
+        /// The SpirV bytes for the program.
+        /// </summary>
+        public byte[] ProgramBytes { get; set; } = null!;
+
+        /// <summary>
+        /// The cross-compiled program text.
+        /// </summary>
+        public string ProgramText { get; set; } = null!;
+
+        /// <summary>
+        /// A reflection of the shader program, describing the layout of resources.
+        /// </summary>
+        public SpirvReflection Reflection { get; set; } = null!;
+    }
+}

--- a/osu.Framework/Graphics/Shaders/ComputeProgramCompilation.cs
+++ b/osu.Framework/Graphics/Shaders/ComputeProgramCompilation.cs
@@ -8,6 +8,11 @@ namespace osu.Framework.Graphics.Shaders
     public class ComputeProgramCompilation
     {
         /// <summary>
+        /// Whether this compilation was retrieved from cache.
+        /// </summary>
+        public bool WasCached { get; set; }
+
+        /// <summary>
         /// The SpirV bytes for the program.
         /// </summary>
         public byte[] ProgramBytes { get; set; } = null!;

--- a/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
@@ -23,7 +23,10 @@ namespace osu.Framework.Graphics.Shaders
             string filename = $"{vertexText.ComputeMD5Hash()}#{fragmentText.ComputeMD5Hash()}#{(int)target}";
 
             if (tryGetCached(filename, out VertexFragmentShaderCompilation? existing))
+            {
+                existing.WasCached = true;
                 return existing;
+            }
 
             // Debug preserves names for reflection.
             byte[] vertexBytes = SpirvCompilation.CompileGlslToSpirv(vertexText, null, ShaderStages.Vertex, new GlslCompileOptions(true)).SpirvBytes;
@@ -50,7 +53,10 @@ namespace osu.Framework.Graphics.Shaders
             string filename = $"{programText.ComputeMD5Hash()}#{(int)target}";
 
             if (tryGetCached(filename, out ComputeProgramCompilation? existing))
+            {
+                existing.WasCached = true;
                 return existing;
+            }
 
             // Debug preserves names for reflection.
             byte[] programBytes = SpirvCompilation.CompileGlslToSpirv(programText, null, ShaderStages.Compute, new GlslCompileOptions(true)).SpirvBytes;

--- a/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Newtonsoft.Json;
+using osu.Framework.Extensions;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using Veldrid;
+using Veldrid.SPIRV;
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public class ShaderCompilationStore
+    {
+        public Storage? CacheStorage { private get; set; }
+
+        public VertexFragmentShaderCompilation CompileVertexFragment(string vertexText, string fragmentText, CrossCompileTarget target)
+        {
+            // vertexHash#fragmentHash#target
+            string filename = $"{vertexText.ComputeMD5Hash()}#{fragmentText.ComputeMD5Hash()}#{(int)target}";
+
+            if (tryGetCached(filename, out VertexFragmentShaderCompilation? existing))
+                return existing;
+
+            // Debug preserves names for reflection.
+            byte[] vertexBytes = SpirvCompilation.CompileGlslToSpirv(vertexText, null, ShaderStages.Vertex, new GlslCompileOptions(true)).SpirvBytes;
+            byte[] fragmentBytes = SpirvCompilation.CompileGlslToSpirv(fragmentText, null, ShaderStages.Fragment, new GlslCompileOptions(true)).SpirvBytes;
+
+            VertexFragmentCompilationResult crossResult = SpirvCompilation.CompileVertexFragment(vertexBytes, fragmentBytes, target, new CrossCompileOptions());
+            VertexFragmentShaderCompilation compilation = new VertexFragmentShaderCompilation
+            {
+                VertexBytes = vertexBytes,
+                FragmentBytes = fragmentBytes,
+                VertexText = crossResult.VertexShader,
+                FragmentText = crossResult.FragmentShader,
+                Reflection = crossResult.Reflection
+            };
+
+            saveToCache(filename, compilation);
+
+            return compilation;
+        }
+
+        public ComputeProgramCompilation CompileCompute(string programText, CrossCompileTarget target)
+        {
+            // programHash#target
+            string filename = $"{programText.ComputeMD5Hash()}#{(int)target}";
+
+            if (tryGetCached(filename, out ComputeProgramCompilation? existing))
+                return existing;
+
+            // Debug preserves names for reflection.
+            byte[] programBytes = SpirvCompilation.CompileGlslToSpirv(programText, null, ShaderStages.Compute, new GlslCompileOptions(true)).SpirvBytes;
+
+            ComputeCompilationResult crossResult = SpirvCompilation.CompileCompute(programBytes, target, new CrossCompileOptions());
+            ComputeProgramCompilation compilation = new ComputeProgramCompilation
+            {
+                ProgramBytes = programBytes,
+                ProgramText = crossResult.ComputeShader,
+                Reflection = crossResult.Reflection
+            };
+
+            saveToCache(filename, compilation);
+
+            return compilation;
+        }
+
+        private bool tryGetCached<T>(string filename, [NotNullWhen(true)] out T? compilation)
+            where T : class
+        {
+            compilation = null;
+
+            try
+            {
+                if (CacheStorage == null)
+                    return false;
+
+                if (!CacheStorage.Exists(filename))
+                    return false;
+
+                using var stream = CacheStorage.GetStream(filename);
+                using var br = new BinaryReader(stream);
+
+                string checksum = br.ReadString();
+                string data = br.ReadString();
+
+                if (data.ComputeMD5Hash() != checksum)
+                {
+                    // Data corrupted..
+                    Logger.Log("Cached shader data is corrupted - recompiling.");
+                    return false;
+                }
+
+                compilation = JsonConvert.DeserializeObject<T>(data)!;
+                return true;
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to read cached shader compilation - recompiling.");
+            }
+
+            return false;
+        }
+
+        private void saveToCache(string filename, object compilation)
+        {
+            if (CacheStorage == null)
+                return;
+
+            try
+            {
+                // ensure any stale cached versions are deleted.
+                CacheStorage.Delete(filename);
+
+                using var stream = CacheStorage.CreateFileSafely(filename);
+                using var bw = new BinaryWriter(stream);
+
+                string data = JsonConvert.SerializeObject(compilation);
+                string checksum = data.ComputeMD5Hash();
+
+                bw.Write(checksum);
+                bw.Write(data);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to save shader to cache.");
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Shaders/VertexFragmentShaderCompilation.cs
+++ b/osu.Framework/Graphics/Shaders/VertexFragmentShaderCompilation.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Veldrid.SPIRV;
+
+namespace osu.Framework.Graphics.Shaders
+{
+    public class VertexFragmentShaderCompilation
+    {
+        /// <summary>
+        /// The SpirV bytes for the vertex shader.
+        /// </summary>
+        public byte[] VertexBytes { get; set; } = null!;
+
+        /// <summary>
+        /// The SpirV bytes for the fragment shader.
+        /// </summary>
+        public byte[] FragmentBytes { get; set; } = null!;
+
+        /// <summary>
+        /// The cross-compiled vertex shader text.
+        /// </summary>
+        public string VertexText { get; set; } = null!;
+
+        /// <summary>
+        /// The cross-compiled fragment shader text.
+        /// </summary>
+        public string FragmentText { get; set; } = null!;
+
+        /// <summary>
+        /// A reflection of the shader program, describing the layout of resources.
+        /// </summary>
+        public SpirvReflection Reflection { get; set; } = null!;
+    }
+}

--- a/osu.Framework/Graphics/Shaders/VertexFragmentShaderCompilation.cs
+++ b/osu.Framework/Graphics/Shaders/VertexFragmentShaderCompilation.cs
@@ -8,6 +8,11 @@ namespace osu.Framework.Graphics.Shaders
     public class VertexFragmentShaderCompilation
     {
         /// <summary>
+        /// Whether this compilation was retrieved from cache.
+        /// </summary>
+        public bool WasCached { get; set; }
+
+        /// <summary>
         /// The SpirV bytes for the vertex shader.
         /// </summary>
         public byte[] VertexBytes { get; set; } = null!;

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
@@ -110,8 +110,6 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
         private void compile()
         {
-            Logger.Log($"🖍️ Compiling shader {name}...");
-
             Debug.Assert(parts.Length == 2);
 
             VeldridShaderPart vertex = parts.Single(p => p.Type == ShaderPartType.Vertex);
@@ -119,6 +117,8 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
             try
             {
+                bool cached = true;
+
                 vertexShaderDescription = new ShaderDescription(
                     ShaderStages.Vertex,
                     Array.Empty<byte>(),
@@ -134,6 +134,8 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                     vertex.GetRawText(),
                     fragment.GetRawText(),
                     RuntimeInfo.IsMobile ? CrossCompileTarget.ESSL : CrossCompileTarget.GLSL);
+
+                cached &= compilation.WasCached;
 
                 if (renderer.SurfaceType == GraphicsSurfaceType.Vulkan)
                 {
@@ -158,6 +160,8 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                             vertex.GetRawText(),
                             fragment.GetRawText(),
                             target);
+
+                        cached &= platformCompilation.WasCached;
                     }
 
                     vertexShaderDescription.ShaderBytes = Encoding.UTF8.GetBytes(platformCompilation.VertexText);
@@ -203,7 +207,9 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
                     }
                 }
 
-                Logger.Log($"🖍️ Shader {name} compiled!");
+                Logger.Log(cached
+                    ? $"🖍️ Shader {name} loaded from cache!"
+                    : $"🖍️ Shader {name} compiled!");
             }
             catch (SpirvCompilationException e)
             {

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShaderPart.cs
@@ -115,10 +115,10 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
                         if (!string.IsNullOrEmpty(backbufferCode))
                         {
-                            string realMainName = "real_main_" + Guid.NewGuid().ToString("N");
+                            const string real_main_name = "__internal_real_main";
 
-                            backbufferCode = backbufferCode.Replace("{{ real_main }}", realMainName);
-                            code = Regex.Replace(code, @"void main\((.*)\)", $"void {realMainName}()") + backbufferCode + '\n';
+                            backbufferCode = backbufferCode.Replace("{{ real_main }}", real_main_name);
+                            code = Regex.Replace(code, @"void main\((.*)\)", $"void {real_main_name}()") + backbufferCode + '\n';
                         }
                     }
                 }

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -572,8 +572,8 @@ namespace osu.Framework.Graphics.Veldrid
         protected override IShaderPart CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType)
             => new VeldridShaderPart(rawData, partType, store);
 
-        protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer)
-            => new VeldridShader(this, name, parts.Cast<VeldridShaderPart>().ToArray(), globalUniformBuffer);
+        protected override IShader CreateShader(string name, IShaderPart[] parts, IUniformBuffer<GlobalUniformData> globalUniformBuffer, ShaderCompilationStore compilationStore)
+            => new VeldridShader(this, name, parts.Cast<VeldridShaderPart>().ToArray(), globalUniformBuffer, compilationStore);
 
         public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
             => new VeldridFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -942,6 +942,7 @@ namespace osu.Framework.Platform
             Logger.Log($"🖼️ Initialising \"{renderer.GetType().ReadableName().Replace("Renderer", "")}\" renderer with \"{surfaceType}\" surface");
 
             Renderer = renderer;
+            Renderer.CacheStorage = CacheStorage.GetStorageForDirectory("shaders");
 
             // Prepare window
             Window = CreateWindow(surfaceType);


### PR DESCRIPTION
Shader compilation dominates our startup time, so they're now cached to disk (spirv + cross-compile + reflection) at `cache/shaders/`.

| Test | Before | After (cold) | After (hot) |
| --- | --- | --- | --- |
| framework | ![image](https://github.com/ppy/osu-framework/assets/1329837/56190029-52a1-4e33-bdd8-0f874289bd48) | ![image](https://github.com/ppy/osu-framework/assets/1329837/a5cf9d62-8223-40f1-a06d-be319481baa3) | ![image](https://github.com/ppy/osu-framework/assets/1329837/d2a15b93-b0d0-4e8f-90e8-5d6e23cdd6fe)
| osu | ![image](https://github.com/ppy/osu-framework/assets/1329837/7372ec28-8652-4c14-ae5f-aa60ecf26dc0) | ![image](https://github.com/ppy/osu-framework/assets/1329837/a4a87e2e-d973-427a-9802-cc54cf52e02f) | ![image](https://github.com/ppy/osu-framework/assets/1329837/28eb9c2a-64f8-41f0-856f-157b0875d3cc) |

* For framework, only the main thread is pictured. Snapshot lasts until the game is loaded.
* For osu, all threads are pictured because we use the async loader spinner to load shaders at startup. Snapshot lasts until the intro starts displaying (after the loading spinner).

On Vulkan, the refactoring means only one compilation occurs now:

| Before | After (cold) |
| --- | --- |
| ![image](https://github.com/ppy/osu-framework/assets/1329837/80528994-ed46-4600-bab2-d56a05efea7b) | ![image](https://github.com/ppy/osu-framework/assets/1329837/0a4c8500-25de-4265-982b-8f54ad91a36c) |

The results are also significant on the D3D and Metal surfaces which have to compile twice - once to GLSL for reflection and a second time to the destination platform. I haven't added profiling results for these but they can be imagined by doubling every duration from the first table.