### PR TITLE
Remove `Dropdown.AddDropdownItem(text, value)` overload

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -95,19 +95,12 @@ namespace osu.Framework.Graphics.UserInterface
         /// Add a menu item directly while automatically generating a label.
         /// </summary>
         /// <param name="value">Value selected by the menu item.</param>
-        public void AddDropdownItem(T value) => AddDropdownItem(GenerateItemText(value), value);
-
-        /// <summary>
-        /// Add a menu item directly.
-        /// </summary>
-        /// <param name="text">Text to display on the menu item.</param>
-        /// <param name="value">Value selected by the menu item.</param>
-        protected void AddDropdownItem(LocalisableString text, T value)
+        public void AddDropdownItem(T value)
         {
             if (boundItemSource != null)
                 throw new InvalidOperationException($"Cannot manually add dropdown items when an {nameof(ItemSource)} is bound.");
 
-            addDropdownItem(text, value);
+            addDropdownItem(GenerateItemText(value), value);
         }
 
         private void addDropdownItem(LocalisableString text, T value)

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.UserInterface
                 return;
 
             foreach (var entry in items)
-                addDropdownItem(GenerateItemText(entry), entry);
+                addDropdownItem(entry);
 
             if (Current.Value == null || !itemMap.Keys.Contains(Current.Value, EqualityComparer<T>.Default))
                 Current.Value = itemMap.Keys.FirstOrDefault();
@@ -100,15 +100,15 @@ namespace osu.Framework.Graphics.UserInterface
             if (boundItemSource != null)
                 throw new InvalidOperationException($"Cannot manually add dropdown items when an {nameof(ItemSource)} is bound.");
 
-            addDropdownItem(GenerateItemText(value), value);
+            addDropdownItem(value);
         }
 
-        private void addDropdownItem(LocalisableString text, T value)
+        private void addDropdownItem(T value)
         {
             if (itemMap.ContainsKey(value))
                 throw new ArgumentException($"The item {value} already exists in this {nameof(Dropdown<T>)}.");
 
-            var newItem = new DropdownMenuItem<T>(text, value, () =>
+            var newItem = new DropdownMenuItem<T>(GenerateItemText(value), value, () =>
             {
                 if (!Current.Disabled)
                     Current.Value = value;

--- a/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osuTK;
 
 namespace osu.Framework.Testing.Drawables.Sections
@@ -59,11 +60,11 @@ namespace osu.Framework.Testing.Drawables.Sections
             };
         }
 
-        public void AddAssembly(string name, Assembly assembly) => assemblyDropdown.AddAssembly(name, assembly);
+        public void AddAssembly(Assembly assembly) => assemblyDropdown.AddAssembly(assembly);
 
         private partial class AssemblyDropdown : BasicDropdown<Assembly>
         {
-            public void AddAssembly(string name, Assembly assembly)
+            public void AddAssembly(Assembly assembly)
             {
                 if (assembly == null) return;
 
@@ -73,8 +74,10 @@ namespace osu.Framework.Testing.Drawables.Sections
                         RemoveDropdownItem(item.Value);
                 }
 
-                AddDropdownItem(name, assembly);
+                AddDropdownItem(assembly);
             }
+
+            protected override LocalisableString GenerateItemText(Assembly assembly) => assembly.GetName().Name;
         }
     }
 }

--- a/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System.Linq;
 using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -17,7 +14,7 @@ namespace osu.Framework.Testing.Drawables.Sections
 {
     public partial class ToolbarAssemblySection : ToolbarSection
     {
-        private AssemblyDropdown assemblyDropdown;
+        private AssemblyDropdown assemblyDropdown = null!;
 
         public ToolbarAssemblySection()
         {
@@ -60,24 +57,11 @@ namespace osu.Framework.Testing.Drawables.Sections
             };
         }
 
-        public void AddAssembly(Assembly assembly) => assemblyDropdown.AddAssembly(assembly);
+        public void AddAssembly(Assembly assembly) => assemblyDropdown.AddDropdownItem(assembly);
 
         private partial class AssemblyDropdown : BasicDropdown<Assembly>
         {
-            public void AddAssembly(Assembly assembly)
-            {
-                if (assembly == null) return;
-
-                foreach (var item in MenuItems.ToArray())
-                {
-                    if (item.Text.Value.ToString().Contains("dynamic"))
-                        RemoveDropdownItem(item.Value);
-                }
-
-                AddDropdownItem(assembly);
-            }
-
-            protected override LocalisableString GenerateItemText(Assembly assembly) => assembly.GetName().Name;
+            protected override LocalisableString GenerateItemText(Assembly assembly) => assembly.GetName().Name ?? "unknonwn";
         }
     }
 }

--- a/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
+++ b/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
@@ -79,6 +79,6 @@ namespace osu.Framework.Testing.Drawables
             };
         }
 
-        public void AddAssembly(string name, Assembly assembly) => assemblySection.AddAssembly(name, assembly);
+        public void AddAssembly(Assembly assembly) => assemblySection.AddAssembly(assembly);
     }
 }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -245,7 +245,7 @@ namespace osu.Framework.Testing
                 HotReloadCallbackReceiver.CompilationFinished += compileFinished;
 
             foreach (Assembly asm in assemblies)
-                toolbar.AddAssembly(asm.GetName().Name, asm);
+                toolbar.AddAssembly(asm);
 
             Assembly.BindValueChanged(updateList);
             RunAllSteps.BindValueChanged(_ => runTests(null));


### PR DESCRIPTION
This overload is hard to work with, as I would expect that calling `GenerateItemText()` on an existing dropdown item to be idempotent. (I've had this expectation in mind when trying to properly fix https://github.com/ppy/osu/pull/23858.)

Since this overload is `protected`, no one really used it (zero osu!-side usages). So I hope it would be fine to remove.

# Breaking changes

## `AddDropdownItem(LocalisableString text, T value)` has been removed

If you were using this, refactor your code to use `LocalisableString GenerateItemText(T value)` instead.

Easiest way is to add `LocalisableString? CustomDropdownText` to your `T`, or wrap `T` in a class that has one.
Then simply change `GenerateItemText()` to use that:

```cs
public partial class MyDropdown : Dropdown<T>
{
    protected override LocalisableString GenerateItemText(T value)
        => value.CustomDropdownText ?? base.GenerateItemText(value);
}
```