### PR TITLE
Add include guards to all shaders

### DIFF
--- a/osu.Framework/Resources/Shaders/Internal/sh_Compatibility.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Compatibility.h
@@ -1,4 +1,9 @@
 // This file is automatically included in every shader.
 
+#ifndef INTERNAL_COMPATIBILITY_H
+#define INTERNAL_COMPATIBILITY_H
+
 #version 450
 #extension GL_ARB_uniform_buffer_object : enable
+
+#endif

--- a/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
@@ -1,5 +1,8 @@
 // This file is automatically included in every shader.
 
+#ifndef INTERNAL_GLOBAL_UNIFORMS_H
+#define INTERNAL_GLOBAL_UNIFORMS_H
+
 layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
 {
     // Whether the backbuffer is currently being drawn to.
@@ -37,3 +40,5 @@ layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
     int g_WrapModeS;
     int g_WrapModeT;
 };
+
+#endif

--- a/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Output.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_Vertex_Output.h
@@ -1,5 +1,8 @@
 // Automatically included for every vertex shader.
 
+#ifndef INTERNAL_VERTEX_OUTPUT_H
+#define INTERNAL_VERTEX_OUTPUT_H
+
 // The -1 is a placeholder value to offset all vertex input members
 // of the actual vertex shader during inclusion of this header.
 layout(location = -1) in highp float m_BackbufferDrawDepth;
@@ -22,3 +25,5 @@ void main()
     if (g_IsClipSpaceYInverted || requiresFramebufferInvert)
         gl_Position.y = -gl_Position.y;
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Blur.fs
+++ b/osu.Framework/Resources/Shaders/sh_Blur.fs
@@ -1,5 +1,9 @@
+#ifndef BLUR_FS
+#define BLUR_FS
+
 #include "sh_Utils.h"
 
+#undef INV_SQRT_2PI
 #define INV_SQRT_2PI 0.39894
 
 layout(location = 0) in mediump vec2 v_TexCoord;
@@ -50,3 +54,5 @@ void main(void)
 {
 	o_Colour = blur(g_Radius, g_BlurDirection, v_TexCoord, g_TexSize, g_Sigma);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Blur.vs
+++ b/osu.Framework/Resources/Shaders/sh_Blur.vs
@@ -1,3 +1,6 @@
+#ifndef BLUR_VS
+#define BLUR_VS
+
 #include "sh_Utils.h"
 
 layout(location = 0) in highp vec2 m_Position;
@@ -10,3 +13,5 @@ void main(void)
 	v_TexCoord = m_TexCoord;
 	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0, 1.0);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
@@ -1,4 +1,8 @@
-﻿#define HIGH_PRECISION_VERTEX
+﻿#ifndef CIRCULAR_BLOB_FS
+#define CIRCULAR_BLOB_FS
+
+#undef HIGH_PRECISION_VERTEX
+#define HIGH_PRECISION_VERTEX
 
 #include "sh_Utils.h"
 #include "sh_Masking.h"
@@ -31,3 +35,5 @@ void main(void)
 
     o_Colour = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition));
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_CircularBlobUtils.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlobUtils.h
@@ -1,4 +1,10 @@
-﻿#define HALF_PI 1.57079632679
+﻿#ifndef CIRCULAR_BLOB_UTILS_H
+#define CIRCULAR_BLOB_UTILS_H
+
+#undef HALF_PI
+#define HALF_PI 1.57079632679
+
+#undef TWO_PI
 #define TWO_PI 6.28318530718
 
 // 2D noise and random https://thebookofshaders.com/11/
@@ -56,3 +62,5 @@ lowp float blobAlphaAt(highp vec2 pixelPos, mediump float innerRadius, highp flo
     
     return smoothstep(texelSize, 0.0, shortestDistance - pathRadius);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -1,4 +1,8 @@
-﻿#define HIGH_PRECISION_VERTEX
+﻿#ifndef CIRCULAR_PROGRESS_FS
+#define CIRCULAR_PROGRESS_FS
+
+#undef HIGH_PRECISION_VERTEX
+#define HIGH_PRECISION_VERTEX
 
 #include "sh_Utils.h"
 #include "sh_Masking.h"
@@ -30,3 +34,5 @@ void main(void)
 
     o_Colour = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgressUtils.h
@@ -1,5 +1,13 @@
-﻿#define PI 3.1415926536
+﻿#ifndef CIRCULAR_PROGRESS_UTILS_H
+#define CIRCULAR_PROGRESS_UTILS_H
+
+#undef PI
+#define PI 3.1415926536
+
+#undef HALF_PI
 #define HALF_PI 1.57079632679
+
+#undef TWO_PI
 #define TWO_PI 6.28318530718
 
 highp float dstToLine(highp vec2 start, highp vec2 end, highp vec2 pixelPos)
@@ -57,3 +65,5 @@ lowp float progressAlphaAt(highp vec2 pixelPos, mediump float progress, mediump 
     
     return smoothstep(texelSize, 0.0, distanceToProgress(pixelPos, progress, innerRadius, roundedCaps, texelSize)) * subAAMultiplier;
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
@@ -1,3 +1,7 @@
+#ifndef HUE_SELECTOR_BACKGROUND_FS
+#define HUE_SELECTOR_BACKGROUND_FS
+
+#undef HIGH_PRECISION_VERTEX
 #define HIGH_PRECISION_VERTEX
 
 #include "sh_Utils.h"
@@ -12,3 +16,5 @@ void main(void)
     highp float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
     o_Colour = getRoundedColor(hsv2rgb(vec4(hueValue, 1, 1, 1)), v_TexCoord);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -1,4 +1,7 @@
-﻿layout(location = 0) in highp vec2 v_MaskingPosition;
+﻿#ifndef MASKING_H
+#define MASKING_H
+
+layout(location = 0) in highp vec2 v_MaskingPosition;
 layout(location = 1) in lowp vec4 v_Colour;
 
 #ifdef HIGH_PRECISION_VERTEX
@@ -124,3 +127,5 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	borderColour.a *= 1.0 - colourWeight;
 	return blend(borderColour, contentColour);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Particle.vs
+++ b/osu.Framework/Resources/Shaders/sh_Particle.vs
@@ -1,3 +1,6 @@
+#ifndef PARTICLE_VS
+#define PARTICLE_VS
+
 layout(location = 0) in vec2 m_Position;
 layout(location = 1) in vec2 m_TexCoord;
 layout(location = 2) in float m_Time;
@@ -23,3 +26,5 @@ void main(void)
 	v_Colour = vec4(1.0, 1.0, 1.0, 1.0 - clamp(g_FadeClock / m_Time, 0.0, 1.0));
 	v_TexCoord = m_TexCoord;
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Position.vs
+++ b/osu.Framework/Resources/Shaders/sh_Position.vs
@@ -1,3 +1,6 @@
+#ifndef POSITION_VS
+#define POSITION_VS
+
 layout(location = 0) in highp vec2 m_Position;
 
 layout(location = 0) out highp vec2 v_Position;
@@ -7,3 +10,5 @@ void main(void)
 	gl_Position = g_ProjMatrix * vec4(m_Position.xy, 1.0, 1.0);
 	v_Position = m_Position;
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -1,3 +1,7 @@
+#ifndef SATURATION_SELECTOR_BACKGROUND_FS
+#define SATURATION_SELECTOR_BACKGROUND_FS
+
+#undef HIGH_PRECISION_VERTEX
 #define HIGH_PRECISION_VERTEX
 
 #include "sh_Utils.h"
@@ -18,3 +22,5 @@ void main(void)
     highp vec2 pixelPos = v_TexCoord / resolution;
     o_Colour = getRoundedColor(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0)), v_TexCoord);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Texture.fs
+++ b/osu.Framework/Resources/Shaders/sh_Texture.fs
@@ -1,3 +1,6 @@
+#ifndef TEXTURE_FS
+#define TEXTURE_FS
+
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 #include "sh_TextureWrapping.h"
@@ -14,3 +17,5 @@ void main(void)
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Texture2D.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture2D.vs
@@ -1,3 +1,6 @@
+#ifndef TEXTURE2D_VS
+#define TEXTURE2D_VS
+
 #include "sh_Utils.h"
 
 layout(location = 0) in highp vec2 m_Position;
@@ -25,3 +28,5 @@ void main(void)
 
 	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0, 1.0);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Texture3D.vs
+++ b/osu.Framework/Resources/Shaders/sh_Texture3D.vs
@@ -1,3 +1,6 @@
+#ifndef TEXTURE3D_VS
+#define TEXTURE3D_VS
+
 #include "sh_Utils.h"
 
 layout(location = 0) in highp vec3 m_Position;
@@ -23,3 +26,5 @@ void main(void)
 	v_TexCoord = m_TexCoord;
 	gl_Position = g_ProjMatrix * vec4(m_Position, 1.0);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
+++ b/osu.Framework/Resources/Shaders/sh_TextureWrapping.h
@@ -1,3 +1,6 @@
+#ifndef TEXTURE_WRAPPING_H
+#define TEXTURE_WRAPPING_H
+
 float wrap(float coord, int mode, float rangeMin, float rangeMax)
 {
     if (mode == 1)
@@ -25,3 +28,5 @@ vec4 wrappedSampler(vec2 wrappedCoord, vec4 texRect, texture2D wrapTexture, samp
 
     return texture(sampler2D(wrapTexture, wrapSampler), wrappedCoord, lodBias);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -1,4 +1,8 @@
-﻿#define GAMMA 2.4
+﻿#ifndef UTILS_H
+#define UTILS_H
+
+#undef GAMMA
+#define GAMMA 2.4
 
 // perform alpha compositing of two colour components.
 // see http://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha.html
@@ -23,3 +27,5 @@ vec4 hsv2rgb(vec4 c)
     vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
     return vec4(c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y), c.w);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_Video.fs
+++ b/osu.Framework/Resources/Shaders/sh_Video.fs
@@ -1,3 +1,6 @@
+#ifndef VIDEO_FS
+#define VIDEO_FS
+
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 #include "sh_yuv2rgb.h"
@@ -11,3 +14,5 @@ void main(void)
     vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     o_Colour = getRoundedColor(wrappedSamplerRgb(wrappedCoord, v_TexRect, 0.0), wrappedCoord);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_mipmap.fs
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.fs
@@ -1,3 +1,6 @@
+#ifndef MIPMAP_FS
+#define MIPMAP_FS
+
 layout(location = 0) in highp vec2 v_TexCoord;
 
 layout(set = 0, binding = 0) uniform lowp texture2D m_Texture;
@@ -9,3 +12,5 @@ void main()
 {
     o_Colour = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, 0.0);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_mipmap.vs
+++ b/osu.Framework/Resources/Shaders/sh_mipmap.vs
@@ -1,3 +1,6 @@
+#ifndef MIPMAP_VS
+#define MIPMAP_VS
+
 layout(location = 0) in highp vec2 m_Position;
 layout(location = 0) out highp vec2 v_TexCoord;
 
@@ -7,3 +10,5 @@ void main()
     vec2 position = vec2(m_Position.x, 1.0 - m_Position.y);
     gl_Position = vec4(2.0 * position - vec2(1.0), 0.0, 1.0);
 }
+
+#endif

--- a/osu.Framework/Resources/Shaders/sh_yuv2rgb.h
+++ b/osu.Framework/Resources/Shaders/sh_yuv2rgb.h
@@ -1,3 +1,6 @@
+#ifndef YUV2RGB_H
+#define YUV2RGB_H
+
 #include "sh_TextureWrapping.h"
 
 layout(set = 0, binding = 0) uniform lowp texture2D m_TextureY;
@@ -26,3 +29,5 @@ lowp vec4 wrappedSamplerRgb(vec2 wrappedCoord, vec4 texRect, float lodBias)
     lowp float v = texture(sampler2D(m_TextureV, m_SamplerV), wrappedCoord, lodBias).r;
     return vec4(yuvCoeff * (vec3(y, u, v) + offsets), 1.0);
 }
+
+#endif


### PR DESCRIPTION
This is [standard practice](https://en.wikipedia.org/wiki/Include_guard) in the C/C++ world.