### PR TITLE
Update README.md to include VS Code plugin prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This framework is intended to take steps beyond what you would normally expect f
 - A desktop platform with the [.NET 6.0 SDK](https://dotnet.microsoft.com/download).
 - When running on linux, please have a system-wide ffmpeg installation available to support video decoding.
 - When running on Windows 7 or 8.1, *[additional prerequisites](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=net60&pivots=os-windows#dependencies)** may be required to correctly run .NET 6 applications if your operating system is not up-to-date with the latest service packs.
-- When working with the codebase, we recommend using an IDE with intellisense and syntax highlighting, such as [Visual Studio 2019+](https://visualstudio.microsoft.com/vs/), [Jetbrains Rider](https://www.jetbrains.com/rider/) or [Visual Studio Code](https://code.visualstudio.com/).
+- When working with the codebase, we recommend using an IDE with intellisense and syntax highlighting, such as [Visual Studio 2019+](https://visualstudio.microsoft.com/vs/), [Jetbrains Rider](https://www.jetbrains.com/rider/), or [Visual Studio Code](https://code.visualstudio.com/) with the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) plugin installed.
 
 ### Building
 


### PR DESCRIPTION
VS Code needs the C# plugin installed in-order to work with Dotnet projects. Additionally, the EditorConfig plugin needs to be installed to work on the project without 1000+ errors; Visual Studio 2019+ and Jetbrains Rider support EditorConfig by default, VS Code does not.