### PR TITLE
Remove overrides of PopIn/PopOut in FocusedOverlayContainer

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -289,13 +289,11 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             protected override void PopIn()
             {
-                base.PopIn();
                 stateText.Text = State.ToString();
             }
 
             protected override void PopOut()
             {
-                base.PopOut();
                 stateText.Text = State.ToString();
             }
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
@@ -203,16 +203,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 this.FadeIn(1000, Easing.OutQuint);
                 this.ScaleTo(1, 1000, Easing.OutElastic);
-
-                base.PopIn();
             }
 
             protected override void PopOut()
             {
                 this.FadeOut(1000, Easing.OutQuint);
                 this.ScaleTo(0.4f, 1000, Easing.OutQuint);
-
-                base.PopOut();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
+
 namespace osu.Framework.Graphics.Containers
 {
     /// <summary>
@@ -12,15 +14,21 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool AcceptsFocus => State.Value == Visibility.Visible;
 
-        protected override void PopIn()
+        protected override void UpdateState(ValueChangedEvent<Visibility> state)
         {
-            Schedule(() => GetContainingInputManager().TriggerFocusContention(this));
-        }
+            base.UpdateState(state);
 
-        protected override void PopOut()
-        {
-            if (HasFocus)
-                GetContainingInputManager().ChangeFocus(null);
+            switch (state.NewValue)
+            {
+                case Visibility.Hidden:
+                    if (HasFocus)
+                        GetContainingInputManager().ChangeFocus(null);
+                    break;
+
+                case Visibility.Visible:
+                    Schedule(() => GetContainingInputManager().TriggerFocusContention(this));
+                    break;
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -19,13 +19,17 @@ namespace osu.Framework.Graphics.UserInterface
     /// It typically is activated by another control and includes an arrow pointing to the location from which it emerged.
     /// (loosely paraphrasing: https://developer.apple.com/design/human-interface-guidelines/ios/views/popovers/)
     /// </summary>
-    public abstract partial class Popover : FocusedOverlayContainer
+    public abstract partial class Popover : OverlayContainer
     {
         protected override bool BlockPositionalInput => true;
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Body.ReceivePositionalInputAt(screenSpacePos) || Arrow.ReceivePositionalInputAt(screenSpacePos);
 
         public override bool HandleNonPositionalInput => State.Value == Visibility.Visible;
+
+        public override bool RequestsFocus => State.Value == Visibility.Visible;
+
+        public override bool AcceptsFocus => State.Value == Visibility.Visible;
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/5621

Moves focus logic outside of `PopIn`/`PopOut` methods in `FocusedOverlayContainer`

Forces  non-abstract inheritors of `FocusedOverlayContainer` to correctly implement these methods.

# Breaking changes

## Subclasses of `FocusedOverlayContainer` must now implement `Pop{In,Out}()`

Previously, subclasses of `FocusedOverlayContainer` were not forced to implement `Pop{In,Out}` themselves, despite actually needing to do so for the overlay to actually play transitions out correctly. This has now been changed and inheritors of the class must always implement `Pop{In,Out}`.

In practice this should not break any reasonable consumers of the class, except for the need to remove any `base.Pop{In,Out}()` calls in classes that directly inherit `FocusedOverlayContainer` and call base in `Pop{In,Out}()`.