### PR TITLE
Add new `DeferredStagingBuffer` type

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -13,6 +13,7 @@ namespace osu.Framework
         public static bool ForceTestGC { get; }
         public static GraphicsSurfaceType? PreferredGraphicsSurface { get; }
         public static string? PreferredGraphicsRenderer { get; }
+        public static int? StagingBufferType { get; }
 
         static FrameworkEnvironment()
         {
@@ -21,6 +22,9 @@ namespace osu.Framework
             ForceTestGC = Environment.GetEnvironmentVariable("OSU_TESTS_FORCED_GC") == "1";
             PreferredGraphicsSurface = Enum.TryParse<GraphicsSurfaceType>(Environment.GetEnvironmentVariable("OSU_GRAPHICS_SURFACE"), true, out var surface) ? surface : null;
             PreferredGraphicsRenderer = Environment.GetEnvironmentVariable("OSU_GRAPHICS_RENDERER")?.ToLowerInvariant();
+
+            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_GRAPHICS_STAGING_BUFFER_TYPE"), out int stagingBufferImplementation))
+                StagingBufferType = stagingBufferImplementation;
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Buffers/Staging/DeferredStagingBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/Staging/DeferredStagingBuffer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Memory;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Buffers.Staging
+{
+    /// <summary>
+    /// A staging buffer that stores data in managed memory and uses an intermediate driver buffer for copies.
+    /// </summary>
+    internal class DeferredStagingBuffer<T> : IStagingBuffer<T>
+        where T : unmanaged
+    {
+        private readonly VeldridRenderer renderer;
+        private readonly IMemoryOwner<T> memoryOwner;
+
+        private readonly Memory<T> cpuBuffer;
+        private readonly DeviceBuffer driverBuffer;
+
+        public DeferredStagingBuffer(VeldridRenderer renderer, uint count)
+        {
+            this.renderer = renderer;
+            Count = count;
+            SizeInBytes = (uint)(Unsafe.SizeOf<T>() * count);
+
+            memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<T>((int)Count, AllocationOptions.Clean);
+            cpuBuffer = memoryOwner.Memory;
+
+            driverBuffer = renderer.Factory.CreateBuffer(new BufferDescription(SizeInBytes, BufferUsage.Staging));
+        }
+
+        public uint SizeInBytes { get; }
+
+        public uint Count { get; }
+
+        public BufferUsage CopyTargetUsageFlags => 0;
+
+        public Span<T> Data => cpuBuffer.Span;
+
+        public void CopyTo(DeviceBuffer buffer, uint srcOffset, uint dstOffset, uint count)
+        {
+            renderer.Device.UpdateBuffer(
+                driverBuffer,
+                (uint)(srcOffset * Unsafe.SizeOf<T>()),
+                ref Data[(int)srcOffset],
+                (uint)(count * Unsafe.SizeOf<T>()));
+
+            renderer.BufferUpdateCommands.CopyBuffer(
+                driverBuffer,
+                (uint)(srcOffset * Unsafe.SizeOf<T>()),
+                buffer,
+                (uint)(dstOffset * Unsafe.SizeOf<T>()),
+                (uint)(count * Unsafe.SizeOf<T>()));
+        }
+
+        public void Dispose()
+        {
+            memoryOwner.Dispose();
+            driverBuffer.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
@@ -603,21 +604,32 @@ namespace osu.Framework.Graphics.Veldrid
         internal IStagingBuffer<T> CreateStagingBuffer<T>(uint count)
             where T : unmanaged
         {
-            switch (Device.BackendType)
+            switch (FrameworkEnvironment.StagingBufferType)
             {
-                // D3D11 benefits from persistently mapped buffers.
-                case GraphicsBackend.Direct3D11:
-                // Persistently mapped buffers appear to work by default on Vulkan.
-                case GraphicsBackend.Vulkan:
+                case 0:
+                    return new ManagedStagingBuffer<T>(this, count);
+
+                case 1:
                     return new PersistentStagingBuffer<T>(this, count);
 
+                case 2:
+                    return new DeferredStagingBuffer<T>(this, count);
+
                 default:
-                // Metal uses a more optimal path that elides a Blit Command Encoder.
-                case GraphicsBackend.Metal:
-                // OpenGL backends need additional work to support coherency and persistently mapped buffers.
-                case GraphicsBackend.OpenGL:
-                case GraphicsBackend.OpenGLES:
-                    return new ManagedStagingBuffer<T>(this, count);
+                    switch (Device.BackendType)
+                    {
+                        case GraphicsBackend.Direct3D11:
+                        case GraphicsBackend.Vulkan:
+                            return new PersistentStagingBuffer<T>(this, count);
+
+                        default:
+                        // Metal uses a more optimal path that elides a Blit Command Encoder.
+                        case GraphicsBackend.Metal:
+                        // OpenGL backends need additional work to support coherency and persistently mapped buffers.
+                        case GraphicsBackend.OpenGL:
+                        case GraphicsBackend.OpenGLES:
+                            return new ManagedStagingBuffer<T>(this, count);
+                    }
             }
         }
 


### PR DESCRIPTION
On occasion, I have noticed the new `PersistentStagingBuffer` causing graphics corruption. At least, I _think_ it's because of this type and its undefined nature (part of the reason why we now have an `Unmap()` inside the copy function).

As a result, I'm going back to buffers to figure out the most efficient update strategy. This implements a new `DeferredStagingBuffer`, which uses a managed CPU buffer and an intermediate driver-side `Staging` buffer, to do updates.
The new type is off by default, and is only accessible with an environment variable:

<table>
<tr>
<th>Name</th>
<th>Values</th>
</tr>
<tr>
<td>

`OSU_GRAPHICS_STAGING_BUFFER_TYPE`

</td>
<td>

`0` = `ManagedStagingBuffer`
`1` = `PersistentStagingBuffer`
`2` = `DeferredStagingBuffer`

</td>
<tr>
<table>

I'd like to test this new type over time, with the intent of it replacing `PersistentStagingBuffer`. I'm currently unable to reproduce the graphics corruption I was seeing previously, so I intend to be able to reproduce that once more first to see whether it was a fluke.

| Type | Fullscreen? | Performance |
| --- | --- | --- |
| `ManagedStagingBuffer` | No | ![image](https://github.com/ppy/osu-framework/assets/1329837/c9ef1c80-d3c1-4548-8038-957ab6cf092c) |
| `ManagedStagingBuffer` | Yes | ![image](https://github.com/ppy/osu-framework/assets/1329837/f384c0d5-4d1a-4fd6-b3ca-1cc9e8c4d2b8) |
| `PersistentStagingBuffer` | No | ![image](https://github.com/ppy/osu-framework/assets/1329837/e30bd57c-4852-474d-b05e-0187f90f257c) |
| `PersistentStagingBuffer` | Yes | ![image](https://github.com/ppy/osu-framework/assets/1329837/912b6cef-d070-43df-bc7b-ad4d32a8211d) |
| `DeferredStagingBuffer` | No | ![image](https://github.com/ppy/osu-framework/assets/1329837/be1d7272-44ce-46c4-b94e-d1c5ec9562fd) |
| `DeferredStagingBuffer` | Yes | ![image](https://github.com/ppy/osu-framework/assets/1329837/709ed103-89fe-4bb4-a8b8-c09d36fea572) |