### PR TITLE
Move midi initialisation to a thread

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Input.Handlers.Midi
                 }
             }, true);
 
-            return refreshDevices();
+            return true;
         }
 
         private bool refreshDevices()


### PR DESCRIPTION
MIDI is rarely used. On top of that, on macOS the overhead on first call to the `Devices` enum is very expensive (>1s). This shouldn't delay startup of the game.

![JetBrains Rider 2023-06-13 at 06 18 12](https://github.com/ppy/osu-framework/assets/191335/1a86c2f2-146d-45ae-a2ab-523e9493e434)


Implementation is copied from `OpenTabletDriveHandler`, which should be quite reliable.