### PR TITLE
Fix `WaitUntilNextFrameReady` not being accounted for as `Sleep` time

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -477,12 +477,14 @@ namespace osu.Framework.Platform
                 return;
 
             Renderer.AllowTearing = windowMode.Value == WindowMode.Fullscreen;
-            Renderer.WaitUntilNextFrameReady();
 
             ObjectUsage<DrawNode> buffer;
 
             using (drawMonitor.BeginCollecting(PerformanceCollectionType.Sleep))
+            {
+                Renderer.WaitUntilNextFrameReady();
                 buffer = DrawRoots.GetForRead();
+            }
 
             if (buffer == null)
                 return;


### PR DESCRIPTION
Before:

![SampleGame Desktop 2023-06-13 at 07 07 35](https://github.com/ppy/osu-framework/assets/191335/393119a3-098b-4a18-8dad-15eb2c343713)

After:

![SampleGame Desktop 2023-06-13 at 07 09 48](https://github.com/ppy/osu-framework/assets/191335/2507f467-add9-42af-832b-baeb5d8f7774)
