### PR TITLE
Fix nested DI candidates not analysed in non-candidate parent types

### DIFF
--- a/osu.Framework.SourceGeneration/Analysers/DiagnosticRules.cs
+++ b/osu.Framework.SourceGeneration/Analysers/DiagnosticRules.cs
@@ -13,12 +13,12 @@ namespace osu.Framework.SourceGeneration.Analysers
 
         public static readonly DiagnosticDescriptor MAKE_DI_CLASS_PARTIAL = new DiagnosticDescriptor(
             "OFSG001",
-            "This class is a candidate for dependency injection and should be partial",
-            "This class is a candidate for dependency injection and should be partial",
+            "This type, or a nested type, is a candidate for dependency injection and should be partial",
+            "This type, or a nested type, is a candidate for dependency injection and should be partial",
             "Performance",
             DiagnosticSeverity.Warning,
             true,
-            "Classes that are candidates for dependency injection should be made partial to benefit from compile-time optimisations.");
+            "Types that are candidates for dependency injection should be made partial to benefit from compile-time optimisations.");
 
 #pragma warning restore RS2008
     }


### PR DESCRIPTION
Current:
![image](https://github.com/ppy/osu-framework/assets/1329837/024d7913-9b1f-4fba-9a4b-37404bbf72bf)

Expected:
![image](https://github.com/ppy/osu-framework/assets/1329837/e51927d7-b635-44f7-8365-c7eaa34702ad)

No change in performance:

Before:

```sh
$ # Partial build
$ for i in {1..5}; do (touch osu.Framework/Game.cs && dotnet build osu-framework.Desktop.slnf -v:q) | tail -1; done

Time Elapsed 00:00:03.55
Time Elapsed 00:00:02.39
Time Elapsed 00:00:02.43
Time Elapsed 00:00:02.48
Time Elapsed 00:00:02.41
```
```sh
$ # Full rebuild
$ for i in {1..5}; do (dotnet clean osu-framework.Desktop.slnf -v:q && dotnet build osu-framework.Desktop.slnf -v:q) | tail -1; done

Time Elapsed 00:00:05.78
Time Elapsed 00:00:05.77
Time Elapsed 00:00:05.38
Time Elapsed 00:00:05.37
Time Elapsed 00:00:05.43
```

After:

```sh
$ # Partial build
$ for i in {1..5}; do (touch osu.Framework/Game.cs && dotnet build osu-framework.Desktop.slnf -v:q) | tail -1; done

Time Elapsed 00:00:03.29
Time Elapsed 00:00:02.45
Time Elapsed 00:00:02.91
Time Elapsed 00:00:02.45
Time Elapsed 00:00:02.48
```
```sh
$ # Full rebuild
$ for i in {1..5}; do (dotnet clean osu-framework.Desktop.slnf -v:q && dotnet build osu-framework.Desktop.slnf -v:q) | tail -1; done

Time Elapsed 00:00:05.86
Time Elapsed 00:00:05.22
Time Elapsed 00:00:05.44
Time Elapsed 00:00:04.55
Time Elapsed 00:00:04.95
```