### PR TITLE
Fix performance when viewing the tail end of a long / zoomed-in waveform

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -27,7 +27,9 @@ namespace osu.Framework.Tests.Visual.Drawables
         private Track track;
         private Waveform waveform;
         private Container<Drawable> waveformContainer;
-        private readonly Bindable<float> zoom = new BindableFloat(1) { MinValue = 0.1f, MaxValue = 20 };
+        private readonly BindableFloat zoom = new BindableFloat(1) { MinValue = 0.1f, MaxValue = 2000 };
+
+        private ScrollContainer<Drawable> scroll;
 
         private ITrackStore store;
 
@@ -75,7 +77,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                             },
                         },
                     },
-                    new BasicScrollContainer(Direction.Horizontal)
+                    scroll = new BasicScrollContainer(Direction.Horizontal)
                     {
                         RelativeSizeAxes = Axes.Both,
                         Child = waveformContainer = new FillFlowContainer
@@ -106,6 +108,26 @@ namespace osu.Framework.Tests.Visual.Drawables
         public void SetUpSteps()
         {
             AddStep("Load stereo track", () => loadTrack(true));
+        }
+
+        /// <summary>
+        /// When zooming in very close – or even zooming in a normal amount on a very long track – the number of points in the waveform
+        /// can become very high (in the millions).
+        ///
+        /// In this case, we need to be careful no iteration is performed over the point data. This tests the case of being scrolled to the
+        /// far end of the waveform, which is the worse-case-scenario and requires special consideration.
+        /// </summary>
+        [Test]
+        public void TestHighZoomEndOfTrackPerformance()
+        {
+            TestWaveform graph = null;
+
+            AddStep("create waveform", () => waveformContainer.Child = graph = new TestWaveform(track, 1) { Waveform = waveform });
+            AddUntilStep("wait for load", () => graph.Regenerated);
+
+            AddStep("set zoom to highest", () => zoom.Value = zoom.MaxValue);
+
+            AddStep("seek to end", () => scroll.ScrollToEnd());
         }
 
         [Test]

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,8 +27,8 @@ namespace osu.Framework.Graphics.Audio
     /// </summary>
     public partial class WaveformGraph : Drawable
     {
-        private IShader shader;
-        private Texture texture;
+        private IShader shader = null!;
+        private Texture texture = null!;
 
         [BackgroundDependencyLoader]
         private void load(ShaderManager shaders, IRenderer renderer)
@@ -61,12 +59,12 @@ namespace osu.Framework.Graphics.Audio
             }
         }
 
-        private Waveform waveform;
+        private Waveform? waveform;
 
         /// <summary>
         /// The <see cref="Framework.Audio.Track.Waveform"/> to display.
         /// </summary>
-        public Waveform Waveform
+        public Waveform? Waveform
         {
             get => waveform;
             set
@@ -174,10 +172,10 @@ namespace osu.Framework.Graphics.Audio
             return result;
         }
 
-        private CancellationTokenSource cancelSource = new CancellationTokenSource();
+        private CancellationTokenSource? cancelSource = new CancellationTokenSource();
 
         private long resampledVersion;
-        private Waveform.Point[] resampledPoints;
+        private Waveform.Point[]? resampledPoints;
         private int? resampledPointCount;
         private double resampledMaxHighIntensity;
         private double resampledMaxMidIntensity;
@@ -186,7 +184,7 @@ namespace osu.Framework.Graphics.Audio
         private void queueRegeneration() => Scheduler.AddOnce(() =>
         {
             int requiredPointCount = (int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution);
-            if (requiredPointCount == resampledPointCount && !cancelSource.IsCancellationRequested)
+            if (requiredPointCount == resampledPointCount && cancelSource?.IsCancellationRequested != false)
                 return;
 
             cancelGeneration();
@@ -259,10 +257,10 @@ namespace osu.Framework.Graphics.Audio
 
         private class WaveformDrawNode : DrawNode
         {
-            private IShader shader;
-            private Texture texture;
+            private IShader shader = null!;
+            private Texture? texture;
 
-            private List<Waveform.Point> points;
+            private List<Waveform.Point>? points;
 
             private Vector2 drawSize;
 
@@ -319,7 +317,7 @@ namespace osu.Framework.Graphics.Audio
                 }
             }
 
-            private IVertexBatch<TexturedVertex2D> vertexBatch;
+            private IVertexBatch<TexturedVertex2D>? vertexBatch;
 
             public override void Draw(IRenderer renderer)
             {

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -340,7 +340,7 @@ namespace osu.Framework.Graphics.Audio
 
                 float separation = drawSize.X / (points.Count - 1);
 
-                // Equates to making sure that rightX >= localMaskingRectangle.Left (see assertions in loop, which enforce the same thing).
+                // Equates to making sure that rightX >= localMaskingRectangle.Left at startIndex and leftX <= localMaskingRectangle.Right at endIndex.
                 // Without this pre-check, very long waveform displays can get slow just from running the loop below (point counts in excess of 1mil).
                 int startIndex = (int)Math.Clamp(localMaskingRectangle.Left / separation, 0, points.Count - 1);
                 int endIndex = (int)Math.Clamp(localMaskingRectangle.Right / separation + 1, 0, points.Count - 1);

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -340,16 +340,15 @@ namespace osu.Framework.Graphics.Audio
 
                 float separation = drawSize.X / (points.Count - 1);
 
-                for (int i = 0; i < points.Count - 1; i++)
+                // Equates to making sure that rightX >= localMaskingRectangle.Left (see assertions in loop, which enforce the same thing).
+                // Without this pre-check, very long waveform displays can get slow just from running the loop below (point counts in excess of 1mil).
+                int startIndex = (int)Math.Clamp(localMaskingRectangle.Left / separation, 0, points.Count - 1);
+                int endIndex = (int)Math.Clamp(localMaskingRectangle.Right / separation + 1, 0, points.Count - 1);
+
+                for (int i = startIndex; i < endIndex; i++)
                 {
                     float leftX = i * separation;
                     float rightX = (i + 1) * separation;
-
-                    if (rightX < localMaskingRectangle.Left)
-                        continue;
-
-                    if (leftX > localMaskingRectangle.Right)
-                        break; // X is always increasing
 
                     Color4 frequencyColour = baseColour;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/23905

| before | after |
| -- | -- |
|![osu Framework Tests 2023-06-16 at 07 41 08](https://github.com/ppy/osu-framework/assets/191335/ca0a4310-a600-4e14-b55b-ded3a97841d6)|![osu Framework Tests 2023-06-16 at 07 40 21](https://github.com/ppy/osu-framework/assets/191335/acbb9fae-739f-4a27-bff5-fe1bdfa62d69)|