### PR TITLE
Remove automatic conversion of vertical scroll to horizontal when holding shift

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -397,14 +397,18 @@ namespace osu.Framework.Graphics.Containers
                     return false;
             }
 
-            bool isPrecise = e.IsPrecise;
+            float scrollDeltaFloat = ScrollDirection == Direction.Horizontal
+                ? e.ScrollDelta.X
+                : e.ScrollDelta.Y;
 
-            Vector2 scrollDelta = e.ScrollDelta;
-            float scrollDeltaFloat = scrollDelta.Y;
-            if (ScrollDirection == Direction.Horizontal && scrollDelta.X != 0)
-                scrollDeltaFloat = scrollDelta.X;
+            // Let's assume precision scroll devices have both axes of scroll available.
+            //
+            // Then, for non-precision scroll devices, let's assuming the user's intention when scrolling
+            // is to *scroll*, regardless of the ScrollDirection.
+            if (!e.IsPrecise && scrollDeltaFloat == 0)
+                scrollDeltaFloat = e.ScrollDelta.Y + e.ScrollDelta.X;
 
-            scrollByOffset(ScrollDistance * -scrollDeltaFloat, true, isPrecise ? 0.05 : DistanceDecayScroll);
+            scrollByOffset(ScrollDistance * -scrollDeltaFloat, true, e.IsPrecise ? 0.05 : DistanceDecayScroll);
             return true;
         }
 

--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -34,9 +34,6 @@ namespace osu.Framework.Input.StateChanges
 
             if (Delta != Vector2.Zero)
             {
-                if (!IsPrecise && Delta.X == 0 && state.Keyboard.ShiftPressed)
-                    Delta = new Vector2(Delta.Y, 0);
-
                 var lastScroll = mouse.Scroll;
                 mouse.Scroll += Delta;
                 mouse.LastSource = this;


### PR DESCRIPTION
This was breaking binding behaviour too often, and is a pretty niche use case. `ScrollContainer` already automatically converts vertical scroll to horizontal, so this really doesn't do much for us.

Also in 092f28c0a, I've refactored `ScrollContainer` scroll delta handling logic to be more understandable

It was previously not clear the `Y` delta would be used if no `X` delta was present.

Note that this also adds considerations for precision scroll devices.  Without it, dual-axis scrolls could feel quite weird if the user happens to scroll a perfectly vertical line (would be unexpectedly converted to horizontal).