### PR TITLE
Ensure renderer-api-driven frame wait is only invoked when a frame is actually drawn

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -484,9 +484,9 @@ namespace osu.Framework.Platform
 
             using (drawMonitor.BeginCollecting(PerformanceCollectionType.Sleep))
             {
-                // Importantly, only wait on renderer frame availability if we actually rendered a frame.
-                // Without this, the wait handle will potentially be in a bad state and take the timeout
-                // value (1 second) to recover.
+                // Importantly, only wait on renderer frame availability if we actually rendered a frame since the last `WaitUntilNextFrameReady()`.
+                // Without this, the wait handle, internally used in the Veldrid-side implementation of `WaitUntilNextFrameReady()`,
+                // will potentially be in a bad state and take the timeout value (1 second) to recover.
                 if (didRenderFrame)
                     Renderer.WaitUntilNextFrameReady();
 


### PR DESCRIPTION
I noticed very long pauses when loading song select on my windows PC. Tracking this down, the game was getting stuck on the D3D11Swapchain [wait handle](https://github.com/ppy/veldrid/blob/d4340776eba0541aa3598856dafccf25633072f2/src/Veldrid/D3D11/D3D11Swapchain.cs#L303) until the full one second timeout.

It turns out that the wait handle will not be set unless a frame finishes rendering. The fail case is where the update thread takes over 100ms to prepare a frame, causing `TripleBuffer.GetForRead` to timeout and return `null`, which early exits the draw frame method.

This would happen anywhere the game takes slightly too long to render an update frame. I could reproduce:

- Entering song select
- Opening settings
- Opening beatmap listing

To confirm / reproduce this issue, remove the 1000ms timeout from `WaitOne` in veldrid and add a single `Thread.Sleep(150)` in any update thread code, and watch the game deadlock indefinitely.

For good measure, here's a visual example of this happening:

![image](https://github.com/ppy/osu-framework/assets/191335/9792c29a-55cc-46f6-8162-4b1cb0a4bf27)
