### PR TITLE
Improve metal frame rendering when more than one display is connected

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -44,6 +44,7 @@ using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Serialization;
 using osu.Framework.IO.Stores;
 using osu.Framework.Localisation;
+using Rectangle = System.Drawing.Rectangle;
 using Size = System.Drawing.Size;
 
 namespace osu.Framework.Platform
@@ -989,6 +990,16 @@ namespace osu.Framework.Platform
 
             currentDisplayMode = Window.CurrentDisplayMode.GetBoundCopy();
             currentDisplayMode.BindValueChanged(_ => updateFrameSyncMode());
+
+            Window.CurrentDisplayBindable.BindValueChanged(display =>
+            {
+                if (Renderer is VeldridRenderer veldridRenderer)
+                {
+                    Rectangle bounds = display.NewValue.Bounds;
+
+                    veldridRenderer.Device.UpdateActiveDisplay(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+                }
+            }, true);
 
             IsActive.BindTo(Window.IsActive);
         }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.3-g31346ea477" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.3-g7beb1270bf" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
Incorporating @ILW8's work (https://github.com/ppy/veldrid/pull/20) to more correctly provide hinting to metal as to where the window is running on the host, which allows better selection of refresh rates and display timings.

Tested on single display macbook and dual display mac pro (with two external displays). In these cases, I'm not noticing anything working better than before, but it runs fine without any signs of regression.

Closes #5828.