### PR TITLE
Fix item labels not generated while dropdown is in `Ready` state

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -369,12 +369,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("close dropdown", () => InputManager.Key(Key.Escape));
         }
 
+        /// <summary>
+        /// Adds an item before a dropdown is loaded, and ensures item labels are assigned correctly.
+        /// </summary>
+        /// <remarks>
+        /// Ensures item labels are assigned after the dropdown finishes loading (reaches <see cref="LoadState.Ready"/> state),
+        /// so any dependency from BDL can be retrieved first before calling <see cref="Dropdown{T}.GenerateItemText"/>.
+        /// </remarks>
         [Test]
-        public void TestAccessBdlInGenerateItemText()
+        public void TestAddItemBeforeDropdownLoad()
         {
             BdlDropdown dropdown = null!;
 
-            AddStep("add dropdown that uses BDL", () => Add(dropdown = new BdlDropdown
+            AddStep("setup dropdown", () => Add(dropdown = new BdlDropdown
             {
                 Width = 150,
                 Position = new Vector2(250, 350),
@@ -385,27 +392,59 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         /// <summary>
-        /// Checks that <see cref="Dropdown{T}.GenerateItemText"/> is not called before load when initialising with <see cref="Dropdown{T}.Current"/>.
+        /// Adds an item after the dropdown is in <see cref="LoadState.Ready"/> state, and ensures item labels are assigned correctly and not ignored by <see cref="Dropdown{T}"/>.
         /// </summary>
         [Test]
-        public void TestBdlWithCurrent()
+        public void TestAddItemWhileDropdownIsInReadyState()
         {
             BdlDropdown dropdown = null!;
 
-            Bindable<TestModel> bindable = null!;
+            AddStep("setup dropdown", () =>
+            {
+                Child = dropdown = new BdlDropdown
+                {
+                    Width = 150,
+                    Position = new Vector2(250, 350),
+                };
+
+                dropdown.Items = new TestModel("test").Yield();
+            });
+
+            AddAssert("text is expected", () => dropdown.Menu.DrawableMenuItems.First(d => d.IsSelected).ChildrenOfType<SpriteText>().First().Text.ToString(), () => Is.EqualTo("loaded: test"));
+        }
+
+        /// <summary>
+        /// Sets a non-existent item dropdown and ensures its label is assigned correctly.
+        /// </summary>
+        /// <param name="afterBdl">Whether the non-existent item should be defined after dropdown finishes from BDL.</param>
+        [Test]
+        public void TestSetNonExistentItemBeforeDropdownIsLoaded([Values] bool afterBdl)
+        {
+            BdlDropdown dropdown = null!;
+            Bindable<TestModel> bindable;
 
             AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
-            AddStep("create current", () => bindable = new Bindable<TestModel>(bindableList[1]));
 
-            AddStep("add dropdown that uses BDL", () => Add(dropdown = new BdlDropdown
+            AddStep("add dropdown that uses BDL", () =>
             {
-                Width = 150,
-                Position = new Vector2(250, 350),
-                ItemSource = bindableList,
-                Current = bindable,
-            }));
+                bindable = new Bindable<TestModel>();
 
-            AddAssert("text is expected", () => dropdown.Menu.DrawableMenuItems.First(d => d.IsSelected).ChildrenOfType<SpriteText>().First().Text.ToString(), () => Is.EqualTo("loaded: two"));
+                if (!afterBdl)
+                    bindable.Value = new TestModel("non-existent item");
+
+                Add(dropdown = new BdlDropdown
+                {
+                    Width = 150,
+                    Position = new Vector2(250, 350),
+                    ItemSource = bindableList,
+                    Current = bindable,
+                });
+
+                if (afterBdl)
+                    bindable.Value = new TestModel("non-existent item");
+            });
+
+            AddAssert("text is expected", () => dropdown.SelectedItem.Text.Value.ToString(), () => Is.EqualTo("loaded: non-existent item"));
         }
 
         private void toggleDropdownViaClick(TestDropdown dropdown, string dropdownName = null) => AddStep($"click {dropdownName ?? "dropdown"}", () =>

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -416,9 +416,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
         /// <summary>
         /// Sets a non-existent item dropdown and ensures its label is assigned correctly.
         /// </summary>
-        /// <param name="afterBdl">Whether the non-existent item should be defined after dropdown finishes from BDL.</param>
+        /// <param name="afterBdl">Whether the non-existent item should be set before or after the dropdown's BDL has run.</param>
         [Test]
-        public void TestSetNonExistentItemBeforeDropdownIsLoaded([Values] bool afterBdl)
+        public void TestSetNonExistentItem([Values] bool afterBdl)
         {
             BdlDropdown dropdown = null!;
             Bindable<TestModel> bindable;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -401,11 +401,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("setup dropdown", () =>
             {
-                Child = dropdown = new BdlDropdown
+                Add(dropdown = new BdlDropdown
                 {
                     Width = 150,
                     Position = new Vector2(250, 350),
-                };
+                });
 
                 dropdown.Items = new TestModel("test").Yield();
             });

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -117,8 +117,8 @@ namespace osu.Framework.Graphics.UserInterface
                 Menu.State = MenuState.Closed;
             });
 
-            // inheritors expect that `virtual GenerateItemText` is only called when this dropdown is fully loaded.
-            if (IsLoaded)
+            // inheritors expect that `virtual GenerateItemText` is only called when this dropdown finishes from BDL.
+            if (LoadState >= LoadState.Ready)
                 item.Text.Value = GenerateItemText(value);
 
             Menu.Add(item);

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Menu.State = MenuState.Closed;
             });
 
-            // inheritors expect that `virtual GenerateItemText` is only called when this dropdown finishes from BDL.
+            // inheritors expect that `virtual GenerateItemText` is only called when this dropdown's BDL has run to completion.
             if (LoadState >= LoadState.Ready)
                 item.Text.Value = GenerateItemText(value);
 


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu-framework/pull/5836

Originally reported in [Discord](https://discord.com/channels/188630481301012481/589331078574112768/1120261143819210855). This regression affected the (not really useful) assembly dropdown in visual tests, and also the duration dropdown in playlists screen osu!-side.