### PR TITLE
Ensure triple buffer never uses the same buffer twice in a row

### DIFF
--- a/osu.Framework.Tests/Graphics/TripleBufferTest.cs
+++ b/osu.Framework.Tests/Graphics/TripleBufferTest.cs
@@ -329,7 +329,7 @@ namespace osu.Framework.Tests.Graphics
 
             public override string ToString()
             {
-                return $"{base.ToString()} buffer index: {ID}";
+                return $"{base.ToString()} ID: {ID}";
             }
         }
     }

--- a/osu.Framework/Allocation/ObjectUsage.cs
+++ b/osu.Framework/Allocation/ObjectUsage.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Allocation
@@ -10,15 +8,18 @@ namespace osu.Framework.Allocation
     public class ObjectUsage<T> : IDisposable
         where T : class
     {
-        public T Object;
+        public T? Object;
 
+        /// <summary>
+        /// Whether this usage is actively being written to or read from.
+        /// </summary>
         public UsageType Usage;
 
         public readonly int Index;
 
-        private readonly Action<ObjectUsage<T>> finish;
+        private readonly Action<ObjectUsage<T>>? finish;
 
-        public ObjectUsage(int index, Action<ObjectUsage<T>> finish)
+        public ObjectUsage(int index, Action<ObjectUsage<T>>? finish)
         {
             Index = index;
             this.finish = finish;

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Allocation
     public class TripleBuffer<T>
         where T : class
     {
-        private readonly ObjectUsage<T>[] buffers = new ObjectUsage<T>[3];
+        private readonly ObjectUsage<T>[] buffers = new ObjectUsage<T>[buffer_count];
 
         /// <summary>
         /// The freshest buffer index which has finished a write, and is waiting to be read.

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 
 namespace osu.Framework.Allocation
@@ -16,11 +18,22 @@ namespace osu.Framework.Allocation
     {
         private readonly ObjectUsage<T>[] buffers = new ObjectUsage<T>[3];
 
-        private int? lastCompletedWriteIndex;
+        /// <summary>
+        /// The freshest buffer index which has finished a write, and is waiting to be read.
+        /// Will be set to <c>null</c> after being read once.
+        /// </summary>
+        private int? pendingCompletedWriteIndex;
 
+        /// <summary>
+        /// The last buffer index which was obtained for writing.
+        /// </summary>
+        private int? lastWriteIndex;
+
+        /// <summary>
+        /// The last buffer index which was obtained for reading.
+        /// Note that this will remain "active" even after a <see cref="GetForRead"/> ends, to give benefit of doubt that the usage may still be accessing it.
+        /// </summary>
         private int? lastReadIndex;
-
-        private int? activeReadIndex;
 
         private readonly ManualResetEventSlim writeCompletedEvent = new ManualResetEventSlim();
 
@@ -34,6 +47,9 @@ namespace osu.Framework.Allocation
 
         public ObjectUsage<T> GetForWrite()
         {
+            // Only one read should be allowed at once
+            Debug.Assert(buffers.All(b => b.Usage != UsageType.Write));
+
             ObjectUsage<T> buffer;
 
             lock (buffers)
@@ -49,18 +65,21 @@ namespace osu.Framework.Allocation
 
         public ObjectUsage<T>? GetForRead()
         {
+            // Only one read should be allowed at once
+            Debug.Assert(buffers.All(b => b.Usage != UsageType.Read));
+
             writeCompletedEvent.Reset();
 
             lock (buffers)
             {
-                if (lastCompletedWriteIndex != null)
+                if (pendingCompletedWriteIndex != null)
                 {
-                    var buffer = buffers[lastCompletedWriteIndex.Value];
-                    lastCompletedWriteIndex = null;
+                    var buffer = buffers[pendingCompletedWriteIndex.Value];
+                    pendingCompletedWriteIndex = null;
                     buffer.Usage = UsageType.Read;
 
-                    Debug.Assert(activeReadIndex == null);
-                    activeReadIndex = buffer.Index;
+                    Debug.Assert(lastReadIndex != buffer.Index);
+                    lastReadIndex = buffer.Index;
                     return buffer;
                 }
             }
@@ -75,16 +94,21 @@ namespace osu.Framework.Allocation
 
         private ObjectUsage<T> getNextWriteBuffer()
         {
-            for (int i = 0; i < buffer_count - 1; i++)
+            for (int i = 0; i <= buffer_count - 1; i++)
             {
-                if (i == activeReadIndex) continue;
+                // Never write to the last read index.
+                // We assume there could be some reads still occurring even after the usage is finished.
                 if (i == lastReadIndex) continue;
-                if (i == lastCompletedWriteIndex) continue;
 
+                // Never write to the same buffer twice in a row.
+                // This would defeat the purpose of having a triple buffer.
+                if (i == lastWriteIndex) continue;
+
+                lastWriteIndex = i;
                 return buffers[i];
             }
 
-            return buffers[buffer_count - 1];
+            throw new InvalidOperationException("No buffer could be obtained. This should never ever happen.");
         }
 
         private void finishUsage(ObjectUsage<T> obj)
@@ -93,15 +117,9 @@ namespace osu.Framework.Allocation
             {
                 switch (obj.Usage)
                 {
-                    case UsageType.Read:
-                        Debug.Assert(activeReadIndex != null);
-                        lastReadIndex = activeReadIndex;
-                        activeReadIndex = null;
-                        break;
-
                     case UsageType.Write:
-                        Debug.Assert(lastCompletedWriteIndex != obj.Index);
-                        lastCompletedWriteIndex = obj.Index;
+                        Debug.Assert(pendingCompletedWriteIndex != obj.Index);
+                        pendingCompletedWriteIndex = obj.Index;
 
                         writeCompletedEvent.Set();
                         break;

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Allocation
 
         public ObjectUsage<T> GetForWrite()
         {
-            // Only one read should be allowed at once
+            // Only one write should be allowed at once
             Debug.Assert(buffers.All(b => b.Usage != UsageType.Write));
 
             ObjectUsage<T> buffer;

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Allocation
 
         private ObjectUsage<T> getNextWriteBuffer()
         {
-            for (int i = 0; i <= buffer_count - 1; i++)
+            for (int i = 0; i < buffer_count; i++)
             {
                 // Never write to the last read index.
                 // We assume there could be some reads still occurring even after the usage is finished.

--- a/osu.Framework/Allocation/TripleBuffer.cs
+++ b/osu.Framework/Allocation/TripleBuffer.cs
@@ -9,6 +9,7 @@ namespace osu.Framework.Allocation
     /// <summary>
     /// Handles triple-buffering of any object type.
     /// Thread safety assumes at most one writer and one reader.
+    /// Comes with the added assurance that the most recent <see cref="GetForRead"/> object is not written to.
     /// </summary>
     public class TripleBuffer<T>
         where T : class
@@ -16,6 +17,8 @@ namespace osu.Framework.Allocation
         private readonly ObjectUsage<T>[] buffers = new ObjectUsage<T>[3];
 
         private int? lastCompletedWriteIndex;
+
+        private int? lastReadIndex;
 
         private int? activeReadIndex;
 
@@ -75,6 +78,7 @@ namespace osu.Framework.Allocation
             for (int i = 0; i < buffer_count - 1; i++)
             {
                 if (i == activeReadIndex) continue;
+                if (i == lastReadIndex) continue;
                 if (i == lastCompletedWriteIndex) continue;
 
                 return buffers[i];
@@ -91,6 +95,7 @@ namespace osu.Framework.Allocation
                 {
                     case UsageType.Read:
                         Debug.Assert(activeReadIndex != null);
+                        lastReadIndex = activeReadIndex;
                         activeReadIndex = null;
                         break;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -498,6 +498,8 @@ namespace osu.Framework.Platform
             if (buffer == null)
                 return;
 
+            Debug.Assert(buffer.Object != null);
+
             try
             {
                 using (drawMonitor.BeginCollecting(PerformanceCollectionType.DrawReset))


### PR DESCRIPTION
As discussed in #osu-framework, this is probably a safer way of implementing the draw node triple buffer. It ensures that the last read buffer will never be written to. This may be helpful in scenarios where an external resource (ie. the GPU) is still interacting with the last read object's content.

This comes with no changes to lockability overheads, and only updates the naive approach previously used to find the next usable buffer.