### PR TITLE
Remove assembly dropdown from visual test browser

### DIFF
--- a/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarAssemblySection.cs
@@ -1,21 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Localisation;
 using osuTK;
 
 namespace osu.Framework.Testing.Drawables.Sections
 {
     public partial class ToolbarAssemblySection : ToolbarSection
     {
-        private AssemblyDropdown assemblyDropdown = null!;
-
         public ToolbarAssemblySection()
         {
             AutoSizeAxes = Axes.X;
@@ -33,17 +28,6 @@ namespace osu.Framework.Testing.Drawables.Sections
                 AutoSizeAxes = Axes.X,
                 Children = new Drawable[]
                 {
-                    new SpriteText
-                    {
-                        Padding = new MarginPadding(5),
-                        Font = FrameworkFont.Condensed,
-                        Text = "Assembly"
-                    },
-                    assemblyDropdown = new AssemblyDropdown
-                    {
-                        Width = 250,
-                        Current = browser.Assembly
-                    },
                     new BasicCheckbox
                     {
                         LabelText = "Run all steps",
@@ -55,13 +39,6 @@ namespace osu.Framework.Testing.Drawables.Sections
                     },
                 }
             };
-        }
-
-        public void AddAssembly(Assembly assembly) => assemblyDropdown.AddDropdownItem(assembly);
-
-        private partial class AssemblyDropdown : BasicDropdown<Assembly>
-        {
-            protected override LocalisableString GenerateItemText(Assembly assembly) => assembly.GetName().Name ?? "unknonwn";
         }
     }
 }

--- a/osu.Framework/Testing/Drawables/Sections/ToolbarRunAllStepsSection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarRunAllStepsSection.cs
@@ -9,9 +9,9 @@ using osuTK;
 
 namespace osu.Framework.Testing.Drawables.Sections
 {
-    public partial class ToolbarAssemblySection : ToolbarSection
+    public partial class ToolbarRunAllStepsSection : ToolbarSection
     {
-        public ToolbarAssemblySection()
+        public ToolbarRunAllStepsSection()
         {
             AutoSizeAxes = Axes.X;
             Masking = false;

--- a/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
+++ b/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Testing.Drawables
                         {
                             new Drawable[]
                             {
-                                new ToolbarAssemblySection { RelativeSizeAxes = Axes.Y },
+                                new ToolbarRunAllStepsSection { RelativeSizeAxes = Axes.Y },
                                 new ToolbarRateSection { RelativeSizeAxes = Axes.Both },
                                 new Container
                                 {

--- a/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
+++ b/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
-using System.Reflection;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,8 +11,6 @@ namespace osu.Framework.Testing.Drawables
 {
     internal partial class TestBrowserToolbar : CompositeDrawable
     {
-        private ToolbarAssemblySection assemblySection;
-
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -50,7 +45,7 @@ namespace osu.Framework.Testing.Drawables
                         {
                             new Drawable[]
                             {
-                                assemblySection = new ToolbarAssemblySection { RelativeSizeAxes = Axes.Y },
+                                new ToolbarAssemblySection { RelativeSizeAxes = Axes.Y },
                                 new ToolbarRateSection { RelativeSizeAxes = Axes.Both },
                                 new Container
                                 {
@@ -78,7 +73,5 @@ namespace osu.Framework.Testing.Drawables
                 }
             };
         }
-
-        public void AddAssembly(Assembly assembly) => assemblySection.AddAssembly(assembly);
     }
 }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -54,67 +54,36 @@ namespace osu.Framework.Testing
 
         private bool interactive;
 
-        private readonly List<Assembly> assemblies;
-
         /// <summary>
         /// Creates a new TestBrowser that displays the TestCases of every assembly that start with either "osu" or the specified namespace (if it isn't null)
         /// </summary>
         /// <param name="assemblyNamespace">Assembly prefix which is used to match assemblies whose tests should be displayed</param>
         public TestBrowser(string assemblyNamespace = null)
         {
-            assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(n =>
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(n =>
             {
                 Debug.Assert(n.FullName != null);
                 return n.FullName.StartsWith("osu", StringComparison.Ordinal) || (assemblyNamespace != null && n.FullName.StartsWith(assemblyNamespace, StringComparison.Ordinal));
             }).ToList();
 
             //we want to build the lists here because we're interested in the assembly we were *created* on.
-            foreach (Assembly asm in assemblies.ToList())
+            foreach (Assembly asm in assemblies)
             {
-                var tests = asm.GetLoadableTypes().Where(isValidVisualTest).ToList();
-
-                if (!tests.Any())
-                {
-                    assemblies.Remove(asm);
-                    continue;
-                }
-
-                foreach (Type type in tests)
+                foreach (Type type in asm.GetLoadableTypes().Where(isValidVisualTest))
                     TestTypes.Add(type);
             }
 
             TestTypes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
         }
 
-        private bool isValidVisualTest(Type t) => t.IsSubclassOf(typeof(TestScene)) && !t.IsAbstract && t.IsPublic && !t.GetCustomAttributes<HeadlessTestAttribute>().Any() && t.IsSupportedOnCurrentOSPlatform();
-
-        private void updateList(ValueChangedEvent<Assembly> args)
-        {
-            leftFlowContainer.Clear();
-
-            //Add buttons for each TestCase.
-            string namespacePrefix = TestTypes.Select(t => t.Namespace).GetCommonPrefix();
-
-            leftFlowContainer.AddRange(TestTypes.Where(t => t.Assembly == args.NewValue)
-                                                .GroupBy(
-                                                    t =>
-                                                    {
-                                                        string group = t.Namespace?.AsSpan(namespacePrefix.Length).TrimStart('.').ToString();
-                                                        return string.IsNullOrWhiteSpace(group) ? "Ungrouped" : group;
-                                                    },
-                                                    t => t,
-                                                    (group, types) => new TestGroup { Name = group, TestTypes = types.ToArray() }
-                                                ).OrderBy(g => g.Name)
-                                                .Select(t => new TestGroupButton(type => LoadTest(type), t)));
-        }
+        private bool isValidVisualTest(Type t) =>
+            t.IsSubclassOf(typeof(TestScene)) && !t.IsAbstract && t.IsPublic && !t.GetCustomAttributes<HeadlessTestAttribute>().Any() && t.IsSupportedOnCurrentOSPlatform();
 
         internal readonly BindableDouble PlaybackRate = new BindableDouble(1) { MinValue = 0, MaxValue = 2, Default = 1 };
-        internal readonly Bindable<Assembly> Assembly = new Bindable<Assembly>();
         internal readonly Bindable<bool> RunAllSteps = new Bindable<bool>();
         internal readonly Bindable<RecordState> RecordState = new Bindable<RecordState>();
         internal readonly BindableInt CurrentFrame = new BindableInt { MinValue = 0, MaxValue = 0 };
 
-        private TestBrowserToolbar toolbar;
         private Container leftContainer;
         private Container mainContainer;
 
@@ -175,7 +144,7 @@ namespace osu.Framework.Testing
                                 }
                             }
                         },
-                        toolbar = new TestBrowserToolbar
+                        new TestBrowserToolbar
                         {
                             RelativeSizeAxes = Axes.X,
                             Height = 50,
@@ -244,16 +213,33 @@ namespace osu.Framework.Testing
             if (RuntimeInfo.IsDesktop)
                 HotReloadCallbackReceiver.CompilationFinished += compileFinished;
 
-            foreach (Assembly asm in assemblies)
-                toolbar.AddAssembly(asm);
-
-            Assembly.BindValueChanged(updateList);
             RunAllSteps.BindValueChanged(_ => runTests(null));
             PlaybackRate.BindValueChanged(e =>
             {
                 rateAdjustClock.Rate = e.NewValue;
                 audioRateAdjust.Value = e.NewValue;
             }, true);
+
+            updateTestList();
+        }
+
+        private void updateTestList()
+        {
+            leftFlowContainer.Clear();
+
+            //Add buttons for each TestCase.
+            string namespacePrefix = TestTypes.Select(t => t.Namespace).GetCommonPrefix();
+
+            leftFlowContainer.AddRange(TestTypes.GroupBy(
+                                                    t =>
+                                                    {
+                                                        string group = t.Namespace?.AsSpan(namespacePrefix.Length).TrimStart('.').ToString();
+                                                        return string.IsNullOrWhiteSpace(group) ? "Ungrouped" : group;
+                                                    },
+                                                    t => t,
+                                                    (group, types) => new TestGroup { Name = group, TestTypes = types.ToArray() }
+                                                ).OrderBy(g => g.Name)
+                                                .Select(t => new TestGroupButton(type => LoadTest(type), t)));
         }
 
         private void compileFinished(Type[] updatedTypes) => Schedule(() =>
@@ -369,8 +355,6 @@ namespace osu.Framework.Testing
             var newTest = (TestScene)Activator.CreateInstance(testType);
 
             Debug.Assert(newTest != null);
-
-            Assembly.Value = testType.Assembly;
 
             CurrentTest = newTest;
             CurrentTest.OnLoadComplete += _ => Schedule(() => finishLoad(newTest, onCompletion));
@@ -575,8 +559,12 @@ namespace osu.Framework.Testing
 
                 case MethodInfo sm:
                     int methodParamsLength = sm.GetParameters().Length;
+
                     if (methodParamsLength != (tcs.MethodParams?.Length ?? 0))
-                        throw new InvalidOperationException($"The given source method parameters count doesn't match the method. (attribute has {tcs.MethodParams?.Length ?? 0}, method has {methodParamsLength})");
+                    {
+                        throw new InvalidOperationException(
+                            $"The given source method parameters count doesn't match the method. (attribute has {tcs.MethodParams?.Length ?? 0}, method has {methodParamsLength})");
+                    }
 
                     return (IEnumerable)sm.Invoke(null, tcs.MethodParams);
 


### PR DESCRIPTION
Maintains support for multiple assemblies but removes the dropdown as proposed a while back on discord.

Open for feedback on this – if the assembly name being in the toolbar was seen as good hinting to have, we could choose to either leave this dropdown in place, or display it as text. Personally I think the window title is enough hinting for me, but let's see what people think.