### PR TITLE
Bump OpenTabletDriver version to 0.6.1.0

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.0.4" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
## Includes many tablet configuration updates!

### Added support

- FlooGoo FMA100
- Gaomon GM156HD
- Gaomon PD2200
- Gaomon S830
- Genius i405x
- Huion G930L
- Huion H320M
- Huion H610 Pro V3
- Huion H690
- Huion Kamvas 12
- Huion Kamvas Pro 16 (2.5k)
- Huion RTM-500
- KENTING K5540
- Monoprice 10594
- UGEE S640
- UGTABLET M708 V2
- Veikk A15 V2
- Veikk A30 V2
- Veikk VK1060
- Veikk VK430
- Veikk Viola (VO1060)
- Wacom CTE-660
- Wacom CTH-301
- Wacom CTH-661-SE
- Wacom DTK-1300
- Wacom DTK-1660
- Wacom DTZ-1200W
- XP-PEN MT0960B (Deco Pro SW)
- XP-Pen Artist 10 (2nd Gen)
- XP-Pen Artist 13 (2nd Gen)
- XP-Pen Artist 13.3
- XP-Pen Artist 16 Pro
- XP-Pen Artist Pro 16TP

### Improved support

- Gaomon 1060 Pro
- Gaomon M6
- Gaomon S56K
- Gaomon S620
- Huion GC610
- Huion H1060P
- Huion H320M
- Huion H610 Pro V2
- Huion H610X
- Huion H640P
- Huion HC16
- Lifetec LT9570
- Monoprice MP1060-HA60
- Wacom CTH-461
- Wacom CTH-661
- Wacom CTL-4100WL
- Wacom CTL-6100WL
- Wacom DTK-1660
- XP-Pen Deco 01 V2

Original changelog for reference: https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v0.6.1

## Issues fixed

- Fixes #5423 
- Fixes https://github.com/ppy/osu/issues/17711
- Fixes https://github.com/ppy/osu/issues/21078