### PR TITLE
Fix possible nullref when binding textures under Veldrid

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -170,7 +170,13 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             set => resourcesArray[0] = value;
         }
 
-        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList() => resourcesArray!;
+        public virtual IReadOnlyList<VeldridTextureResources> GetResourceList()
+        {
+            if (resources == null)
+                return Array.Empty<VeldridTextureResources>();
+
+            return resourcesArray!;
+        }
 
         public void FlushUploads()
         {


### PR DESCRIPTION
I noticed this when opening texture visualiser (Ctrl+F3) and then the FPS display (Ctrl+F11). Likely what's happening here, though I haven't gone into it, is that the `TextureVisualiser` is attempting to display some textures from the FPS display that haven't been uploaded yet.

At the moment, I have no reason to believe this could occur in any other normal execution.