### PR TITLE
Define stencil attachment for swap-chain frame buffers in Veldrid

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -382,7 +382,6 @@ namespace osu.Framework.Graphics.OpenGL
         public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
         {
             All glFilteringMode;
-            RenderbufferInternalFormat[]? glFormats = null;
 
             switch (filteringMode)
             {
@@ -398,37 +397,7 @@ namespace osu.Framework.Graphics.OpenGL
                     throw new ArgumentException($"Unsupported filtering mode: {filteringMode}", nameof(filteringMode));
             }
 
-            if (renderBufferFormats != null)
-            {
-                glFormats = new RenderbufferInternalFormat[renderBufferFormats.Length];
-
-                for (int i = 0; i < renderBufferFormats.Length; i++)
-                {
-                    switch (renderBufferFormats[i])
-                    {
-                        case RenderBufferFormat.D16:
-                            glFormats[i] = RenderbufferInternalFormat.DepthComponent16;
-                            break;
-
-                        case RenderBufferFormat.D32:
-                            glFormats[i] = RenderbufferInternalFormat.DepthComponent32f;
-                            break;
-
-                        case RenderBufferFormat.D24S8:
-                            glFormats[i] = RenderbufferInternalFormat.Depth24Stencil8;
-                            break;
-
-                        case RenderBufferFormat.D32S8:
-                            glFormats[i] = RenderbufferInternalFormat.Depth32fStencil8;
-                            break;
-
-                        default:
-                            throw new ArgumentException($"Unsupported render buffer format: {renderBufferFormats[i]}", nameof(renderBufferFormats));
-                    }
-                }
-            }
-
-            return new GLFrameBuffer(this, glFormats, glFilteringMode);
+            return new GLFrameBuffer(this, renderBufferFormats, glFilteringMode);
         }
 
         protected override IUniformBuffer<TData> CreateUniformBuffer<TData>() => new GLUniformBuffer<TData>(this);

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyFrameBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Textures;
 using osuTK;
 
@@ -13,6 +14,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
     internal class DummyFrameBuffer : IFrameBuffer
     {
         public Texture Texture { get; }
+        public IReadOnlyList<RenderBufferFormat>? Formats => null;
 
         public Vector2 Size
         {

--- a/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics.Textures;
 using osuTK;
 
@@ -13,6 +14,11 @@ namespace osu.Framework.Graphics.Rendering
         /// The framebuffer's backing texture.
         /// </summary>
         Texture Texture { get; }
+
+        /// <summary>
+        /// The list of other pixel formats for this framebuffer, or null if not defined.
+        /// </summary>
+        IReadOnlyList<RenderBufferFormat>? Formats { get; }
 
         /// <summary>
         /// The framebuffer's texture size.

--- a/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/IFrameBuffer.cs
@@ -36,4 +36,23 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         void Unbind();
     }
+
+    public static class RenderBufferFormatExtensions
+    {
+        public static bool HasStencilAttachment(this IFrameBuffer frameBuffer)
+        {
+            if (frameBuffer.Formats == null)
+                return false;
+
+            for (int i = 0; i < frameBuffer.Formats.Count; i++)
+            {
+                var format = frameBuffer.Formats[i];
+
+                if (format == RenderBufferFormat.D24S8 || format == RenderBufferFormat.D32S8)
+                    return true;
+            }
+
+            return false;
+        }
+    }
 }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -45,6 +45,12 @@ namespace osu.Framework.Graphics.Rendering
         public const int MAX_QUADS = ushort.MaxValue / INDICES_PER_QUAD;
 
         /// <summary>
+        /// The depth-stencil format used for the swap-chain frame buffer.
+        /// </summary>
+        // todo: this should match with GLRenderer, which currently specifies depth & stencil component sizes in SDL2GraphicsSurface.
+        public const RenderBufferFormat DEPTH_STENCIL_FORMAT = RenderBufferFormat.D32S8;
+
+        /// <summary>
         /// Enables or disables vertical sync.
         /// </summary>
         protected internal bool VerticalSync { get; set; }

--- a/osu.Framework/Graphics/Rendering/RenderBufferFormat.cs
+++ b/osu.Framework/Graphics/Rendering/RenderBufferFormat.cs
@@ -25,4 +25,9 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         D32S8
     }
+
+    public static class RenderBufferFormatExtensions
+    {
+        public static bool HasStencilAttachment(this RenderBufferFormat format) => format == RenderBufferFormat.D24S8 || format == RenderBufferFormat.D32S8;
+    }
 }

--- a/osu.Framework/Graphics/Rendering/RenderBufferFormat.cs
+++ b/osu.Framework/Graphics/Rendering/RenderBufferFormat.cs
@@ -25,9 +25,4 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         D32S8
     }
-
-    public static class RenderBufferFormatExtensions
-    {
-        public static bool HasStencilAttachment(this RenderBufferFormat format) => format == RenderBufferFormat.D24S8 || format == RenderBufferFormat.D32S8;
-    }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -751,7 +751,7 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentStencilInfo.Equals(stencilInfo))
                 return;
 
-            if (stencilInfo.StencilTest && FrameBuffer != null && (FrameBuffer.Formats == null || !FrameBuffer.Formats[0].HasStencilAttachment()))
+            if (stencilInfo.StencilTest && FrameBuffer?.HasStencilAttachment() == false)
                 throw new InvalidOperationException("Cannot enable stencil tests on a frame buffer with no stencil attachment.");
 
             FlushCurrentBatch(FlushBatchSource.SetStencilInfo);
@@ -957,7 +957,7 @@ namespace osu.Framework.Graphics.Rendering
             if (frameBuffer == FrameBuffer && !force)
                 return;
 
-            if (CurrentStencilInfo.StencilTest && frameBuffer != null && (frameBuffer.Formats == null || !frameBuffer.Formats[0].HasStencilAttachment()))
+            if (CurrentStencilInfo.StencilTest && frameBuffer?.HasStencilAttachment() == false)
                 throw new InvalidOperationException("Cannot bind a frame buffer with no stencil attachment while stencil tests are enabled.");
 
             FlushCurrentBatch(FlushBatchSource.SetFrameBuffer);

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -751,6 +751,9 @@ namespace osu.Framework.Graphics.Rendering
             if (CurrentStencilInfo.Equals(stencilInfo))
                 return;
 
+            if (stencilInfo.StencilTest && FrameBuffer != null && (FrameBuffer.Formats == null || !FrameBuffer.Formats[0].HasStencilAttachment()))
+                throw new InvalidOperationException("Cannot enable stencil tests on a frame buffer with no stencil attachment.");
+
             FlushCurrentBatch(FlushBatchSource.SetStencilInfo);
             SetStencilInfoImplementation(stencilInfo);
 
@@ -953,6 +956,9 @@ namespace osu.Framework.Graphics.Rendering
         {
             if (frameBuffer == FrameBuffer && !force)
                 return;
+
+            if (CurrentStencilInfo.StencilTest && frameBuffer != null && (frameBuffer.Formats == null || !frameBuffer.Formats[0].HasStencilAttachment()))
+                throw new InvalidOperationException("Cannot bind a frame buffer with no stencil attachment while stencil tests are enabled.");
 
             FlushCurrentBatch(FlushBatchSource.SetFrameBuffer);
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -18,9 +19,12 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
     {
         public osu.Framework.Graphics.Textures.Texture Texture { get; }
 
+        public IReadOnlyList<RenderBufferFormat>? Formats => formats;
+
         public Framebuffer Framebuffer { get; private set; }
 
         private readonly VeldridRenderer renderer;
+        private readonly RenderBufferFormat[]? formats;
         private readonly PixelFormat? depthFormat;
 
         private readonly VeldridTexture colourTarget;
@@ -50,15 +54,16 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         private readonly bool externalColourTarget;
 
-        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
+        public VeldridFrameBuffer(VeldridRenderer renderer, RenderBufferFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
         {
             // todo: we probably want the arguments separated to "PixelFormat[] colorFormats, PixelFormat depthFormat".
             if (formats?.Length > 1)
                 throw new ArgumentException("Veldrid framebuffer cannot contain more than one depth target.");
 
             this.renderer = renderer;
+            this.formats = formats;
 
-            depthFormat = formats?[0];
+            depthFormat = formats?[0].ToPixelFormat();
 
             colourTarget = new FrameBufferTexture(renderer, filteringMode);
             Texture = renderer.CreateTexture(colourTarget);

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -116,6 +116,27 @@ namespace osu.Framework.Graphics.Veldrid
             return writeMask;
         }
 
+        public static PixelFormat ToPixelFormat(this RenderBufferFormat renderBufferFormat)
+        {
+            switch (renderBufferFormat)
+            {
+                case RenderBufferFormat.D16:
+                    return PixelFormat.R16_UNorm;
+
+                case RenderBufferFormat.D32:
+                    return PixelFormat.R32_Float;
+
+                case RenderBufferFormat.D24S8:
+                    return PixelFormat.D24_UNorm_S8_UInt;
+
+                case RenderBufferFormat.D32S8:
+                    return PixelFormat.D32_Float_S8_UInt;
+
+                default:
+                    throw new ArgumentException($"Unsupported render buffer format: {renderBufferFormat}", nameof(renderBufferFormat));
+            }
+        }
+
         public static PixelFormat[] ToPixelFormats(this RenderBufferFormat[] renderBufferFormats)
         {
             var pixelFormats = new PixelFormat[renderBufferFormats.Length];

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Veldrid
             var options = new GraphicsDeviceOptions
             {
                 HasMainSwapchain = true,
-                SwapchainDepthFormat = PixelFormat.R16_UNorm,
+                SwapchainDepthFormat = IRenderer.DEPTH_STENCIL_FORMAT.ToPixelFormat(),
                 SyncToVerticalBlank = true,
                 ResourceBindingModel = ResourceBindingModel.Improved,
             };

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -576,7 +576,7 @@ namespace osu.Framework.Graphics.Veldrid
             => new VeldridShader(this, name, parts.Cast<VeldridShaderPart>().ToArray(), globalUniformBuffer, compilationStore);
 
         public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
-            => new VeldridFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
+            => new VeldridFrameBuffer(this, renderBufferFormats, filteringMode.ToSamplerFilter());
 
         protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, Rendering.PrimitiveTopology primitiveType)
         {


### PR DESCRIPTION
- [ ] Depends on #5863 (for the `ToPixelFormat` extension)
- One other and final step towards resolving https://github.com/ppy/osu/issues/23970
- May result in resolving https://github.com/ppy/osu-framework/issues/5858 (it doesn't on Metal)