### PR TITLE
Apply NRT to all files where it can be easily applied

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 ba1385330cc501f34937e08257e586c84e35d772
 # Make everything partial
 9bbc6a81a2b8f035e2b043d3718d2db6e4f1d868
+# Mass NRT enabling
+75ed421f60228920abd819cebc5982cb7799bbbb

--- a/SampleGame.iOS/Application.cs
+++ b/SampleGame.iOS/Application.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.iOS;
 
 namespace SampleGame.iOS

--- a/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Benchmarks
                 new CharacterGlyph(character, character, character, character, character, null),
                 new DummyRenderer().CreateTexture(1, 1));
 
-            public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+            public Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character) => Task.Run<ITexturedCharacterGlyph?>(() => Get(fontName, character));
         }
     }
 }

--- a/osu.Framework.Tests.iOS/Application.cs
+++ b/osu.Framework.Tests.iOS/Application.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.iOS;
 
 namespace osu.Framework.Tests

--- a/osu.Framework.Tests/Audio/AudioCollectionManagerTest.cs
+++ b/osu.Framework.Tests/Audio/AudioCollectionManagerTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Audio;

--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Audio.Sample;

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using ManagedBass;

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Threading;

--- a/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 

--- a/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 
 namespace osu.Framework.Tests.Audio

--- a/osu.Framework.Tests/Audio/TestAudioAdjustments.cs
+++ b/osu.Framework.Tests/Audio/TestAudioAdjustments.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Runtime.CompilerServices;

--- a/osu.Framework.Tests/AutomatedVisualTestGame.cs
+++ b/osu.Framework.Tests/AutomatedVisualTestGame.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests

--- a/osu.Framework.Tests/Bindables/BindableBoolTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBoolTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableEnumTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableEnumTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableIntTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableIntTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableLongTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLongTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableMarginPaddingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableMarginPaddingTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Bindables/BindableSizeTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableSizeTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using System.Drawing;
 using osu.Framework.Bindables;

--- a/osu.Framework.Tests/Bindables/BindableStringTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableStringTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 

--- a/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Bindables;

--- a/osu.Framework.Tests/Bindables/RangeConstrainedBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/RangeConstrainedBindableTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Bindables;

--- a/osu.Framework.Tests/Configuration/FrameworkConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/FrameworkConfigManagerTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Extensions/TestExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestExtensions.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Extensions;

--- a/osu.Framework.Tests/Extensions/TestStreamExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestStreamExtensions.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.IO;
 using System.Linq;

--- a/osu.Framework.Tests/Graphics/ColourTest.cs
+++ b/osu.Framework.Tests/Graphics/ColourTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Numerics;

--- a/osu.Framework.Tests/Graphics/ShaderRegexTest.cs
+++ b/osu.Framework.Tests/Graphics/ShaderRegexTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics.OpenGL.Shaders;

--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.IO;

--- a/osu.Framework.Tests/IO/TestSortedListSerialization.cs
+++ b/osu.Framework.Tests/IO/TestSortedListSerialization.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.Lists;

--- a/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Input.Bindings;

--- a/osu.Framework.Tests/Input/ReadableKeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/ReadableKeyCombinationTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Input;

--- a/osu.Framework.Tests/Lists/TestEnumerableExtensions.cs
+++ b/osu.Framework.Tests/Lists/TestEnumerableExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;

--- a/osu.Framework.Tests/Lists/TestWeakList.cs
+++ b/osu.Framework.Tests/Lists/TestWeakList.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableDescriptionAttributeTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using NUnit.Framework;

--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
+++ b/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Platform/PortableInstallationTest.cs
+++ b/osu.Framework.Tests/Platform/PortableInstallationTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Configuration;

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
+++ b/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClipperFuzzingTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
+++ b/osu.Framework.Tests/Polygons/ConvexPolygonClippingTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Primitives/TriangleTest.cs
+++ b/osu.Framework.Tests/Primitives/TriangleTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;
 using osuTK;

--- a/osu.Framework.Tests/Primitives/Vector2ExtensionsTest.cs
+++ b/osu.Framework.Tests/Primitives/Vector2ExtensionsTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using NUnit.Framework;

--- a/osu.Framework.Tests/TestGame.cs
+++ b/osu.Framework.Tests/TestGame.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.IO.Stores;

--- a/osu.Framework.Tests/Transforms/TestSceneTransformEventBindings.cs
+++ b/osu.Framework.Tests/Transforms/TestSceneTransformEventBindings.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using ManagedBass;

--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;

--- a/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
+++ b/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using osu.Framework.Bindables;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneBufferedContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osuTK;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCoordinateSpaces.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCoordinateSpaces.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Globalization;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneDynamicDepth.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBufferedContainer.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackTriangle.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackTriangle.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBorderSmoothing.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBorderSmoothing.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneColourGradient.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneColourGradient.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneEffects.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneEffects.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneHollowEdgeEffect.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneHollowEdgeEffect.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePropertyBoundaries.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/FrameworkGridTestScene.cs
+++ b/osu.Framework.Tests/Visual/FrameworkGridTestScene.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Testing;
 

--- a/osu.Framework.Tests/Visual/FrameworkTestScene.cs
+++ b/osu.Framework.Tests/Visual/FrameworkTestScene.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual

--- a/osu.Framework.Tests/Visual/FrameworkTestSceneTestRunner.cs
+++ b/osu.Framework.Tests/Visual/FrameworkTestSceneTestRunner.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.IO.Stores;

--- a/osu.Framework.Tests/Visual/Input/TestSceneHandleInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneHandleInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputQueueChange.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputQueueChange.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/osu.Framework.Tests/Visual/Input/TestSceneMidi.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMidi.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using osu.Framework.Allocation;
@@ -36,7 +34,7 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         protected override void LoadComplete()
         {

--- a/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Input/TestSceneReadableKeyCombinationProvider.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneReadableKeyCombinationProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -104,7 +102,7 @@ namespace osu.Framework.Tests.Visual.Input
         public partial class Key : CompositeDrawable
         {
             [Resolved]
-            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; } = null!;
 
             private readonly Box box;
             private readonly SpriteText text;
@@ -177,7 +175,7 @@ namespace osu.Framework.Tests.Visual.Input
         public partial class PressedKeyCombinationDisplay : CompositeDrawable
         {
             [Resolved]
-            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; }
+            private ReadableKeyCombinationProvider readableKeyCombinationProvider { get; set; } = null!;
 
             private readonly SpriteText text;
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using osu.Framework.Allocation;
@@ -49,7 +47,7 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         protected override void LoadComplete()
         {

--- a/osu.Framework.Tests/Visual/Platform/TestSceneAllowSuspension.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneAllowSuspension.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Allocation;

--- a/osu.Framework.Tests/Visual/Platform/TestSceneExternalLinks.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneExternalLinks.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -15,7 +13,7 @@ namespace osu.Framework.Tests.Visual.Platform
     public partial class TestSceneExternalLinks : FrameworkTestScene
     {
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         public TestSceneExternalLinks()
         {

--- a/osu.Framework.Tests/Visual/Platform/TestScenePresentFileExternally.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestScenePresentFileExternally.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -17,10 +15,10 @@ namespace osu.Framework.Tests.Visual.Platform
     public partial class TestScenePresentFileExternally : FrameworkTestScene
     {
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         [Resolved]
-        private Storage storage { get; set; }
+        private Storage storage { get; set; } = null!;
 
         protected override void LoadComplete()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimationLayout.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimationLayout.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -126,7 +124,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         private partial class TestTextureAnimation : TextureAnimation
         {
             [Resolved]
-            private FontStore fontStore { get; set; }
+            private FontStore fontStore { get; set; } = null!;
 
             public TestTextureAnimation()
             {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using NUnit.Framework;
@@ -44,7 +42,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         }
 
         [Resolved]
-        private FrameworkConfigManager config { get; set; }
+        private FrameworkConfigManager config { get; set; } = null!;
 
         [Test]
         public void TestToggleRomanisedState()

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSmoothedEdges.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSmoothedEdges.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteText.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTexturedTriangle.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTexturedTriangle.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideoLayout.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideoLayout.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.IO;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethods.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethods.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Tests.Visual.Testing
 {

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Testing;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedSource.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDrawVisualiser.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDrawVisualiser.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneIgnore.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneIgnore.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 
 namespace osu.Framework.Tests.Visual.Testing

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithExternalSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithExternalSource.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithValues.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithValues.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Tests.Bindables;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneButton.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneButton.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDirectorySelector.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDirectorySelector.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFileSelector.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFileSelector.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
@@ -25,9 +25,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 restitutionBacking = value;
 
-                if (sim == null)
-                    return;
-
                 foreach (var d in sim.Children)
                     d.Restitution = value;
                 sim.Restitution = value;
@@ -42,9 +39,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             set
             {
                 frictionBacking = value;
-
-                if (sim == null)
-                    return;
 
                 foreach (var d in sim.Children)
                     d.FrictionCoefficient = value;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -1099,7 +1099,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
                 if (shouldTakeOutLease)
                 {
-                    DummyBindable.BindTo(((TestScreen)e.Last).DummyBindable);
+                    DummyBindable.BindTo(((TestScreen)e.Last!).DummyBindable);
                     LeasedCopy = DummyBindable.BeginLease(true);
                 }
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneUnclosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneUnclosableMenu.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using NUnit.Framework;
 using osu.Framework.Bindables;

--- a/osu.Framework.Tests/VisualTestGame.cs
+++ b/osu.Framework.Tests/VisualTestGame.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.IO;

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -21,22 +21,28 @@ namespace osu.Framework.iOS.Graphics.Textures
 
         protected override Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
-            using (var uiImage = UIImage.LoadFromData(NSData.FromStream(stream)))
+            using (var nativeData = NSData.FromStream(stream))
             {
-                if (uiImage == null) throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+                if (nativeData == null)
+                    throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-                int width = (int)uiImage.Size.Width;
-                int height = (int)uiImage.Size.Height;
+                using (var uiImage = UIImage.LoadFromData(nativeData))
+                {
+                    if (uiImage == null) throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-                // TODO: Use pool/memory when builds success with Xamarin.
-                // Probably at .NET Core 3.1 time frame.
-                byte[] data = new byte[width * height * 4];
-                using (CGBitmapContext textureContext = new CGBitmapContext(data, width, height, 8, width * 4, CGColorSpace.CreateDeviceRGB(), CGImageAlphaInfo.PremultipliedLast))
-                    textureContext.DrawImage(new CGRect(0, 0, width, height), uiImage.CGImage);
+                    int width = (int)uiImage.Size.Width;
+                    int height = (int)uiImage.Size.Height;
 
-                var image = Image.LoadPixelData<TPixel>(data, width, height);
+                    // TODO: Use pool/memory when builds success with Xamarin.
+                    // Probably at .NET Core 3.1 time frame.
+                    byte[] data = new byte[width * height * 4];
+                    using (CGBitmapContext textureContext = new CGBitmapContext(data, width, height, 8, width * 4, CGColorSpace.CreateDeviceRGB(), CGImageAlphaInfo.PremultipliedLast))
+                        textureContext.DrawImage(new CGRect(0, 0, width, height), uiImage.CGImage);
 
-                return image;
+                    var image = Image.LoadPixelData<TPixel>(data, width, height);
+
+                    return image;
+                }
             }
         }
     }

--- a/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
+++ b/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.IO;
 using System.Runtime.InteropServices;

--- a/osu.Framework.iOS/IOSStorage.cs
+++ b/osu.Framework.iOS/IOSStorage.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Platform;
 

--- a/osu.Framework.iOS/IOSStorage.cs
+++ b/osu.Framework.iOS/IOSStorage.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using osu.Framework.Platform;
 
 namespace osu.Framework.iOS

--- a/osu.Framework.iOS/Properties/AssemblyInfo.cs
+++ b/osu.Framework.iOS/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 using ObjCRuntime;
 

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Bindables

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString(string format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
+        public override string ToString(string? format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<double> CreateInstance() => new BindableDouble();
     }

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Bindables

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString(string format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
+        public override string ToString(string? format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<float> CreateInstance() => new BindableFloat();
     }

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable disable
+
 using System;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Diagnostics;
 using System.Linq;

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Development
         public static bool LogPerformanceIssues { get; internal set; }
 
         // https://stackoverflow.com/a/2186634
-        private static bool isDebugAssembly(Assembly assembly) => assembly?.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled) ?? false;
+        private static bool isDebugAssembly(Assembly? assembly) => assembly?.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled) ?? false;
 
         /// <summary>
         /// Gets the entry assembly, or calling assembly otherwise.

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Performance;
 
 namespace osu.Framework.Graphics.Containers
@@ -136,7 +137,7 @@ namespace osu.Framework.Graphics.Containers
 
             public void Dispose()
             {
-                if (Drawable != null)
+                if (Drawable.IsNotNull())
                     Drawable.LifetimeChanged -= drawableLifetimeChanged;
             }
         }

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownFencedCodeBlock.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownFencedCodeBlock.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Markdig.Syntax;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
@@ -23,7 +21,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         private readonly FencedCodeBlock fencedCodeBlock;
 
         [Resolved]
-        private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
+        private IMarkdownTextFlowComponent parentFlowComponent { get; set; } = null!;
 
         public MarkdownFencedCodeBlock(FencedCodeBlock fencedCodeBlock)
         {

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cursor;
@@ -24,10 +22,10 @@ namespace osu.Framework.Graphics.Containers.Markdown
         public LocalisableString TooltipText => Url;
 
         [Resolved]
-        private IMarkdownTextComponent parentTextComponent { get; set; }
+        private IMarkdownTextComponent parentTextComponent { get; set; } = null!;
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         private readonly string text;
 

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownParagraph.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownParagraph.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using Markdig.Syntax;
 using osu.Framework.Allocation;
@@ -16,7 +14,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         private readonly ParagraphBlock paragraphBlock;
 
         [Resolved]
-        private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
+        private IMarkdownTextFlowComponent parentFlowComponent { get; set; } = null!;
 
         public MarkdownParagraph(ParagraphBlock paragraphBlock)
         {

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownQuoteBlock.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownQuoteBlock.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Markdig.Syntax;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
@@ -21,7 +19,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         private readonly QuoteBlock quoteBlock;
 
         [Resolved]
-        private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
+        private IMarkdownTextFlowComponent parentFlowComponent { get; set; } = null!;
 
         public MarkdownQuoteBlock(QuoteBlock quoteBlock)
         {

--- a/osu.Framework/Graphics/Containers/Markdown/NotImplementedMarkdown.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/NotImplementedMarkdown.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
             var text = parentTextComponent.CreateSpriteText();
             text.Colour = new Color4(255, 0, 0, 255);
             text.Font = text.Font.With(size: 21);
-            text.Text = markdownObject?.GetType() + " Not implemented.";
+            text.Text = markdownObject.GetType() + " Not implemented.";
             return text;
         }
     }

--- a/osu.Framework/Graphics/Containers/Markdown/NotImplementedMarkdown.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/NotImplementedMarkdown.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Markdig.Syntax;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Sprites;
@@ -18,7 +16,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         private readonly IMarkdownObject markdownObject;
 
         [Resolved]
-        private IMarkdownTextComponent parentTextComponent { get; set; }
+        private IMarkdownTextComponent parentTextComponent { get; set; } = null!;
 
         public NotImplementedMarkdown(IMarkdownObject markdownObject)
         {

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Allocation;
@@ -18,7 +16,7 @@ namespace osu.Framework.Graphics.Lines
     public partial class SmoothPath : Path
     {
         [Resolved]
-        private IRenderer renderer { get; set; }
+        private IRenderer renderer { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework/Graphics/Sprites/IHasText.cs
+++ b/osu.Framework/Graphics/Sprites/IHasText.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Localisation;
 
 namespace osu.Framework.Graphics.Sprites

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework/Graphics/Textures/ITextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ITextureUpload.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Colour;

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Threading;
 using System;
-using JetBrains.Annotations;
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Graphics
@@ -249,7 +248,7 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0,
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, Bindable<TValue> bindable, TValue newValue, double duration = 0,
                                                                           Easing easing = Easing.None)
             where T : class, ITransformable
             => t.TransformBindableTo(bindable, newValue, duration, new DefaultEasingFunction(easing));
@@ -487,7 +486,7 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue, TEasing>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration, TEasing easing)
+        public static TransformSequence<T> TransformBindableTo<T, TValue, TEasing>(this TransformSequence<T> t, Bindable<TValue> bindable, TValue newValue, double duration, TEasing easing)
             where T : class, ITransformable
             where TEasing : IEasingFunction
             => t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing));

--- a/osu.Framework/Graphics/Transforms/DefaultEasingFunction.cs
+++ b/osu.Framework/Graphics/Transforms/DefaultEasingFunction.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 

--- a/osu.Framework/Graphics/Transforms/ITransformable.cs
+++ b/osu.Framework/Graphics/Transforms/ITransformable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Timing;

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Utils;
 

--- a/osu.Framework/Graphics/UserInterface/BasicButton.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicButton.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;

--- a/osu.Framework/Graphics/UserInterface/BasicButton.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicButton.cs
@@ -15,12 +15,8 @@ namespace osu.Framework.Graphics.UserInterface
     {
         public LocalisableString Text
         {
-            get => SpriteText?.Text ?? default;
-            set
-            {
-                if (SpriteText != null)
-                    SpriteText.Text = value;
-            }
+            get => SpriteText.Text;
+            set => SpriteText.Text = value;
         }
 
         public Color4 BackgroundColour

--- a/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/BasicColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorParentDirectory.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.IO;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;

--- a/osu.Framework/Graphics/UserInterface/BasicHSVColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicHSVColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Shapes;
 

--- a/osu.Framework/Graphics/UserInterface/BasicMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicMenu.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 

--- a/osu.Framework/Graphics/UserInterface/BasicPasswordTextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicPasswordTextBox.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input;
 
 namespace osu.Framework.Graphics.UserInterface

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osuTK;
 using osuTK.Graphics;

--- a/osu.Framework/Graphics/UserInterface/BasicTextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicTextBox.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/Caret.cs
+++ b/osu.Framework/Graphics/UserInterface/Caret.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Containers;
 using osuTK;

--- a/osu.Framework/Graphics/UserInterface/Checkbox.cs
+++ b/osu.Framework/Graphics/UserInterface/Checkbox.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;

--- a/osu.Framework/Graphics/UserInterface/ColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/ColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/Counter.cs
+++ b/osu.Framework/Graphics/UserInterface/Counter.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;

--- a/osu.Framework/Graphics/UserInterface/DropdownMenuItem.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownMenuItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Localisation;
 

--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/IHasCurrentValue.cs
+++ b/osu.Framework/Graphics/UserInterface/IHasCurrentValue.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Graphics.UserInterface

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -496,7 +496,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             // Check if there is a sub menu to display
-            if (item.Item.Items?.Count == 0)
+            if (item.Item.Items.Count == 0)
             {
                 // This item must have attempted to invoke an action - close all menus if item allows
                 if (item.CloseMenuOnClick)
@@ -625,7 +625,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (IsHovered || (parentMenu?.IsHovered ?? false)) return;
 
-            if (triggeringItem?.Item.Items?.Contains(source) ?? triggeringItem == null)
+            if (triggeringItem?.Item.Items.Contains(source) ?? triggeringItem == null)
             {
                 Close();
                 parentMenu?.closeFromChild(triggeringItem?.Item);
@@ -834,7 +834,7 @@ namespace osu.Framework.Graphics.UserInterface
             /// </summary>
             protected bool IsActionable => hasSubmenu || (!Item.Action.Disabled && Item.Action.Value != null);
 
-            private bool hasSubmenu => Item.Items?.Count > 0;
+            private bool hasSubmenu => Item.Items.Count > 0;
 
             /// <summary>
             /// Called after the <see cref="BackgroundColour"/> is modified or the hover state changes.
@@ -892,7 +892,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (!IsActionable)
                     return true;
 
-                Item.Action.Value.Invoke();
+                Item.Action.Value?.Invoke();
                 Clicked?.Invoke(this);
                 return true;
             }

--- a/osu.Framework/Graphics/UserInterface/MenuItem.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuItem.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using osu.Framework.Bindables;

--- a/osu.Framework/Graphics/UserInterface/MenuItem.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuItem.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// The <see cref="Action"/> that is performed when this <see cref="MenuItem"/> is clicked.
         /// </summary>
-        public readonly Bindable<Action> Action = new Bindable<Action>();
+        public readonly Bindable<Action?> Action = new Bindable<Action?>();
 
         /// <summary>
         /// A list of items which are to be displayed in a sub-menu originating from this <see cref="MenuItem"/>.
@@ -48,7 +48,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         /// <param name="text">The text to display.</param>
         /// <param name="action">The <see cref="Action"/> to perform when clicked.</param>
-        public MenuItem(LocalisableString text, Action action)
+        public MenuItem(LocalisableString text, Action? action)
             : this(text)
         {
             Action.Value = action;

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Extensions;

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Globalization;
 using osu.Framework.Bindables;

--- a/osu.Framework/Graphics/Vector2Extensions.cs
+++ b/osu.Framework/Graphics/Vector2Extensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Primitives;

--- a/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
+++ b/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using FFmpeg.AutoGen;

--- a/osu.Framework/Graphics/Video/FFmpegExtensions.cs
+++ b/osu.Framework/Graphics/Video/FFmpegExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using FFmpeg.AutoGen;
 
 namespace osu.Framework.Graphics.Video

--- a/osu.Framework/Graphics/Video/HardwareVideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/HardwareVideoDecoder.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.ComponentModel;

--- a/osu.Framework/Graphics/Video/StdIo.cs
+++ b/osu.Framework/Graphics/Video/StdIo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Graphics.Video
 {
     internal static class StdIo

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics.Textures;
 using osuTK.Graphics.ES30;

--- a/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using ManagedBass;

--- a/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using ManagedBass.Mix;

--- a/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Linq;

--- a/osu.Framework/Graphics/Visualisation/IContainVisualisedDrawables.cs
+++ b/osu.Framework/Graphics/Visualisation/IContainVisualisedDrawables.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Graphics.Visualisation
 {
     /// <summary>

--- a/osu.Framework/Graphics/Visualisation/TitleBar.cs
+++ b/osu.Framework/Graphics/Visualisation/TitleBar.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework/Graphics/Visualisation/ToolWindow.cs
+++ b/osu.Framework/Graphics/Visualisation/ToolWindow.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/IO/Serialization/ISerializableBindable.cs
+++ b/osu.Framework/IO/Serialization/ISerializableBindable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Newtonsoft.Json;
 using osu.Framework.Bindables;
 

--- a/osu.Framework/IO/Serialization/ISerializableSortedList.cs
+++ b/osu.Framework/IO/Serialization/ISerializableSortedList.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using Newtonsoft.Json;
 using osu.Framework.Lists;
 

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -3,13 +3,12 @@
 
 #nullable disable
 
-using osu.Framework.Graphics.Textures;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using osu.Framework.Logging;
-using System.Collections.Concurrent;
-using JetBrains.Annotations;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Text;
 
@@ -131,7 +130,6 @@ namespace osu.Framework.IO.Stores
             base.RemoveStore(store);
         }
 
-        [CanBeNull]
         public ITexturedCharacterGlyph Get(string fontName, char character)
         {
             var key = (fontName, character);

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -6,6 +6,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
@@ -142,7 +143,7 @@ namespace osu.Framework.IO.Stores
             foreach (var store in glyphStores)
             {
                 if ((string.IsNullOrEmpty(fontName) || fontName == store.FontName) && store.HasGlyph(character))
-                    return namespacedGlyphCache[key] = new TexturedCharacterGlyph(store.Get(character), Get(textureName), 1 / ScaleAdjust);
+                    return namespacedGlyphCache[key] = new TexturedCharacterGlyph(store.Get(character).AsNonNull(), Get(textureName), 1 / ScaleAdjust);
             }
 
             foreach (var store in nestedFontStores)

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -118,7 +118,6 @@ namespace osu.Framework.IO.Stores
             return $@"{AssetName}_{page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png";
         }
 
-        [CanBeNull]
         public CharacterGlyph Get(char character)
         {
             if (Font == null)

--- a/osu.Framework/IO/Stores/IGlyphStore.cs
+++ b/osu.Framework/IO/Stores/IGlyphStore.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Threading.Tasks;
 using osu.Framework.Text;

--- a/osu.Framework/IO/Stores/IGlyphStore.cs
+++ b/osu.Framework/IO/Stores/IGlyphStore.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.IO.Stores
         /// </summary>
         /// <param name="character">The character to retrieve the <see cref="CharacterGlyph"/> for.</param>
         /// <returns>The <see cref="CharacterGlyph"/> containing associated spacing information for <paramref name="character"/>.</returns>
-        CharacterGlyph Get(char character);
+        CharacterGlyph? Get(char character);
 
         /// <summary>
         /// Retrieves the kerning for a pair of characters.

--- a/osu.Framework/IO/Stores/NamespacedResourceStore.cs
+++ b/osu.Framework/IO/Stores/NamespacedResourceStore.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/IStateful.cs
+++ b/osu.Framework/IStateful.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework

--- a/osu.Framework/Input/Bindings/IKeyBinding.cs
+++ b/osu.Framework/Input/Bindings/IKeyBinding.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Input.Bindings
 {

--- a/osu.Framework/Input/Bindings/IKeyBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IKeyBindingHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;

--- a/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.Events;
 

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Utils;
 

--- a/osu.Framework/Input/Bindings/KeyBindingExtensions.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingExtensions.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Input.Bindings
 {

--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Immutable;
 using System.Linq;

--- a/osu.Framework/Input/Events/ClickEvent.cs
+++ b/osu.Framework/Input/Events/ClickEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/DoubleClickEvent.cs
+++ b/osu.Framework/Input/Events/DoubleClickEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/DragEndEvent.cs
+++ b/osu.Framework/Input/Events/DragEndEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/DragEvent.cs
+++ b/osu.Framework/Input/Events/DragEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/DragStartEvent.cs
+++ b/osu.Framework/Input/Events/DragStartEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/FocusEvent.cs
+++ b/osu.Framework/Input/Events/FocusEvent.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Input.States;
 
@@ -15,8 +14,7 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// The <see cref="Drawable"/> that has lost focus, or <c>null</c> if nothing was previously focused.
         /// </summary>
-        [CanBeNull]
-        public readonly Drawable PreviouslyFocused;
+        public readonly Drawable? PreviouslyFocused;
 
         public FocusEvent(InputState state, Drawable previouslyFocused)
             : base(state)

--- a/osu.Framework/Input/Events/FocusEvent.cs
+++ b/osu.Framework/Input/Events/FocusEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using JetBrains.Annotations;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/Events/FocusEvent.cs
+++ b/osu.Framework/Input/Events/FocusEvent.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input.Events
         /// </summary>
         public readonly Drawable? PreviouslyFocused;
 
-        public FocusEvent(InputState state, Drawable previouslyFocused)
+        public FocusEvent(InputState state, Drawable? previouslyFocused)
             : base(state)
         {
             PreviouslyFocused = previouslyFocused;

--- a/osu.Framework/Input/Events/FocusLostEvent.cs
+++ b/osu.Framework/Input/Events/FocusLostEvent.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input.Events
         /// </summary>
         public readonly Drawable? NextFocused;
 
-        public FocusLostEvent(InputState state, Drawable nextFocused)
+        public FocusLostEvent(InputState state, Drawable? nextFocused)
             : base(state)
         {
             NextFocused = nextFocused;

--- a/osu.Framework/Input/Events/FocusLostEvent.cs
+++ b/osu.Framework/Input/Events/FocusLostEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using JetBrains.Annotations;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/Events/FocusLostEvent.cs
+++ b/osu.Framework/Input/Events/FocusLostEvent.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Graphics;
 using osu.Framework.Input.States;
 
@@ -15,8 +14,7 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// The <see cref="Drawable"/> that will gain focus, or <c>null</c> if nothing will gain focus.
         /// </summary>
-        [CanBeNull]
-        public readonly Drawable NextFocused;
+        public readonly Drawable? NextFocused;
 
         public FocusLostEvent(InputState state, Drawable nextFocused)
             : base(state)

--- a/osu.Framework/Input/Events/HoverEvent.cs
+++ b/osu.Framework/Input/Events/HoverEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events

--- a/osu.Framework/Input/Events/HoverLostEvent.cs
+++ b/osu.Framework/Input/Events/HoverLostEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events

--- a/osu.Framework/Input/Events/JoystickAxisMoveEvent.cs
+++ b/osu.Framework/Input/Events/JoystickAxisMoveEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using JetBrains.Annotations;
 using osu.Framework.Extensions.TypeExtensions;

--- a/osu.Framework/Input/Events/JoystickAxisMoveEvent.cs
+++ b/osu.Framework/Input/Events/JoystickAxisMoveEvent.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 
@@ -27,7 +26,7 @@ namespace osu.Framework.Input.Events
         /// </summary>
         public float Delta => Axis.Value - LastValue;
 
-        public JoystickAxisMoveEvent([NotNull] InputState state, JoystickAxis axis, float lastValue)
+        public JoystickAxisMoveEvent(InputState state, JoystickAxis axis, float lastValue)
             : base(state)
         {
             LastValue = lastValue;

--- a/osu.Framework/Input/Events/JoystickButtonEvent.cs
+++ b/osu.Framework/Input/Events/JoystickButtonEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/JoystickEvent.cs
+++ b/osu.Framework/Input/Events/JoystickEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Input/Events/JoystickEvent.cs
+++ b/osu.Framework/Input/Events/JoystickEvent.cs
@@ -3,14 +3,13 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events
 {
     public abstract class JoystickEvent : UIEvent
     {
-        protected JoystickEvent([NotNull] InputState state)
+        protected JoystickEvent(InputState state)
             : base(state)
         {
         }

--- a/osu.Framework/Input/Events/JoystickPressEvent.cs
+++ b/osu.Framework/Input/Events/JoystickPressEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events

--- a/osu.Framework/Input/Events/JoystickReleaseEvent.cs
+++ b/osu.Framework/Input/Events/JoystickReleaseEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events

--- a/osu.Framework/Input/Events/KeyBindingEvent.cs
+++ b/osu.Framework/Input/Events/KeyBindingEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/KeyBindingPressEvent.cs
+++ b/osu.Framework/Input/Events/KeyBindingPressEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/KeyBindingReleaseEvent.cs
+++ b/osu.Framework/Input/Events/KeyBindingReleaseEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/KeyBindingScrollEvent.cs
+++ b/osu.Framework/Input/Events/KeyBindingScrollEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/KeyDownEvent.cs
+++ b/osu.Framework/Input/Events/KeyDownEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/KeyUpEvent.cs
+++ b/osu.Framework/Input/Events/KeyUpEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK.Input;
 

--- a/osu.Framework/Input/Events/KeyboardEvent.cs
+++ b/osu.Framework/Input/Events/KeyboardEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/MidiDownEvent.cs
+++ b/osu.Framework/Input/Events/MidiDownEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using JetBrains.Annotations;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/MidiDownEvent.cs
+++ b/osu.Framework/Input/Events/MidiDownEvent.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events
 {
     public class MidiDownEvent : MidiEvent
     {
-        public MidiDownEvent([NotNull] InputState state, MidiKey key, byte velocity)
+        public MidiDownEvent(InputState state, MidiKey key, byte velocity)
             : base(state, key, velocity)
         {
         }

--- a/osu.Framework/Input/Events/MidiEvent.cs
+++ b/osu.Framework/Input/Events/MidiEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using JetBrains.Annotations;

--- a/osu.Framework/Input/Events/MidiEvent.cs
+++ b/osu.Framework/Input/Events/MidiEvent.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 
@@ -28,7 +27,7 @@ namespace osu.Framework.Input.Events
         /// </summary>
         public IEnumerable<MidiKey> PressedKeys => CurrentState.Midi.Keys;
 
-        protected MidiEvent([NotNull] InputState state, MidiKey key, byte velocity)
+        protected MidiEvent(InputState state, MidiKey key, byte velocity)
             : base(state)
         {
             Key = key;

--- a/osu.Framework/Input/Events/MidiUpEvent.cs
+++ b/osu.Framework/Input/Events/MidiUpEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using JetBrains.Annotations;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/MidiUpEvent.cs
+++ b/osu.Framework/Input/Events/MidiUpEvent.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using JetBrains.Annotations;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events
 {
     public class MidiUpEvent : MidiEvent
     {
-        public MidiUpEvent([NotNull] InputState state, MidiKey key)
+        public MidiUpEvent(InputState state, MidiKey key)
             : base(state, key, 0)
         {
         }

--- a/osu.Framework/Input/Events/MouseButtonEvent.cs
+++ b/osu.Framework/Input/Events/MouseButtonEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/Events/MouseDownEvent.cs
+++ b/osu.Framework/Input/Events/MouseDownEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/MouseEvent.cs
+++ b/osu.Framework/Input/Events/MouseEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/MouseMoveEvent.cs
+++ b/osu.Framework/Input/Events/MouseMoveEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/Events/MouseUpEvent.cs
+++ b/osu.Framework/Input/Events/MouseUpEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;

--- a/osu.Framework/Input/Events/ScrollEvent.cs
+++ b/osu.Framework/Input/Events/ScrollEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/TabletAuxiliaryButtonEvent.cs
+++ b/osu.Framework/Input/Events/TabletAuxiliaryButtonEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/TabletAuxiliaryButtonPressEvent.cs
+++ b/osu.Framework/Input/Events/TabletAuxiliaryButtonPressEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/TabletAuxiliaryButtonReleaseEvent.cs
+++ b/osu.Framework/Input/Events/TabletAuxiliaryButtonReleaseEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/TabletEvent.cs
+++ b/osu.Framework/Input/Events/TabletEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using JetBrains.Annotations;

--- a/osu.Framework/Input/Events/TabletEvent.cs
+++ b/osu.Framework/Input/Events/TabletEvent.cs
@@ -2,14 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events
 {
     public abstract class TabletEvent : UIEvent
     {
-        protected TabletEvent([NotNull] InputState state)
+        protected TabletEvent(InputState state)
             : base(state)
         {
         }

--- a/osu.Framework/Input/Events/TabletPenButtonEvent.cs
+++ b/osu.Framework/Input/Events/TabletPenButtonEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/Events/TabletPenButtonPressEvent.cs
+++ b/osu.Framework/Input/Events/TabletPenButtonPressEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/TabletPenButtonReleaseEvent.cs
+++ b/osu.Framework/Input/Events/TabletPenButtonReleaseEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/Events/TouchDownEvent.cs
+++ b/osu.Framework/Input/Events/TouchDownEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.Events

--- a/osu.Framework/Input/Events/TouchEvent.cs
+++ b/osu.Framework/Input/Events/TouchEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/Events/TouchMoveEvent.cs
+++ b/osu.Framework/Input/Events/TouchMoveEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 

--- a/osu.Framework/Input/Events/TouchUpEvent.cs
+++ b/osu.Framework/Input/Events/TouchUpEvent.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.States;
 using osuTK;
 

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Input.Bindings;
 

--- a/osu.Framework/Input/Handlers/IHasCursorSensitivity.cs
+++ b/osu.Framework/Input/Handlers/IHasCursorSensitivity.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Input.Handlers

--- a/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
+++ b/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osuTK;
 
 namespace osu.Framework.Input.Handlers

--- a/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Bindables;

--- a/osu.Framework/Input/Handlers/Keyboard/KeyboardHandler.cs
+++ b/osu.Framework/Input/Handlers/Keyboard/KeyboardHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;

--- a/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
+++ b/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Pointer;

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 using osuTK;

--- a/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osuTK;
 

--- a/osu.Framework/Input/InputResampler.cs
+++ b/osu.Framework/Input/InputResampler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework/Input/JoystickAxis.cs
+++ b/osu.Framework/Input/JoystickAxis.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Input
 {
     public readonly struct JoystickAxis

--- a/osu.Framework/Input/JoystickAxisSource.cs
+++ b/osu.Framework/Input/JoystickAxisSource.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Input
 {

--- a/osu.Framework/Input/JoystickButton.cs
+++ b/osu.Framework/Input/JoystickButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Input
 {
     public enum JoystickButton

--- a/osu.Framework/Input/JoystickButtonEventManager.cs
+++ b/osu.Framework/Input/JoystickButtonEventManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/JoystickButtonEventManager.cs
+++ b/osu.Framework/Input/JoystickButtonEventManager.cs
@@ -17,12 +17,7 @@ namespace osu.Framework.Input
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new JoystickPressEvent(state, Button));
 
-        protected override void HandleButtonUp(InputState state, List<Drawable> targets)
-        {
-            if (targets == null)
-                return;
-
+        protected override void HandleButtonUp(InputState state, List<Drawable> targets) =>
             PropagateButtonEvent(targets, new JoystickReleaseEvent(state, Button));
-        }
     }
 }

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -31,12 +31,7 @@ namespace osu.Framework.Input
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new KeyDownEvent(state, Button));
 
-        protected override void HandleButtonUp(InputState state, List<Drawable> targets)
-        {
-            if (targets == null)
-                return;
-
+        protected override void HandleButtonUp(InputState state, List<Drawable> targets) =>
             PropagateButtonEvent(targets, new KeyUpEvent(state, Button));
-        }
     }
 }

--- a/osu.Framework/Input/MidiKey.cs
+++ b/osu.Framework/Input/MidiKey.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Input
 {

--- a/osu.Framework/Input/MidiKeyEventManager.cs
+++ b/osu.Framework/Input/MidiKeyEventManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/MidiKeyEventManager.cs
+++ b/osu.Framework/Input/MidiKeyEventManager.cs
@@ -17,12 +17,7 @@ namespace osu.Framework.Input
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new MidiDownEvent(state, Button, state.Midi.Velocities[Button]));
 
-        protected override void HandleButtonUp(InputState state, List<Drawable> targets)
-        {
-            if (targets == null)
-                return;
-
+        protected override void HandleButtonUp(InputState state, List<Drawable> targets) =>
             PropagateButtonEvent(targets, new MidiUpEvent(state, Button));
-        }
     }
 }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
@@ -181,13 +182,13 @@ namespace osu.Framework.Input
             new TouchInput(touchStateDifference.deactivated, false).Apply(CurrentState, this);
             new TouchInput(touchStateDifference.activated, true).Apply(CurrentState, this);
 
-            new JoystickButtonInput(state?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
-            new JoystickAxisInput(state?.Joystick?.GetAxes()).Apply(CurrentState, this);
+            new JoystickButtonInput(state?.Joystick?.Buttons ?? new ButtonStates<JoystickButton>(), CurrentState.Joystick.Buttons).Apply(CurrentState, this);
+            new JoystickAxisInput(state?.Joystick?.GetAxes() ?? Array.Empty<JoystickAxis>()).Apply(CurrentState, this);
 
-            new MidiKeyInput(state?.Midi, CurrentState.Midi).Apply(CurrentState, this);
+            new MidiKeyInput(state?.Midi ?? new MidiState(), CurrentState.Midi).Apply(CurrentState, this);
 
-            new TabletPenButtonInput(state?.Tablet.PenButtons, CurrentState.Tablet.PenButtons).Apply(CurrentState, this);
-            new TabletAuxiliaryButtonInput(state?.Tablet.AuxiliaryButtons, CurrentState.Tablet.AuxiliaryButtons).Apply(CurrentState, this);
+            new TabletPenButtonInput(state?.Tablet.PenButtons ?? new ButtonStates<TabletPenButton>(), CurrentState.Tablet.PenButtons).Apply(CurrentState, this);
+            new TabletAuxiliaryButtonInput(state?.Tablet.AuxiliaryButtons ?? new ButtonStates<TabletAuxiliaryButton>(), CurrentState.Tablet.AuxiliaryButtons).Apply(CurrentState, this);
         }
     }
 }

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
@@ -19,7 +17,7 @@ namespace osu.Framework.Input
     public partial class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalKeyboardInput
     {
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
         public PlatformActionContainer()
             : base(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Modifiers)

--- a/osu.Framework/Input/SDL2WindowTextInput.cs
+++ b/osu.Framework/Input/SDL2WindowTextInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Platform;

--- a/osu.Framework/Input/SDL2WindowTextInput.cs
+++ b/osu.Framework/Input/SDL2WindowTextInput.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Input
             }
         }
 
-        private void handleTextEditing(string text, int selectionStart, int selectionLength)
+        private void handleTextEditing(string? text, int selectionStart, int selectionLength)
         {
             if (text == null) return;
 

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using osu.Framework.Input.StateChanges.Events;

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Input.StateChanges
         /// </remarks>
         /// <param name="current">The newer <see cref="ButtonStates{TButton}"/>.</param>
         /// <param name="previous">The older <see cref="ButtonStates{TButton}"/>.</param>
-        protected ButtonInput(ButtonStates<TButton> current, ButtonStates<TButton> previous)
+        protected ButtonInput(ButtonStates<TButton>? current, ButtonStates<TButton>? previous)
         {
             var difference = (current ?? new ButtonStates<TButton>()).EnumerateDifference(previous ?? new ButtonStates<TButton>());
 

--- a/osu.Framework/Input/StateChanges/ButtonInputEntry.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInputEntry.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Input.StateChanges
 {
     /// <summary>

--- a/osu.Framework/Input/StateChanges/Events/ButtonStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/ButtonStateChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using JetBrains.Annotations;

--- a/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using JetBrains.Annotations;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.StateChanges.Events
@@ -16,14 +15,12 @@ namespace osu.Framework.Input.StateChanges.Events
         /// <summary>
         /// The <see cref="InputState"/> changed by this event.
         /// </summary>
-        [NotNull]
         public readonly InputState State;
 
         /// <summary>
         /// The <see cref="IInput"/> that caused this input state change.
         /// </summary>
-        [CanBeNull]
-        public readonly IInput Input;
+        public readonly IInput? Input;
 
         protected InputStateChangeEvent(InputState state, IInput input)
         {

--- a/osu.Framework/Input/StateChanges/Events/JoystickAxisChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/JoystickAxisChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/Events/MouseScrollChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MouseScrollChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/IInput.cs
+++ b/osu.Framework/Input/StateChanges/IInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/StateChanges/IInputStateChangeHandler.cs
+++ b/osu.Framework/Input/StateChanges/IInputStateChangeHandler.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.StateChanges.Events;
 

--- a/osu.Framework/Input/StateChanges/JoystickAxisInput.cs
+++ b/osu.Framework/Input/StateChanges/JoystickAxisInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework/Input/StateChanges/JoystickButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/JoystickButtonInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Input.States;
 

--- a/osu.Framework/Input/StateChanges/KeyboardKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/KeyboardKeyInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Input.States;
 using osuTK.Input;

--- a/osu.Framework/Input/StateChanges/KeyboardKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/KeyboardKeyInput.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Input.StateChanges
         {
         }
 
-        public KeyboardKeyInput(ButtonStates<Key> current, ButtonStates<Key> previous)
+        public KeyboardKeyInput(ButtonStates<Key>? current, ButtonStates<Key>? previous)
             : base(current, previous)
         {
         }

--- a/osu.Framework/Input/StateChanges/MidiKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/MidiKeyInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Input/StateChanges/MouseButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using osu.Framework.Input.States;
 using osuTK.Input;

--- a/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.StateChanges.Events;
 using osuTK.Input;

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.StateChanges.Events;
 

--- a/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK;

--- a/osu.Framework/Input/StateChanges/TabletAuxiliaryButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/TabletAuxiliaryButtonInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/StateChanges/TabletPenButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/TabletPenButtonInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Input.States;

--- a/osu.Framework/Input/StateChanges/TouchInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchInput.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections;

--- a/osu.Framework/Input/States/JoystickState.cs
+++ b/osu.Framework/Input/States/JoystickState.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 

--- a/osu.Framework/Input/States/KeyboardState.cs
+++ b/osu.Framework/Input/States/KeyboardState.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osuTK.Input;
 

--- a/osu.Framework/Input/States/MidiState.cs
+++ b/osu.Framework/Input/States/MidiState.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 

--- a/osu.Framework/Input/States/TabletState.cs
+++ b/osu.Framework/Input/States/TabletState.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Extensions.TypeExtensions;
 using osuTK;

--- a/osu.Framework/Input/States/TouchState.cs
+++ b/osu.Framework/Input/States/TouchState.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
+++ b/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
+++ b/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
@@ -17,12 +17,6 @@ namespace osu.Framework.Input
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletAuxiliaryButtonPressEvent(state, Button));
 
-        protected override void HandleButtonUp(InputState state, List<Drawable> targets)
-        {
-            if (targets == null)
-                return;
-
-            PropagateButtonEvent(targets, new TabletAuxiliaryButtonReleaseEvent(state, Button));
-        }
+        protected override void HandleButtonUp(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletAuxiliaryButtonReleaseEvent(state, Button));
     }
 }

--- a/osu.Framework/Input/TabletPenButtonEventManager.cs
+++ b/osu.Framework/Input/TabletPenButtonEventManager.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/TabletPenButtonEventManager.cs
+++ b/osu.Framework/Input/TabletPenButtonEventManager.cs
@@ -17,12 +17,6 @@ namespace osu.Framework.Input
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletPenButtonPressEvent(state, Button));
 
-        protected override void HandleButtonUp(InputState state, List<Drawable> targets)
-        {
-            if (targets == null)
-                return;
-
-            PropagateButtonEvent(targets, new TabletPenButtonReleaseEvent(state, Button));
-        }
+        protected override void HandleButtonUp(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletPenButtonReleaseEvent(state, Button));
     }
 }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Drawing;

--- a/osu.Framework/Layout/InvalidationSource.cs
+++ b/osu.Framework/Layout/InvalidationSource.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Graphics;

--- a/osu.Framework/Lists/INotifyArrayChanged.cs
+++ b/osu.Framework/Lists/INotifyArrayChanged.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Lists

--- a/osu.Framework/Lists/IWeakList.cs
+++ b/osu.Framework/Lists/IWeakList.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 

--- a/osu.Framework/Lists/LazyList.cs
+++ b/osu.Framework/Lists/LazyList.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/osu.Framework/Localisation/ILocalisedBindableString.cs
+++ b/osu.Framework/Localisation/ILocalisedBindableString.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Bindables;
 

--- a/osu.Framework/Localisation/LocalisableDescriptionAttribute.cs
+++ b/osu.Framework/Localisation/LocalisableDescriptionAttribute.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Extensions;

--- a/osu.Framework/Logging/LoadingComponentsLogger.cs
+++ b/osu.Framework/Logging/LoadingComponentsLogger.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using System.Threading;

--- a/osu.Framework/Logging/RollingTime.cs
+++ b/osu.Framework/Logging/RollingTime.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Logging

--- a/osu.Framework/Physics/IRigidBody.cs
+++ b/osu.Framework/Physics/IRigidBody.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osuTK;

--- a/osu.Framework/Physics/RigidBodySimulation.cs
+++ b/osu.Framework/Physics/RigidBodySimulation.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osuTK;
 using osu.Framework.Graphics;
 using System.Collections.Generic;

--- a/osu.Framework/Platform/DesktopStorage.cs
+++ b/osu.Framework/Platform/DesktopStorage.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Platform
 {

--- a/osu.Framework/Platform/ExecutionMode.cs
+++ b/osu.Framework/Platform/ExecutionMode.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.ComponentModel;
 

--- a/osu.Framework/Platform/FlushingStream.cs
+++ b/osu.Framework/Platform/FlushingStream.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.IO;
 

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 

--- a/osu.Framework/Platform/Linux/LinuxReadableKeyCombinationProvider.cs
+++ b/osu.Framework/Platform/Linux/LinuxReadableKeyCombinationProvider.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.Bindings;
 using osu.Framework.Platform.SDL2;

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Platform.MacOS.Native;
 using SixLabors.ImageSharp;

--- a/osu.Framework/Platform/MacOS/MacOSReadableKeyCombinationProvider.cs
+++ b/osu.Framework/Platform/MacOS/MacOSReadableKeyCombinationProvider.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Input.Bindings;
 using osu.Framework.Platform.SDL2;

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/osu.Framework/Platform/MacOS/Native/NSArray.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSArray.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Platform.MacOS.Native

--- a/osu.Framework/Platform/MacOS/Native/NSData.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSData.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Runtime.InteropServices;

--- a/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Platform.MacOS.Native

--- a/osu.Framework/Platform/MacOS/Native/NSNotificationCenter.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSNotificationCenter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Platform.MacOS.Native

--- a/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Platform.MacOS.Native

--- a/osu.Framework/Platform/MacOS/Native/NSStringEncoding.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSStringEncoding.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Platform.MacOS.Native
 {

--- a/osu.Framework/Platform/MacOS/Native/Selector.cs
+++ b/osu.Framework/Platform/MacOS/Native/Selector.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
 

--- a/osu.Framework/Platform/MonoPInvokeCallbackAttribute.cs
+++ b/osu.Framework/Platform/MonoPInvokeCallbackAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Runtime.CompilerServices;
 

--- a/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ReadableKeyCombinationProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Globalization;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;

--- a/osu.Framework/Platform/SDL2/SDL2Structs.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Structs.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Runtime.InteropServices;

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.

--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Runtime.CompilerServices;
 using System.Reflection.Metadata;
 using osu.Framework.Testing;

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Diagnostics;

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -20,7 +18,7 @@ namespace osu.Framework.Screens
         public sealed override bool RemoveWhenNotAlive => false;
 
         [Resolved]
-        protected Game Game { get; private set; }
+        protected Game Game { get; private set; } = null!;
 
         public Screen()
         {

--- a/osu.Framework/Screens/ScreenExitEvent.cs
+++ b/osu.Framework/Screens/ScreenExitEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Screens
 {

--- a/osu.Framework/Screens/ScreenTransitionEvent.cs
+++ b/osu.Framework/Screens/ScreenTransitionEvent.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Screens
 {

--- a/osu.Framework/Screens/ScreenTransitionEvent.cs
+++ b/osu.Framework/Screens/ScreenTransitionEvent.cs
@@ -11,14 +11,14 @@ namespace osu.Framework.Screens
         /// <summary>
         /// The <see cref="IScreen"/> which has been transitioned from.
         /// </summary>
-        public IScreen Last { get; }
+        public IScreen? Last { get; }
 
         /// <summary>
         /// The <see cref="IScreen"/> which has been transitioned to.
         /// </summary>
         public IScreen Next { get; }
 
-        public ScreenTransitionEvent(IScreen last, IScreen next)
+        public ScreenTransitionEvent(IScreen? last, IScreen next)
         {
             Last = last;
             Next = next;

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 

--- a/osu.Framework/Statistics/IGlobalStatistic.cs
+++ b/osu.Framework/Statistics/IGlobalStatistic.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Statistics
 {

--- a/osu.Framework/Statistics/TypePerformanceMonitor.cs
+++ b/osu.Framework/Statistics/TypePerformanceMonitor.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using System.Collections.Generic;

--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Testing
             };
         }
 
-        [BackgroundDependencyLoader(true)]
+        [BackgroundDependencyLoader]
         private void load(TestBrowser? browser)
         {
             if (browser != null)

--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -31,7 +30,7 @@ namespace osu.Framework.Testing
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load([CanBeNull] TestBrowser browser)
+        private void load(TestBrowser? browser)
         {
             if (browser != null)
             {

--- a/osu.Framework/Testing/Drawables/Sections/ToolbarRateSection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarRateSection.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/Drawables/Steps/LabelStep.cs
+++ b/osu.Framework/Testing/Drawables/Steps/LabelStep.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osuTK.Graphics;
 

--- a/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using osu.Framework.Graphics;
 using osuTK.Graphics;

--- a/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Testing.Drawables.Steps
         {
             State = !State;
             Light.FadeColour(State ? on_colour : off_colour);
-            reloadCallback?.Invoke(State);
+            reloadCallback.Invoke(State);
 
             if (!State)
                 Success();

--- a/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/ToggleStepButton.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 {
     public partial class ToggleStepButton : StepButton
     {
-        private readonly Action<bool> reloadCallback;
+        private readonly Action<bool>? reloadCallback;
         private static readonly Color4 off_colour = Color4.Red;
         private static readonly Color4 on_colour = Color4.YellowGreen;
 
@@ -17,7 +17,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         public override int RequiredRepetitions => 2;
 
-        public ToggleStepButton(Action<bool> reloadCallback)
+        public ToggleStepButton(Action<bool>? reloadCallback)
         {
             this.reloadCallback = reloadCallback;
             Action = clickAction;
@@ -28,7 +28,7 @@ namespace osu.Framework.Testing.Drawables.Steps
         {
             State = !State;
             Light.FadeColour(State ? on_colour : off_colour);
-            reloadCallback.Invoke(State);
+            reloadCallback?.Invoke(State);
 
             if (!State)
                 Success();

--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Testing.Drawables
 {
     internal partial class TestGroupButton : VisibilityContainer, IFilterable
     {
-        public IEnumerable<LocalisableString> FilterTerms => headerButton?.FilterTerms ?? Enumerable.Empty<LocalisableString>();
+        public IEnumerable<LocalisableString> FilterTerms => headerButton.FilterTerms;
 
         public bool MatchingFilter
         {

--- a/osu.Framework/Testing/Drawables/ToolbarSection.cs
+++ b/osu.Framework/Testing/Drawables/ToolbarSection.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Containers;
 

--- a/osu.Framework/Testing/GridTestScene.cs
+++ b/osu.Framework/Testing/GridTestScene.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Testing/HeadlessTestAttribute.cs
+++ b/osu.Framework/Testing/HeadlessTestAttribute.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using JetBrains.Annotations;

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using System;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/Input/TestCursorContainer.cs
+++ b/osu.Framework/Testing/Input/TestCursorContainer.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Linq;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/SetUpStepsAttribute.cs
+++ b/osu.Framework/Testing/SetUpStepsAttribute.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using JetBrains.Annotations;

--- a/osu.Framework/Testing/TearDownStepsAttribute.cs
+++ b/osu.Framework/Testing/TearDownStepsAttribute.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System;
 using JetBrains.Annotations;

--- a/osu.Framework/Testing/TestBrowserConfig.cs
+++ b/osu.Framework/Testing/TestBrowserConfig.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Configuration;
 using osu.Framework.Platform;

--- a/osu.Framework/Testing/TestingExtensions.cs
+++ b/osu.Framework/Testing/TestingExtensions.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Collections.Generic;
 using osu.Framework.Graphics;

--- a/osu.Framework/Testing/TestingExtensions.cs
+++ b/osu.Framework/Testing/TestingExtensions.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Testing
         /// <summary>
         /// Find all children recursively of a specific type. As this is expensive and dangerous, it should only be used for testing purposes.
         /// </summary>
-        public static IEnumerable<T> ChildrenOfType<T>(this Drawable drawable)
+        public static IEnumerable<T> ChildrenOfType<T>(this Drawable? drawable)
         {
             if (drawable is T match)
                 yield return match;

--- a/osu.Framework/Text/ICharacterGlyph.cs
+++ b/osu.Framework/Text/ICharacterGlyph.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 namespace osu.Framework.Text
 {

--- a/osu.Framework/Text/ITexturedCharacterGlyph.cs
+++ b/osu.Framework/Text/ITexturedCharacterGlyph.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using osu.Framework.Graphics.Textures;
 

--- a/osu.Framework/Text/ITexturedCharacterGlyph.cs
+++ b/osu.Framework/Text/ITexturedCharacterGlyph.cs
@@ -33,6 +33,6 @@ namespace osu.Framework.Text
         /// </summary>
         public static bool IsWhiteSpace<T>(this T glyph)
             where T : ITexturedCharacterGlyph
-            => glyph.Texture == null || char.IsWhiteSpace(glyph.Character);
+            => char.IsWhiteSpace(glyph.Character);
     }
 }

--- a/osu.Framework/Text/ITexturedGlyphLookupStore.cs
+++ b/osu.Framework/Text/ITexturedGlyphLookupStore.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Threading.Tasks;
 

--- a/osu.Framework/Text/ITexturedGlyphLookupStore.cs
+++ b/osu.Framework/Text/ITexturedGlyphLookupStore.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Text
         /// <param name="fontName">The name of the font.</param>
         /// <param name="character">The character to retrieve.</param>
         /// <returns>The character glyph.</returns>
-        ITexturedCharacterGlyph Get(string fontName, char character);
+        ITexturedCharacterGlyph? Get(string fontName, char character);
 
         /// <summary>
         /// Retrieves a glyph from the store asynchronously.
@@ -21,6 +21,6 @@ namespace osu.Framework.Text
         /// <param name="fontName">The name of the font.</param>
         /// <param name="character">The character to retrieve.</param>
         /// <returns>The character glyph.</returns>
-        Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character);
+        Task<ITexturedCharacterGlyph?> GetAsync(string fontName, char character);
     }
 }

--- a/osu.Framework/Text/TextBuilder.cs
+++ b/osu.Framework/Text/TextBuilder.cs
@@ -356,9 +356,9 @@ namespace osu.Framework.Text
         private ITexturedCharacterGlyph getTexturedGlyph(char character)
         {
             return store.Get(font.FontName, character)
-                   ?? store.Get(null, character)
+                   ?? store.Get(string.Empty, character)
                    ?? store.Get(font.FontName, fallbackCharacter)
-                   ?? store.Get(null, fallbackCharacter);
+                   ?? store.Get(string.Empty, fallbackCharacter);
         }
     }
 }

--- a/osu.Framework/Text/TextBuilderGlyph.cs
+++ b/osu.Framework/Text/TextBuilderGlyph.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Primitives;

--- a/osu.Framework/Text/TexturedCharacterGlyph.cs
+++ b/osu.Framework/Text/TexturedCharacterGlyph.cs
@@ -1,7 +1,5 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
-
-#nullable disable
 
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Textures;


### PR DESCRIPTION
Something I've had sitting around. Tested against osu! (see https://github.com/ppy/osu/pull/24019).

Another pass will follow, but feel that getting this one out of the way is a good first step.

- 75ed421 is an automated pass. reviewing it separately is recommended as it should be a breeze
- 3064650 are manual fixes after the automated pass to fix non-compile-time warnings (aka r#)
- d002fda is stuff rider didn't pick up on (CI script unfortunately crashes locally for me)
- BOM in files is inconsistent in our repository. this arbitrarily changes BOM. please don't focus on this. we should normalise this at a later point.