### PR TITLE
Fix NRT-related issues found game-side

### DIFF
--- a/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/InputStateChangeEvent.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Input.StateChanges.Events
         /// <summary>
         /// The <see cref="IInput"/> that caused this input state change.
         /// </summary>
-        public readonly IInput? Input;
+        public readonly IInput Input;
 
         protected InputStateChangeEvent(InputState state, IInput input)
         {

--- a/osu.Framework/Platform/DesktopStorage.cs
+++ b/osu.Framework/Platform/DesktopStorage.cs
@@ -5,7 +5,7 @@ namespace osu.Framework.Platform
 {
     public class DesktopStorage : NativeStorage
     {
-        public DesktopStorage(string path, DesktopGameHost host)
+        public DesktopStorage(string path, DesktopGameHost? host)
             : base(path, host)
         {
         }


### PR DESCRIPTION
The intention of this PR is to unblock https://github.com/ppy/osu/pull/24019, as CI detected a few more inspections there that in my judgement need to be fixed framework-side.

## 5873cab9a3267a207fea6edabda4718a403a9e22: Remove nullability specification on `InputStateChangeEvent.Input`

The nullability spec was carried over from R# annotations, but it really isn't clear _why_ it is there. None of the five subclasses of `InputStateChangeEvent` allow construction with a null input.

Spotted in https://github.com/ppy/osu/blob/511451770c98161daced844b082b4975c94f02dd/osu.Game/Rulesets/UI/RulesetInputManager.cs#L153.

## dcb7e2f63411d34a7c5eea088d4c92547ba70703: Allow nullable host in `DesktopStorage` ctor

The base `NativeStorage` is null-tolerant anyways.

This was relied on here: https://github.com/ppy/osu/blob/511451770c98161daced844b082b4975c94f02dd/osu.Game.Tournament/IPC/FileBasedIPC.cs#L67