### PR TITLE
Fix tablet output area is not updated when switching fullscreen and borderless mode on MacOS with metal renderer.

### DIFF
--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -439,8 +439,14 @@ namespace osu.Framework.Platform
             if (w <= 0 || drawableW <= 0)
                 return;
 
+            Size lastClientSize = ClientSize;
             Scale = (float)drawableW / w;
-            Size = new Size(w, h);
+            size = new Size(w, h);
+
+            if (lastClientSize != ClientSize)
+            {
+                Resized?.Invoke();
+            }
 
             // This function may be invoked before the SDL internal states are all changed. (as documented here: https://wiki.libsdl.org/SDL_SetEventFilter)
             // Scheduling the store to config until after the event poll has run will ensure the window is in the correct state.


### PR DESCRIPTION
Log of fetchWindowSize
```
Window Size:{Width=1792, Height=1067} Drawable Size: {Width=3586, Height=2134}
Window Size:{Width=1792, Height=1067} Drawable Size: {Width=3584, Height=2134}
Window Size:{Width=1304, Height=537} Drawable Size: {Width=3584, Height=2134}
Window Size:{Width=1304, Height=537} Drawable Size: {Width=2608, Height=1074}
Window Size:{Width=1304, Height=537} Drawable Size: {Width=2608, Height=1074}
****Window Size:{Width=1792, Height=1120} Drawable Size: {Width=2608, Height=1074}
Window Size:{Width=1792, Height=1120} Drawable Size: {Width=3584, Height=2240}
Window Size:{Width=1792, Height=1120} Drawable Size: {Width=3584, Height=2240}
Window Size:{Width=1792, Height=1120} Drawable Size: {Width=3584, Height=2240}
```

The drawable size is updated at the beginning of the frame, so the client size and window size might not be synchronised.

https://github.com/ppy/osu-framework/blob/19cbb8f4a681b4e8cb7838127ddcf91b71870cea/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs#L206-L212

The tablet driver takes the wrong client size, as the event is only triggered when the window size changes.

https://github.com/ppy/osu-framework/blob/19cbb8f4a681b4e8cb7838127ddcf91b71870cea/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs#L123-L144
