### PR TITLE
Fix `IWindow.Resized` being invoked with invalid data during `WindowMode` switch

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowModeResizedEvent.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowModeResizedEvent.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Drawing;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Visual.Platform
+{
+    [Ignore("This test cannot run in headless mode (a window instance is required).")]
+    [System.ComponentModel.Description($"Checks that {nameof(IWindow.Resized)} behaves correctly when {nameof(IWindow.WindowMode)} is changed.")]
+    public partial class TestSceneWindowModeResizedEvent : FrameworkTestScene
+    {
+        private static readonly Size windowed_size = new Size(1280, 720);
+
+        private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
+        private IWindow window = null!;
+
+        private readonly Queue<Size> resizeInvokes = new Queue<Size>();
+
+        [Resolved]
+        private FrameworkConfigManager config { get; set; } = null!;
+
+        public TestSceneWindowModeResizedEvent()
+        {
+            Child = new WindowDisplaysPreview
+            {
+                RelativeSizeAxes = Axes.Both
+            };
+
+            AddLabel("set up defaults");
+            AddStep($"set windowed size to {windowed_size}", () => config.SetValue(FrameworkSetting.WindowedSize, windowed_size));
+            AddStep("set default fullscreen size", () => config.GetBindable<Size>(FrameworkSetting.SizeFullscreen).SetDefault());
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            window = host.Window!;
+            window.Resized += windowResized;
+            config.BindWith(FrameworkSetting.WindowMode, windowMode);
+        }
+
+        private void windowResized() => resizeInvokes.Enqueue(window.ClientSize);
+
+        private void setUp(WindowMode startingMode, WindowMode finalMode)
+        {
+            AddStep($"set mode to {startingMode}", () => windowMode.Value = startingMode);
+            AddStep("clear resize queue", () => resizeInvokes.Clear());
+            AddStep($"set mode to {finalMode}", () => windowMode.Value = finalMode);
+        }
+
+        [TestCase(WindowMode.Borderless, WindowMode.Fullscreen)]
+        [TestCase(WindowMode.Fullscreen, WindowMode.Borderless)]
+        public void TestFullscreenAndBorderless(WindowMode startingMode, WindowMode finalMode)
+        {
+            setUp(startingMode, finalMode);
+            // since the two window modes take up the entire display, the size of the window shouldn't change.
+            AddAssert("resize queue is empty", () => resizeInvokes, () => Is.Empty);
+        }
+
+        [TestCase(WindowMode.Windowed, WindowMode.Borderless)]
+        [TestCase(WindowMode.Windowed, WindowMode.Fullscreen)]
+        [TestCase(WindowMode.Fullscreen, WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless, WindowMode.Windowed)]
+        public void TestModeSwitchWindowed([Values] WindowMode startingMode, [Values] WindowMode finalMode)
+        {
+            setUp(startingMode, finalMode);
+            AddAssert("only one resize event", () => resizeInvokes, () => Has.Count.EqualTo(1));
+            if (finalMode == WindowMode.Windowed)
+                AddAssert("resized to windowed size", () => resizeInvokes.Dequeue(), () => Is.EqualTo(windowed_size));
+            else
+                AddAssert("resized to display size", () => resizeInvokes.Dequeue(), () => Is.EqualTo(window.CurrentDisplayBindable.Value.Bounds.Size));
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (window.IsNotNull())
+                window.Resized -= windowResized;
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowModeResizedEvent.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowModeResizedEvent.cs
@@ -10,6 +10,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
+using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
@@ -33,10 +34,6 @@ namespace osu.Framework.Tests.Visual.Platform
             {
                 RelativeSizeAxes = Axes.Both
             };
-
-            AddLabel("set up defaults");
-            AddStep($"set windowed size to {windowed_size}", () => config.SetValue(FrameworkSetting.WindowedSize, windowed_size));
-            AddStep("set default fullscreen size", () => config.GetBindable<Size>(FrameworkSetting.SizeFullscreen).SetDefault());
         }
 
         [BackgroundDependencyLoader]
@@ -48,6 +45,13 @@ namespace osu.Framework.Tests.Visual.Platform
         }
 
         private void windowResized() => resizeInvokes.Enqueue(window.ClientSize);
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep($"set windowed size to {windowed_size}", () => config.SetValue(FrameworkSetting.WindowedSize, windowed_size));
+            AddStep("set default fullscreen size", () => config.GetBindable<Size>(FrameworkSetting.SizeFullscreen).SetDefault());
+        }
 
         private void setUp(WindowMode startingMode, WindowMode finalMode)
         {

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -326,7 +326,7 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_EventType.SDL_WINDOWEVENT:
                     // polling via SDL_PollEvent blocks on resizes (https://stackoverflow.com/a/50858339)
-                    if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED)
+                    if (evt.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED && !updatingWindowStateAndSize)
                         fetchWindowSize();
 
                     break;

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -534,7 +534,9 @@ namespace osu.Framework.Platform
                 windowState = pendingWindowState.Value;
                 pendingWindowState = null;
 
+                updatingWindowStateAndSize = true;
                 UpdateWindowStateAndSize(windowState, currentDisplay, currentDisplayMode.Value);
+                updatingWindowStateAndSize = false;
 
                 fetchWindowSize();
 
@@ -721,6 +723,15 @@ namespace osu.Framework.Platform
         /// Set to <c>true</c> while the window size is being stored to config to avoid bindable feedback.
         /// </summary>
         private bool storingSizeToConfig;
+
+        /// <summary>
+        /// Set when <see cref="UpdateWindowStateAndSize"/> is in progress to avoid <see cref="fetchWindowSize"/> being called with invalid data.
+        /// </summary>
+        /// <remarks>
+        /// Since <see cref="UpdateWindowStateAndSize"/> is a multi-step process, intermediary windows size changes might be invalid.
+        /// This is usually not a problem, but since <see cref="HandleEventFromFilter"/> runs out-of-band, invalid data might appear in those events.
+        /// </remarks>
+        private bool updatingWindowStateAndSize;
 
         private void storeWindowSizeToConfig()
         {

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -574,6 +574,9 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Should be run after a local window state change, to propagate the correct SDL actions.
         /// </summary>
+        /// <remarks>
+        /// Call sites need to set <see cref="updatingWindowStateAndSize"/> appropriately.
+        /// </remarks>
         protected virtual void UpdateWindowStateAndSize(WindowState state, Display display, DisplayMode displayMode)
         {
             switch (state)


### PR DESCRIPTION
- Resolves #5879 

As seen in that issue, `Resized` would get invoked when the window was invalid / in the process of changing window modes. This is because we have a multi-step window mode change process _and_ we're fetching the window size with an event filter (SDL would usually coalesce those events to a single event with the last set, valid size).

Callstack from one `fetchWindowSize()` that would fetch the invalid size. Notice how `UpdateWindowStateAndSize()` is in progress.

![image](https://github.com/ppy/osu-framework/assets/16479013/2d57b821-28ec-4fba-ab05-d9de8b44cb28)
