### PR TITLE
Make `IWindow` and `IGraphicsSurface` implementations `internal`

### DIFF
--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Android
 {
-    public class AndroidGameWindow : OsuTKWindow
+    internal class AndroidGameWindow : OsuTKWindow
     {
         private readonly AndroidGameView view;
 

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -12,7 +12,7 @@ using UIKit;
 
 namespace osu.Framework.iOS
 {
-    public class IOSWindow : SDL2Window
+    internal class IOSWindow : SDL2Window
     {
         private UIWindow? window;
 

--- a/osu.Framework/Input/SDL2WindowTextInput.cs
+++ b/osu.Framework/Input/SDL2WindowTextInput.cs
@@ -6,7 +6,7 @@ using osu.Framework.Platform;
 
 namespace osu.Framework.Input
 {
-    public class SDL2WindowTextInput : TextInputSource
+    internal class SDL2WindowTextInput : TextInputSource
     {
         private readonly SDL2Window window;
 

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.IO;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
@@ -70,6 +71,11 @@ namespace osu.Framework.Platform
         /// Invoked when the system keyboard layout has changed.
         /// </summary>
         event Action? KeymapChanged;
+
+        /// <summary>
+        /// Invoked when the user drops a file into the window.
+        /// </summary>
+        public event Action<string>? DragDrop;
 
         /// <summary>
         /// Whether the OS cursor is currently contained within the game window.
@@ -174,6 +180,11 @@ namespace osu.Framework.Platform
         /// Whether the window currently has focus.
         /// </summary>
         bool Focused { get; }
+
+        /// <summary>
+        /// Sets the window icon to the provided <paramref name="imageStream"/>.
+        /// </summary>
+        public void SetIconFromStream(Stream imageStream);
 
         /// <summary>
         /// Convert a screen based coordinate to local window space.

--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Platform.MacOS
     /// <summary>
     /// macOS-specific subclass of <see cref="SDL2Window"/>.
     /// </summary>
-    public class MacOSWindow : SDL2DesktopWindow
+    internal class MacOSWindow : SDL2DesktopWindow
     {
         private static readonly IntPtr sel_hasprecisescrollingdeltas = Selector.Get("hasPreciseScrollingDeltas");
         private static readonly IntPtr sel_scrollingdeltax = Selector.Get("scrollingDeltaX");

--- a/osu.Framework/Platform/OsuTKGraphicsSurface.cs
+++ b/osu.Framework/Platform/OsuTKGraphicsSurface.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Platform
 {
-    public class OsuTKGraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface
+    internal class OsuTKGraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface
     {
         private readonly OsuTKWindow window;
 

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -415,7 +415,7 @@ namespace osu.Framework.Platform
 
         public void ProcessEvents() => OsuTKGameWindow.ProcessEvents();
 
-        public void SetIconFromStream(Stream imageStream) => throw new InvalidOperationException($@"{nameof(SetIconFromStream)} is not supported.");
+        public void SetIconFromStream(Stream imageStream) => throw new NotSupportedException($@"{nameof(SetIconFromStream)} is not supported.");
 
         public Point PointToClient(Point point) => OsuTKGameWindow.PointToClient(point);
         public Point PointToScreen(Point point) => OsuTKGameWindow.PointToScreen(point);

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -13,6 +13,7 @@ using osuTK.Platform;
 using osuTK.Input;
 using System.ComponentModel;
 using System.Drawing;
+using System.IO;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -22,7 +23,7 @@ using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Platform
 {
-    public abstract class OsuTKWindow : IWindow, IGameWindow
+    internal abstract class OsuTKWindow : IWindow, IGameWindow
     {
         private readonly IGraphicsSurface graphicsSurface;
         IGraphicsSurface IWindow.GraphicsSurface => graphicsSurface;
@@ -60,6 +61,9 @@ namespace osu.Framework.Platform
 
         /// <inheritdoc cref="IWindow.KeymapChanged"/>
         public event Action KeymapChanged { add { } remove { } }
+
+        /// <inheritdoc cref="IWindow.DragDrop"/>
+        public event Action<string> DragDrop { add { } remove { } }
 
         /// <summary>
         /// Invoked when any key has been pressed.
@@ -410,6 +414,9 @@ namespace osu.Framework.Platform
         public void Close() => OsuTKGameWindow.Close();
 
         public void ProcessEvents() => OsuTKGameWindow.ProcessEvents();
+
+        public void SetIconFromStream(Stream imageStream) => throw new InvalidOperationException($@"{nameof(SetIconFromStream)} is not supported.");
+
         public Point PointToClient(Point point) => OsuTKGameWindow.PointToClient(point);
         public Point PointToScreen(Point point) => OsuTKGameWindow.PointToScreen(point);
 

--- a/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
@@ -13,7 +13,7 @@ using SDL2;
 
 namespace osu.Framework.Platform.SDL2
 {
-    public class SDL2GraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface, IMetalGraphicsSurface, ILinuxGraphicsSurface
+    internal class SDL2GraphicsSurface : IGraphicsSurface, IOpenGLGraphicsSurface, IMetalGraphicsSurface, ILinuxGraphicsSurface
     {
         private readonly SDL2Window window;
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -5,7 +5,7 @@ using SDL2;
 
 namespace osu.Framework.Platform
 {
-    public class SDL2DesktopWindow : SDL2Window
+    internal class SDL2DesktopWindow : SDL2Window
     {
         public SDL2DesktopWindow(GraphicsSurfaceType surfaceType)
             : base(surfaceType)

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Platform
     /// <summary>
     /// Default implementation of a window, using SDL for windowing and graphics support.
     /// </summary>
-    public abstract partial class SDL2Window : IWindow
+    internal abstract partial class SDL2Window : IWindow
     {
         internal IntPtr SDLWindowHandle { get; private set; } = IntPtr.Zero;
 
@@ -542,11 +542,11 @@ namespace osu.Framework.Platform
 
         #endregion
 
-        public void SetIconFromStream(Stream stream)
+        public void SetIconFromStream(Stream imageStream)
         {
             using (var ms = new MemoryStream())
             {
-                stream.CopyTo(ms);
+                imageStream.CopyTo(ms);
                 ms.Position = 0;
 
                 var imageInfo = Image.Identify(ms);

--- a/osu.Framework/Platform/SDL2Window_Input.cs
+++ b/osu.Framework/Platform/SDL2Window_Input.cs
@@ -20,7 +20,7 @@ using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Platform
 {
-    public partial class SDL2Window
+    internal partial class SDL2Window
     {
         private void setupInput(FrameworkConfigManager config)
         {

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -17,7 +17,7 @@ using SDL2;
 
 namespace osu.Framework.Platform
 {
-    public partial class SDL2Window
+    internal partial class SDL2Window
     {
         private void setupWindowing(FrameworkConfigManager config)
         {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -15,7 +15,7 @@ using Icon = osu.Framework.Platform.Windows.Native.Icon;
 namespace osu.Framework.Platform.Windows
 {
     [SupportedOSPlatform("windows")]
-    public class WindowsWindow : SDL2DesktopWindow
+    internal class WindowsWindow : SDL2DesktopWindow
     {
         private const int seticon_message = 0x0080;
         private const int icon_big = 1;


### PR DESCRIPTION
See https://github.com/ppy/osu-framework/pull/5880#discussion_r1248888299. Having these be public isn't doing any good.

Public members of `SDL2Window` that should have been exposed are now properly exposed in `IWindow`. Notably, `DragDrop` and `SetIconFromStream()` that were used in osu!.

Graphics surfaces are also changed to `internal` to make the compiler happy (using `internal` window in `public` ctor). If that is not desired, only the ctor can be made `internal`.

# Breaking changes

## `IWindow` implementations (SDL, osuTK) are now `internal`

If you were using public members of `SDLWindow`/`OsuTKWindow`, change to use the appropriate `IWindow` member. If you find that you were using a member that is not available in `IWindow`, please open a discussion describing your use case.