### PR TITLE
Reduce complexity overhead (and avoid one copy) when obtaining character SSDQs in `SpriteTextDrawNode`

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkSpriteText.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSpriteText.cs
@@ -1,0 +1,96 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace osu.Framework.Benchmarks
+{
+    public partial class BenchmarkSpriteText : GameBenchmark
+    {
+        private TestGame game = null!;
+
+        [Test]
+        [Benchmark]
+        public void TestStaticText()
+        {
+            game.Mode = 0;
+            RunSingleFrame();
+        }
+
+        [Test]
+        [Benchmark]
+        public void TestMovingText()
+        {
+            game.Mode = 1;
+            RunSingleFrame();
+        }
+
+        [Test]
+        [Benchmark]
+        public void TestChangingText()
+        {
+            game.Mode = 2;
+            RunSingleFrame();
+        }
+
+        protected override Game CreateGame() => game = new TestGame();
+
+        private partial class TestGame : Game
+        {
+            public int Mode;
+
+            private readonly string text1 = Guid.NewGuid().ToString();
+            private readonly string text2 = Guid.NewGuid().ToString();
+
+            private long frame;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                for (int i = 0; i < 1000; i++)
+                {
+                    Add(new SpriteText
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Text = "i am some relatively long text",
+                    });
+                }
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                switch (Mode)
+                {
+                    case 0:
+                        break;
+
+                    case 1:
+                        var pos = new Vector2(RNG.NextSingle(100));
+
+                        foreach (var text in Children.OfType<SpriteText>())
+                            text.Position = pos;
+
+                        break;
+
+                    case 2:
+                        foreach (var text in Children.OfType<SpriteText>())
+                            text.Text = frame % 2 == 0 ? text1 : text2;
+                        break;
+                }
+
+                frame++;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -27,8 +27,6 @@ namespace osu.Framework.Graphics.Sprites
     /// </summary>
     public partial class SpriteText : Drawable, IHasLineBaseHeight, ITexturedShaderDrawable, IHasText, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>
     {
-        private const float default_text_size = 20;
-
         /// <remarks>
         /// <c>U+00A0</c> is the Unicode NON-BREAKING SPACE character (distinct from the standard ASCII space).
         /// <c>U+202F</c> is the Unicode NARROW NO-BREAK SPACE character.
@@ -56,8 +54,6 @@ namespace osu.Framework.Graphics.Sprites
             });
 
             AddLayout(charactersCache);
-            AddLayout(parentScreenSpaceCache);
-            AddLayout(localScreenSpaceCache);
             AddLayout(shadowOffsetCache);
             AddLayout(textBuilderCache);
         }
@@ -501,53 +497,6 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        private readonly LayoutValue parentScreenSpaceCache = new LayoutValue(Invalidation.DrawSize | Invalidation.Presence | Invalidation.DrawInfo, InvalidationSource.Parent);
-        private readonly LayoutValue localScreenSpaceCache = new LayoutValue(Invalidation.MiscGeometry, InvalidationSource.Self);
-
-        private readonly List<ScreenSpaceCharacterPart> screenSpaceCharactersBacking = new List<ScreenSpaceCharacterPart>();
-
-        /// <summary>
-        /// The characters in screen space. These are ready to be drawn.
-        /// </summary>
-        private List<ScreenSpaceCharacterPart> screenSpaceCharacters
-        {
-            get
-            {
-                computeScreenSpaceCharacters();
-                return screenSpaceCharactersBacking;
-            }
-        }
-
-        private void computeScreenSpaceCharacters()
-        {
-            if (!parentScreenSpaceCache.IsValid)
-            {
-                localScreenSpaceCache.Invalidate();
-                parentScreenSpaceCache.Validate();
-            }
-
-            if (localScreenSpaceCache.IsValid)
-                return;
-
-            screenSpaceCharactersBacking.Clear();
-
-            Vector2 inflationAmount = DrawInfo.MatrixInverse.ExtractScale().Xy;
-
-            foreach (var character in characters)
-            {
-                screenSpaceCharactersBacking.Add(new ScreenSpaceCharacterPart
-                {
-                    DrawQuad = ToScreenSpace(character.DrawRectangle.Inflate(inflationAmount)),
-                    InflationPercentage = new Vector2(
-                        character.DrawRectangle.Size.X == 0 ? 0 : inflationAmount.X / character.DrawRectangle.Size.X,
-                        character.DrawRectangle.Size.Y == 0 ? 0 : inflationAmount.Y / character.DrawRectangle.Size.Y),
-                    Texture = character.Texture
-                });
-            }
-
-            localScreenSpaceCache.Validate();
-        }
-
         private readonly LayoutValue<Vector2> shadowOffsetCache = new LayoutValue<Vector2>(Invalidation.DrawInfo, InvalidationSource.Parent);
 
         private Vector2 premultipliedShadowOffset =>
@@ -564,9 +513,6 @@ namespace osu.Framework.Graphics.Sprites
 
             if (textBuilder)
                 InvalidateTextBuilder();
-
-            parentScreenSpaceCache.Invalidate();
-            localScreenSpaceCache.Invalidate();
 
             Invalidate(Invalidation.RequiredParentSizeToFit);
         }

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -88,8 +88,13 @@ namespace osu.Framework.Graphics.Sprites
             {
                 int partCount = Source.characters.Count;
 
-                parts ??= new List<ScreenSpaceCharacterPart>(partCount);
-                parts.Clear();
+                if (parts == null)
+                    parts = new List<ScreenSpaceCharacterPart>(partCount);
+                else
+                {
+                    parts.Clear();
+                    parts.EnsureCapacity(partCount);
+                }
 
                 Vector2 inflationAmount = DrawInfo.MatrixInverse.ExtractScale().Xy;
 


### PR DESCRIPTION

Of note, this doesn't show a huge improvement in benchmarks, but in an edge case noticed in osu!, the `AddRange` operation can add a perceivable overhead:

![JetBrains Rider 2023-07-03 at 08 17 17](https://github.com/ppy/osu-framework/assets/191335/d4afac1c-1209-4ce0-a404-c665675fe436)

| Before | After |
| :---: | :---: |
| ![JetBrains Rider 2023-07-03 at 08 16 07](https://github.com/ppy/osu-framework/assets/191335/c20539ce-9cab-43a4-8cbd-2ee16fcbfad2) | ![JetBrains Rider 2023-07-03 at 08 15 11](https://github.com/ppy/osu-framework/assets/191335/5213b2e7-a2a6-417c-b4d3-04102569b4fb) |

We believe this may be a dotnet runtime quirk.

Even though this change can't be shown in isolated benchmarks, I'd argue the code quality improvement is worth it.

Of note, the caching of the SSDQs at `SpriteText` was a bit redundant as it was being invalidated by basically everything. So it makes sense to just fetch it every time, regardless, in the draw node itself.

The only potential saving we could obtain with the previous logic would be to shift the load to the `Update` frame. But this wasn't being done. Rather than investigating whether that has any benefits, I'd rather focus on getting `SpriteText` rewritten to use an optimised shader.

master

|           Method |        Mean |     Error |    StdDev | Allocated |
|----------------- |------------:|----------:|----------:|----------:|
|   TestStaticText |    984.4 us |   1.30 us |   1.22 us |       6 B |
|   TestMovingText |  2,701.5 us |  47.68 us |  42.27 us |     117 B |
| TestChangingText | 11,381.6 us | 161.87 us | 143.49 us |   64182 B |

this pr (pooled at 2967626edae655123d64ac5a8ef10d683ddece38)

|           Method |        Mean |     Error |    StdDev | Allocated |
|----------------- |------------:|----------:|----------:|----------:|
|   TestStaticText |    985.3 us |   2.46 us |   2.30 us |       6 B |
|   TestMovingText |  2,928.0 us |  57.80 us |  75.16 us |     119 B |
| TestChangingText | 11,426.4 us | 186.17 us | 155.46 us |   64184 B |


this pr (list at 90a2e286bc84e1bacbd76d8f32606ce7b09685de)

|           Method |        Mean |     Error |    StdDev | Allocated |
|----------------- |------------:|----------:|----------:|----------:|
|   TestStaticText |    985.5 us |   1.80 us |   1.68 us |       6 B |
|   TestMovingText |  2,476.1 us |  47.54 us |  50.86 us |     110 B |
| TestChangingText | 10,793.3 us | 211.44 us | 217.14 us |   64180 B |
