### PR TITLE
Fix game tools being rendered outside safe area

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -113,10 +113,14 @@ namespace osu.Framework
                 RelativeSizeAxes = Axes.Both,
             });
 
-            base.AddInternal(overlayContent = new DrawSizePreservingFillContainer
+            base.AddInternal(new SafeAreaContainer
             {
-                TargetDrawSize = new Vector2(1280, 960),
                 RelativeSizeAxes = Axes.Both,
+                Child = overlayContent = new DrawSizePreservingFillContainer
+                {
+                    TargetDrawSize = new Vector2(1280, 960),
+                    RelativeSizeAxes = Axes.Both,
+                }
             });
         }
 


### PR DESCRIPTION
Happens a lot with frame visualiser on iOS, part of it gets rendered within the phone's corner no matter the screen orientation.