### PR TITLE
Add basic "render scale" support for mobile devices

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneRenderer.cs
@@ -6,9 +6,11 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Platform;
+using osuTK;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
@@ -30,13 +32,43 @@ namespace osu.Framework.Tests.Visual.Platform
                 Font = FrameworkFont.Regular.With(size: 24),
             });
 
-            Add(new BasicDropdown<RendererType>
+            Add(new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Items = host.GetPreferredRenderersForCurrentPlatform().OrderBy(t => t),
-                Current = config.GetBindable<RendererType>(FrameworkSetting.Renderer),
-                Width = 200f,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(10f),
+                Children = new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Renderer",
+                    },
+                    new BasicDropdown<RendererType>
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Items = host.GetPreferredRenderersForCurrentPlatform().OrderBy(t => t),
+                        Current = config.GetBindable<RendererType>(FrameworkSetting.Renderer),
+                        Width = 200f,
+                    },
+                    new SpriteText
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Text = "Render Scale",
+                    },
+                    new BasicSliderBar<float>
+                    {
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                        Current = config.GetBindable<float>(FrameworkSetting.RenderScale),
+                        Size = new Vector2(200f, 30f),
+                    }
+                }
             });
         });
     }

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -40,6 +40,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
             SetDefault(FrameworkSetting.Renderer, RendererType.Automatic);
+            SetDefault(FrameworkSetting.RenderScale, 1.0f, 0.1f, 1.0f, 0.01f);
             SetDefault(FrameworkSetting.ShowUnicode, false);
             SetDefault(FrameworkSetting.Locale, string.Empty);
 
@@ -92,6 +93,7 @@ namespace osu.Framework.Configuration
         SizeFullscreen,
 
         Renderer,
+        RenderScale,
         WindowMode,
         ConfineMouseMode,
         FrameSync,


### PR DESCRIPTION
Opened as draft as it's been mentioned that this breaks front-to-back passes on Android. Probably requires further investigation before merge, but opening it anyway rather than leaving the change in my machine.