### PR TITLE
Fix frame statistics display showing `CADisplayLink` callback delays under "WndProc" time

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gc93d085d10" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gf4e09bb395" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
The game run loop is wrapped under `CADisplayLink`, therefore the time spent between two loop calls indicates `CADisplayLink` waiting for next V-Sync request.

Before:

![IMG_6107](https://github.com/ppy/osu-framework/assets/22781491/34c7945e-5bed-4b7d-a82e-5c5137f6d701)

After:

![IMG_2370B57B2E93-1](https://github.com/ppy/osu-framework/assets/22781491/c6d51dc5-4b48-4d37-988b-2c4f97b6a2da)
