### PR TITLE
Pool and limit how many GC boxes can be displayed on `FrameStatisticsDisplay` at once

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -19,6 +19,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Input.Events;
 using osuTK;
@@ -59,6 +60,8 @@ namespace osu.Framework.Graphics.Performance
         private readonly Container timeBarsContainer;
 
         private readonly ArrayPool<Rgba32> uploadPool;
+
+        private readonly DrawablePool<GCBox> gcBoxPool;
 
         private readonly Drawable[] legendMapping = new Drawable[FrameStatistics.NUM_PERFORMANCE_COLLECTION_TYPES];
         private readonly Dictionary<StatisticsCounterType, CounterBar> counterBars = new Dictionary<StatisticsCounterType, CounterBar>();
@@ -182,8 +185,9 @@ namespace osu.Framework.Graphics.Performance
                     mainContainer = new Container
                     {
                         Size = new Vector2(WIDTH, HEIGHT),
-                        Children = new[]
+                        Children = new Drawable[]
                         {
+                            gcBoxPool = new DrawablePool<GCBox>(20, 20),
                             timeBarsContainer = new Container
                             {
                                 Masking = true,
@@ -277,15 +281,34 @@ namespace osu.Framework.Graphics.Performance
 
         private void addEvent(int type)
         {
-            Box b = new Box
+            if (gcBoxPool.CountAvailable == 0)
             {
-                Origin = Anchor.TopCentre,
-                Position = new Vector2(timeBarX, type * 3),
-                Colour = garbage_collect_colors[type],
-                Size = new Vector2(3, 3)
-            };
+                // If we've run out of pooled boxes, remove earlier usages.
+                //
+                // This is to avoid a runaway situation where more boxes being displayed causes more overhead,
+                // causing slower progression of the time bars causing more dense boxes causing more overhead...
+                for (int i = 0; i < timeBars.Length; i++)
+                {
+                    // Offset to check the previous time bar first.
+                    var timeBar = timeBars[(timeBarIndex + i + 1) % timeBars.Length];
 
-            timeBars[timeBarIndex].Add(b);
+                    var firstBox = timeBar.OfType<GCBox>().FirstOrDefault();
+
+                    if (firstBox != null)
+                    {
+                        timeBar.RemoveInternal(firstBox, false);
+                        break;
+                    }
+                }
+            }
+
+            var box = gcBoxPool.Get(b =>
+            {
+                b.Position = new Vector2(timeBarX, type * 3);
+                b.Colour = garbage_collect_colors[type];
+            });
+
+            timeBars[timeBarIndex].Add(box);
         }
 
         private bool running = true;
@@ -626,6 +649,25 @@ namespace osu.Framework.Graphics.Performance
 
                 if (expanded)
                     text.Text = $@"{Label}: {NumberFormatter.PrintWithSiSuffix(value)}";
+            }
+        }
+
+        private partial class GCBox : PoolableDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Origin = Anchor.TopCentre;
+                Size = new Vector2(3, 3);
+
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.White,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                };
             }
         }
     }


### PR DESCRIPTION
When running on mobile, we've seen gen 0 GCs almost every frame. I'm not sure if this is good or bad, but ignoring that for a moment, this would cause opening the frame statistics graphs to slowly grind the game to a halt as it tries to display this with box markers.

Pooling the boxes reduces the alloc overhead. Custom logic cleans up old squares to ensure things don't runaway in terms of performance.


https://github.com/ppy/osu-framework/assets/191335/bc2134c9-5715-4861-8861-1b790eabd1c0

