### PR TITLE
Fix `PerformanceOverlay` autosize not working due to incorrect anchor

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -118,7 +118,6 @@ namespace osu.Framework.Graphics.Performance
 
             this.uploadPool = uploadPool;
 
-            Origin = Anchor.TopRight;
             AutoSizeAxes = Axes.Both;
             Alpha = alpha_when_active;
 

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -90,6 +90,7 @@ namespace osu.Framework.Graphics.Performance
                         Add(infoText = new TextFlowContainer(cp => cp.Font = FrameworkFont.Condensed)
                         {
                             Alpha = 0.75f,
+                            Anchor = Anchor.TopRight,
                             Origin = Anchor.TopRight,
                             TextAnchor = Anchor.TopRight,
                             AutoSizeAxes = Axes.Both,
@@ -98,7 +99,14 @@ namespace osu.Framework.Graphics.Performance
                         updateInfoText();
 
                         foreach (GameThread t in host.Threads)
-                            Add(new FrameStatisticsDisplay(t, uploadPool) { State = state });
+                        {
+                            Add(new FrameStatisticsDisplay(t, uploadPool)
+                            {
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
+                                State = state
+                            });
+                        }
                     }
 
                     this.FadeIn(100);


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu-framework/pull/5897/files/05a935442013cc2d07a0ac73e4edbd8887e2fd1c..4e4e4d6e3a2b39ec3cd9554650693a32e094414c#diff-21428f5fd4a0ed5b32fd7d887aaf536f1c93cbbdc973eaf94425abd346f2be52R78-R80.