### PR TITLE
Switch osu!framework iOS projects to use AOT compilation on release configurations

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -8,11 +8,11 @@
     <NoWarn>$(NoWarn);MT7091</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <!-- On debug configurations, we need Mono interpreter for faster compilation. -->
+    <!-- On debug configurations, we use Mono interpreter for faster compilation. -->
     <UseInterpreter>true</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <!-- On release configurations, we need AOT compiler for optimal performance. -->
+    <!-- On release configurations, we use AOT compiler for optimal performance. -->
     <UseInterpreter>false</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'iPhone'">

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -1,14 +1,19 @@
 ﻿<Project>
   <PropertyGroup>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <!-- Mono Interpreter resolves many AOT issues occuring on runtime,
-         and will be enabled by default on .NET 8+: https://github.com/dotnet/maui/issues/13019 -->
-    <UseInterpreter>true</UseInterpreter>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
     <!-- MT7091 occurs when referencing a .framework bundle that consists of a static library.
          It only warns about not copying the library to the app bundle to save space,
          so there's nothing to be worried about. -->
     <NoWarn>$(NoWarn);MT7091</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <!-- On debug configurations, we need Mono interpreter for faster compilation. -->
+    <UseInterpreter>true</UseInterpreter>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- On release configurations, we need AOT compiler for optimal performance. -->
+    <UseInterpreter>false</UseInterpreter>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'iPhone'">
     <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>

--- a/osu.Framework.iOS/GameApplication.cs
+++ b/osu.Framework.iOS/GameApplication.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.iOS
 
             game = target;
 
+            SDL.PrepareLibraryForIOS();
             SDL.SDL_UIKitRunApp(0, IntPtr.Zero, main);
         }
 

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using ObjCRuntime;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using SDL2;
@@ -60,7 +61,16 @@ namespace osu.Framework.iOS
             // frame rate with multi-threaded mode turned on, but it is going to give them worse input latency
             // and higher power usage.
             SDL.SDL_iPhoneSetEventPump(SDL.SDL_bool.SDL_FALSE);
-            SDL.SDL_iPhoneSetAnimationCallback(SDLWindowHandle, 1, _ => RunFrame(), IntPtr.Zero);
+            SDL.SDL_iPhoneSetAnimationCallback(SDLWindowHandle, 1, runFrame, ObjectHandle.Handle);
+        }
+
+        [ObjCRuntime.MonoPInvokeCallback(typeof(SDL.SDL_iPhoneAnimationCallback))]
+        private static void runFrame(IntPtr userdata)
+        {
+            var handle = new ObjectHandle<IOSWindow>(userdata);
+
+            if (handle.GetTarget(out IOSWindow window))
+                window.RunFrame();
         }
 
         private void updateSafeArea()

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -174,11 +174,14 @@ namespace osu.Framework.Platform
         [UsedImplicitly]
         private SDL.SDL_EventFilter? eventFilterDelegate;
 
-        private ObjectHandle<SDL2Window> objectHandle;
+        /// <summary>
+        /// Represents a handle to this <see cref="SDL2Window"/> instance, used for unmanaged callbacks.
+        /// </summary>
+        protected ObjectHandle<SDL2Window> ObjectHandle { get; private set; }
 
         protected SDL2Window(GraphicsSurfaceType surfaceType)
         {
-            objectHandle = new ObjectHandle<SDL2Window>(this, GCHandleType.Normal);
+            ObjectHandle = new ObjectHandle<SDL2Window>(this, GCHandleType.Normal);
 
             if (SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_GAMECONTROLLER) < 0)
             {
@@ -250,7 +253,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public void Run()
         {
-            SDL.SDL_SetEventFilter(eventFilterDelegate = eventFilter, objectHandle.Handle);
+            SDL.SDL_SetEventFilter(eventFilterDelegate = eventFilter, ObjectHandle.Handle);
 
             RunMainLoop();
         }
@@ -614,7 +617,7 @@ namespace osu.Framework.Platform
             Close();
             SDL.SDL_Quit();
 
-            objectHandle.Dispose();
+            ObjectHandle.Dispose();
         }
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.3-gf4e09bb395" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.3-g9f8aa2931a" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g3e4b9f196a" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->
@@ -38,7 +38,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
-    <PackageReference Include="ppy.SDL2-CS" Version="1.0.669-alpha" />
+    <PackageReference Include="ppy.SDL2-CS" Version="1.0.671-alpha" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2023.619.0" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/veldrid/pull/29
- [x] Depends on https://github.com/ppy/SDL2-CS/pull/169

First step towards #5902. After recent investigations, turns out Mono interpreter isn't as efficient as AOT is, and is the cause of many minor overheads that are affecting draw time negatively.

Switching osu! to use AOT compilation is going to be a considerable effort so I'll change this on o!f first and begin investigating iOS performance on a higher scale before moving into osu!.

Note that we're intentionally not using the `--interpreter=all` flag here (which allows the app to fall back to interpretation for dynamic code rather than throw exception), as we don't want to rely on interpretation at all until we come across a case where we can't help it.