### PR TITLE
Disable front-to-back pass by default on all platforms

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -44,8 +44,6 @@ namespace osu.Framework.iOS
                 defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThread);
 
             base.SetupConfig(defaultOverrides);
-
-            DebugConfig.SetValue(DebugSetting.BypassFrontToBackPass, true);
         }
 
         public override bool OnScreenKeyboardOverlapsGameWindow => true;

--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 namespace osu.Framework.Configuration
 {
     public class FrameworkDebugConfigManager : IniConfigManager<DebugSetting>
     {
-        protected override string Filename => null;
+        protected override string Filename => string.Empty;
 
         public FrameworkDebugConfigManager()
             : base(null)
@@ -18,7 +16,7 @@ namespace osu.Framework.Configuration
         {
             base.InitialiseDefaults();
 
-            SetDefault(DebugSetting.BypassFrontToBackPass, false);
+            SetDefault(DebugSetting.BypassFrontToBackPass, true);
         }
     }
 


### PR DESCRIPTION
When it works well, it works very well (ie. in isolated tests) but it's very rare for performance improvements to be seen as a result of front-to-back being enabled.

The reasoning for disabling by default is:
- It breaks on android when the render scale PR is applied (#5888). This could likely be resolved but as [pointed out](https://github.com/ppy/osu-framework/pull/5888#issuecomment-1622272437) by @bdach, the overall performance on android is considerably worse with front-to-back enabled – even in an optimal scenario where it should be helping.
- It's disabled on iOS as it doesn't work there
- It's showing worse performance on desktop in seemingly benign cases, as discovered on @frenzibyte's new performance tests in #5904:

https://github.com/ppy/osu-framework/assets/191335/c217f2b1-bd94-4826-9492-8c469e1b0410

I've chosen to leave it in the debug configuration manager so we have the option of toggling it on to test localised cases in the future.