### PR TITLE
Add caching for Veldrid staging buffers in favour of `CommandList.UpdateBuffer`

### DIFF
--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -823,11 +823,12 @@ namespace osu.Framework.Graphics.Rendering
             {
                 if (buf.InUse && FrameIndex - buf.LastUseFrameIndex > RESOURCE_FREE_NO_USAGE_LENGTH)
                 {
+                    // Calling Free will mark InUse as false internally, which allows the cleanup below to work.
                     buf.Free();
-                    vertexBuffersInUse.Remove(buf);
-                    break;
                 }
             }
+
+            vertexBuffersInUse.RemoveAll(b => !b.InUse);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -104,6 +104,7 @@ namespace osu.Framework.Graphics.Rendering
         private readonly GlobalStatistic<int> statTextureUploadsQueued;
         private readonly GlobalStatistic<int> statTextureUploadsDequeued;
         private readonly GlobalStatistic<int> statTextureUploadsPerformed;
+        private readonly GlobalStatistic<int> vboInUse;
 
         private readonly ConcurrentQueue<ScheduledDelegate> expensiveOperationQueue = new ConcurrentQueue<ScheduledDelegate>();
         private readonly ConcurrentQueue<INativeTexture> textureUploadQueue = new ConcurrentQueue<INativeTexture>();
@@ -155,6 +156,7 @@ namespace osu.Framework.Graphics.Rendering
             statTextureUploadsDequeued = GlobalStatistics.Get<int>(GetType().Name, "Texture uploads dequeued");
             statTextureUploadsQueued = GlobalStatistics.Get<int>(GetType().Name, "Texture upload queue length");
             statExpensiveOperationsQueued = GlobalStatistics.Get<int>(GetType().Name, "Expensive operation queue length");
+            vboInUse = GlobalStatistics.Get<int>(GetType().Name, "VBOs in use");
 
             whitePixel = new Lazy<TextureWhitePixel>(() =>
                 new TextureAtlas(this, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, true).WhitePixel);
@@ -267,6 +269,7 @@ namespace osu.Framework.Graphics.Rendering
             Clear(new ClearInfo(Color4.Black));
 
             freeUnusedVertexBuffers();
+            vboInUse.Value = vertexBuffersInUse.Count;
 
             statTextureUploadsQueued.Value = textureUploadQueue.Count;
             statTextureUploadsDequeued.Value = 0;

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -36,10 +36,9 @@ namespace osu.Framework.Graphics.Rendering
     public abstract class Renderer : IRenderer
     {
         /// <summary>
-        /// The interval (in frames) before checking whether VBOs should be freed.
-        /// VBOs may remain unused for at most double this length before they are recycled.
+        /// The length of no usage (in frames) before freeing unused resources.
         /// </summary>
-        internal const int RESOURCE_FREE_CHECK_INTERVAL = 300;
+        internal const int RESOURCE_FREE_NO_USAGE_LENGTH = 300;
 
         protected internal abstract bool VerticalSync { get; set; }
         protected internal abstract bool AllowTearing { get; set; }
@@ -817,16 +816,15 @@ namespace osu.Framework.Graphics.Rendering
 
         private void freeUnusedVertexBuffers()
         {
-            if (FrameIndex % RESOURCE_FREE_CHECK_INTERVAL != 0)
-                return;
-
             foreach (var buf in vertexBuffersInUse)
             {
-                if (buf.InUse && FrameIndex - buf.LastUseFrameIndex > RESOURCE_FREE_CHECK_INTERVAL)
+                if (buf.InUse && FrameIndex - buf.LastUseFrameIndex > RESOURCE_FREE_NO_USAGE_LENGTH)
+                {
                     buf.Free();
+                    vertexBuffersInUse.Remove(buf);
+                    break;
+                }
             }
-
-            vertexBuffersInUse.RemoveAll(b => !b.InUse);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -37,7 +37,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 for (ushort i = 0; i < amountVertices; i++)
                     indices[i] = i;
 
-                renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedLinearIndex.Buffer, 0, indices);
+                var staging = renderer.GetFreeStagingBuffer(renderer.SharedLinearIndex.Buffer.SizeInBytes);
+                renderer.Device.UpdateBuffer(staging, 0, indices);
+                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedLinearIndex.Buffer, 0, staging.SizeInBytes);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -51,7 +51,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                     indices[j + 5] = (ushort)(i + 1);
                 }
 
-                renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedQuadIndex.Buffer, 0, indices);
+                var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);
+                renderer.Device.UpdateBuffer(staging, 0, indices);
+                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedQuadIndex.Buffer, 0, staging.SizeInBytes);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -32,7 +32,10 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             set
             {
                 data = value;
-                renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, ref data);
+
+                var staging = renderer.GetFreeStagingBuffer(buffer.SizeInBytes);
+                renderer.Device.UpdateBuffer(staging, 0, ref data);
+                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, buffer, 0, buffer.SizeInBytes);
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -75,6 +75,7 @@ namespace osu.Framework.Graphics.Veldrid
         public VeldridIndexData SharedQuadIndex { get; }
 
         private readonly VeldridStagingTexturePool stagingTexturePool;
+        private readonly VeldridStagingBufferPool stagingBufferPool;
 
         private readonly HashSet<IVeldridUniformBuffer> uniformBufferResetList = new HashSet<IVeldridUniformBuffer>();
         private readonly Dictionary<int, VeldridTextureResources> boundTextureUnits = new Dictionary<int, VeldridTextureResources>();
@@ -96,6 +97,7 @@ namespace osu.Framework.Graphics.Veldrid
             SharedLinearIndex = new VeldridIndexData(this);
             SharedQuadIndex = new VeldridIndexData(this);
             stagingTexturePool = new VeldridStagingTexturePool(this);
+            stagingBufferPool = new VeldridStagingBufferPool(this);
         }
 
         protected override void Initialise(IGraphicsSurface graphicsSurface)
@@ -248,6 +250,7 @@ namespace osu.Framework.Graphics.Veldrid
             uniformBufferResetList.Clear();
 
             stagingTexturePool.NewFrame();
+            stagingBufferPool.NewFrame();
 
             Commands.Begin();
             BufferUpdateCommands.Begin();
@@ -676,6 +679,8 @@ namespace osu.Framework.Graphics.Veldrid
         protected override void SetUniformImplementation<T>(IUniformWithValue<T> uniform)
         {
         }
+
+        public DeviceBuffer GetFreeStagingBuffer(uint sizeInBytes) => stagingBufferPool.Get(sizeInBytes);
 
         public void RegisterUniformBufferForReset(IVeldridUniformBuffer buffer)
         {

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Framework.Statistics;
 using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Statistics;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    internal class VeldridStagingBufferPool : VeldridStagingResourcePool<DeviceBuffer>
+    {
+        public VeldridStagingBufferPool(VeldridRenderer renderer)
+            : base(renderer, "staging buffers")
+        {
+        }
+
+        public DeviceBuffer Get(uint sizeInBytes)
+        {
+            if (TryGet(b => b.SizeInBytes >= sizeInBytes, out DeviceBuffer? buffer))
+                return buffer;
+
+            buffer = Renderer.Factory.CreateBuffer(new BufferDescription(sizeInBytes, BufferUsage.Staging));
+            AddNewResource(buffer);
+            return buffer;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingBufferPool.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Graphics.Veldrid
     internal class VeldridStagingBufferPool : VeldridStagingResourcePool<DeviceBuffer>
     {
         public VeldridStagingBufferPool(VeldridRenderer renderer)
-            : base(renderer, "staging buffers")
+            : base(renderer, nameof(VeldridStagingBufferPool))
         {
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -33,15 +33,14 @@ namespace osu.Framework.Graphics.Veldrid
             {
                 if (match(existing.Resource))
                 {
-                    available.Remove(existing);
-                    usageStat.Value.CurrentPoolSize--;
-
                     existing.FrameUsageIndex = Renderer.FrameIndex;
 
+                    available.Remove(existing);
                     used.Add(existing);
-                    usageStat.Value.CountInUse++;
 
                     resource = existing.Resource;
+
+                    updateStats();
                     return true;
                 }
             }
@@ -53,7 +52,7 @@ namespace osu.Framework.Graphics.Veldrid
         protected void AddNewResource(T resource)
         {
             used.Add(new PooledUsage(resource, Renderer.FrameIndex));
-            usageStat.Value.CountInUse++;
+            updateStats();
         }
 
         /// <summary>
@@ -75,7 +74,6 @@ namespace osu.Framework.Graphics.Veldrid
                     break;
 
                 available.Add(texture);
-                usageStat.Value.CurrentPoolSize++;
 
                 used.RemoveAt(i--);
                 usageStat.Value.CountInUse--;
@@ -92,10 +90,17 @@ namespace osu.Framework.Graphics.Veldrid
                 {
                     texture.Resource.Dispose();
                     available.Remove(texture);
-                    usageStat.Value.CurrentPoolSize--;
                     break;
                 }
             }
+
+            updateStats();
+        }
+
+        private void updateStats()
+        {
+            usageStat.Value.CountAvailable = available.Count;
+            usageStat.Value.CountInUse = used.Count;
         }
 
         private class PooledUsage
@@ -122,14 +127,14 @@ namespace osu.Framework.Graphics.Veldrid
             /// <summary>
             /// Total number of drawables available for use (in the pool).
             /// </summary>
-            public int CurrentPoolSize;
+            public int CountAvailable;
 
             /// <summary>
             /// Total number of drawables currently in use.
             /// </summary>
             public int CountInUse;
 
-            public override string ToString() => $"{CountInUse}/{CurrentPoolSize}";
+            public override string ToString() => $"{CountInUse}/{CountAvailable + CountInUse}";
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -79,9 +79,7 @@ namespace osu.Framework.Graphics.Veldrid
                     break;
 
                 available.Add(item);
-
                 used.RemoveAt(i--);
-                usageStat.Value.CountInUse--;
             }
 
             // free any resource that hasn't been used for a while.

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -29,8 +29,13 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected bool TryGet(Predicate<T> match, [NotNullWhen(true)] out T? resource)
         {
-            foreach (var existing in available)
+            // Reverse iteration is important to prefer reusing recently returned textures.
+            // This avoids the case of a large pool being constantly cycled and therefore never
+            // freed.
+            for (int i = available.Count - 1; i >= 0; i--)
             {
+                var existing = available[i];
+
                 if (match(existing.Resource))
                 {
                     existing.FrameUsageIndex = Renderer.FrameIndex;

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -67,13 +67,13 @@ namespace osu.Framework.Graphics.Veldrid
             // return any resource that the GPU has finished using in the last frame.
             for (int i = 0; i < used.Count; i++)
             {
-                var texture = used[i];
+                var item = used[i];
 
                 // Usages are sequential so we can stop checking after the first non-completed usage.
-                if (texture.FrameUsageIndex > Renderer.LatestCompletedFrameIndex)
+                if (item.FrameUsageIndex > Renderer.LatestCompletedFrameIndex)
                     break;
 
-                available.Add(texture);
+                available.Add(item);
 
                 used.RemoveAt(i--);
                 usageStat.Value.CountInUse--;
@@ -82,14 +82,14 @@ namespace osu.Framework.Graphics.Veldrid
             // free any resource that hasn't been used for a while.
             for (int i = 0; i < available.Count; i++)
             {
-                var texture = available[i];
+                var item = available[i];
 
-                ulong framesSinceUsage = Renderer.LatestCompletedFrameIndex - texture.FrameUsageIndex;
+                ulong framesSinceUsage = Renderer.LatestCompletedFrameIndex - item.FrameUsageIndex;
 
                 if (framesSinceUsage >= Rendering.Renderer.RESOURCE_FREE_NO_USAGE_LENGTH)
                 {
-                    texture.Resource.Dispose();
-                    available.Remove(texture);
+                    item.Resource.Dispose();
+                    available.Remove(item);
                     break;
                 }
             }

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Statistics;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    internal abstract class VeldridStagingResourcePool<T>
+        where T : class, DeviceResource, IDisposable
+    {
+        protected readonly VeldridRenderer Renderer;
+
+        private readonly List<StagingResourceCache> available = new List<StagingResourceCache>();
+        private readonly List<StagingResourceCache> used = new List<StagingResourceCache>();
+
+        private readonly GlobalStatistic<int> statAvailable;
+        private readonly GlobalStatistic<int> statUsed;
+
+        protected VeldridStagingResourcePool(VeldridRenderer renderer, string name)
+        {
+            Renderer = renderer;
+
+            statAvailable = GlobalStatistics.Get<int>(nameof(VeldridRenderer), $"Total {name} available");
+            statUsed = GlobalStatistics.Get<int>(nameof(VeldridRenderer), $"Total {name} used");
+        }
+
+        protected bool TryGet(Predicate<T> match, [NotNullWhen(true)] out T? resource)
+        {
+            foreach (var existing in available)
+            {
+                if (match(existing.Resource))
+                {
+                    available.Remove(existing);
+                    statAvailable.Value--;
+
+                    used.Add(existing with { FrameUsageIndex = Renderer.FrameIndex });
+                    statUsed.Value++;
+
+                    resource = existing.Resource;
+                    return true;
+                }
+            }
+
+            resource = null;
+            return false;
+        }
+
+        protected void AddNewResource(T resource)
+        {
+            used.Add(new StagingResourceCache(resource, Renderer.FrameIndex));
+            statUsed.Value++;
+        }
+
+        /// <summary>
+        /// Updates the state of the resources in this pool in two steps:
+        /// <list type="bullet">
+        /// <item>Returns all textures that the GPU has finished from back to the pool.</item>
+        /// <item>Frees any texture that has not been used for a while, specifically after <see cref="Rendering.Renderer.RESOURCE_FREE_CHECK_INTERVAL"/> number of frames.</item>
+        /// </list>
+        /// </summary>
+        public void NewFrame()
+        {
+            // return any resource that the GPU has finished from.
+            for (int i = 0; i < used.Count; i++)
+            {
+                var texture = used[i];
+
+                if (texture.FrameUsageIndex <= Renderer.LatestCompletedFrameIndex)
+                {
+                    available.Add(texture);
+                    statAvailable.Value++;
+
+                    used.RemoveAt(i--);
+                    statUsed.Value--;
+                }
+            }
+
+            // dispose of any resource that we haven't used for a while.
+            if (Renderer.FrameIndex % Rendering.Renderer.RESOURCE_FREE_CHECK_INTERVAL == 0)
+            {
+                for (int i = 0; i < available.Count; i++)
+                {
+                    var texture = available[i];
+
+                    if (Renderer.FrameIndex - texture.FrameUsageIndex < Rendering.Renderer.RESOURCE_FREE_CHECK_INTERVAL)
+                        break;
+
+                    texture.Resource.Dispose();
+                    available.Remove(texture);
+                    statAvailable.Value--;
+                }
+            }
+        }
+
+        private record struct StagingResourceCache(T Resource, ulong FrameUsageIndex);
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
@@ -1,26 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Framework.Graphics.Rendering;
-using osu.Framework.Statistics;
 using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid
 {
-    internal class VeldridStagingTexturePool
+    internal class VeldridStagingTexturePool : VeldridStagingResourcePool<Texture>
     {
-        private readonly VeldridRenderer renderer;
-
-        private readonly List<StagingTextureCache> available = new List<StagingTextureCache>();
-        private readonly List<StagingTextureCache> used = new List<StagingTextureCache>();
-
-        private static readonly GlobalStatistic<int> stat_available = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Total staging textures available");
-        private static readonly GlobalStatistic<int> stat_used = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Total staging textures used");
-
         public VeldridStagingTexturePool(VeldridRenderer renderer)
+            : base(renderer, "staging textures")
         {
-            this.renderer = renderer;
         }
 
         /// <summary>
@@ -28,72 +17,14 @@ namespace osu.Framework.Graphics.Veldrid
         /// This should be written once by the CPU as it is handed over to the GPU for copying its data to the target texture,
         /// once the GPU has finished copying, the staging texture will eventually return back to the pool for reuse.
         /// </summary>
-        /// <param name="width">The minimum width of the texture required for uploading.</param>
-        /// <param name="height">The minimum height of the texture required for uploading.</param>
-        /// <param name="format">The pixel format of the texture.</param>
         public Texture Get(int width, int height, PixelFormat format)
         {
-            foreach (var existing in available)
-            {
-                if (existing.Texture.Format == format && existing.Texture.Width >= width && existing.Texture.Height >= height)
-                {
-                    available.Remove(existing);
-                    stat_available.Value--;
+            if (TryGet(t => t.Width >= width && t.Height >= height && t.Format == format, out var texture))
+                return texture;
 
-                    used.Add(existing with { FrameUsageIndex = renderer.FrameIndex });
-                    stat_used.Value++;
-
-                    return existing.Texture;
-                }
-            }
-
-            var texture = renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, format, TextureUsage.Staging));
-            used.Add(new StagingTextureCache(texture, renderer.FrameIndex));
-            stat_used.Value++;
+            texture = Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, format, TextureUsage.Staging));
+            AddNewResource(texture);
             return texture;
         }
-
-        /// <summary>
-        /// Updates the state of the resources in this pool in two steps:
-        /// <list type="bullet">
-        /// <item>Returns all textures that the GPU has finished from back to the pool.</item>
-        /// <item>Frees any texture that has not been used for a while, specifically after <see cref="Renderer.RESOURCE_FREE_CHECK_INTERVAL"/> number of frames.</item>
-        /// </list>
-        /// </summary>
-        public void NewFrame()
-        {
-            // return any resource that the GPU has finished from.
-            for (int i = 0; i < used.Count; i++)
-            {
-                var texture = used[i];
-
-                if (texture.FrameUsageIndex <= renderer.LatestCompletedFrameIndex)
-                {
-                    available.Add(texture);
-                    stat_available.Value++;
-
-                    used.RemoveAt(i--);
-                    stat_used.Value--;
-                }
-            }
-
-            // dispose of any resource that we haven't used for a while.
-            if (renderer.FrameIndex % Renderer.RESOURCE_FREE_CHECK_INTERVAL == 0)
-            {
-                for (int i = 0; i < available.Count; i++)
-                {
-                    var texture = available[i];
-
-                    if (renderer.FrameIndex - texture.FrameUsageIndex < Renderer.RESOURCE_FREE_CHECK_INTERVAL)
-                        break;
-
-                    texture.Texture.Dispose();
-                    available.Remove(texture);
-                    stat_available.Value--;
-                }
-            }
-        }
-
-        private record struct StagingTextureCache(Texture Texture, ulong FrameUsageIndex);
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Graphics.Veldrid
     internal class VeldridStagingTexturePool : VeldridStagingResourcePool<Texture>
     {
         public VeldridStagingTexturePool(VeldridRenderer renderer)
-            : base(renderer, "staging textures")
+            : base(renderer, nameof(VeldridStagingTexturePool))
         {
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
@@ -12,11 +12,6 @@ namespace osu.Framework.Graphics.Veldrid
         {
         }
 
-        /// <summary>
-        /// Retrieves a staging texture to use as an intermediate storage for uploading textures to the GPU.
-        /// This should be written once by the CPU as it is handed over to the GPU for copying its data to the target texture,
-        /// once the GPU has finished copying, the staging texture will eventually return back to the pool for reuse.
-        /// </summary>
         public Texture Get(int width, int height, PixelFormat format)
         {
             if (TryGet(t => t.Width >= width && t.Height >= height && t.Format == format, out var texture))


### PR DESCRIPTION
- [x] Depends on #5911 (for caching logic)

Staging buffer cache has been removed from Metal in https://github.com/ppy/veldrid/pull/31, and needs to be brought back here to maintain performance. Needs testing on all platforms, especially D3D11 since it's the only backend that doesn't allocate a staging buffer in `CommandList.UpdateBuffer` (if there's any sign of performance degradation, I can easily revert back just for D3D11).