### PR TITLE
Replace most usages of `IsDynamicCodeCompiled` with `IsDynamicCodeSupported`

### DIFF
--- a/osu.Framework/Audio/Callbacks/BassCallback.cs
+++ b/osu.Framework/Audio/Callbacks/BassCallback.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Audio.Callbacks
 
         protected BassCallback()
         {
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
                 handle = new ObjectHandle<BassCallback>(this, GCHandleType.Normal);
         }
 

--- a/osu.Framework/Audio/Callbacks/FileCallbacks.cs
+++ b/osu.Framework/Audio/Callbacks/FileCallbacks.cs
@@ -41,14 +41,14 @@ namespace osu.Framework.Audio.Callbacks
 
         public FileCallbacks(IFileProcedures implementation)
         {
-            Callbacks = RuntimeFeature.IsDynamicCodeCompiled ? instanceProcedures : static_procedures;
+            Callbacks = RuntimeFeature.IsDynamicCodeSupported ? instanceProcedures : static_procedures;
             this.implementation = implementation;
             procedures = null;
         }
 
         public FileCallbacks(FileProcedures procedures)
         {
-            Callbacks = RuntimeFeature.IsDynamicCodeCompiled ? instanceProcedures : static_procedures;
+            Callbacks = RuntimeFeature.IsDynamicCodeSupported ? instanceProcedures : static_procedures;
             this.procedures = procedures;
             implementation = null;
         }

--- a/osu.Framework/Audio/Callbacks/SyncCallback.cs
+++ b/osu.Framework/Audio/Callbacks/SyncCallback.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Audio.Callbacks
     /// </summary>
     public class SyncCallback : BassCallback
     {
-        public SyncProcedure Callback => RuntimeFeature.IsDynamicCodeCompiled ? Sync : syncCallback;
+        public SyncProcedure Callback => RuntimeFeature.IsDynamicCodeSupported ? Sync : syncCallback;
 
         public readonly SyncProcedure Sync;
 


### PR DESCRIPTION
`IsDynamicCodeSupported` returns true in iOS when building with interpreter mode on, so it's probably better to use that instead (kind of as a way of testing dynamic code on iOS). Note that I have kept the `TransformCustom` cases as they generate CIL instructions, which I'm not sure would outperform reflection in an interpretation environment (I have tested this and I didn't see any noticeable differences, but felt safer not to change it).