### PR TITLE
Use staging buffers for metal UBO uploads

### DIFF
--- a/osu.Framework.Tests/Visual/Performance/TestSceneVertexUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneVertexUploadPerformance.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Performance
+{
+    public partial class TestSceneVertexUploadPerformance : PerformanceTestScene
+    {
+        private int count;
+
+        private FillFlowContainer<CircularProgress>? fill;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AddSliderStep("count", 1, 1000, 400, v =>
+            {
+                count = v;
+                recreate();
+            });
+        }
+
+        private void recreate()
+        {
+            Child = fill = new FillFlowContainer<CircularProgress>
+            {
+                RelativeSizeAxes = Axes.X,
+                Width = 0.5f,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Full,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+
+            for (int i = 0; i < count; i++)
+            {
+                fill.Add(new CircularProgress
+                {
+                    Size = new Vector2(10),
+                    Current = { Value = 1 }
+                });
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var col = Interpolation.ValueAt((MathF.Sin((float)Time.Current / 1000) + 1) / 2, Color4.Red, Color4.SkyBlue, 0f, 1f);
+
+            if (fill != null)
+            {
+                fill.Colour = col;
+                fill.Rotation += (float)Time.Elapsed * 0.001f;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -37,9 +37,16 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 for (ushort i = 0; i < amountVertices; i++)
                     indices[i] = i;
 
-                var staging = renderer.GetFreeStagingBuffer(renderer.SharedLinearIndex.Buffer.SizeInBytes);
-                renderer.Device.UpdateBuffer(staging, 0, indices);
-                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedLinearIndex.Buffer, 0, staging.SizeInBytes);
+                if (renderer.Device.BackendType == GraphicsBackend.Metal)
+                {
+                    var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);
+                    renderer.Device.UpdateBuffer(staging, 0, indices);
+                    renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedQuadIndex.Buffer, 0, staging.SizeInBytes);
+                }
+                else
+                {
+                    renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedLinearIndex.Buffer, 0, indices);
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridLinearBuffer.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                 for (ushort i = 0; i < amountVertices; i++)
                     indices[i] = i;
 
+                // These pathways are faster on respective platforms.
+                // Test using TestSceneVertexUploadPerformance.
                 if (renderer.Device.BackendType == GraphicsBackend.Metal)
                 {
                     var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -51,9 +51,16 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                     indices[j + 5] = (ushort)(i + 1);
                 }
 
-                var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);
-                renderer.Device.UpdateBuffer(staging, 0, indices);
-                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedQuadIndex.Buffer, 0, staging.SizeInBytes);
+                if (renderer.Device.BackendType == GraphicsBackend.Metal)
+                {
+                    var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);
+                    renderer.Device.UpdateBuffer(staging, 0, indices);
+                    renderer.BufferUpdateCommands.CopyBuffer(staging, 0, renderer.SharedQuadIndex.Buffer, 0, staging.SizeInBytes);
+                }
+                else
+                {
+                    renderer.BufferUpdateCommands.UpdateBuffer(renderer.SharedQuadIndex.Buffer, 0, indices);
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridQuadBuffer.cs
@@ -51,6 +51,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
                     indices[j + 5] = (ushort)(i + 1);
                 }
 
+                // These pathways are faster on respective platforms.
+                // Test using TestSceneVertexUploadPerformance.
                 if (renderer.Device.BackendType == GraphicsBackend.Metal)
                 {
                     var staging = renderer.GetFreeStagingBuffer(renderer.SharedQuadIndex.Buffer.SizeInBytes);

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -33,6 +33,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             {
                 data = value;
 
+                // These pathways are faster on respective platforms.
+                // Test using TestSceneVertexUploadPerformance.
                 if (renderer.Device.BackendType == GraphicsBackend.Metal)
                 {
                     var staging = renderer.GetFreeStagingBuffer(buffer.SizeInBytes);

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -33,9 +33,16 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             {
                 data = value;
 
-                var staging = renderer.GetFreeStagingBuffer(buffer.SizeInBytes);
-                renderer.Device.UpdateBuffer(staging, 0, ref data);
-                renderer.BufferUpdateCommands.CopyBuffer(staging, 0, buffer, 0, buffer.SizeInBytes);
+                if (renderer.Device.BackendType == GraphicsBackend.Metal)
+                {
+                    renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, data);
+                }
+                else
+                {
+                    var staging = renderer.GetFreeStagingBuffer(buffer.SizeInBytes);
+                    renderer.Device.UpdateBuffer(staging, 0, ref data);
+                    renderer.BufferUpdateCommands.CopyBuffer(staging, 0, buffer, 0, buffer.SizeInBytes);
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -35,13 +35,13 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
                 if (renderer.Device.BackendType == GraphicsBackend.Metal)
                 {
-                    renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, data);
-                }
-                else
-                {
                     var staging = renderer.GetFreeStagingBuffer(buffer.SizeInBytes);
                     renderer.Device.UpdateBuffer(staging, 0, ref data);
                     renderer.BufferUpdateCommands.CopyBuffer(staging, 0, buffer, 0, buffer.SizeInBytes);
+                }
+                else
+                {
+                    renderer.BufferUpdateCommands.UpdateBuffer(buffer, 0, data);
                 }
             }
         }


### PR DESCRIPTION
As proposed by @smoogipoo. In the vertex upload performance test scene, this performs ~50% better on macOS for me.

Making this PR to track a potential improvement.


- [ ] Depends on https://github.com/ppy/osu-framework/pull/5917