### PR TITLE
Improve `Clipboard` class for use in tests and on Android

### DIFF
--- a/osu.Framework.Android/AndroidClipboard.cs
+++ b/osu.Framework.Android/AndroidClipboard.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.Content;
+using osu.Framework.Platform;
+using SixLabors.ImageSharp;
+
+namespace osu.Framework.Android
+{
+    public class AndroidClipboard : Clipboard
+    {
+        private readonly ClipboardManager? clipboardManager;
+
+        public AndroidClipboard(AndroidGameView view)
+        {
+            clipboardManager = view.Activity.GetSystemService(Context.ClipboardService) as ClipboardManager;
+        }
+
+        public override string? GetText() => clipboardManager?.PrimaryClip?.GetItemAt(0)?.Text;
+
+        public override void SetText(string text)
+        {
+            if (clipboardManager != null)
+                clipboardManager.PrimaryClip = ClipData.NewPlainText(null, text);
+        }
+
+        public override Image<TPixel>? GetImage<TPixel>() => null;
+
+        public override bool SetImage(Image image) => false;
+    }
+}

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -43,6 +43,8 @@ namespace osu.Framework.Android
 
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new AndroidGameWindow(gameView);
 
+        protected override Clipboard CreateClipboard() => new AndroidClipboard(gameView);
+
         public override bool CanExit => false;
 
         public override bool CanSuspendToBackground => true;

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -14,7 +14,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    [Ignore("This test should not be run in headless mode, as it mutates the clipboard.")]
+    [Ignore("This test cannot run in headless mode (a window instance is required).")]
     public partial class TestSceneClipboard : FrameworkTestScene
     {
         [Resolved]
@@ -28,6 +28,17 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private Image<Rgba32>? originalImage;
         private Image<Rgba32>? clipboardImage;
+
+        // empty text doesn't really matter, since it doesn't actually make sense (text editors generally don't allow copying nothing)
+        // it's here to just show how it behaves
+        [TestCase("")]
+        [TestCase("hello!")]
+        public void TestText(string text)
+        {
+            AddStep("set clipboard text", () => clipboard.SetText(text));
+            AddAssert("clipboard text is expected", () => clipboard.GetText(), () => Is.EqualTo(text));
+            AddAssert("clipboard image is null", () => clipboard.GetImage<Rgba32>(), () => Is.Null);
+        }
 
         [Test]
         public void TestImage()
@@ -50,6 +61,8 @@ namespace osu.Framework.Tests.Visual.Platform
             {
                 clipboard.SetImage(originalImage!);
             });
+
+            AddAssert("clipboard text is null", () => clipboard.GetText(), () => Is.Null);
 
             AddStep("retrieve image from clipboard", () =>
             {

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Rendering;
@@ -14,7 +15,6 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    [Ignore("This test cannot run in headless mode (a window instance is required).")]
     public partial class TestSceneClipboard : FrameworkTestScene
     {
         [Resolved]
@@ -43,6 +43,9 @@ namespace osu.Framework.Tests.Visual.Platform
         [Test]
         public void TestImage()
         {
+            if (DebugUtils.IsNUnitRunning)
+                Assert.Ignore("This test cannot run in headless mode (a window instance is required).");
+
             AddStep("clear previous screenshots", Clear);
 
             AddStep("screenshot screen", () =>

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
@@ -20,15 +18,15 @@ namespace osu.Framework.Tests.Visual.Platform
     public partial class TestSceneClipboard : FrameworkTestScene
     {
         [Resolved]
-        private IRenderer renderer { get; set; }
+        private IRenderer renderer { get; set; } = null!;
 
         [Resolved]
-        private GameHost host { get; set; }
+        private GameHost host { get; set; } = null!;
 
-        private Image<Rgba32> originalImage;
-        private Image<Rgba32> clipboardImage;
+        private Image<Rgba32>? originalImage;
+        private Image<Rgba32>? clipboardImage;
 
-        private Clipboard clipboard => host.GetClipboard();
+        private Clipboard clipboard => host.GetClipboard()!;
 
         [Test]
         public void TestImage()
@@ -49,13 +47,13 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddStep("copy image to clipboard", () =>
             {
-                clipboard.SetImage(originalImage);
+                clipboard.SetImage(originalImage!);
             });
 
             AddStep("retrieve image from clipboard", () =>
             {
                 var image = clipboard.GetImage<Rgba32>();
-                clipboardImage = image.Clone();
+                clipboardImage = image!.Clone();
 
                 var texture = renderer.CreateTexture(image.Width, image.Height);
                 texture.SetData(new TextureUpload(image));
@@ -74,7 +72,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddAssert("compare images", () =>
             {
-                if (originalImage.Width != clipboardImage.Width || originalImage.Height != clipboardImage.Height)
+                if (originalImage!.Width != clipboardImage!.Width || originalImage.Height != clipboardImage.Height)
                     return false;
 
                 for (int x = 0; x < originalImage.Width; x++)

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -23,10 +23,11 @@ namespace osu.Framework.Tests.Visual.Platform
         [Resolved]
         private GameHost host { get; set; } = null!;
 
+        [Resolved]
+        private Clipboard clipboard { get; set; } = null!;
+
         private Image<Rgba32>? originalImage;
         private Image<Rgba32>? clipboardImage;
-
-        private Clipboard clipboard => host.GetClipboard()!;
 
         [Test]
         public void TestImage()

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -118,7 +118,8 @@ namespace osu.Framework.Graphics.UserInterface
         [Resolved]
         private TextInputSource textInput { get; set; }
 
-        private Clipboard clipboard;
+        [Resolved]
+        private Clipboard clipboard { get; set; }
 
         /// <summary>
         /// Whether the <see cref="GameHost"/> is active (has keyboard focus).
@@ -199,7 +200,6 @@ namespace osu.Framework.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            clipboard = host.GetClipboard();
             isActive = host.IsActive.GetBoundCopy();
         }
 
@@ -242,7 +242,7 @@ namespace osu.Framework.Graphics.UserInterface
                 case PlatformAction.Copy:
                     if (string.IsNullOrEmpty(SelectedText) || !AllowClipboardExport) return true;
 
-                    clipboard?.SetText(SelectedText);
+                    clipboard.SetText(SelectedText);
 
                     if (e.Action == PlatformAction.Cut)
                         DeleteBy(0);
@@ -258,7 +258,7 @@ namespace osu.Framework.Graphics.UserInterface
                         // This is currently only happening on iOS since it relies on a hidden UITextField for software keyboard.
                         return true;
 
-                    InsertString(clipboard?.GetText());
+                    InsertString(clipboard.GetText());
                     return true;
 
                 case PlatformAction.SelectAll:

--- a/osu.Framework/Platform/Clipboard.cs
+++ b/osu.Framework/Platform/Clipboard.cs
@@ -12,31 +12,25 @@ namespace osu.Framework.Platform
     public abstract class Clipboard
     {
         /// <summary>
-        /// Retrieve text from the clipboard
+        /// Retrieve text from the clipboard.
         /// </summary>
         public abstract string? GetText();
 
         /// <summary>
-        /// Copy text to the clipboard
+        /// Copy text to the clipboard.
         /// </summary>
-        /// <param name="selectedText">Text to copy to the clipboard</param>
-        public abstract void SetText(string selectedText);
+        /// <param name="text">Text to copy to the clipboard</param>
+        public abstract void SetText(string text);
 
         /// <summary>
-        /// Retrieve image from the clipboard.
+        /// Retrieve an image from the clipboard.
         /// </summary>
-        /// <remarks>
-        /// Currently only supported on Windows.
-        /// </remarks>
         public abstract Image<TPixel>? GetImage<TPixel>()
             where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>
         /// Copy the image to the clipboard.
         /// </summary>
-        /// <remarks>
-        /// Currently only supported on Windows.
-        /// </remarks>
         /// <param name="image">The image to copy to the clipboard</param>
         /// <returns>Whether the image was successfully copied or not</returns>
         public abstract bool SetImage(Image image);

--- a/osu.Framework/Platform/Clipboard.cs
+++ b/osu.Framework/Platform/Clipboard.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -16,7 +14,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Retrieve text from the clipboard
         /// </summary>
-        public abstract string GetText();
+        public abstract string? GetText();
 
         /// <summary>
         /// Copy text to the clipboard
@@ -30,7 +28,7 @@ namespace osu.Framework.Platform
         /// <remarks>
         /// Currently only supported on Windows.
         /// </remarks>
-        public abstract Image<TPixel> GetImage<TPixel>()
+        public abstract Image<TPixel>? GetImage<TPixel>()
             where TPixel : unmanaged, IPixel<TPixel>;
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -174,8 +174,10 @@ namespace osu.Framework.Platform
         /// </summary>
         protected abstract IWindow CreateWindow(GraphicsSurfaceType preferredSurface);
 
-        [CanBeNull]
-        public virtual Clipboard GetClipboard() => null;
+        [Obsolete($"Resolve {nameof(Clipboard)} via DI.")] // can be removed 20231010
+        public Clipboard GetClipboard() => Dependencies.Get<Clipboard>();
+
+        protected abstract Clipboard CreateClipboard();
 
         protected virtual ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new ReadableKeyCombinationProvider();
 
@@ -737,6 +739,7 @@ namespace osu.Framework.Platform
 
                 Dependencies.CacheAs(readableKeyCombinationProvider = CreateReadableKeyCombinationProvider());
                 Dependencies.CacheAs(CreateTextInput());
+                Dependencies.CacheAs(CreateClipboard());
 
                 ExecutionState = ExecutionState.Running;
                 threadRunner.Start();

--- a/osu.Framework/Platform/HeadlessClipboard.cs
+++ b/osu.Framework/Platform/HeadlessClipboard.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using SixLabors.ImageSharp;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Virtual clipboard for use in headless execution.
+    /// </summary>
+    /// <remarks>
+    /// Stores all data in-memory, so the host OS clipboard is not affected.
+    /// </remarks>
+    public class HeadlessClipboard : Clipboard
+    {
+        private string? clipboardText;
+        private Image? clipboardImage;
+
+        public override string? GetText() => clipboardText;
+
+        public override void SetText(string text)
+        {
+            clipboardImage = null;
+            clipboardText = text;
+        }
+
+        public override Image<TPixel>? GetImage<TPixel>() => clipboardImage?.CloneAs<TPixel>();
+
+        public override bool SetImage(Image image)
+        {
+            clipboardText = null;
+            clipboardImage = image;
+            return true;
+        }
+    }
+}

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -49,6 +49,8 @@ namespace osu.Framework.Platform
 
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => null;
 
+        protected override Clipboard CreateClipboard() => new HeadlessClipboard();
+
         protected override void ChooseAndSetupRenderer() => SetupRendererAndWindow(new DummyRenderer(), GraphicsSurfaceType.OpenGL);
 
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -11,9 +11,9 @@ namespace osu.Framework.Platform.MacOS
     {
         private readonly NSPasteboard generalPasteboard = NSPasteboard.GeneralPasteboard();
 
-        public override string GetText() => Cocoa.FromNSString(getFromPasteboard(Class.Get("NSString")));
+        public override string? GetText() => Cocoa.FromNSString(getFromPasteboard(Class.Get("NSString")));
 
-        public override Image<TPixel> GetImage<TPixel>() => Cocoa.FromNSImage<TPixel>(getFromPasteboard(Class.Get("NSImage")));
+        public override Image<TPixel>? GetImage<TPixel>() => Cocoa.FromNSImage<TPixel>(getFromPasteboard(Class.Get("NSImage")));
 
         public override void SetText(string selectedText) => setToPasteboard(Cocoa.ToNSString(selectedText));
 

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Platform.MacOS
 
         public override Image<TPixel>? GetImage<TPixel>() => Cocoa.FromNSImage<TPixel>(getFromPasteboard(Class.Get("NSImage")));
 
-        public override void SetText(string selectedText) => setToPasteboard(Cocoa.ToNSString(selectedText));
+        public override void SetText(string text) => setToPasteboard(Cocoa.ToNSString(text));
 
         public override bool SetImage(Image image) => setToPasteboard(Cocoa.ToNSImage(image));
 

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Platform.MacOS
             }
         }
 
-        public override Clipboard GetClipboard() => new MacOSClipboard();
+        protected override Clipboard CreateClipboard() => new MacOSClipboard();
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new MacOSReadableKeyCombinationProvider();
 

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -93,9 +91,9 @@ namespace osu.Framework.Platform.MacOS.Native
         private static readonly IntPtr sel_c_string_using_encoding = Selector.Get("cStringUsingEncoding:");
         private static readonly IntPtr sel_tiff_representation = Selector.Get("TIFFRepresentation");
 
-        public static string FromNSString(IntPtr handle) => Marshal.PtrToStringUni(SendIntPtr(handle, sel_c_string_using_encoding, (uint)NSStringEncoding.Unicode));
+        public static string? FromNSString(IntPtr handle) => Marshal.PtrToStringUni(SendIntPtr(handle, sel_c_string_using_encoding, (uint)NSStringEncoding.Unicode));
 
-        public static Image<TPixel> FromNSImage<TPixel>(IntPtr handle)
+        public static Image<TPixel>? FromNSImage<TPixel>(IntPtr handle)
             where TPixel : unmanaged, IPixel<TPixel>
         {
             if (handle == IntPtr.Zero)
@@ -105,7 +103,7 @@ namespace osu.Framework.Platform.MacOS.Native
             return Image.Load<TPixel>(tiffRepresentation.ToBytes());
         }
 
-        public static unsafe IntPtr ToNSString(string str)
+        public static unsafe IntPtr ToNSString(string? str)
         {
             if (str == null)
                 return IntPtr.Zero;
@@ -117,7 +115,7 @@ namespace osu.Framework.Platform.MacOS.Native
             }
         }
 
-        public static IntPtr ToNSImage(Image image)
+        public static IntPtr ToNSImage(Image? image)
         {
             if (image == null)
                 return IntPtr.Zero;

--- a/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
@@ -8,7 +8,10 @@ namespace osu.Framework.Platform.SDL2
 {
     public class SDL2Clipboard : Clipboard
     {
-        public override string? GetText() => SDL.SDL_GetClipboardText();
+        // SDL cannot differentiate between string.Empty and no text (eg. empty clipboard or an image)
+        // doesn't matter as text editors don't really allow copying empty strings.
+        // assume that empty text means no text.
+        public override string? GetText() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE ? SDL.SDL_GetClipboardText() : null;
 
         public override void SetText(string text) => SDL.SDL_SetClipboardText(text);
 

--- a/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Platform.SDL2
     {
         public override string? GetText() => SDL.SDL_GetClipboardText();
 
-        public override void SetText(string selectedText) => SDL.SDL_SetClipboardText(selectedText);
+        public override void SetText(string text) => SDL.SDL_SetClipboardText(text);
 
         public override Image<TPixel>? GetImage<TPixel>()
         {

--- a/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using SDL2;
 using SixLabors.ImageSharp;
 
@@ -10,11 +8,11 @@ namespace osu.Framework.Platform.SDL2
 {
     public class SDL2Clipboard : Clipboard
     {
-        public override string GetText() => SDL.SDL_GetClipboardText();
+        public override string? GetText() => SDL.SDL_GetClipboardText();
 
         public override void SetText(string selectedText) => SDL.SDL_SetClipboardText(selectedText);
 
-        public override Image<TPixel> GetImage<TPixel>()
+        public override Image<TPixel>? GetImage<TPixel>()
         {
             return null;
         }

--- a/osu.Framework/Platform/SDL2GameHost.cs
+++ b/osu.Framework/Platform/SDL2GameHost.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Platform
             return base.CreateTextInput();
         }
 
-        public override Clipboard GetClipboard() => new SDL2Clipboard();
+        protected override Clipboard CreateClipboard() => new SDL2Clipboard();
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() =>
             new InputHandler[]

--- a/osu.Framework/Platform/Windows/WindowsClipboard.cs
+++ b/osu.Framework/Platform/Windows/WindowsClipboard.cs
@@ -69,10 +69,10 @@ namespace osu.Framework.Platform.Windows
             return getClipboard(cf_unicodetext, bytes => Encoding.Unicode.GetString(bytes).TrimEnd('\0'));
         }
 
-        public override void SetText(string selectedText)
+        public override void SetText(string text)
         {
-            int bytes = (selectedText.Length + 1) * 2;
-            var source = Marshal.StringToHGlobalUni(selectedText);
+            int bytes = (text.Length + 1) * 2;
+            var source = Marshal.StringToHGlobalUni(text);
 
             setClipboard(source, bytes, cf_unicodetext);
         }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Platform.Windows
     {
         private TimePeriod? timePeriod;
 
-        public override Clipboard GetClipboard() => new WindowsClipboard();
+        protected override Clipboard CreateClipboard() => new WindowsClipboard();
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new WindowsReadableKeyCombinationProvider();
 


### PR DESCRIPTION
As noted in https://github.com/ppy/osu/pull/24171, clipboard can't be used in headless tests. This PR adds a virtual clipboard that can be used in test, and improves old clipboard code along the way.

Changes:
- `Clipboard` is now a cached dependency (instead of acquiring it from `GameHost.GetClipboard()`) this brings it in line with osu-framework best practises(maybe?) and allows overriding it for tests if necessary
- `HeadlessGameHost` now uses a `HeadlessClipboard` that stores the data in-memory and doesn't modify the host OS clipboard
- `AndroidClipboard` has been added, text only for now to keep it simple. [docs](https://developer.android.com/develop/ui/views/touch-and-input/copy-paste)

## Breaking changes

### `GameHost.GetClipboard()` is obsolete

The new way to retrieve a `Clipboard` instance is to resolve it via dependency injection directly. This does not require resolving the `GameHost` anymore:

```diff
 [BackgroundDependencyLoader]
-private void load(GameHost host)
+private void load(Clipboard clipboard)
 {
-    host?.Clipboard.SetText("example");
+    clipboard.SetText("example");
 }
```