### PR TITLE
Add a fence pool for frame tracking fences

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -220,9 +220,6 @@ namespace osu.Framework.Graphics.Veldrid
             BufferUpdateCommands = Factory.CreateCommandList();
 
             pipeline.Outputs = Device.SwapchainFramebuffer.OutputDescription;
-
-            for (int i = 0; i < 16; i++)
-                perFrameFencePool.Enqueue(Factory.CreateFence(false));
         }
 
         private Vector2 currentSize;
@@ -296,7 +293,8 @@ namespace osu.Framework.Graphics.Veldrid
 
             // This is returned via the end-of-lifetime tracking in `pendingFrameFences`.
             // See `updateLastCompletedFrameIndex`.
-            Fence fence = perFrameFencePool.Dequeue();
+            if (!perFrameFencePool.TryDequeue(out Fence? fence))
+                fence = Factory.CreateFence(false);
 
             Commands.End();
             Device.SubmitCommands(Commands, fence);


### PR DESCRIPTION
Ignoring the fact that these tracking fences are doing nothing in D3D (they are set immediately https://github.com/ppy/veldrid/blob/6a43198af1b069e56ac53770249a5424c1859500/src/Veldrid/D3D11/D3D11GraphicsDevice.cs#L229-L232):

This is a regression so let's fix it locally for the time being.

Time spent in `ManualResetEvent` construction:

![Parallels Desktop 2023-07-11 at 05 01 20](https://github.com/ppy/osu-framework/assets/191335/42f7bfa6-7147-4634-a0c7-89f55aed2406)

Before this PR:

![Parallels Desktop 2023-07-11 at 05 07 32](https://github.com/ppy/osu-framework/assets/191335/ea5a597e-0841-488c-b1b5-9f37e6a22a5e)

After this PR:

![Parallels Desktop 2023-07-11 at 05 05 52](https://github.com/ppy/osu-framework/assets/191335/4f5d4555-ef15-498f-a6b7-13a0c29a2e39)
