### PR TITLE
Split texture upload performance test into own `TestScene`

### DIFF
--- a/osu.Framework.Tests/Visual/Performance/TestSceneTexturePerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTexturePerformance.cs
@@ -1,19 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
-using osuTK.Graphics.ES30;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.Performance
 {
@@ -24,7 +18,6 @@ namespace osu.Framework.Tests.Visual.Performance
 
         private Texture nonMipmappedSampleTexture = null!;
         private Texture mipmappedSampleTexture = null!;
-        private PersistentTextureUpload sampleTextureUpload = null!;
 
         private IResourceStore<TextureUpload> textureLoaderStore = null!;
 
@@ -38,7 +31,6 @@ namespace osu.Framework.Tests.Visual.Performance
 
             mipmappedSampleTexture = store.Get(@"sample-texture");
             nonMipmappedSampleTexture = new TextureStore(renderer, textureLoaderStore, manualMipmaps: true).Get(@"sample-texture");
-            sampleTextureUpload = new PersistentTextureUpload(textureLoaderStore.Get(@"sample-texture"));
         }
 
         protected override void LoadComplete()
@@ -51,28 +43,6 @@ namespace osu.Framework.Tests.Visual.Performance
         }
 
         protected override double TimePerAction => 100;
-
-        [Test]
-        public void TestUploadPerformance()
-        {
-            AddStep("clear textures", () =>
-            {
-                foreach (var sprite in this.ChildrenOfType<TestSprite>())
-                    sprite.Texture = renderer.CreateTexture(mipmappedSampleTexture.Width, mipmappedSampleTexture.Height);
-            });
-
-            AddRepeatStep("upload texture", () =>
-            {
-                foreach (var sprite in this.ChildrenOfType<TestSprite>())
-                    sprite.Texture.SetData(sampleTextureUpload);
-            }, 25);
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            sampleTextureUpload.Dispose();
-            base.Dispose(isDisposing);
-        }
 
         protected override Drawable CreateDrawable() => new TestSprite(mipmappedSampleTexture, nonMipmappedSampleTexture)
         {
@@ -121,34 +91,6 @@ namespace osu.Framework.Tests.Visual.Performance
                 else
                     Texture = DisableMipmaps.Value ? nonMipmappedTexture : mipmappedTexture;
             }
-        }
-
-        private class PersistentTextureUpload : ITextureUpload
-        {
-            private readonly ITextureUpload upload;
-
-            public ReadOnlySpan<Rgba32> Data => upload.Data;
-
-            public int Level => upload.Level;
-
-            public RectangleI Bounds
-            {
-                get => upload.Bounds;
-                set => upload.Bounds = value;
-            }
-
-            public PixelFormat Format => upload.Format;
-
-            public PersistentTextureUpload(ITextureUpload upload)
-            {
-                this.upload = upload;
-            }
-
-            void IDisposable.Dispose()
-            {
-            }
-
-            public void Dispose() => upload.Dispose();
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
+using osuTK;
+using SixLabors.ImageSharp.PixelFormats;
+using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
+
+namespace osu.Framework.Tests.Visual.Performance
+{
+    public partial class TestSceneTextureUploadPerformance : PerformanceTestScene
+    {
+        private int count;
+
+        private FillFlowContainer<Sprite>? fill;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        private PersistentTextureUpload sampleTextureUpload = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(Game game, GameHost host)
+        {
+            var textureLoaderStore = host.CreateTextureLoaderStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Textures"));
+
+            sampleTextureUpload = new PersistentTextureUpload(textureLoaderStore.Get(@"sample-texture"));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AddSliderStep("count", 1, 100, 1, v =>
+            {
+                count = v;
+                recreate();
+            });
+        }
+
+        private void recreate()
+        {
+            Child = fill = new FillFlowContainer<Sprite>
+            {
+                RelativeSizeAxes = Axes.X,
+                Width = 0.5f,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Full,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+            };
+
+            for (int i = 0; i < count; i++)
+            {
+                fill.Add(new Sprite
+                {
+                    Size = new Vector2(128),
+                    Texture = renderer.CreateTexture(512, 512)
+                });
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (fill == null) return;
+
+            foreach (var sprite in fill)
+                sprite.Texture.SetData(sampleTextureUpload);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            sampleTextureUpload.Dispose();
+            base.Dispose(isDisposing);
+        }
+
+        private class PersistentTextureUpload : ITextureUpload
+        {
+            private readonly ITextureUpload upload;
+
+            public ReadOnlySpan<Rgba32> Data => upload.Data;
+
+            public int Level => upload.Level;
+
+            public RectangleI Bounds
+            {
+                get => upload.Bounds;
+                set => upload.Bounds = value;
+            }
+
+            public PixelFormat Format => upload.Format;
+
+            public PersistentTextureUpload(ITextureUpload upload)
+            {
+                this.upload = upload;
+            }
+
+            void IDisposable.Dispose()
+            {
+            }
+
+            public void Dispose() => upload.Dispose();
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
@@ -19,8 +19,6 @@ namespace osu.Framework.Tests.Visual.Performance
 {
     public partial class TestSceneTextureUploadPerformance : PerformanceTestScene
     {
-        private int count;
-
         private FillFlowContainer<Sprite>? fill;
 
         [Resolved]
@@ -40,15 +38,6 @@ namespace osu.Framework.Tests.Visual.Performance
         {
             base.LoadComplete();
 
-            AddSliderStep("count", 1, 100, 10, v =>
-            {
-                count = v;
-                recreate();
-            });
-        }
-
-        private void recreate()
-        {
             Child = fill = new FillFlowContainer<Sprite>
             {
                 RelativeSizeAxes = Axes.X,
@@ -58,15 +47,21 @@ namespace osu.Framework.Tests.Visual.Performance
                 Origin = Anchor.Centre,
             };
 
-            for (int i = 0; i < count; i++)
+            AddSliderStep("count", 1, 100, 10, newCount =>
             {
-                fill.Add(new Sprite
-                {
-                    Size = new Vector2(128),
-                    Texture = renderer.CreateTexture(512, 512)
-                });
-            }
+                for (int i = fill.Count - 1; i >= newCount; i--)
+                    fill.Remove(fill.Children[i], true);
+
+                for (int i = fill.Count; i < newCount; i++)
+                    fill.Add(createSprite());
+            });
         }
+
+        private Sprite createSprite() => new Sprite
+        {
+            Size = new Vector2(64),
+            Texture = renderer.CreateTexture(512, 512)
+        };
 
         private ulong lastUploadedFrame;
 

--- a/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Tests.Visual.Performance
         {
             base.LoadComplete();
 
-            AddSliderStep("count", 1, 100, 1, v =>
+            AddSliderStep("count", 1, 100, 10, v =>
             {
                 count = v;
                 recreate();
@@ -69,14 +69,20 @@ namespace osu.Framework.Tests.Visual.Performance
             }
         }
 
+        private ulong lastUploadedFrame;
+
         protected override void Update()
         {
             base.Update();
 
             if (fill == null) return;
 
-            foreach (var sprite in fill)
-                sprite.Texture.SetData(sampleTextureUpload);
+            if (lastUploadedFrame != renderer.FrameIndex)
+            {
+                foreach (var sprite in fill)
+                    sprite.Texture.SetData(sampleTextureUpload);
+                lastUploadedFrame = renderer.FrameIndex;
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
@@ -52,7 +52,6 @@ namespace osu.Framework.Tests.Visual.Performance
             Child = fill = new FillFlowContainer<Sprite>
             {
                 RelativeSizeAxes = Axes.X,
-                Width = 0.5f,
                 AutoSizeAxes = Axes.Y,
                 Direction = FillDirection.Full,
                 Anchor = Anchor.Centre,

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -53,6 +53,8 @@ namespace osu.Framework.Graphics.Rendering.Dummy
             WhitePixel = new TextureWhitePixel(new Texture(new DummyNativeTexture(this), WrapMode.None, WrapMode.None));
         }
 
+        public ulong FrameIndex => 1;
+
         bool IRenderer.VerticalSync { get; set; } = true;
 
         bool IRenderer.AllowTearing { get; set; }

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
             WhitePixel = new TextureWhitePixel(new Texture(new DummyNativeTexture(this), WrapMode.None, WrapMode.None));
         }
 
-        public ulong FrameIndex => 1;
+        public ulong FrameIndex { get; private set; }
 
         bool IRenderer.VerticalSync { get; set; } = true;
 
@@ -68,6 +68,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
 
         void IRenderer.BeginFrame(Vector2 windowSize)
         {
+            FrameIndex++;
         }
 
         void IRenderer.FinishFrame()

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -34,6 +34,8 @@ namespace osu.Framework.Graphics.Rendering
 
         public const int INDICES_PER_QUAD = VERTICES_PER_QUAD + 2;
 
+        public ulong FrameIndex { get; }
+
         /// <summary>
         /// Maximum number of vertices in a linear vertex buffer.
         /// </summary>

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -34,8 +34,6 @@ namespace osu.Framework.Graphics.Rendering
 
         public const int INDICES_PER_QUAD = VERTICES_PER_QUAD + 2;
 
-        public ulong FrameIndex { get; }
-
         /// <summary>
         /// Maximum number of vertices in a linear vertex buffer.
         /// </summary>
@@ -57,6 +55,11 @@ namespace osu.Framework.Graphics.Rendering
         /// A <see cref="Storage"/> that can be used to cache objects.
         /// </summary>
         protected internal Storage? CacheStorage { set; }
+
+        /// <summary>
+        /// The current frame index.
+        /// </summary>
+        ulong FrameIndex { get; }
 
         /// <summary>
         /// The maximum allowed texture size.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -57,9 +57,6 @@ namespace osu.Framework.Graphics.Rendering
         public abstract bool IsUvOriginTopLeft { get; }
         public abstract bool IsClipSpaceYInverted { get; }
 
-        /// <summary>
-        /// The current frame index.
-        /// </summary>
         public ulong FrameIndex { get; private set; }
 
         public ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo;


### PR DESCRIPTION
This also makes the uploads happen every frame, as this is more useful for diagnosing contention edge cases.

Notes from testing:

- Metal can show signs of corruption with higher texture upload counts.
- D3D has very low performance compared to metal with similar texture upload counts.