### PR TITLE
Fix texture uploads getting corrupted on Metal with non-Apple GPUs

### DIFF
--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -30,7 +30,6 @@ using Veldrid.OpenGLBinding;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = Veldrid.PixelFormat;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
-using Texture = osu.Framework.Graphics.Textures.Texture;
 
 namespace osu.Framework.Graphics.Veldrid
 {

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -30,6 +30,7 @@ using Veldrid.OpenGLBinding;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = Veldrid.PixelFormat;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
+using Texture = osu.Framework.Graphics.Textures.Texture;
 
 namespace osu.Framework.Graphics.Veldrid
 {
@@ -64,6 +65,10 @@ namespace osu.Framework.Graphics.Veldrid
 
         public CommandList Commands { get; private set; } = null!;
         public CommandList BufferUpdateCommands { get; private set; } = null!;
+
+        public CommandList TextureUpdateCommands { get; private set; } = null!;
+
+        private bool beganTextureUpdateCommands;
 
         /// <summary>
         /// A list of fences which tracks in-flight frames for the purpose of knowing the last completed frame.
@@ -213,6 +218,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             Commands = Factory.CreateCommandList();
             BufferUpdateCommands = Factory.CreateCommandList();
+            TextureUpdateCommands = Factory.CreateCommandList();
 
             pipeline.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }
@@ -353,9 +359,11 @@ namespace osu.Framework.Graphics.Veldrid
         public void UpdateTexture<T>(global::Veldrid.Texture texture, int x, int y, int width, int height, int level, ReadOnlySpan<T> data)
             where T : unmanaged
         {
+            ensureTextureUploadCommandsBegan();
+
             var staging = stagingTexturePool.Get(width, height, texture.Format);
             Device.UpdateTexture(staging, data, 0, 0, 0, (uint)width, (uint)height, 1, (uint)level, 0);
-            BufferUpdateCommands.CopyTexture(staging, 0, 0, 0, 0, 0, texture, (uint)x, (uint)y, 0, (uint)level, 0, (uint)width, (uint)height, 1, 1);
+            TextureUpdateCommands.CopyTexture(staging, 0, 0, 0, 0, 0, texture, (uint)x, (uint)y, 0, (uint)level, 0, (uint)width, (uint)height, 1, 1);
         }
 
         /// <summary>
@@ -488,6 +496,13 @@ namespace osu.Framework.Graphics.Veldrid
 
         public void DrawVertices(PrimitiveTopology type, int indexStart, int indicesCount)
         {
+            // normally we would flush/submit all texture upload commands at the end of the frame, since no actual rendering by the GPU will happen until then,
+            // but turns out on macOS with non-apple GPU, this results in rendering corruption.
+            // flushing the texture upload commands here before a draw call fixes the corruption, and there's no explanation as to why that's the case,
+            // but there is nothing to be lost in flushing here except for a frame that contains many sprites with Texture.BypassTextureUploadQueue = true.
+            // until that appears to be problem, let's just flush here.
+            flushTextureUploadCommands();
+
             var veldridShader = (VeldridShader)Shader!;
 
             pipeline.PrimitiveTopology = type;
@@ -537,6 +552,26 @@ namespace osu.Framework.Graphics.Veldrid
             }
 
             Commands.DrawIndexed((uint)indicesCount, 1, (uint)indexStart, 0, 0);
+        }
+
+        private void ensureTextureUploadCommandsBegan()
+        {
+            if (beganTextureUpdateCommands)
+                return;
+
+            TextureUpdateCommands.Begin();
+            beganTextureUpdateCommands = true;
+        }
+
+        private void flushTextureUploadCommands()
+        {
+            if (!beganTextureUpdateCommands)
+                return;
+
+            TextureUpdateCommands.End();
+            Device.SubmitCommands(TextureUpdateCommands);
+
+            beganTextureUpdateCommands = false;
         }
 
         /// <summary>


### PR DESCRIPTION
- Closes #5923 

Please test thoroughly and check multiple times that this does fix the issue, I have no explanation for how this fixes the issue (I rather have suspicion it's hiding the issue instead), but I cannot reproduce this on my machine (M1 Pro) and there's not much to lose in flushing before drawcall so why not.