### PR TITLE
Fix screenshots not working on Metal

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -11,9 +11,11 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Events;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
@@ -53,6 +55,17 @@ namespace osu.Framework.Tests.Visual.Sprites
             };
 
             AddStep("take screenshot", takeScreenshot);
+        }
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.F12)
+            {
+                takeScreenshot();
+                return true;
+            }
+
+            return base.OnKeyDown(e);
         }
 
         private void takeScreenshot()


### PR DESCRIPTION
- Regressed in https://github.com/ppy/veldrid/pull/30

Initially I was looking into properly implementing a "wait for fence" logic over at Veldrid using [`notifyListener:atValue:block`](https://developer.apple.com/documentation/metal/mtlsharedevent/2966574-notifylistener?changes=_8&language=objc), but I've stumbled across issues with P/Invokes specific to that function, and tried going back and fourth on it for over an hour to no avail. For the time being, I'm working around this locally. 