### PR TITLE
Fix `FrameBufferScale` not working when `PixelSnapping` is enabled

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -59,9 +59,8 @@ namespace osu.Framework.Graphics
             clipDrawRectangle();
 
             frameBufferSize = new Vector2(MathF.Ceiling(screenSpaceDrawRectangle.Width * frameBufferScale.X), MathF.Ceiling(screenSpaceDrawRectangle.Height * frameBufferScale.Y));
-            DrawRectangle = SharedData.PixelSnapping
-                ? new RectangleF(screenSpaceDrawRectangle.X, screenSpaceDrawRectangle.Y, frameBufferSize.X, frameBufferSize.Y)
-                : screenSpaceDrawRectangle;
+
+            DrawRectangle = screenSpaceDrawRectangle;
 
             Child.ApplyState();
         }


### PR DESCRIPTION
Weird code was weird.

Note that this will result in `Nearest` scaling being applied. I think it's fine. Better than not working at all (it used to scale the content to be smaller on-screen).

https://github.com/ppy/osu-framework/assets/191335/74754480-0afb-4af8-9d88-a0f5fa0e9c16



