### PR TITLE
Revert iOS frame-rate display fix to resolve issues with running multi-threaded mode

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1063,19 +1063,15 @@ namespace osu.Framework.Platform
 
         private void windowUpdate()
         {
-            outsideRunLoopCollectionPeriod?.Dispose();
-            outsideRunLoopCollectionPeriod = null;
+            inputPerformanceCollectionPeriod?.Dispose();
+            inputPerformanceCollectionPeriod = null;
 
             if (suspended)
                 return;
 
             threadRunner.RunMainLoop();
 
-            outsideRunLoopCollectionPeriod = RuntimeInfo.OS == RuntimeInfo.Platform.iOS
-                // in iOS, the game loop is wrapped around CADisplayLink which waits for the next V-Sync point before processing next frame,
-                // therefore we should mark this as "sleep" time in draw thread instead.
-                ? drawMonitor.BeginCollecting(PerformanceCollectionType.Sleep)
-                : inputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);
+            inputPerformanceCollectionPeriod = inputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);
         }
 
         /// <summary>
@@ -1149,7 +1145,7 @@ namespace osu.Framework.Platform
             Root = root;
         }
 
-        private InvokeOnDisposal outsideRunLoopCollectionPeriod;
+        private InvokeOnDisposal inputPerformanceCollectionPeriod;
 
         private Bindable<bool> bypassFrontToBackPass;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24242

In multi-threaded mode, `windowUpdate` will begin collecting "sleep" time as draw thread while in input thread, meanwhile `DrawFrame` will also begin collecting "sleep" time in the draw thread, therefore they collide together and produce 5 different exceptions.

Reverting for now as there's not a simple solution towards this.