### PR TITLE
Change source generators to only run for release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,10 @@ jobs:
        fail-fast: false
        matrix:
           os:
-            - { prettyname: Windows, fullname: windows-latest }
-            - { prettyname: macOS, fullname: macos-latest }
-            - { prettyname: Linux, fullname: ubuntu-latest }
+            - { prettyname: Windows, fullname: windows-latest, configuration: Debug }
+            - { prettyname: macOS, fullname: macos-latest, configuration: Debug }
+            - { prettyname: Linux, fullname: ubuntu-latest, configuration: Debug }
+            - { prettyname: Linux (Release), fullname: ubuntu-latest, configuration: Release }
           threadingMode: ['SingleThread', 'MultiThreaded']
     timeout-minutes: 60
 
@@ -84,10 +85,10 @@ jobs:
         shell: bash
 
       - name: Compile
-        run: dotnet build -c Debug -warnaserror osu-framework.Desktop.slnf
+        run: dotnet build -c ${{matrix.os.configuration}} -warnaserror osu-framework.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/**/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
+        run: dotnet test $pwd/**/*.Tests/bin/Debug/*/*.Tests.dll --no-build --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
         shell: pwsh
 
       # Attempt to upload results even if test fails.
@@ -96,8 +97,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
-          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
+          name: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}
+          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx
 
   build-only-android:
     name: Build only (Android)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             - { prettyname: Windows, fullname: windows-latest, configuration: Debug }
             - { prettyname: macOS, fullname: macos-latest, configuration: Debug }
             - { prettyname: Linux, fullname: ubuntu-latest, configuration: Debug }
-            - { prettyname: Linux (Release), fullname: ubuntu-latest, configuration: Release }
+            - { prettyname: Linux, fullname: ubuntu-latest, configuration: Release }
           threadingMode: ['SingleThread', 'MultiThreaded']
     timeout-minutes: 60
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         run: dotnet build -c ${{matrix.os.configuration}} -warnaserror osu-framework.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/**/*.Tests/bin/Debug/*/*.Tests.dll --no-build --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
+        run: dotnet test $pwd/**/*.Tests/bin/${{matrix.os.configuration}}/*/*.Tests.dll --no-build --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
         shell: pwsh
 
       # Attempt to upload results even if test fails.

--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -141,6 +141,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ParameterHidesMember/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ParameterOnlyUsedForPreconditionCheck_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ParameterOnlyUsedForPreconditionCheck_002ELocal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialMethodWithSinglePart/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PartialTypeWithSinglePart/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PatternAlwaysOfType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleInterfaceMemberAmbiguity/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpMultiPhaseSourceGeneratorVerifier_Test.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpMultiPhaseSourceGeneratorVerifier_Test.cs
@@ -34,6 +34,9 @@ namespace osu.Framework.SourceGeneration.Tests.Verifiers
             {
                 driver = CSharpGeneratorDriver.Create(generator = new TSourceGenerator());
                 driver = driver.WithUpdatedParseOptions(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion));
+
+                generator.ForceRun = true;
+
                 this.commonSources = commonSources;
                 this.commonGenerated = commonGenerated;
                 this.multiPhaseSources = multiPhaseSources;

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier.cs
@@ -4,13 +4,13 @@
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using osu.Framework.SourceGeneration.Generators;
 
 namespace osu.Framework.SourceGeneration.Tests.Verifiers
 {
     public partial class CSharpSourceGeneratorVerifier<TSourceGenerator>
-        where TSourceGenerator : IIncrementalGenerator, new()
+        where TSourceGenerator : AbstractIncrementalGenerator, new()
     {
         public static async Task VerifyAsync(
             (string filename, string content)[] commonSources,

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
@@ -7,11 +7,12 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
+using osu.Framework.SourceGeneration.Generators;
 
 namespace osu.Framework.SourceGeneration.Tests.Verifiers
 {
     public partial class CSharpSourceGeneratorVerifier<TSourceGenerator>
-        where TSourceGenerator : IIncrementalGenerator, new()
+        where TSourceGenerator : AbstractIncrementalGenerator, new()
     {
         public class Test : CSharpSourceGeneratorTest<EmptySourceGeneratorProvider, XUnitVerifier>
         {
@@ -19,7 +20,7 @@ namespace osu.Framework.SourceGeneration.Tests.Verifiers
 
             protected override IEnumerable<ISourceGenerator> GetSourceGenerators() => new[]
             {
-                new TSourceGenerator().AsSourceGenerator()
+                new TSourceGenerator { ForceRun = true }.AsSourceGenerator()
             };
 
             protected override ParseOptions CreateParseOptions()

--- a/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
+++ b/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
@@ -14,6 +14,11 @@ namespace osu.Framework.SourceGeneration.Generators
     {
         public readonly GeneratorEventDriver EventDriver = new GeneratorEventDriver();
 
+        /// <summary>
+        /// Whether the generator should be forcefully run, even if building as debug.
+        /// </summary>
+        public bool ForceRun;
+
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             // Stage 1: Create SyntaxTarget objects for all classes.
@@ -23,7 +28,7 @@ namespace osu.Framework.SourceGeneration.Generators
                            (ctx, _) => returnWithEvent(new IncrementalSyntaxTarget((ClassDeclarationSyntax)ctx.Node, ctx.SemanticModel), EventDriver.OnSyntaxTargetCreated))
                        .Select((t, _) => t.WithName())
                        .Combine(context.CompilationProvider)
-                       .Where(c => c.Right.Options.OptimizationLevel == OptimizationLevel.Release)
+                       .Where(c => ForceRun || c.Right.Options.OptimizationLevel == OptimizationLevel.Release)
                        .Select((t, _) => t.Item1)
                        .Select((t, _) => returnWithEvent(t.WithSemanticTarget(CreateSemanticTarget), EventDriver.OnSemanticTargetCreated));
 

--- a/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
+++ b/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
@@ -22,6 +22,9 @@ namespace osu.Framework.SourceGeneration.Generators
                            (n, _) => isSyntaxTarget(n),
                            (ctx, _) => returnWithEvent(new IncrementalSyntaxTarget((ClassDeclarationSyntax)ctx.Node, ctx.SemanticModel), EventDriver.OnSyntaxTargetCreated))
                        .Select((t, _) => t.WithName())
+                       .Combine(context.CompilationProvider)
+                       .Where(c => c.Right.Options.OptimizationLevel == OptimizationLevel.Release)
+                       .Select((t, _) => t.Item1)
                        .Select((t, _) => returnWithEvent(t.WithSemanticTarget(CreateSemanticTarget), EventDriver.OnSemanticTargetCreated));
 
             // Stage 2: Separate out the old and new syntax targets for the same class object.

--- a/osu.Framework.SourceGeneration/Generators/GeneratorEventDriver.cs
+++ b/osu.Framework.SourceGeneration/Generators/GeneratorEventDriver.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 
 namespace osu.Framework.SourceGeneration.Generators
 {
@@ -47,7 +46,10 @@ namespace osu.Framework.SourceGeneration.Generators
             conditionalInvoke(Emit, candidate);
         }
 
-        [Conditional("DEBUG")]
+        // Since we're running source generators in release configuration along with tests,
+        // we need this to always fire. Because we're not really worried about the compile
+        // overhead (due to only incurring on release builds) this isn't seen as a huge issue.
+        // [Conditional("DEBUG")]
         private void conditionalInvoke<T>(Action<T>? @event, T arg)
         {
             @event?.Invoke(arg);

--- a/osu.Framework.Tests/Dependencies/Reflection/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/CachedAttributeTest.cs
@@ -9,7 +9,9 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
 
+// ReSharper disable ValueParameterNotUsed
 #pragma warning disable IDE0052 // Unread private member
+#pragma warning disable CS0169 // Private unused fields
 
 namespace osu.Framework.Tests.Dependencies.Reflection
 {
@@ -458,7 +460,6 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             public object Provided1
             {
                 get => null;
-                // ReSharper disable once ValueParameterNotUsed
                 set
                 {
                 }
@@ -470,7 +471,6 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             [Cached]
             public object Provided1
             {
-                // ReSharper disable once ValueParameterNotUsed
                 set
                 {
                 }

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
 
 #pragma warning disable IDE0052 // Unread private member
+#pragma warning disable CS0169 // Private unused fields
 
 namespace osu.Framework.Tests.Dependencies.SourceGeneration
 {

--- a/osu.Framework/Graphics/Drawable_HandleInputCache.cs
+++ b/osu.Framework/Graphics/Drawable_HandleInputCache.cs
@@ -86,6 +86,7 @@ namespace osu.Framework.Graphics
 
             public static bool RequestsPositionalInput(Drawable drawable)
             {
+                // ReSharper disable once SuspiciousTypeConversion.Global (this is used by source generators, but only in release builds).
                 if (drawable is ISourceGeneratedHandleInputCache sgInput && sgInput.KnownType == drawable.GetType())
                     return sgInput.RequestsPositionalInput;
 
@@ -94,6 +95,7 @@ namespace osu.Framework.Graphics
 
             public static bool RequestsNonPositionalInput(Drawable drawable)
             {
+                // ReSharper disable once SuspiciousTypeConversion.Global (this is used by source generators, but only in release builds).
                 if (drawable is ISourceGeneratedHandleInputCache sgInput && sgInput.KnownType == drawable.GetType())
                     return sgInput.RequestsNonPositionalInput;
 

--- a/osu.Framework/Graphics/Drawable_IsLongRunning.cs
+++ b/osu.Framework/Graphics/Drawable_IsLongRunning.cs
@@ -12,6 +12,7 @@ namespace osu.Framework.Graphics
         {
             get
             {
+                // ReSharper disable once SuspiciousTypeConversion.Global (this is used by source generators, but only in release builds).
                 if (this is ISourceGeneratedLongRunningLoadCache sgCache && sgCache.KnownType == GetType())
                     return sgCache.IsLongRunning;
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.671-alpha" />
-    <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2023.709.0" />
+    <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2023.720.0" />
 
     <!-- DO NOT use ProjectReference for native packaging project.
          See https://github.com/NuGet/Home/issues/4514 and https://github.com/dotnet/sdk/issues/765 . -->


### PR DESCRIPTION

## Breaking Changes

### Source generators will now only run on release builds

As we continue to add more source generators, we've seen increases in compile-time overheads, with local testing showing over 2x compile times with source generators turned on.

osu!framework source generators are made to optimise builds at runtime (mostly by removing reflection overhead). As such, it doesn't make sense to run these for debug releases as they are basically custom release-targeting optimisations.

This should not result in a noticeable change in runtime performance during debug, but will reduce compilation times by over 50% in most cases. This is valuable during debug as the most common case is frequently building / hot reloading for quick iteration.