### PR TITLE
Fix building iOS projects in AOT mode via command line not working

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -45,7 +45,8 @@
     <ItemGroup>
       <StubFiles Include="$(MSBuildThisFileDirectory)osu.Framework.iOS\stubs\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(StubFiles)" DestinationFolder="obj\$(Platform)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\" />
+    <Copy Condition="'$(Platform)' == 'AnyCPU'" SourceFiles="@(StubFiles)" DestinationFolder="obj\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\" />
+    <Copy Condition="'$(Platform)' != 'AnyCPU'" SourceFiles="@(StubFiles)" DestinationFolder="obj\$(Platform)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\" />
   </Target>
   <!-- OpenTabletDriver contains P/Invokes to the "Quartz" framework for native macOS code.
        This leads iOS linker into attempting to include that framework, despite not existing on such platform.


### PR DESCRIPTION
![CleanShot 2023-07-22 at 12 18 27](https://github.com/ppy/osu-framework/assets/22781491/066d8324-3805-47a8-880b-8354f58cf8d2)

`dotnet build` by default builds on the `AnyCPU` platform. Explicitly adding `-p:Platform=iPhone` doesn't work halfway through the build for reasons I don't think I want to know (it reverts back to `AnyCPU` platform). Fixed the workaround instead to copy to the correct directory if no custom `Platform` is specified (eventually the `Platform != AnyCPU` branch won't exist along with the entire `iPhone`/`iPhoneSimulator` configuration [once Rider becomes smart about choosing which RID to build with](https://youtrack.jetbrains.com/issue/RIDER-76794/Cannot-deploy-MAUI-project-to-physical-iOS-device)).