### PR TITLE
Use better method for `NSString` conversion to avoid potentially pasting garbage content from clipboard

### DIFF
--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -88,10 +88,10 @@ namespace osu.Framework.Platform.MacOS.Native
             AppKitLibrary = dlopen(LIB_APPKIT, RTLD_NOW);
         }
 
-        private static readonly IntPtr sel_c_string_using_encoding = Selector.Get("cStringUsingEncoding:");
+        private static readonly IntPtr sel_utf8_string = Selector.Get("UTF8String");
         private static readonly IntPtr sel_tiff_representation = Selector.Get("TIFFRepresentation");
 
-        public static string? FromNSString(IntPtr handle) => Marshal.PtrToStringUni(SendIntPtr(handle, sel_c_string_using_encoding, (uint)NSStringEncoding.Unicode));
+        public static string? FromNSString(IntPtr handle) => Marshal.PtrToStringUTF8(SendIntPtr(handle, sel_utf8_string));
 
         public static Image<TPixel>? FromNSImage<TPixel>(IntPtr handle)
             where TPixel : unmanaged, IPixel<TPixel>


### PR DESCRIPTION
Originally reported in [discord](https://discord.com/channels/188630481301012481/589331078574112768/1133129653553463386). The new implementation mimicks Xamarin's implementation, see https://github.com/xamarin/xamarin-macios/blob/d1d3dcdf68928303f8a00719a26dc1844b8567d9/src/Foundation/NSString.cs#L183-L200:

![CleanShot 2023-07-25 at 01 10 19](https://github.com/ppy/osu-framework/assets/22781491/4361796b-ec7d-4466-a4b3-b31da042a144)
