### PR TITLE
Fix integer vertex atributes being cast to floats

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexUtils.cs
@@ -60,7 +60,56 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             for (int i = 0; i < attributes.Count; i++)
             {
                 GL.EnableVertexAttribArray(i);
-                GL.VertexAttribPointer(i, attributes[i].Count, attributes[i].Type, attributes[i].Normalized, STRIDE, attributes[i].Offset);
+
+                if (isIntegerType(attributes[i].Type) && !attributes[i].Normalized)
+                    GL.VertexAttribIPointer(i, attributes[i].Count, convertIntegerType(attributes[i].Type), STRIDE, attributes[i].Offset);
+                else
+                    GL.VertexAttribPointer(i, attributes[i].Count, attributes[i].Type, attributes[i].Normalized, STRIDE, attributes[i].Offset);
+            }
+        }
+
+        private static bool isIntegerType(VertexAttribPointerType type)
+        {
+            switch (type)
+            {
+                case VertexAttribPointerType.Int:
+                    return true;
+
+                case VertexAttribPointerType.UnsignedInt:
+                    return true;
+
+                case VertexAttribPointerType.Byte:
+                    return true;
+
+                case VertexAttribPointerType.UnsignedByte:
+                    return true;
+
+                case VertexAttribPointerType.Short:
+                    return true;
+
+                case VertexAttribPointerType.UnsignedShort:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static VertexAttribIntegerType convertIntegerType(VertexAttribPointerType type)
+        {
+            switch (type)
+            {
+                case VertexAttribPointerType.Int:
+                case VertexAttribPointerType.UnsignedInt:
+                case VertexAttribPointerType.Byte:
+                case VertexAttribPointerType.UnsignedByte:
+                case VertexAttribPointerType.Short:
+                case VertexAttribPointerType.UnsignedShort:
+                    // These appear to be 1-1 conversions.
+                    return (VertexAttribIntegerType)type;
+
+                default:
+                    throw new ArgumentException($"\"{type}\" is not an integer type.", nameof(type));
             }
         }
     }


### PR DESCRIPTION
This PR can be merged independently and should not result in breaking changes.

Ints passed through `glVertexAttribPointer` are converted to floats. This is documented as such in the description (https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glVertexAttribPointer.xhtml), and appears like this in RenderDoc:
![image](https://github.com/ppy/osu-framework/assets/1329837/ce19c293-7c9a-4f33-8ea1-6093bd165291)
(Notice `R32_SINT Cast to float`)

The result is that these attributes are not usable as ints in shaders.

The code in this PR is the same as what veldrid does: https://github.com/ppy/veldrid/blob/5ea442d15d3bead92c9d32a876bf3f8b8e453d95/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs#L338-L358