### PR TITLE
Prevent re-entrancy into `VertexBatch.Draw()`

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLVertexBatch.cs
@@ -105,27 +105,27 @@ namespace osu.Framework.Graphics.OpenGL.Batches
 
         public int Draw()
         {
-            if (currentVertexIndex == 0)
+            int countToDraw = currentVertexIndex;
+            currentVertexIndex = 0;
+
+            if (countToDraw == 0)
                 return 0;
 
             GLVertexBuffer<T> vertexBuffer = currentVertexBuffer;
             if (changeBeginIndex >= 0)
                 vertexBuffer.UpdateRange(changeBeginIndex, changeEndIndex);
 
-            vertexBuffer.DrawRange(0, currentVertexIndex);
-
-            int count = currentVertexIndex;
+            vertexBuffer.DrawRange(0, countToDraw);
 
             // When using multiple buffers we advance to the next one with every draw to prevent contention on the same buffer with future vertex updates.
             //TODO: let us know if we exceed and roll over to zero here.
             currentBufferIndex = (currentBufferIndex + 1) % maxBuffers;
-            currentVertexIndex = 0;
             changeBeginIndex = -1;
 
             FrameStatistics.Increment(StatisticsCounterType.DrawCalls);
-            FrameStatistics.Add(StatisticsCounterType.VerticesDraw, count);
+            FrameStatistics.Add(StatisticsCounterType.VerticesDraw, countToDraw);
 
-            return count;
+            return countToDraw;
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
@@ -144,33 +144,29 @@ namespace osu.Framework.Graphics.Veldrid.Batches
 
         public int Draw()
         {
-            if (currentVertexIndex == currentDrawIndex)
+            int countToDraw = currentVertexIndex - currentDrawIndex;
+            int drawStartIndex = currentDrawIndex;
+            currentDrawIndex = currentVertexIndex;
+
+            if (countToDraw == 0)
                 return 0;
 
-            var buffers = currentVertexBuffers;
-
-            if (buffers.Count == 0)
-                return 0;
-
-            int verticesCount = currentVertexIndex - currentDrawIndex;
-
-            IVeldridVertexBuffer<T> buffer = buffers[currentBufferIndex];
+            IVeldridVertexBuffer<T> buffer = currentVertexBuffers[currentBufferIndex];
 
             if (synchronisationBeginIndex >= 0)
                 buffer.UpdateRange(synchronisationBeginIndex, synchronisationEndIndex);
 
             renderer.BindVertexBuffer(buffer);
             renderer.BindIndexBuffer(indexLayout, Size);
-            renderer.DrawVertices(primitiveType, currentDrawIndex, verticesCount);
+            renderer.DrawVertices(primitiveType, drawStartIndex, countToDraw);
 
             // When using multiple buffers we advance to the next one with every draw to prevent contention on the same buffer with future vertex updates.
-            currentDrawIndex = currentVertexIndex;
             synchronisationBeginIndex = -1;
 
             FrameStatistics.Increment(StatisticsCounterType.DrawCalls);
-            FrameStatistics.Add(StatisticsCounterType.VerticesDraw, verticesCount);
+            FrameStatistics.Add(StatisticsCounterType.VerticesDraw, countToDraw);
 
-            return verticesCount;
+            return countToDraw;
         }
     }
 }


### PR DESCRIPTION
This can be merged independently and will not cause a breaking change.

In upcoming changes, I'll have `VeldridRenderer.DrawVertices()` and the soon-to-be `GLRenderer.DrawVertices()` binding uniform and array buffers locally. Doing this will trigger a `FlushCurrentBatch()` that currently causes a stack overflow. This should be a no-op.