### PR TITLE
Fix `BindableList` being unsafe for complex bind trees

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -377,6 +377,26 @@ namespace osu.Framework.Tests.Bindables
             Assert.Contains(item, bindableStringList);
         }
 
+        [Test]
+        public void TestAddBranchingBinds()
+        {
+            var b1 = new BindableList<int> { 1, 2, 3, 4, 5 };
+
+            var b2 = b1.GetBoundCopy();
+            var b3 = b1.GetBoundCopy();
+
+            var b4 = new BindableList<int>();
+            b4.BindTo(b2);
+            b4.BindTo(b3);
+
+            b1.Add(6);
+
+            Assert.That(b1.Count, Is.EqualTo(6));
+            Assert.That(b2.Count, Is.EqualTo(6));
+            Assert.That(b3.Count, Is.EqualTo(6));
+            Assert.That(b4.Count, Is.EqualTo(6));
+        }
+
         #endregion
 
         #region .AddRange(items)
@@ -433,6 +453,26 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(list1, Is.EquivalentTo(0.Yield()));
             Assert.That(list2, Is.EquivalentTo(0.Yield()));
             Assert.That(counter, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestAddRangeBranchingBinds()
+        {
+            var b1 = new BindableList<int> { 1, 2, 3, 4, 5 };
+
+            var b2 = b1.GetBoundCopy();
+            var b3 = b1.GetBoundCopy();
+
+            var b4 = new BindableList<int>();
+            b4.BindTo(b2);
+            b4.BindTo(b3);
+
+            b1.AddRange(new[] { 6, 7 });
+
+            Assert.That(b1.Count, Is.EqualTo(7));
+            Assert.That(b2.Count, Is.EqualTo(7));
+            Assert.That(b3.Count, Is.EqualTo(7));
+            Assert.That(b4.Count, Is.EqualTo(7));
         }
 
         #endregion
@@ -574,6 +614,28 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(triggeredArgsB2, Is.Not.Null);
         }
 
+        [Test]
+        public void TestMoveRangeBranchingBinds()
+        {
+            var b1 = new BindableList<int> { 1, 2, 3, 4, 5 };
+
+            var b2 = b1.GetBoundCopy();
+            var b3 = b1.GetBoundCopy();
+
+            var b4 = new BindableList<int>();
+
+            b4.BindTo(b2);
+            b4.BindTo(b3);
+
+            b1.Move(0, 1);
+
+            foreach (var list in new[] { b1, b2, b3, b4 })
+            {
+                Assert.That(list[0], Is.EqualTo(2));
+                Assert.That(list[1], Is.EqualTo(1));
+            }
+        }
+
         #endregion
 
         #region .Insert
@@ -646,6 +708,26 @@ namespace osu.Framework.Tests.Bindables
                 Assert.AreEqual("1", list[1]);
                 Assert.AreEqual("2", list[2]);
             });
+        }
+
+        [Test]
+        public void TestInsertBranchingBinds()
+        {
+            var b1 = new BindableList<int> { 1, 2, 3, 4, 5 };
+
+            var b2 = b1.GetBoundCopy();
+            var b3 = b1.GetBoundCopy();
+
+            var b4 = new BindableList<int>();
+            b4.BindTo(b2);
+            b4.BindTo(b3);
+
+            b1.Insert(0, 0);
+
+            Assert.That(b1.Count, Is.EqualTo(6));
+            Assert.That(b2.Count, Is.EqualTo(6));
+            Assert.That(b3.Count, Is.EqualTo(6));
+            Assert.That(b4.Count, Is.EqualTo(6));
         }
 
         #endregion
@@ -993,6 +1075,21 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
             Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("abc"));
             Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestRemoveAtBranchingBinds()
+        {
+            var b1 = new BindableList<int> { 1, 2, 3, 4, 5 };
+
+            var b2 = b1.GetBoundCopy();
+            var b3 = b1.GetBoundCopy();
+
+            var b4 = new BindableList<int>();
+            b4.BindTo(b2);
+            b4.BindTo(b3);
+
+            b1.RemoveAt(b1.Count - 1);
         }
 
         #endregion
@@ -1349,7 +1446,7 @@ namespace osu.Framework.Tests.Bindables
 
         #endregion
 
-        #region .GetEnumberator()
+        #region .GetEnumerator()
 
         [Test]
         public void TestGetEnumeratorDoesNotReturnNull()

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -355,11 +355,7 @@ namespace osu.Framework.Bindables
         /// <returns>Whether the current instance has already been applied.</returns>
         private bool checkAlreadyApplied(HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return true;
-
-            appliedInstances.Add(this);
-            return false;
+            return !appliedInstances.Add(this);
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -59,10 +59,7 @@ namespace osu.Framework.Bindables
 
         private void setIndex(int index, T item, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -89,10 +86,7 @@ namespace osu.Framework.Bindables
 
         private void add(T item, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -125,10 +119,7 @@ namespace osu.Framework.Bindables
 
         private void insert(int index, T item, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -152,10 +143,7 @@ namespace osu.Framework.Bindables
 
         private void clear(HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -195,10 +183,8 @@ namespace osu.Framework.Bindables
 
         private bool remove(T item, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
+            if (checkAlreadyApplied(appliedInstances))
                 return false;
-
-            appliedInstances.Add(this);
 
             ensureMutationAllowed();
 
@@ -240,10 +226,7 @@ namespace osu.Framework.Bindables
 
         private void removeRange(int index, int count, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -277,10 +260,7 @@ namespace osu.Framework.Bindables
 
         private void removeAt(int index, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -306,10 +286,8 @@ namespace osu.Framework.Bindables
 
         private int removeAll(Predicate<T> match, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
+            if (checkAlreadyApplied(appliedInstances))
                 return 0;
-
-            appliedInstances.Add(this);
 
             ensureMutationAllowed();
 
@@ -342,10 +320,7 @@ namespace osu.Framework.Bindables
 
         private void replaceRange(int index, int count, IList newItems, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -368,6 +343,23 @@ namespace osu.Framework.Bindables
             }
 
             notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, removedItems, index));
+        }
+
+        /// <summary>
+        /// As we are applying non-atomic operations on a potentially complex bindable tree, care needs to be taken to not apply
+        /// the same operation twice to the same bindable instance.
+        ///
+        /// This call tracks all instances which an operation has already been applied to.
+        /// </summary>
+        /// <param name="appliedInstances">A hash set to be passed down the recursive call tree tracking all applied instances.</param>
+        /// <returns>Whether the current instance has already been applied.</returns>
+        private bool checkAlreadyApplied(HashSet<BindableList<T>> appliedInstances)
+        {
+            if (appliedInstances.Contains(this))
+                return true;
+
+            appliedInstances.Add(this);
+            return false;
         }
 
         /// <summary>
@@ -554,10 +546,7 @@ namespace osu.Framework.Bindables
 
         private void addRange(IList items, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
@@ -582,10 +571,7 @@ namespace osu.Framework.Bindables
 
         private void move(int oldIndex, int newIndex, HashSet<BindableList<T>> appliedInstances)
         {
-            if (appliedInstances.Contains(this))
-                return;
-
-            appliedInstances.Add(this);
+            if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/5953 (using solution 1).
- *Probably* also covers https://github.com/ppy/osu-framework/issues/5635 (see call stack, matches original investigation). I'm not listing this as closing the issue, because the threading concern is likely still real, but the specific stack in that issue suggests it will cover that case.
- Closes https://github.com/ppy/osu/issues/16026
- Closes https://github.com/ppy/osu/issues/24085

Given how egregious this issue is, I would argue we use this solution as it's very simple to implement and review. Performance overhead should be negligible, and either way shouldn't matter as primary goal should be to get this in a robust state.
