### PR TITLE
Fix `ModelBackedDrawable` potentially crashing on badly timed `null`

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         public void TestEmptyDefaultState()
         {
             AddStep("setup", () => createModelBackedDrawable(false));
+            AddUntilStep("wait for load", () => backedDrawable.DelayedLoadFinished);
             AddAssert("nothing shown", () => backedDrawable.DisplayedDrawable == null);
         }
 
@@ -265,8 +266,8 @@ namespace osu.Framework.Tests.Visual.Drawables
         private partial class TestModelBackedDrawable : ModelBackedDrawable<TestModel>
         {
             public bool ShowNullModel;
-
             public bool HasIntermediate;
+            public bool DelayedLoadFinished;
 
             protected override Drawable? CreateDrawable(TestModel? model)
             {
@@ -284,6 +285,18 @@ namespace osu.Framework.Tests.Visual.Drawables
             }
 
             protected override bool TransformImmediately => HasIntermediate;
+
+            protected override void OnLoadStarted()
+            {
+                base.OnLoadStarted();
+                DelayedLoadFinished = false;
+            }
+
+            protected override void OnLoadFinished()
+            {
+                base.OnLoadFinished();
+                DelayedLoadFinished = true;
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using NUnit.Framework;
@@ -18,7 +16,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 {
     public partial class TestSceneModelBackedDrawable : FrameworkTestScene
     {
-        private TestModelBackedDrawable backedDrawable;
+        private TestModelBackedDrawable backedDrawable = null!;
 
         private void createModelBackedDrawable(bool hasIntermediate, bool showNullModel = false) =>
             Child = backedDrawable = new TestModelBackedDrawable
@@ -40,7 +38,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         [Test]
         public void TestModelDefaultState()
         {
-            TestDrawableModel drawableModel = null;
+            TestDrawableModel drawableModel = null!;
 
             AddStep("setup", () =>
             {
@@ -55,8 +53,8 @@ namespace osu.Framework.Tests.Visual.Drawables
         [TestCase(true)]
         public void TestChangeModel(bool hasIntermediate)
         {
-            TestDrawableModel firstModel = null;
-            TestDrawableModel secondModel = null;
+            TestDrawableModel firstModel = null!;
+            TestDrawableModel secondModel = null!;
 
             AddStep("setup", () =>
             {
@@ -77,9 +75,9 @@ namespace osu.Framework.Tests.Visual.Drawables
         [TestCase(true)]
         public void TestChangeModelDuringLoad(bool hasIntermediate)
         {
-            TestDrawableModel firstModel = null;
-            TestDrawableModel secondModel = null;
-            TestDrawableModel thirdModel = null;
+            TestDrawableModel firstModel = null!;
+            TestDrawableModel secondModel = null!;
+            TestDrawableModel thirdModel = null!;
 
             AddStep("setup", () =>
             {
@@ -106,8 +104,8 @@ namespace osu.Framework.Tests.Visual.Drawables
         [TestCase(true)]
         public void TestOutOfOrderLoad(bool hasIntermediate)
         {
-            TestDrawableModel firstModel = null;
-            TestDrawableModel secondModel = null;
+            TestDrawableModel firstModel = null!;
+            TestDrawableModel secondModel = null!;
 
             AddStep("setup", () =>
             {
@@ -130,7 +128,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         [Test]
         public void TestSetNullModel()
         {
-            TestDrawableModel drawableModel = null;
+            TestDrawableModel drawableModel = null!;
 
             AddStep("setup", () =>
             {
@@ -147,7 +145,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         [Test]
         public void TestInsideBufferedContainer()
         {
-            TestDrawableModel drawableModel = null;
+            TestDrawableModel drawableModel = null!;
 
             AddStep("setup", () =>
             {
@@ -270,7 +268,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             public bool HasIntermediate;
 
-            protected override Drawable CreateDrawable(TestModel model)
+            protected override Drawable? CreateDrawable(TestModel? model)
             {
                 if (model == null && ShowNullModel)
                     return new TestNullDrawableModel();
@@ -278,9 +276,9 @@ namespace osu.Framework.Tests.Visual.Drawables
                 return model?.DrawableModel;
             }
 
-            public new Drawable DisplayedDrawable => base.DisplayedDrawable;
+            public new Drawable? DisplayedDrawable => base.DisplayedDrawable;
 
-            public new TestModel Model
+            public new TestModel? Model
             {
                 set => base.Model = value;
             }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             AddStep("setup", () => createModelBackedDrawable(false));
             AddUntilStep("wait for load", () => backedDrawable.DelayedLoadFinished);
-            AddAssert("nothing shown", () => backedDrawable.DisplayedDrawable == null);
+            AddAssert("nothing shown", () => backedDrawable.DisplayedDrawable, () => Is.Null.Or.InstanceOf(Empty().GetType()));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
@@ -48,6 +48,18 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         [Test]
+        public void TestUnloadingWithNullAfterUnload()
+        {
+            AddStep("mask away", () => backedDrawable.Position = new Vector2(-2));
+            AddUntilStep("drawable unloaded", () => initialDrawable?.IsDisposed == true && backedDrawable.DisplayedDrawable == null);
+
+            AddStep("set providing drawable to null", () => backedDrawable.ReturnNullDrawable = true);
+
+            AddStep("return back", () => backedDrawable.Position = Vector2.Zero);
+            AddUntilStep("new drawable displayed", () => backedDrawable.DisplayedDrawable != null && backedDrawable.DisplayedDrawable != initialDrawable);
+        }
+
+        [Test]
         public void TestChangeWhileMaskedAway()
         {
             AddStep("mask away", () => backedDrawable.Position = new Vector2(-2));
@@ -79,6 +91,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 
         private partial class TestUnloadingModelBackedDrawable : ModelBackedDrawable<int>
         {
+            public bool ReturnNullDrawable = false;
+
             public new Drawable? DisplayedDrawable => base.DisplayedDrawable;
 
             public new int Model
@@ -118,8 +132,11 @@ namespace osu.Framework.Tests.Visual.Drawables
                 return base.ApplyHideTransforms(drawable);
             }
 
-            protected override Drawable CreateDrawable(int model)
+            protected override Drawable? CreateDrawable(int model)
             {
+                if (ReturnNullDrawable)
+                    return null;
+
                 return new Container
                 {
                     RelativeSizeAxes = Axes.Both,

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -18,8 +16,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 {
     public partial class TestSceneModelBackedDrawableWithUnloading : FrameworkTestScene
     {
-        private TestUnloadingModelBackedDrawable backedDrawable;
-        private Drawable initialDrawable;
+        private TestUnloadingModelBackedDrawable backedDrawable = null!;
+        private Drawable? initialDrawable;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -43,7 +41,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         public void TestUnloading()
         {
             AddStep("mask away", () => backedDrawable.Position = new Vector2(-2));
-            AddUntilStep("drawable unloaded", () => initialDrawable.IsDisposed && backedDrawable.DisplayedDrawable == null);
+            AddUntilStep("drawable unloaded", () => initialDrawable?.IsDisposed == true && backedDrawable.DisplayedDrawable == null);
 
             AddStep("return back", () => backedDrawable.Position = Vector2.Zero);
             AddUntilStep("new drawable displayed", () => backedDrawable.DisplayedDrawable != null && backedDrawable.DisplayedDrawable != initialDrawable);
@@ -76,12 +74,12 @@ namespace osu.Framework.Tests.Visual.Drawables
             // on loading, ModelBackedDrawable applies immediate hide transform on new drawable then applies show transform.
             AddAssert("initial hide transform applied", () => backedDrawable.HideTransforms == 1);
             AddAssert("show transform applied", () => backedDrawable.ShowTransforms == 1);
-            AddUntilStep("new drawable alpha = 1", () => backedDrawable.DisplayedDrawable.Alpha == 1);
+            AddUntilStep("new drawable alpha = 1", () => backedDrawable.DisplayedDrawable?.Alpha == 1);
         }
 
         private partial class TestUnloadingModelBackedDrawable : ModelBackedDrawable<int>
         {
-            public new Drawable DisplayedDrawable => base.DisplayedDrawable;
+            public new Drawable? DisplayedDrawable => base.DisplayedDrawable;
 
             public new int Model
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithUnloading.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
         private partial class TestUnloadingModelBackedDrawable : ModelBackedDrawable<int>
         {
-            public bool ReturnNullDrawable = false;
+            public bool ReturnNullDrawable;
 
             public new Drawable? DisplayedDrawable => base.DisplayedDrawable;
 

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Lists;
 
@@ -20,20 +17,20 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The currently displayed <see cref="Drawable"/>. Null if no drawable is displayed.
         /// </summary>
-        protected Drawable DisplayedDrawable => displayedWrapper?.Content;
+        protected Drawable? DisplayedDrawable => displayedWrapper?.Content;
 
         /// <summary>
         /// The <see cref="IEqualityComparer{T}"/> used to compare models to ensure that <see cref="Drawable"/>s are not updated unnecessarily.
         /// </summary>
         protected readonly IEqualityComparer<T> Comparer;
 
-        private T model;
+        private T? model;
 
         /// <summary>
         /// Gets or sets the model, potentially triggering the current <see cref="Drawable"/> to update.
         /// Subclasses should expose this via a nicer property name to better represent the data being set.
         /// </summary>
-        protected T Model
+        protected T? Model
         {
             get => model;
             set
@@ -53,12 +50,12 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The wrapper which has the current displayed content.
         /// </summary>
-        private DelayedLoadWrapper displayedWrapper;
+        private DelayedLoadWrapper? displayedWrapper;
 
         /// <summary>
         /// The wrapper which is currently loading, or has finished loading (i.e <see cref="displayedWrapper"/>).
         /// </summary>
-        private DelayedLoadWrapper currentWrapper;
+        private DelayedLoadWrapper? currentWrapper;
 
         /// <summary>
         /// Constructs a new <see cref="ModelBackedDrawable{T}"/> with the default <typeparamref name="T"/> equality comparer.
@@ -100,10 +97,10 @@ namespace osu.Framework.Graphics.Containers
                 loadDrawable(null);
             }
 
-            loadDrawable(() => CreateDrawable(model));
+            loadDrawable(() => CreateDrawable(model)!);
         }
 
-        private void loadDrawable(Func<Drawable> createDrawableFunc)
+        private void loadDrawable(Func<Drawable>? createDrawableFunc)
         {
             // Remove the previous wrapper if the inner drawable hasn't finished loading.
             if (currentWrapper?.DelayedLoadCompleted == false)
@@ -112,7 +109,9 @@ namespace osu.Framework.Graphics.Containers
                 DisposeChildAsync(currentWrapper);
             }
 
-            currentWrapper = createWrapper(createDrawableFunc, LoadDelay);
+            currentWrapper = createDrawableFunc == null
+                ? null
+                : createWrapper(createDrawableFunc, LoadDelay);
 
             if (currentWrapper == null)
             {
@@ -136,14 +135,19 @@ namespace osu.Framework.Graphics.Containers
         /// Invoked when a <see cref="DelayedLoadWrapper"/> has finished loading its contents.
         /// May be invoked multiple times for each <see cref="DelayedLoadWrapper"/>.
         /// </summary>
-        /// <param name="wrapper">The <see cref="DelayedLoadWrapper"/>.</param>
-        private void finishLoad(DelayedLoadWrapper wrapper)
+        /// <param name="wrapper">The current <see cref="DelayedLoadWrapper"/>.</param>
+        private void finishLoad(DelayedLoadWrapper? wrapper)
         {
-            // Make the wrapper initially hidden.
-            ApplyHideTransforms(wrapper);
-            wrapper?.FinishTransforms();
+            TransformSequence<Drawable>? showTransforms = null;
 
-            var showTransforms = ApplyShowTransforms(wrapper);
+            if (wrapper != null)
+            {
+                // Make the wrapper initially hidden.
+                ApplyHideTransforms(wrapper);
+                wrapper.FinishTransforms();
+
+                showTransforms = ApplyShowTransforms(wrapper);
+            }
 
             // If the wrapper hasn't changed then this invocation must be a result of a reload (e.g. DelayedLoadUnloadWrapper)
             // In that case, we do not want to apply hide transforms and expire the last wrapper.
@@ -172,10 +176,9 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A <see cref="DelayedLoadWrapper"/> or null if <paramref name="createContentFunc"/> returns null.</returns>
         private DelayedLoadWrapper createWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
         {
-            var content = createContentFunc?.Invoke();
-
-            if (content == null)
-                return null;
+            // Note that this only becomes null after the first consumption.
+            // ie. the `createContentFunc` cannot provide a null.
+            Drawable? content = createContentFunc();
 
             return CreateDelayedLoadWrapper(() =>
             {
@@ -224,8 +227,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Allows subclasses to customise the <see cref="DelayedLoadWrapper"/>.
         /// </summary>
-        [NotNull]
-        protected virtual DelayedLoadWrapper CreateDelayedLoadWrapper([NotNull] Func<Drawable> createContentFunc, double timeBeforeLoad) =>
+        protected virtual DelayedLoadWrapper CreateDelayedLoadWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad) =>
             new DelayedLoadWrapper(createContentFunc(), timeBeforeLoad);
 
         /// <summary>
@@ -233,23 +235,22 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="model">The model that the <see cref="Drawable"/> should represent.</param>
         /// <returns>A <see cref="Drawable"/> that represents <paramref name="model"/>, or null if no <see cref="Drawable"/> should be displayed.</returns>
-        [CanBeNull]
-        protected abstract Drawable CreateDrawable([CanBeNull] T model);
+        protected abstract Drawable? CreateDrawable(T? model);
 
         /// <summary>
         /// Hides a drawable.
         /// </summary>
         /// <param name="drawable">The drawable that is to be hidden.</param>
         /// <returns>The transform sequence.</returns>
-        protected virtual TransformSequence<Drawable> ApplyHideTransforms([CanBeNull] Drawable drawable)
-            => drawable?.FadeOut(TransformDuration, Easing.OutQuint);
+        protected virtual TransformSequence<Drawable> ApplyHideTransforms(Drawable drawable)
+            => drawable.FadeOut(TransformDuration, Easing.OutQuint);
 
         /// <summary>
         /// Shows a drawable.
         /// </summary>
         /// <param name="drawable">The drawable that is to be shown.</param>
         /// <returns>The transform sequence.</returns>
-        protected virtual TransformSequence<Drawable> ApplyShowTransforms([CanBeNull] Drawable drawable)
-            => drawable?.FadeIn(TransformDuration, Easing.OutQuint);
+        protected virtual TransformSequence<Drawable> ApplyShowTransforms(Drawable drawable)
+            => drawable.FadeIn(TransformDuration, Easing.OutQuint);
     }
 }

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics.Containers
                 loadDrawable(null);
             }
 
-            loadDrawable(() => CreateDrawable(model)!);
+            loadDrawable(() => CreateDrawable(model) ?? Empty());
         }
 
         private void loadDrawable(Func<Drawable>? createDrawableFunc)


### PR DESCRIPTION
The test added should hopefully explain this one, but here's a text explanation:

`CreateDrawable()` is allowed to return `null`s. The case where it returns `null` on the first call was handled by `loadDrawable()` in the early exit, but the nested case (which is called after unload operations where the first invocation of `CreateDrawable` has already been consumed) was not covered.

To fix this without requiring changes in usages, I've made `ModelBackedDrawable` use an empty drawable in cases it would otherwise have crashed due to `null` (see c341a6365326ae9305f28e047b6d8d1b3761e1df).

I've also applied NRT with existing null expectation to make things clearer.

This fixes flaky tests in `TestSceneBeatmapSetOverlay` (see https://teamcity.ppy.sh/buildConfiguration/Osu_Build/40918?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true):

```csharp
TearDown : System.AggregateException : One or more errors occurred. (Value cannot be null. (Parameter 'component'))
  ----> System.ArgumentNullException : Value cannot be null. (Parameter 'component')
--TearDown
   at osu.Framework.Testing.TestScene.checkForErrors()
   at osu.Framework.Testing.TestScene.RunTestsFromNUnit()
--ArgumentNullException
   at System.ArgumentNullException.Throw(String paramName)
   at osu.Framework.Graphics.Containers.DelayedLoadWrapper.BeginDelayedLoad()
   at osu.Framework.Graphics.Containers.DelayedLoadWrapper.Update()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
```

It is also highly likely this could happen at runtime and lead to user crashes.
