### PR TITLE
Disallow `SafeWriteStream` logic from running on finalisation

### DIFF
--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -179,7 +179,15 @@ namespace osu.Framework.Platform
 
             protected override void Dispose(bool disposing)
             {
-                if (disposing && !isDisposed)
+                // Don't perform any custom logic when arriving via the finaliser.
+                // We assume that all usages of `SafeWriteStream` correctly follow a local disposal pattern.
+                if (!disposing)
+                {
+                    base.Dispose(false);
+                    return;
+                }
+
+                if (!isDisposed)
                 {
                     // this was added to work around some hardware writing zeroes to a file
                     // before writing actual content, causing corrupt files to exist on disk.
@@ -202,7 +210,7 @@ namespace osu.Framework.Platform
 
                 base.Dispose(disposing);
 
-                if (disposing && !isDisposed)
+                if (!isDisposed)
                 {
                     storage.Delete(finalPath);
                     storage.Move(temporaryPath, finalPath);

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -179,7 +179,7 @@ namespace osu.Framework.Platform
 
             protected override void Dispose(bool disposing)
             {
-                if (!isDisposed)
+                if (disposing && !isDisposed)
                 {
                     // this was added to work around some hardware writing zeroes to a file
                     // before writing actual content, causing corrupt files to exist on disk.
@@ -202,7 +202,7 @@ namespace osu.Framework.Platform
 
                 base.Dispose(disposing);
 
-                if (!isDisposed)
+                if (disposing && !isDisposed)
                 {
                     storage.Delete(finalPath);
                     storage.Move(temporaryPath, finalPath);

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -208,7 +208,7 @@ namespace osu.Framework.Platform
                     }
                 }
 
-                base.Dispose(disposing);
+                base.Dispose(true);
 
                 if (!isDisposed)
                 {


### PR DESCRIPTION
RFC.

The core motivation for this change is several failing test runs on the osu! side such as:

- https://github.com/ppy/osu/actions/runs/5726098589/job/15515865792
- https://github.com/ppy/osu/actions/runs/5707825455/job/15464878786
- https://github.com/ppy/osu/actions/runs/5729725579/job/15527053558

in which `SafeWriteStream` appears to be in the process of being finalised and attempting to call `Dispose()`.

Finalisers are [notoriously](https://ericlippert.com/2015/05/18/when-everything-you-know-is-wrong-part-one/) [unreliable](https://ericlippert.com/2015/05/21/when-everything-you-know-is-wrong-part-two/), as they give no guarantees as to if they will be called, when they will be called, how many times they will be called, and so on, so I think having them doing anything in `SafeWriteStream` at all was wrong to begin with and the sane thing is to just not let the class run any of the "substitute the temporary file in-place" logic in the case of finalisation, because there are no sane assumptions to work off at that point anymore.

This change is made with full acknowledgement that this may lead to scenarios that could cause data loss that wouldn't cause data loss before, but the fact that they wouldn't was a pure fluke.