### PR TITLE
Add support for setting corner radius per corner

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainer.cs
@@ -19,11 +19,11 @@ namespace osu.Framework.Tests.Visual.Containers
         public TestSceneCircularContainer()
         {
             AddStep("128x128 box", () => addContainer(new Vector2(128)));
-            AddAssert("Expect CornerRadius = 64", () => Precision.AlmostEquals(container.CornerRadius, 64));
+            AddAssert("Expect CornerRadius = 64", () => Precision.AlmostEquals(container.CornerRadius.Max(), 64));
             AddStep("128x64 box", () => addContainer(new Vector2(128, 64)));
-            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius, 32));
+            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius.Max(), 32));
             AddStep("64x128 box", () => addContainer(new Vector2(64, 128)));
-            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius, 32));
+            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius.Max(), 32));
         }
 
         private void addContainer(Vector2 size)

--- a/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
@@ -36,7 +36,8 @@ namespace osu.Framework.Tests.Visual.Containers
                 @"Nested masking",
                 @"Rounded corner input",
                 @"Offset shadow",
-                @"Negative size"
+                @"Negative size",
+                @"Variable corners"
             };
 
             for (int i = 0; i < testNames.Length; i++)
@@ -523,6 +524,33 @@ namespace osu.Framework.Tests.Visual.Containers
                          .ResizeTo(new Vector2(200, 200), 1000).Loop();
                     }));
                     break;
+
+                case 9:
+                    TestContainer.Add(new FillFlowContainer()
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(20),
+                        Padding = new MarginPadding(20),
+                        Children = new Drawable[]
+                        {
+                            new NonCircularContainerWithInput(new CornersInfo(50, 50, 5, 5)),
+                            new NonCircularContainerWithInput(new CornersInfo(50, 5, 50, 50)),
+                            new NonCircularContainerWithInput(new CornersInfo(50, 0, 0, 0)),
+                            // border
+                            new NonCircularContainerWithInput(new CornersInfo(50, 5, 5, 50))
+                            {
+                                BorderThickness = 5,
+                                BorderColour = Colour4.Blue,
+                            },
+                            new NonCircularContainerWithInput(new CornersInfo(0, 50, 50, 0))
+                            {
+                                BorderThickness = 5,
+                                BorderColour = Colour4.Blue,
+                            },
+                        }
+                    });
+                    break;
             }
 
 #if DEBUG
@@ -542,6 +570,34 @@ namespace osu.Framework.Tests.Visual.Containers
             protected override void OnHoverLost(HoverLostEvent e)
             {
                 this.ScaleTo(1f, 100);
+            }
+        }
+
+        private partial class NonCircularContainerWithInput : Container
+        {
+            private Box box;
+
+            public NonCircularContainerWithInput(CornersInfo corners)
+            {
+                Masking = true;
+                CornerRadius = corners;
+                Size = new Vector2(100, 100);
+                Child = box = new Box
+                {
+                    Colour = Colour4.White,
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                box.FadeColour(Colour4.Red, 100);
+                return true;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                box.FadeColour(Colour4.White, 100);
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1389,14 +1389,23 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Contains(Vector2 screenSpacePos)
         {
-            float cRadius = effectiveCornerRadius;
+            var cRadius = effectiveCornerRadius;
             float cExponent = CornerExponent;
 
             // Select a cheaper contains method when we don't need rounded edges.
-            if (cRadius == 0.0f)
+            if (cRadius.Max() == 0.0f)
                 return base.Contains(screenSpacePos);
 
-            return DrawRectangle.Shrink(cRadius).DistanceExponentiated(ToLocalSpace(screenSpacePos), cExponent) <= Math.Pow(cRadius, cExponent);
+            var localSpacePos = ToLocalSpace(screenSpacePos);
+            var rect = DrawRectangle;
+            int cornerIndex = 0;
+            if (localSpacePos.X > rect.Width / 2)
+                cornerIndex += 2; // right corners are ZW (2, 3)
+            if (localSpacePos.Y > rect.Height / 2)
+                cornerIndex += 1; // bottom corners are YW (1, 3)
+
+            float localRadius = cRadius[cornerIndex]; // radius of closest corner
+            return DrawRectangle.Shrink(localRadius).DistanceExponentiated(localSpacePos, cExponent) <= Math.Pow(localRadius, cExponent);
         }
 
         /// <summary>
@@ -1493,13 +1502,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private float cornerRadius;
+        private CornersInfo cornerRadius;
 
         /// <summary>
         /// Determines how large of a radius is masked away around the corners.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// </summary>
-        public float CornerRadius
+        public CornersInfo CornerRadius
         {
             get => cornerRadius;
             protected set
@@ -1541,7 +1550,7 @@ namespace osu.Framework.Graphics.Containers
 
         // This _hacky_ modification of the corner radius (obtained from playing around) ensures that the corner remains at roughly
         // equal size (perceptually) compared to the circular arc as the CornerExponent is adjusted within the range ~2-5.
-        private float effectiveCornerRadius => CornerRadius * 0.8f * CornerExponent / 2 + 0.2f * CornerRadius;
+        private CornersInfo effectiveCornerRadius => CornerRadius * 0.8f * CornerExponent / 2 + (CornerRadius * 0.2f);
 
         private float borderThickness;
 
@@ -1615,7 +1624,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                float cRadius = CornerRadius;
+                float cRadius = CornerRadius.Max(); //TODO variable radius
                 if (cRadius == 0.0f)
                     return base.BoundingBox;
 
@@ -1635,7 +1644,7 @@ namespace osu.Framework.Graphics.Containers
                 // The above algorithm will return incorrect results if the rounded corners are not fully visible.
                 // To limit bad behavior we at least enforce here, that the bounding box with rounded corners
                 // is never larger than the bounding box without.
-                if (DrawSize.X < CornerRadius * 2 || DrawSize.Y < CornerRadius * 2)
+                if (DrawSize.X < CornerRadius.TopLeft * 2 || DrawSize.Y < CornerRadius.TopLeft * 2)
                     result.Intersect(base.BoundingBox);
 
                 return result;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -82,7 +82,8 @@ namespace osu.Framework.Graphics.Containers
                 float blendRange = Source.MaskingSmoothness * (scale.X + scale.Y) / 2;
 
                 // Calculate a shrunk rectangle which is free from corner radius/smoothing/border effects
-                float shrinkage = Source.CornerRadius - Source.CornerRadius * cos_45 + blendRange + Source.borderThickness;
+                float maxCornerRadius = Source.CornerRadius.Max();
+                float shrinkage = maxCornerRadius - maxCornerRadius * cos_45 + blendRange + Source.borderThickness;
 
                 // Normalise to handle negative sizes, and clamp the shrinkage to prevent size from going negative.
                 RectangleF shrunkDrawRectangle = Source.DrawRectangle.Normalize();

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -377,7 +377,7 @@ namespace osu.Framework.Graphics.Containers
         /// Determines how large of a radius is masked away around the corners.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// </summary>
-        public new float CornerRadius
+        public new CornersInfo CornerRadius
         {
             get => base.CornerRadius;
             set => base.CornerRadius = value;

--- a/osu.Framework/Graphics/CornersInfo.cs
+++ b/osu.Framework/Graphics/CornersInfo.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osuTK;
+
+namespace osu.Framework.Graphics
+{
+    /// <summary>
+    /// Holds data about each <see cref="Drawable"/>'s corner.
+    /// </summary>
+    public readonly struct CornersInfo : IEquatable<CornersInfo>
+    {
+        public readonly Vector4 Vector;
+
+        public float TopLeft => Vector.X;
+        public float BottomLeft => Vector.Y;
+        public float TopRight => Vector.Z;
+        public float BottomRight => Vector.W;
+
+        public CornersInfo(Vector4 vector)
+        {
+            Vector = vector;
+        }
+
+        public CornersInfo(float value)
+        {
+            Vector = new Vector4(value);
+        }
+
+        public CornersInfo(float topLeft, float bottomLeft, float topRight, float bottomRight)
+        {
+            Vector = new Vector4(topLeft, bottomLeft, topRight, bottomRight);
+        }
+
+        public float Max()
+        {
+            return Math.Max(Math.Max(Vector.X, Vector.Y), Math.Max(Vector.Z, Vector.W));
+        }
+
+        public float this[int index] => Vector[index];
+
+        public bool Equals(CornersInfo other)
+        {
+            return Vector == other.Vector;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is CornersInfo other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Vector.GetHashCode();
+        }
+
+        public static bool operator ==(CornersInfo left, CornersInfo right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(CornersInfo left, CornersInfo right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static CornersInfo operator +(CornersInfo left, CornersInfo right)
+        {
+            return new CornersInfo(left.Vector + right.Vector);
+        }
+
+        public static CornersInfo operator -(CornersInfo left, CornersInfo right)
+        {
+            return new CornersInfo(left.Vector - right.Vector);
+        }
+
+        public static CornersInfo operator *(CornersInfo left, float right)
+        {
+            return new CornersInfo(left.Vector * right);
+        }
+
+        public static CornersInfo operator /(CornersInfo left, float right)
+        {
+            return new CornersInfo(left.Vector / right);
+        }
+
+        public static implicit operator CornersInfo(float value) => new CornersInfo(value);
+    }
+}

--- a/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
+++ b/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
@@ -18,9 +18,10 @@ namespace osu.Framework.Graphics.Rendering
         public UniformMatrix4 ProjMatrix;
         public UniformMatrix3 ToMaskingSpace;
         public UniformBool IsMasking;
-        public UniformFloat CornerRadius;
+        private readonly UniformPadding12 pad1;
+        public UniformVector4 CornerRadius;
         public UniformFloat CornerExponent;
-        private readonly UniformPadding4 pad2;
+        private readonly UniformPadding12 pad2;
 
         public UniformVector4 MaskingRect;
         public UniformFloat BorderThickness;
@@ -31,8 +32,10 @@ namespace osu.Framework.Graphics.Rendering
         public UniformFloat AlphaExponent;
         public UniformVector2 EdgeOffset;
         public UniformBool DiscardInner;
-        public UniformFloat InnerCornerRadius;
+        private readonly UniformPadding12 pad4;
+        public UniformVector4 InnerCornerRadius;
         public UniformInt WrapModeS;
         public UniformInt WrapModeT;
+        private readonly UniformPadding8 pad5;
     }
 }

--- a/osu.Framework/Graphics/Rendering/MaskingInfo.cs
+++ b/osu.Framework/Graphics/Rendering/MaskingInfo.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         public Matrix3 ToMaskingSpace;
 
-        public float CornerRadius;
+        public CornersInfo CornerRadius;
         public float CornerExponent;
 
         public float BorderThickness;
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Rendering
         public Vector2 EdgeOffset;
 
         public bool Hollow;
-        public float HollowCornerRadius;
+        public CornersInfo HollowCornerRadius;
 
         public readonly bool Equals(MaskingInfo other) => this == other;
 

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -643,7 +643,7 @@ namespace osu.Framework.Graphics.Rendering
                     maskingInfo.MaskingRect.Right,
                     maskingInfo.MaskingRect.Bottom),
                 ToMaskingSpace = maskingInfo.ToMaskingSpace,
-                CornerRadius = maskingInfo.CornerRadius,
+                CornerRadius = maskingInfo.CornerRadius.Vector,
                 CornerExponent = maskingInfo.CornerExponent,
                 BorderThickness = maskingInfo.BorderThickness / maskingInfo.BlendRange,
                 BorderColour = maskingInfo.BorderThickness > 0
@@ -674,7 +674,7 @@ namespace osu.Framework.Graphics.Rendering
                 EdgeOffset = maskingInfo.EdgeOffset,
                 DiscardInner = maskingInfo.Hollow,
                 InnerCornerRadius = maskingInfo.Hollow
-                    ? maskingInfo.HollowCornerRadius
+                    ? maskingInfo.HollowCornerRadius.Vector
                     : GlobalUniformBuffer.Data.InnerCornerRadius
             };
 

--- a/osu.Framework/Physics/RigidBodyContainer.cs
+++ b/osu.Framework/Physics/RigidBodyContainer.cs
@@ -112,7 +112,9 @@ namespace osu.Framework.Physics
             Vertices.Clear();
             Normals.Clear();
 
-            float cornerRadius = CornerRadius;
+            var radius = CornerRadius;
+
+            float[] radiuses = { radius.TopLeft, radius.TopRight, radius.BottomRight, radius.BottomLeft };
 
             // Sides
             RectangleF rect = DrawRectangle;
@@ -127,28 +129,28 @@ namespace osu.Framework.Physics
                 float length = diff.Length;
                 Vector2 dir = diff / length;
 
-                float usableLength = Math.Max(length - 2 * cornerRadius, 0);
+                float usableLength = Math.Max(length - 2 * radiuses[i], 0);
 
                 Vector2 normal = (b - a).PerpendicularRight.Normalized();
 
                 for (int j = 0; j < amount_side_steps; ++j)
                 {
-                    Vertices.Add(a + dir * (cornerRadius + j * usableLength / (amount_side_steps - 1)));
+                    Vertices.Add(a + dir * (radiuses[i] + j * usableLength / (amount_side_steps - 1)));
                     Normals.Add(normal);
                 }
             }
 
             const int amount_corner_steps = 10;
 
-            if (cornerRadius > 0)
+            if (radius.Max() > 0)
             {
                 // Rounded corners
                 Vector2[] offsets =
                 {
-                    new Vector2(cornerRadius, cornerRadius),
-                    new Vector2(-cornerRadius, cornerRadius),
-                    new Vector2(-cornerRadius, -cornerRadius),
-                    new Vector2(cornerRadius, -cornerRadius),
+                    new Vector2(radiuses[0], radiuses[0]),
+                    new Vector2(-radiuses[1], radiuses[1]),
+                    new Vector2(-radiuses[2], -radiuses[2]),
+                    new Vector2(radiuses[3], -radiuses[3]),
                 };
 
                 for (int i = 0; i < 4; ++i)
@@ -162,7 +164,7 @@ namespace osu.Framework.Physics
                         float theta = startTheta + j * MathF.PI / (2 * (amount_corner_steps - 1));
 
                         Vector2 normal = new Vector2(MathF.Sin(theta), MathF.Cos(theta));
-                        Vertices.Add(a + offsets[i] + normal * cornerRadius);
+                        Vertices.Add(a + offsets[i] + normal * radiuses[i]);
                         Normals.Add(normal);
                     }
                 }

--- a/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
+++ b/osu.Framework/Resources/Shaders/Internal/sh_GlobalUniforms.h
@@ -22,7 +22,7 @@ layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
     mat3 g_ToMaskingSpace;
 
     bool g_IsMasking;
-    highp float g_CornerRadius;
+    highp vec4 g_CornerRadius;
     highp float g_CornerExponent;
     highp vec4 g_MaskingRect;
     highp float g_BorderThickness;
@@ -31,7 +31,7 @@ layout(std140, set = -1, binding = 0) uniform g_GlobalUniforms
     lowp float g_AlphaExponent;
     highp vec2 g_EdgeOffset;
     bool g_DiscardInner;
-    highp float g_InnerCornerRadius;
+    highp vec4 g_InnerCornerRadius;
 
     // 0 -> None
     // 1 -> ClampToEdge

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -61,6 +61,22 @@ lowp vec4 getBorderColour()
     return mix(top, bottom, relativeTexCoord.y);
 }
 
+highp float getCornerRadius()
+{
+	highp vec2 relativeTexCoord = v_MaskingPosition / (g_MaskingRect.zw - g_MaskingRect.xy);
+	lowp float top = mix(g_CornerRadius.x, g_CornerRadius.z, step(0.5, relativeTexCoord.x));
+	lowp float bottom = mix(g_CornerRadius.y, g_CornerRadius.w, step(0.5, relativeTexCoord.x));
+	return mix(top, bottom, step(0.5, relativeTexCoord.y));
+}
+
+highp float getInnerCornerRadius()
+{
+	highp vec2 relativeTexCoord = v_MaskingPosition / (g_MaskingRect.zw - g_MaskingRect.xy);
+	lowp float top = mix(g_InnerCornerRadius.x, g_InnerCornerRadius.z, step(0.5, relativeTexCoord.x));
+	lowp float bottom = mix(g_InnerCornerRadius.y, g_InnerCornerRadius.w, step(0.5, relativeTexCoord.x));
+	return mix(top, bottom, step(0.5, relativeTexCoord.y));
+}
+
 lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 {
 	if (!g_IsMasking && v_BlendRange == vec2(0.0))
@@ -68,19 +84,21 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 		return v_Colour * texel;
 	}
 
-	highp float dist = distanceFromRoundedRect(vec2(0.0), g_CornerRadius);
+	highp float cornerRadius = getCornerRadius();
+	highp float innerCornerRadius = getInnerCornerRadius();
+	highp float dist = distanceFromRoundedRect(vec2(0.0), cornerRadius);
 	lowp float alphaFactor = 1.0;
 
 	// Discard inner pixels
 	if (g_DiscardInner)
 	{
-		highp float innerDist = (g_EdgeOffset == vec2(0.0) && g_InnerCornerRadius == g_CornerRadius) ?
-			dist : distanceFromRoundedRect(g_EdgeOffset, g_InnerCornerRadius);
+		highp float innerDist = (g_EdgeOffset == vec2(0.0) && innerCornerRadius == cornerRadius) ?
+			dist : distanceFromRoundedRect(g_EdgeOffset, innerCornerRadius);
 
 		// v_BlendRange is set from outside in a hacky way to tell us the g_MaskingBlendRange used for the rounded
 		// corners of the edge effect container itself. We can then derive the alpha factor for smooth inner edge
 		// effect from that.
-		highp float innerBlendFactor = (g_InnerCornerRadius - g_MaskingBlendRange - innerDist) / v_BlendRange.x;
+		highp float innerBlendFactor = (innerCornerRadius - g_MaskingBlendRange - innerDist) / v_BlendRange.x;
 		if (innerBlendFactor > 1.0)
 		{
 			return vec4(0.0);
@@ -93,8 +111,8 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	dist /= g_MaskingBlendRange;
 
 	// This correction is needed to avoid fading of the alpha value for radii below 1px.
-	highp float radiusCorrection = g_CornerRadius <= 0.0 ? g_MaskingBlendRange : max(0.0, g_MaskingBlendRange - g_CornerRadius);
-	highp float fadeStart = (g_CornerRadius + radiusCorrection) / g_MaskingBlendRange;
+	highp float radiusCorrection = cornerRadius <= 0.0 ? g_MaskingBlendRange : max(0.0, g_MaskingBlendRange - cornerRadius);
+	highp float fadeStart = (cornerRadius + radiusCorrection) / g_MaskingBlendRange;
 	alphaFactor *= min(fadeStart - dist, 1.0);
 
 	if (v_BlendRange.x > 0.0 || v_BlendRange.y > 0.0)


### PR DESCRIPTION
... i.e. now you can have 3 corners with radius 100 and the 4th with 10, for example.

Half-broken and non-mergeable at this state. Game probably won't run due to transforms.

If the direction is ok, i need help with bounding box calculation (now it calculates using the biggest radius) and uniforms buffer - there are too many paddings and idk how to rearrange the fields so nothing breaks.
Also, non-rounded borders and rounded renders in different manner so their combination looks weird. Didn't understand what to do with this too.
![image](https://github.com/ppy/osu-framework/assets/53872073/8d749b96-a945-45f5-9ea4-c55107aa1b26)
 (bottom one is 0/50, top one is 5/50, notice the step where rounding begins)

xmldocs and interpolations will be done later.
