### PR TITLE
Use RectangleF for masking scissor

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.Containers
                     ? null
                     : new MaskingInfo
                     {
-                        ScreenSpaceScissorArea = Source.ScreenSpaceDrawQuad.AABB,
+                        ScreenSpaceScissorArea = Source.ScreenSpaceDrawQuad.AABBFloat,
                         MaskingArea = Source.DrawRectangle.Normalize(),
                         ConservativeScreenSpaceQuad = Quad.FromRectangle(shrunkDrawRectangle) * DrawInfo.Matrix,
                         ToMaskingSpace = DrawInfo.MatrixInverse,
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.Containers
 
                 MaskingInfo edgeEffectMaskingInfo = maskingInfo.Value;
                 edgeEffectMaskingInfo.MaskingArea = effectRect;
-                edgeEffectMaskingInfo.ScreenSpaceScissorArea = screenSpaceMaskingQuad.Value.AABB;
+                edgeEffectMaskingInfo.ScreenSpaceScissorArea = screenSpaceMaskingQuad.Value.AABBFloat;
                 edgeEffectMaskingInfo.CornerRadius = maskingInfo.Value.CornerRadius + edgeEffect.Radius + edgeEffect.Roundness;
                 edgeEffectMaskingInfo.BorderThickness = 0;
                 // HACK HACK HACK. We abuse blend range to give us the linear alpha gradient of

--- a/osu.Framework/Graphics/Rendering/MaskingInfo.cs
+++ b/osu.Framework/Graphics/Rendering/MaskingInfo.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// A rectangle that defines the scissor area in screen-space coordinates.
         /// </summary>
-        public RectangleI ScreenSpaceScissorArea;
+        public RectangleF ScreenSpaceScissorArea;
 
         /// <summary>
         /// A rectangle that defines the masking area in the local-space (i.e. <see cref="Drawable.DrawRectangle"/>) of the masking container.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -618,18 +618,18 @@ namespace osu.Framework.Graphics.Rendering
 
             if (isPushing)
             {
-                RectangleI scissorRect = maskingInfo.ScreenSpaceScissorArea;
+                RectangleF scissorRect = maskingInfo.ScreenSpaceScissorArea;
 
                 if (!overwritePreviousScissor)
                 {
                     Vector4 currentSmiScissorRectangle = ShaderMaskingStack!.CurrentBuffer[ShaderMaskingStack.CurrentOffset].ScissorRect;
-                    RectangleI currentScissorRectangle = RectangleF.FromLTRB(
+                    RectangleF currentScissorRectangle = RectangleF.FromLTRB(
                         currentSmiScissorRectangle.X,
                         currentSmiScissorRectangle.Y,
                         currentSmiScissorRectangle.Z,
                         currentSmiScissorRectangle.W);
 
-                    scissorRect = RectangleI.Intersect(currentScissorRectangle, scissorRect);
+                    scissorRect = RectangleF.Intersect(currentScissorRectangle, scissorRect);
                 }
 
                 ShaderMaskingStack!.Push(new ShaderMaskingInfo


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/5952

Fixes (at least some) 1px masking errors:

| before | after |
| --- | --- |
| ![osu_2023-08-03_16-05-01](https://github.com/ppy/osu-framework/assets/1329837/b4c5a91e-ad55-425f-ab2c-b0130e634696) | ![osu_2023-08-03_16-05-38](https://github.com/ppy/osu-framework/assets/1329837/f2c7a07d-5423-4350-8fea-f1ffd71f1edb) |
