### PR TITLE
Fix potential user-facing error when same shader is compiled in parallel

### DIFF
--- a/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
@@ -84,17 +84,21 @@ namespace osu.Framework.Graphics.Shaders
                 if (CacheStorage == null)
                     return false;
 
+                string checksum;
+                string data;
+
                 lock (save_lock)
                 {
                     if (!CacheStorage.Exists(filename))
                         return false;
+
+                    using var stream = CacheStorage.GetStream(filename);
+
+                    using var br = new BinaryReader(stream);
+
+                    checksum = br.ReadString();
+                    data = br.ReadString();
                 }
-
-                using var stream = CacheStorage.GetStream(filename);
-                using var br = new BinaryReader(stream);
-
-                string checksum = br.ReadString();
-                string data = br.ReadString();
 
                 if (data.ComputeMD5Hash() != checksum)
                 {

--- a/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
@@ -84,8 +84,11 @@ namespace osu.Framework.Graphics.Shaders
                 if (CacheStorage == null)
                     return false;
 
-                if (!CacheStorage.Exists(filename))
-                    return false;
+                lock (save_lock)
+                {
+                    if (!CacheStorage.Exists(filename))
+                        return false;
+                }
 
                 using var stream = CacheStorage.GetStream(filename);
                 using var br = new BinaryReader(stream);

--- a/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderCompilationStore.cs
@@ -111,28 +111,39 @@ namespace osu.Framework.Graphics.Shaders
             return false;
         }
 
+        private static readonly object save_lock = new object();
+
         private void saveToCache(string filename, object compilation)
         {
-            if (CacheStorage == null)
-                return;
-
-            try
+            // Multiple save operations could happen in parallel due to the asynchronous
+            // and unguarded nature of this store. Without locking, errors may be thrown
+            // as two operations attempt to write to the same destination file.
+            //
+            // Saving to disk is the least expensive part of the process, so locking on
+            // this should be very minimal contention.
+            lock (save_lock)
             {
-                // ensure any stale cached versions are deleted.
-                CacheStorage.Delete(filename);
+                if (CacheStorage == null)
+                    return;
 
-                using var stream = CacheStorage.CreateFileSafely(filename);
-                using var bw = new BinaryWriter(stream);
+                try
+                {
+                    // ensure any stale cached versions are deleted.
+                    CacheStorage.Delete(filename);
 
-                string data = JsonConvert.SerializeObject(compilation);
-                string checksum = data.ComputeMD5Hash();
+                    using var stream = CacheStorage.CreateFileSafely(filename);
+                    using var bw = new BinaryWriter(stream);
 
-                bw.Write(checksum);
-                bw.Write(data);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "Failed to save shader to cache.");
+                    string data = JsonConvert.SerializeObject(compilation);
+                    string checksum = data.ComputeMD5Hash();
+
+                    bw.Write(checksum);
+                    bw.Write(data);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to save shader to cache.");
+                }
             }
         }
     }


### PR DESCRIPTION
Noticed this when testing multiplayer spectator, and more than one user had flashlight enabled.

See inline comment for a better description.


Relevant crash:

```
2023-08-03 10:47:32 [verbose]: Requesting any changes since last known queue id 7370295
2023-08-03 10:47:33 [error]: Failed to save shader to cache.
2023-08-03 10:47:33 [error]: System.IO.IOException: The file '/Users/dean/Library/Application Support/osu-development/cache/shaders/2ad9c747fce2b1e65f237d2355197306#abd6023987102484f5046ab5bd157cca#1' already exists.
2023-08-03 10:47:33 [error]: at System.IO.FileSystem.LinkOrCopyFile(String sourceFullPath, String destFullPath)
2023-08-03 10:47:33 [error]: at System.IO.FileSystem.MoveFile(String sourceFullPath, String destFullPath, Boolean overwrite)
2023-08-03 10:47:33 [error]: at System.IO.File.Move(String sourceFileName, String destFileName, Boolean overwrite)
2023-08-03 10:47:33 [error]: at osu.Framework.Utils.General.AttemptWithRetryOnException[TException](Action action, Int32 attempts, Boolean throwOnFailure)
2023-08-03 10:47:33 [error]: at osu.Framework.Platform.NativeStorage.Move(String from, String to)
2023-08-03 10:47:33 [error]: at osu.Framework.Platform.Storage.SafeWriteStream.Dispose(Boolean disposing)
2023-08-03 10:47:33 [error]: at System.IO.Stream.Close()
2023-08-03 10:47:33 [error]: at System.IO.BinaryWriter.Dispose()
2023-08-03 10:47:33 [error]: at osu.Framework.Graphics.Shaders.ShaderCompilationStore.saveToCache(String filename, Object compilation)
2023-08-03 10:47:33 [verbose]: 🖍️ Shader Texture2D/Video compiled!
```
