### PR TITLE
Add hint to hide iOS home gesture bar

### DIFF
--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.iOS
         {
             base.Create();
 
-            SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "1");
+            SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "2");
 
             window = Runtime.GetNSObject<UIWindow>(WindowHandle);
             updateSafeArea();

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -46,6 +46,8 @@ namespace osu.Framework.iOS
         {
             base.Create();
 
+            SDL.SDL_SetHint(SDL.SDL_HINT_IOS_HIDE_HOME_INDICATOR, "1");
+
             window = Runtime.GetNSObject<UIWindow>(WindowHandle);
             updateSafeArea();
         }


### PR DESCRIPTION
Added to SDL2-CS in https://github.com/flibitijibibo/SDL2-CS/pull/161

https://valadoc.org/sdl2/SDL.Hint.IOS_HIDE_HOME_INDICATOR.html

This hides the annoying gesture bar which gets in the way quite a bit especially on iPhone devices.

Have tested it very briefly since Rider refuses to play nicely with Xcode 15.