### PR TITLE
Fix crash on tablet stylus touch when stylus is over inactive area and mouse confine is off

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -18,6 +19,8 @@ namespace osu.Framework.Tests.Visual.Input
 {
     public partial class TestSceneTabletInput : FrameworkTestScene
     {
+        private readonly FillFlowContainer contentFlow;
+
         public TestSceneTabletInput()
         {
             var penButtonFlow = new FillFlowContainer
@@ -38,7 +41,7 @@ namespace osu.Framework.Tests.Visual.Input
             for (int i = 0; i < 16; i++)
                 auxButtonFlow.Add(new AuxiliaryButtonHandler(i));
 
-            Child = new FillFlowContainer
+            Child = contentFlow = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Direction = FillDirection.Vertical,
@@ -56,7 +59,97 @@ namespace osu.Framework.Tests.Visual.Input
             var tabletHandler = host.AvailableInputHandlers.OfType<OpenTabletDriverHandler>().FirstOrDefault();
 
             if (tabletHandler != null)
+            {
                 AddToggleStep("toggle tablet handling", t => tabletHandler.Enabled.Value = t);
+
+                contentFlow.Insert(-1, new TabletAreaVisualiser(tabletHandler));
+                AddSliderStep("change width", 0, 1, 1f,
+                    width => tabletHandler.AreaSize.Value = new Vector2(
+                        tabletHandler.AreaSize.Default.X * width,
+                        tabletHandler.AreaSize.Value.Y));
+
+                AddSliderStep("change height", 0, 1, 1f,
+                    height => tabletHandler.AreaSize.Value = new Vector2(
+                        tabletHandler.AreaSize.Value.X,
+                        tabletHandler.AreaSize.Default.Y * height));
+
+                AddSliderStep("change X offset", 0, 1, 0.5f,
+                    xOffset => tabletHandler.AreaOffset.Value = new Vector2(
+                        tabletHandler.AreaSize.Default.X * xOffset,
+                        tabletHandler.AreaOffset.Value.Y));
+
+                AddSliderStep("change Y offset", 0, 1, 0.5f,
+                    yOffset => tabletHandler.AreaOffset.Value = new Vector2(
+                        tabletHandler.AreaOffset.Value.X,
+                        tabletHandler.AreaSize.Default.Y * yOffset));
+            }
+        }
+
+        private partial class TabletAreaVisualiser : CompositeDrawable
+        {
+            private readonly OpenTabletDriverHandler handler;
+
+            private Box fullArea = null!;
+            private Container activeArea = null!;
+
+            private Bindable<Vector2> areaSize = null!;
+            private Bindable<Vector2> areaOffset = null!;
+
+            public TabletAreaVisualiser(OpenTabletDriverHandler handler)
+            {
+                this.handler = handler;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Margin = new MarginPadding(10);
+                AutoSizeAxes = Axes.Both;
+                InternalChild = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        fullArea = new Box
+                        {
+                            Width = handler.AreaSize.Default.X,
+                            Height = handler.AreaSize.Default.Y,
+                            Colour = FrameworkColour.GreenDark
+                        },
+                        activeArea = new Container
+                        {
+                            Origin = Anchor.Centre,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = FrameworkColour.YellowGreen
+                                },
+                                new SpriteText
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Text = "Active area"
+                                }
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                areaSize = handler.AreaSize.GetBoundCopy();
+                areaSize.BindValueChanged(size => activeArea.Size = size.NewValue, true);
+                areaSize.DefaultChanged += fullSize => fullArea.Size = fullSize.NewValue;
+                fullArea.Size = areaSize.Default;
+
+                areaOffset = handler.AreaOffset.GetBoundCopy();
+                areaOffset.BindValueChanged(offset => activeArea.Position = offset.NewValue, true);
+            }
         }
 
         private partial class PenButtonHandler : CompositeDrawable

--- a/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTabletInput.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -20,6 +21,9 @@ namespace osu.Framework.Tests.Visual.Input
     public partial class TestSceneTabletInput : FrameworkTestScene
     {
         private readonly FillFlowContainer contentFlow;
+
+        [Resolved]
+        private FrameworkConfigManager frameworkConfigManager { get; set; } = null!;
 
         public TestSceneTabletInput()
         {
@@ -83,6 +87,9 @@ namespace osu.Framework.Tests.Visual.Input
                         tabletHandler.AreaOffset.Value.X,
                         tabletHandler.AreaSize.Default.Y * yOffset));
             }
+
+            AddToggleStep("toggle confine mode", enabled => frameworkConfigManager.SetValue(FrameworkSetting.ConfineMouseMode,
+                enabled ? ConfineMouseMode.Always : ConfineMouseMode.Never));
         }
 
         private partial class TabletAreaVisualiser : CompositeDrawable

--- a/osu.Framework/Input/ButtonEventManager.cs
+++ b/osu.Framework/Input/ButtonEventManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
@@ -95,7 +94,13 @@ namespace osu.Framework.Input
         /// <param name="state">The current <see cref="InputState"/>.</param>
         private void handleButtonUp(InputState state)
         {
-            Debug.Assert(ButtonDownInputQueue != null);
+            // in rare cases, a button up event may arrive without a preceding mouse down event.
+            // one example of this is an absolute mouse up input from a tablet, which happened when the stylus was positioned
+            // outside the bounds of the active tablet area, with confine mouse to window off.
+            // it's an awkward configuration and as such it is not exactly clear what should happen in that case,
+            // but what should definitely not happen is a crash.
+            if (ButtonDownInputQueue == null)
+                return;
 
             HandleButtonUp(state, ButtonDownInputQueue.Where(d => d.IsRootedAt(InputManager)).ToList());
             ButtonDownInputQueue = null;

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -66,6 +66,9 @@ namespace osu.Framework.Input
                     break;
 
                 case ButtonStateChangeEvent<MouseButton> buttonChange:
+                    // presses registered when the mouse pointer is outside the window are ignored.
+                    // however, releases registered when the mouse pointer is outside the window cannot be ignored;
+                    // handling them is essential to correctly handling mouse capture (only applicable when relative mode is disabled).
                     if (buttonChange.Kind == ButtonStateChangeKind.Pressed && Host.Window?.CursorInWindow.Value == false)
                         return;
 


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/24463.

This was always a problem, but got much louder after https://github.com/ppy/osu-framework/pull/5557. Reproduction scenario for issue:

1. Start with game in windowed state
2. Enable tablet handler
3. Change active area to be smaller than available tablet area
4. Disable mouse confine
5. Move tablet stylus to inactive area (which will cause the mouse pointer to leave the game window bounds)
6. Touch tablet

https://github.com/ppy/osu-framework/assets/20418176/e8a7f31c-f479-446a-a5cd-9472b2785329

Part of the cause here is this:

https://github.com/ppy/osu-framework/blob/75ed421f60228920abd819cebc5982cb7799bbbb/osu.Framework/Input/UserInputManager.cs#L68-L72

which allows the button release event to reach the `ButtonEventManager` without a prior press event if the stylus is pressed and released while outside window. Initially I figured I'd just remove the "mouse pressed" condition, but it turns out that doing so breaks correct handling of mouse capture when relative mouse mode is off. This has been explained with an inline comment in 05524832059a3e9c6481240e20b58d8390779d15.

I also considered implementing a "fake confine" in `OpenTabletDriverHandler`; if a positional input is sent outside of the active tablet bounds, or a stylus touch is detected when the mouse isn't inside the game window, discard the input. But this feels weird and I'm not even sure if this'll fix all cases, so I'm beelining for the simplest.