### PR TITLE
Make `KeyBindingContainer.Prioritised` work for positional input too 

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
@@ -25,7 +23,7 @@ namespace osu.Framework.Tests.Visual.Input
             bool pressedReceived = false;
             bool releasedReceived = false;
 
-            TestKeyBindingContainer keyBindingContainer = null;
+            TestKeyBindingContainer keyBindingContainer = null!;
 
             AddStep("add container", () =>
             {
@@ -89,7 +87,7 @@ namespace osu.Framework.Tests.Visual.Input
             List<TestAction> pressedActions = new List<TestAction>();
             List<TestAction> releasedActions = new List<TestAction>();
 
-            TextBox textBox = null;
+            TextBox textBox = null!;
 
             AddStep("add children", () =>
             {
@@ -218,7 +216,7 @@ namespace osu.Framework.Tests.Visual.Input
             int pressedReceived = 0;
             int repeatedReceived = 0;
             bool releasedReceived = false;
-            TestKeyBindingReceptor receptor = null;
+            TestKeyBindingReceptor receptor = null!;
 
             AddStep("add container", () =>
             {
@@ -301,9 +299,9 @@ namespace osu.Framework.Tests.Visual.Input
 
         private partial class TestKeyBindingReceptor : Drawable, IKeyBindingHandler<TestAction>
         {
-            public Action<TestAction> Pressed;
-            public Action<TestAction> Repeated;
-            public Action<TestAction> Released;
+            public Action<TestAction>? Pressed;
+            public Action<TestAction>? Repeated;
+            public Action<TestAction>? Released;
 
             public TestKeyBindingReceptor()
             {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -94,6 +94,20 @@ namespace osu.Framework.Input.Bindings
             return true;
         }
 
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        {
+            if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
+                return false;
+
+            if (Prioritised)
+            {
+                queue.Remove(this);
+                queue.Add(this);
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// All input keys which are currently pressed and have reached this <see cref="KeyBindingContainer"/>.
         /// </summary>


### PR DESCRIPTION
RFC.

This change would allow to replace [this game-side workaround](https://github.com/ppy/osu/blob/34a519f80354d9de353b4feee85be15c221a2d97/osu.Game/Input/Bindings/GlobalActionContainer.cs#L166-L170) with usage of `KeyBindingContainer.IsPrioritised`. The workaround in question is a blocker in resolving a game-side p0 issue (https://github.com/ppy/osu/issues/24248#issuecomment-1652296315).

More specifically, this change ensures that the game-side workaround can be replaced with `IsPrioritised` without regressing issues like https://github.com/ppy/osu/issues/6026. The fail case is when a child of the `KeyBindingContainer` is handling a plain input handler method like `OnMouseDown()`, and handles the positional input before the `KeyBindingContainer` even has a chance to see it. This is covered in the added test cases.