### PR TITLE
Implement popover hinting

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -521,6 +521,56 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("container received click", () => eventHandlingContainer.ClickReceived);
         }
 
+        [Test]
+        public void TestAllowableAnchors()
+        {
+            DrawableWithPopover target = null!;
+
+            AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
+            {
+                Width = 200,
+                Height = 30,
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                RelativePositionAxes = Axes.Both,
+                Text = "open",
+            });
+
+            AddStep("allow popover to only show above & below", () =>
+            {
+                target.HidePopover();
+                target.CreateContent = _ => new BasicPopover
+                {
+                    AllowableAnchors = new[] { Anchor.TopCentre, Anchor.BottomCentre },
+                    Child = new SpriteText { Text = "This popover can only be shown above or below" }
+                };
+                target.ShowPopover();
+            });
+
+            AddStep("allow popover to only show to the sides", () =>
+            {
+                target.HidePopover();
+                target.CreateContent = _ => new BasicPopover
+                {
+                    AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight },
+                    Child = new SpriteText { Text = "This popover can only be shown to the sides" }
+                };
+                target.ShowPopover();
+            });
+
+            AddSliderStep("move X", 0f, 1, 0, x =>
+            {
+                if (target.IsNotNull())
+                    target.X = x;
+            });
+
+            AddSliderStep("move Y", 0f, 1, 0, y =>
+            {
+                if (target.IsNotNull())
+                    target.Y = y;
+            });
+        }
+
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)
             => AddStep("create content", () =>
             {

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -1,12 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -23,10 +22,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public partial class TestScenePopoverContainer : ManualInputManagerTestScene
     {
-        private Container[,] cells;
-        private Container popoverWrapper;
-        private PopoverContainer popoverContainer;
-        private GridContainer gridContainer;
+        private Container[,] cells = null!;
+        private Container popoverWrapper = null!;
+        private PopoverContainer popoverContainer = null!;
+        private GridContainer gridContainer = null!;
 
         [SetUpSteps]
         public void SetUpSteps()
@@ -296,7 +295,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestAutomaticLayouting()
         {
-            DrawableWithPopover target = null;
+            DrawableWithPopover target = null!;
 
             AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
             {
@@ -316,25 +315,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddSliderStep("move X", 0f, 1, 0, x =>
             {
-                if (target != null)
+                if (target.IsNotNull())
                     target.X = x;
             });
 
             AddSliderStep("move Y", 0f, 1, 0, y =>
             {
-                if (target != null)
+                if (target.IsNotNull())
                     target.Y = y;
             });
 
             AddSliderStep("container width", 0f, 1, 1, width =>
             {
-                if (popoverWrapper != null)
+                if (popoverWrapper.IsNotNull())
                     popoverWrapper.Width = width;
             });
 
             AddSliderStep("container height", 0f, 1, 1, height =>
             {
-                if (popoverWrapper != null)
+                if (popoverWrapper.IsNotNull())
                     popoverWrapper.Height = height;
             });
         }
@@ -369,7 +368,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddSliderStep("change content height", 100, 500, 200, height =>
             {
-                if (popoverContainer?.Children.Count == 1)
+                if (popoverContainer.IsNotNull() && popoverContainer.Children.Count == 1)
                     popoverContainer.Child.Height = height;
             });
         }
@@ -377,7 +376,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestExternalPopoverControl()
         {
-            TextBoxWithPopover target = null;
+            TextBoxWithPopover target = null!;
 
             AddStep("create content", () =>
             {
@@ -403,7 +402,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestPopoverCleanupOnTargetDisposal()
         {
-            DrawableWithPopover target = null;
+            DrawableWithPopover target = null!;
 
             AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
             {
@@ -435,7 +434,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestPopoverCleanupOnTargetHide()
         {
-            DrawableWithPopover target = null;
+            DrawableWithPopover target = null!;
 
             AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
             {
@@ -467,8 +466,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestPopoverEventHandling()
         {
-            EventHandlingContainer eventHandlingContainer = null;
-            DrawableWithPopover target = null;
+            EventHandlingContainer eventHandlingContainer = null!;
+            DrawableWithPopover target = null!;
 
             AddStep("add button", () => popoverContainer.Child = eventHandlingContainer = new EventHandlingContainer
             {
@@ -554,7 +553,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private partial class DrawableWithPopover : CircularContainer, IHasPopover
         {
-            public Func<DrawableWithPopover, Popover> CreateContent { get; set; }
+            public Func<DrawableWithPopover, Popover>? CreateContent { get; set; }
 
             public string Text
             {
@@ -585,7 +584,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 };
             }
 
-            public Popover GetPopover() => CreateContent.Invoke(this);
+            public Popover? GetPopover() => CreateContent?.Invoke(this);
 
             protected override bool OnClick(ClickEvent e)
             {

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -88,22 +88,6 @@ namespace osu.Framework.Graphics.Cursor
             content.AutoSizeAxes = AutoSizeAxes;
         }
 
-        /// <summary>
-        /// The <see cref="Anchor"/>s to consider when auto-layouting the popover.
-        /// <see cref="Anchor.Centre"/> is not included, as it is used as a fallback if any other anchor fails.
-        /// </summary>
-        private static readonly Anchor[] candidate_anchors =
-        {
-            Anchor.TopLeft,
-            Anchor.TopCentre,
-            Anchor.TopRight,
-            Anchor.CentreLeft,
-            Anchor.CentreRight,
-            Anchor.BottomLeft,
-            Anchor.BottomCentre,
-            Anchor.BottomRight
-        };
-
         private void updatePopoverPositioning()
         {
             if (target == null || currentPopover == null)
@@ -116,7 +100,7 @@ namespace osu.Framework.Graphics.Cursor
 
             float totalSize = Math.Max(DrawSize.X * DrawSize.Y, 1);
 
-            foreach (var anchor in candidate_anchors)
+            foreach (var anchor in currentPopover.AllowableAnchors)
             {
                 // Compute how much free space is available on this side of the target.
                 var availableSize = availableSizeAroundTargetForAnchor(targetLocalQuad, anchor);

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -2,9 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osuTK;
@@ -58,6 +60,24 @@ namespace osu.Framework.Graphics.UserInterface
                 AnchorUpdated(value);
             }
         }
+
+        /// <summary>
+        /// The collection of <see cref="Anchor"/>s to consider when auto-layouting the popover inside a <see cref="PopoverContainer"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Anchor.Centre"/> is used as a fallback if an empty enumerable is provided, or any other anchor fails.
+        /// </remarks>
+        public IEnumerable<Anchor> AllowableAnchors { get; set; } = new[]
+        {
+            Anchor.TopLeft,
+            Anchor.TopCentre,
+            Anchor.TopRight,
+            Anchor.CentreLeft,
+            Anchor.CentreRight,
+            Anchor.BottomLeft,
+            Anchor.BottomCentre,
+            Anchor.BottomRight
+        };
 
         /// <summary>
         /// The container holding all of this popover's elements (the <see cref="Body"/> and the <see cref="Arrow"/>).

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.UserInterface
         public Anchor PopoverAnchor
         {
             get => Anchor;
-            set
+            internal set
             {
                 BoundingBoxContainer.Origin = value;
                 BoundingBoxContainer.Anchor = value.Opposite();


### PR DESCRIPTION
This is intended to be used for https://github.com/ppy/osu/issues/12045.

The "hinting" in question is more specifically allowing popovers to specify on which sides of the target drawable they're allowed to display, which is achieved by setting the popover's `AllowableAnchors`. This comes in handy in cases like the above when sometimes you want to control the autolayout algorithm so that the popover can only be shown on the sides of a button.

https://github.com/ppy/osu-framework/assets/20418176/2eb4caf6-95ec-4e4d-9182-66a65dd4c3d0