### PR TITLE
Allow gravity in RigidBodySimulation to be adjustable

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
@@ -53,6 +53,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Reset bodies", reset);
 
             AddSliderStep("Simulation speed", 0f, 1f, 0.5f, v => sim.SimulationSpeed = v);
+            AddSliderStep("Gravity", 0f, 10000f, 981f, v => sim.Gravity = v);
             AddSliderStep("Restitution", -1f, 1f, 1f, v => restitution = v);
             AddSliderStep("Friction", -1f, 5f, 0f, v => friction = v);
 

--- a/osu.Framework/Physics/RigidBodySimulation.cs
+++ b/osu.Framework/Physics/RigidBodySimulation.cs
@@ -34,6 +34,11 @@ namespace osu.Framework.Physics
         /// </summary>
         public float SimulationSpeed = 1;
 
+        /// <summary>
+        /// The downward acceleration to apply on all children.
+        /// </summary>
+        public float Gravity = 981f;
+
         private readonly List<IRigidBody> toSimulate = new List<IRigidBody>();
 
         /// <summary>
@@ -69,7 +74,7 @@ namespace osu.Framework.Physics
             // apply the state to each drawable in question.
             foreach (var d in toSimulate)
             {
-                d.Integrate(new Vector2(0, 981f * d.Mass), 0, dt);
+                d.Integrate(new Vector2(0, Gravity * d.Mass), 0, dt);
                 d.ApplyState();
             }
         }


### PR DESCRIPTION
For context, I'm making a top-down game kinda like billiards where I need the gravity to be 0.