### PR TITLE
Add D3D11VA hwaccel type

### DIFF
--- a/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
+++ b/osu.Framework/Graphics/Video/AVHWDeviceTypePerformanceComparer.cs
@@ -15,7 +15,8 @@ namespace osu.Framework.Graphics.Video
             // Windows
             { AVHWDeviceType.AV_HWDEVICE_TYPE_CUDA, 10 },
             { AVHWDeviceType.AV_HWDEVICE_TYPE_QSV, 9 },
-            { AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2, 8 },
+            { AVHWDeviceType.AV_HWDEVICE_TYPE_D3D11VA, 8 },
+            { AVHWDeviceType.AV_HWDEVICE_TYPE_DXVA2, 7 },
             // Linux
             { AVHWDeviceType.AV_HWDEVICE_TYPE_VDPAU, 10 },
             { AVHWDeviceType.AV_HWDEVICE_TYPE_VAAPI, 9 },

--- a/osu.Framework/Graphics/Video/FFmpegExtensions.cs
+++ b/osu.Framework/Graphics/Video/FFmpegExtensions.cs
@@ -61,6 +61,9 @@ namespace osu.Framework.Graphics.Video
                 case AVHWDeviceType.AV_HWDEVICE_TYPE_VIDEOTOOLBOX:
                     return HardwareVideoDecoder.VideoToolbox;
 
+                case AVHWDeviceType.AV_HWDEVICE_TYPE_D3D11VA:
+                    return HardwareVideoDecoder.D3D11VA;
+
                 default:
                     return null;
             }

--- a/osu.Framework/Graphics/Video/HardwareVideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/HardwareVideoDecoder.cs
@@ -63,6 +63,12 @@ namespace osu.Framework.Graphics.Video
         [Description("Apple VideoToolbox")]
         VideoToolbox = 1 << 7,
 
+        /// <remarks>
+        /// Windows only.
+        /// </remarks>
+        [Description("Direct3D 11 Video Acceleration")]
+        D3D11VA = 1 << 8,
+
         [Description("Any")]
         Any = int.MaxValue,
     }


### PR DESCRIPTION
The newer APIs should generally be used if possible, so D3D11VA > DXVA2 (which uses DX9). But vendor-specific implementations should still be preferred.