### PR TITLE
Free AVIOContext and IO buffer

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -904,6 +904,16 @@ namespace osu.Framework.Graphics.Video
                         ffmpeg.avformat_close_input(ptr);
                 }
 
+                if (ioContext != null)
+                {
+                    // This is not handled by avformat_close_input for custom IO:
+                    // https://ffmpeg.org/doxygen/4.3/structAVFormatContext.html#a1e7324262b6b78522e52064daaa7bc87
+                    ffmpeg.av_freep(&ioContext->buffer);
+
+                    fixed (AVIOContext** ptr = &ioContext)
+                        ffmpeg.avio_context_free(ptr);
+                }
+
                 if (codecContext != null)
                 {
                     fixed (AVCodecContext** ptr = &codecContext)


### PR DESCRIPTION
Usually, the IO context would be closed and freed by `avformat_close_input`. But since we're using a custom IO context, this does not happen. So we need to free the IO buffer and context ourselves.

Note that there is no need to `avio_close` because it's never opened in the first place.