### PR TITLE
Fix crash on minimising from non-native fullscreen resolutions

### DIFF
--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -486,22 +486,29 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
                     Focused = true;
-                    // displays can change without a SDL_DISPLAYEVENT being sent, eg. changing resolution.
-                    // force update displays when gaining keyboard focus to always have up-to-date information.
-                    // eg. this covers scenarios when changing resolution outside of the game, and then tabbing in.
-                    fetchDisplays();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
                     Focused = false;
-                    // displays can change without a SDL_DISPLAYEVENT being sent, eg. changing resolution.
-                    // force update displays when gaining keyboard focus to always have up-to-date information.
-                    // eg. this covers scenarios when changing resolution outside of the game, and then tabbing in.
-                    fetchDisplays();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
+                    break;
+            }
+
+            // displays can change without a SDL_DISPLAYEVENT being sent, eg. changing resolution.
+            // force update displays when gaining keyboard focus to always have up-to-date information.
+            // eg. this covers scenarios when changing resolution outside of the game, and then tabbing in.
+            switch (evtWindow.windowEvent)
+            {
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SHOWN:
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_HIDDEN:
+                    fetchDisplays();
                     break;
             }
 

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -495,6 +495,10 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
                     Focused = false;
+                    // displays can change without a SDL_DISPLAYEVENT being sent, eg. changing resolution.
+                    // force update displays when gaining keyboard focus to always have up-to-date information.
+                    // eg. this covers scenarios when changing resolution outside of the game, and then tabbing in.
+                    fetchDisplays();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:


### PR DESCRIPTION
On a Windows PC, I noticed that running osu/osu-framework at non-native resolutions (1280x1024 on a 1920x1080 screen) would crash when minimising a fullscreen window, with:

```
2023-08-24 04:45:55 [error]: An unhandled error has occurred.
2023-08-24 04:45:55 [error]: NUnit.Framework.AssertionException: Stored Displays don't match actual displays: Stored displays:
2023-08-24 04:45:55 [error]: Name: Dell AW2521H, Bounds: {X=0,Y=0,Width=1280,Height=1024}, DisplayModes: 66, Index: 0
2023-08-24 04:45:55 [error]: 
2023-08-24 04:45:55 [error]: Actual displays:
2023-08-24 04:45:55 [error]: Name: Dell AW2521H, Bounds: {X=0,Y=0,Width=1920,Height=1080}, DisplayModes: 66, Index: 0
2023-08-24 04:45:55 [error]: at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2) in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Logging\ThrowingTraceListener.cs:line 27
2023-08-24 04:45:55 [error]: at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
2023-08-24 04:45:55 [error]: at System.Diagnostics.TraceInternal.TraceProvider.Fail(String message, String detailMessage)
2023-08-24 04:45:55 [error]: at System.Diagnostics.Debug.Fail(String message, String detailMessage)
2023-08-24 04:45:55 [error]: at System.Diagnostics.Debug.Assert(Boolean condition, String message, String detailMessage)
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.SDL2Window.assertDisplaysMatchSDL() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\SDL2Window_Windowing.cs:line 318
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.SDL2Window.<handleWindowEvent>b__282_0() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\SDL2Window_Windowing.cs:line 512
2023-08-24 04:45:55 [error]: at osu.Framework.Threading.ScheduledDelegate.InvokeTask() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Threading\ScheduledDelegate.cs:line 106
2023-08-24 04:45:55 [error]: at osu.Framework.Threading.ScheduledDelegate.RunTaskInternal() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Threading\ScheduledDelegate.cs:line 92
2023-08-24 04:45:55 [error]: at osu.Framework.Threading.Scheduler.Update() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Threading\Scheduler.cs:line 124
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.SDL2Window.RunFrame() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\SDL2Window.cs:line 303
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.SDL2Window.RunMainLoop() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\SDL2Window.cs:line 278
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.SDL2Window.Run() in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\SDL2Window.cs:line 262
2023-08-24 04:45:55 [error]: at osu.Framework.Platform.GameHost.Run(Game game) in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework\Platform\GameHost.cs:line 788
2023-08-24 04:45:55 [error]: at osu.Framework.Tests.Program.Main(String[] args) in C:\Users\mangos\Desktop\Share\osu-framework\osu.Framework.Tests\Program.cs:line 23
```

This could be related to the recent AMD drivers that rewrote their OpenGL subsystem, or related to their private drivers which my testing's being done with, or could be a simple expectation of all desktop platforms. Here's the SDL events that happen at startup, minimise, and maximise:

```
Startup:

2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_MOVED, Displays changed: True
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_SIZE_CHANGED, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_RESIZED, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_SHOWN, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_FOCUS_GAINED, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_ENTER, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_EXPOSED, Displays changed: False
2023-08-24 04:37:58 [verbose]: SDL Event: SDL_WINDOWEVENT_EXPOSED, Displays changed: False

Minimised:

2023-08-24 04:42:15 [verbose]: SDL Event: SDL_WINDOWEVENT_SIZE_CHANGED, Displays changed: True
2023-08-24 04:42:15 [verbose]: SDL Event: SDL_WINDOWEVENT_MINIMIZED, Displays changed: False
2023-08-24 04:42:15 [verbose]: SDL Event: SDL_WINDOWEVENT_FOCUS_LOST, Displays changed: False
2023-08-24 04:42:15 [verbose]: SDL Event: SDL_WINDOWEVENT_LEAVE, Displays changed: False

Maximised:

2023-08-24 04:42:23 [verbose]: SDL Event: SDL_WINDOWEVENT_FOCUS_GAINED, Displays changed: False
2023-08-24 04:42:24 [verbose]: SDL Event: SDL_WINDOWEVENT_SIZE_CHANGED, Displays changed: True
2023-08-24 04:42:24 [verbose]: SDL Event: SDL_WINDOWEVENT_RESTORED, Displays changed: False
2023-08-24 04:42:24 [verbose]: SDL Event: SDL_WINDOWEVENT_ENTER, Displays changed: False
2023-08-24 04:42:24 [verbose]: SDL Event: SDL_WINDOWEVENT_EXPOSED, Displays changed: False

Minimised:

2023-08-24 04:42:30 [verbose]: SDL Event: SDL_WINDOWEVENT_SIZE_CHANGED, Displays changed: True
2023-08-24 04:42:30 [verbose]: SDL Event: SDL_WINDOWEVENT_MINIMIZED, Displays changed: False
2023-08-24 04:42:30 [verbose]: SDL Event: SDL_WINDOWEVENT_FOCUS_LOST, Displays changed: False
2023-08-24 04:42:30 [verbose]: SDL Event: SDL_WINDOWEVENT_LEAVE, Displays changed: False
```

Technically, the display change happens on `SDL_WINDOWEVENT_SIZE_CHANGED`, however that's a very wide-reaching event and I'm not sure on the cost of this particular method call. All of these events appear to be "batched" together, so it seems fine to use `SDL_WINDOWEVENT_FOCUS_GAINED`/`SDL_WINDOWEVENT_FOCUS_LOST`.

At least for the most part... WndProc wouldn't guarantee the batching is truly happening, but doing it on `SIZE_CHANGED` and `MOVED` seems excessive/expensive. Curious on @Susko3 's thoughts.

This PR adds code to refetch the displays on `SDL_WINDOWEVENT_FOCUS_LOST`, which seems appropriate since this was already being done in the `SDL_WINDOWEVENT_FOCUS_GAINED` pathway. Also on `SDL_WINDOWEVENT_SHOWN`/`SDL_WINDOWEVENT_HIDDEN` to handle startup (because it looks like `FOCUS_GAINED` is not batched appropriately there).