### PR TITLE
Change behaviour of `Storage.Move` to overwrite existing by default

### DIFF
--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Platform
         {
             // Retry move operations as it can fail on windows intermittently with IOExceptions:
             // The process cannot access the file because it is being used by another process.
-            General.AttemptWithRetryOnException<IOException>(() => File.Move(GetFullPath(from), GetFullPath(to)));
+            General.AttemptWithRetryOnException<IOException>(() => File.Move(GetFullPath(from), GetFullPath(to), true));
         }
 
         public override IEnumerable<string> GetDirectories(string path) => getRelativePaths(Directory.GetDirectories(GetFullPath(path)));

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -103,7 +103,7 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Move a file from one location to another. File must exist. Destination must not exist.
+        /// Move a file from one location to another. File must exist. Destination will be overwritten if exists.
         /// </summary>
         /// <param name="from">The file path to move.</param>
         /// <param name="to">The destination path.</param>


### PR DESCRIPTION
Coming from https://github.com/ppy/osu/actions/runs/5948760882/job/16133189924, the only way I can see this happening is if the underlying `File.Move` logic is less atomic than we expect it to be.

In the process of looking into this, I noticed there's an `overwrite` flag available for `File.Move` which tends to prefer a `rename` operation internally on unix, rather than `link`.

On windows (the failcase in question) it likely won't help at the end of the day.

Anyway, personally I think having it overwrite by default is what we prefer from our API. If that isn't agreed on then closing this without further consideration is fine.
