### PR TITLE
Avoid throwing exception when attempting to access `WebRequest` response in fail path

### DIFF
--- a/osu.Framework/IO/Network/JsonWebRequest.cs
+++ b/osu.Framework/IO/Network/JsonWebRequest.cs
@@ -22,9 +22,6 @@ namespace osu.Framework.IO.Network
 
         protected override void ProcessResponse()
         {
-            if (ResponseStream == null)
-                return;
-
             string response = GetResponseString();
             if (response != null)
                 ResponseObject = JsonConvert.DeserializeObject<T>(response);

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -201,6 +201,9 @@ namespace osu.Framework.IO.Network
         {
             try
             {
+                if (ResponseStream == null)
+                    return null;
+
                 ResponseStream.Seek(0, SeekOrigin.Begin);
                 StreamReader r = new StreamReader(ResponseStream, Encoding.UTF8);
                 return r.ReadToEnd();
@@ -219,6 +222,9 @@ namespace osu.Framework.IO.Network
         {
             try
             {
+                if (ResponseStream == null)
+                    return null;
+
                 ResponseStream.Seek(0, SeekOrigin.Begin);
 
                 return ResponseStream.ReadAllBytesToArray();

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -195,7 +195,10 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Retrieve the full response body as a UTF8 encoded string.
         /// </summary>
-        /// <returns>The response body.</returns>
+        /// <returns>
+        /// The response body.
+        /// Can be <see langword="null"/> if the request hasn't yet <see cref="Completed"/>, or if it has been <see cref="Aborted"/>.
+        /// </returns>
         [CanBeNull]
         public string GetResponseString()
         {
@@ -217,7 +220,10 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Retrieve the full response body as an array of bytes.
         /// </summary>
-        /// <returns>The response body.</returns>
+        /// <returns>
+        /// The response body.
+        /// Can be <see langword="null"/> if the request hasn't yet <see cref="Completed"/>, or if it has been <see cref="Aborted"/>.
+        /// </returns>
         [CanBeNull]
         public byte[] GetResponseData()
         {

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -218,6 +218,7 @@ namespace osu.Framework.IO.Network
         /// Retrieve the full response body as an array of bytes.
         /// </summary>
         /// <returns>The response body.</returns>
+        [CanBeNull]
         public byte[] GetResponseData()
         {
             try


### PR DESCRIPTION
One less potential web request exception = maybe a touch better debug performance? Not sure, but this throws on every timeout of requests [osu! side](https://github.com/ppy/osu/blob/9f842ccdc057e6c6ec60def1ac607f1ea00f02e1/osu.Game/Online/API/APIRequest.cs#L199) and can easily be avoided.