### PR TITLE
Bump OpenTabletDriver to 0.6.3.0

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.1.0" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.3.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/23872

## Tablet Support

### Added

- Adesso Cybertablet K8
- Gaomon PD156 Pro
- Huion GT-221
- Huion H641P
- Huion Kamvas 24 Plus
- Huion Kamvas Pro 24 (4K)
- Huion Q630M
- Huion RDS-160
- Huion RTE-100
- Parblo Ninos N4
- Parblo Ninos N7
- UGEE U1200
- VEIKK VK430 V2
- Waltop Slim Tablet 5.8"
- XP-Pen Artist 16 (2nd Gen)
- XP-Pen Deco L

### Improved

- Gaomon 1060 Pro
- Gaomon M106K Pro
- Gaomon M1230
- Huion H430P
- Huion H610 Pro V3
- Huion HS610
- Huion HS611
- Huion Kamvas Pro 16 (2.5k)
- Huion Kamvas Pro 16
- Huion RTM-500
- VEIKK VK430
- Wacom CTE-650
- Wacom ET-0405A-U
- XP-Pen Star 06C

### Other

- Fix barrel rotation reports causing broken pressure, tilt, and pen buttons on some wacom tablets.

## Driver

### Fix logging sending `LogLevel.Error` on non-fatal exceptions

This fixes issues related to osu! lazer's OTD implementation not working on some scenarios where standalone OTD does.

### Fix input processing race condition

Some devices have multiple endpoints to read from and OTD uses a thread per said endpoint. This change makes it so only one endpoint is processed at any given time via `lock`. Fixes weird issues with some Wacom tablets.

---

**Full Changelog**: https://github.com/OpenTabletDriver/OpenTabletDriver/compare/v0.6.1...v0.6.3.0