### PR TITLE
Fix keyboard handler getting disabled on window creation failure

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -729,6 +729,8 @@ namespace osu.Framework.Platform
 
                 ChooseAndSetupRenderer();
 
+                // Window creation may fail in the case of a catastrophic failure (ie. graphics driver or SDL2 level).
+                // In such cases, we want to throw here to immediately mark this renderer setup as failed.
                 if (RequireWindowExists && Window == null)
                 {
                     Logger.Log("Aborting startup as no window could be created.");
@@ -979,11 +981,10 @@ namespace osu.Framework.Platform
 
                 if (Window == null)
                 {
+                    // Can be null, usually via Headless execution.
                     if (!RequireWindowExists)
                         return;
 
-                    // Window creation may fail in the case of a catastrophic failure (ie. graphics driver or SDL2 level).
-                    // In such cases, we want to throw here to immediately mark this renderer setup as failed.
                     throw new InvalidOperationException("🖼️ Renderer could not be initialised as window creation failed.");
                 }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -972,18 +972,21 @@ namespace osu.Framework.Platform
             Renderer = renderer;
             Renderer.CacheStorage = CacheStorage.GetStorageForDirectory("shaders");
 
-            // Prepare window
-            Window = CreateWindow(surfaceType);
-
-            if (RequireWindowExists && Window == null)
-            {
-                // Window creation may fail in the case of a catastrophic failure (ie. graphics driver or SDL2 level).
-                // In such cases, we want to throw here to immediately mark this renderer setup as failed.
-                throw new InvalidOperationException("🖼️ Renderer could not be initialised as window creation failed.");
-            }
-
             try
             {
+                // Prepare window
+                Window = CreateWindow(surfaceType);
+
+                if (Window == null)
+                {
+                    if (!RequireWindowExists)
+                        return;
+
+                    // Window creation may fail in the case of a catastrophic failure (ie. graphics driver or SDL2 level).
+                    // In such cases, we want to throw here to immediately mark this renderer setup as failed.
+                    throw new InvalidOperationException("🖼️ Renderer could not be initialised as window creation failed.");
+                }
+
                 Window.SetupWindow(Config);
                 Window.Create();
                 Window.Title = $@"osu!framework (running ""{Name}"")";

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -47,6 +47,8 @@ namespace osu.Framework.Platform
             this.realtime = realtime;
         }
 
+        protected override bool RequireWindowExists => false;
+
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => null;
 
         protected override Clipboard CreateClipboard() => new HeadlessClipboard();


### PR DESCRIPTION
Has been reported by multiple users, probably due to a once-off startup failure caused by external factors.

Can be tested with something like:

```diff
diff --git a/osu.Framework/Platform/MacOS/MacOSGameHost.cs b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
index 1600b9af0..2cb5e4432 100644
--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -21,7 +21,7 @@ internal MacOSGameHost(string gameName, HostOptions options)
         {
         }
 
-        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new MacOSWindow(preferredSurface);
+        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => null;
 
         public override IEnumerable<string> UserStoragePaths
         {

```

![JetBrains Rider 2023-09-26 at 06 42 55](https://github.com/ppy/osu-framework/assets/191335/d87d081c-6fd0-46cb-a98d-b01cf6387de4)

---

Closes https://github.com/ppy/osu/issues/24260.
Closes #6007.