### PR TITLE
Stop logging non-error output from OpenTabletDriver

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             Log.Output += (_, logMessage) =>
             {
-                LogLevel level = (int)logMessage.Level > (int)LogLevel.Error ? LogLevel.Error : (LogLevel)logMessage.Level;
+                LogLevel level = (int)logMessage.Level > (int)LogLevel.Error ? LogLevel.Error : LogLevel.Verbose;
                 PostLog?.Invoke($"{logMessage.Group}: {logMessage.Message}", level, null);
             };
 


### PR DESCRIPTION
See https://github.com/ppy/osu/discussions/24915. Maybe wait for a response before going ahead with this, but it doesn't seem worthwhile to log non-errors to the user.
