### PR TITLE
Fix `WaveformGraph` overhead when `DrawPosition` is changed

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -14,7 +14,6 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Layout;
 using osu.Framework.Logging;
 using osu.Framework.Utils;
 using osuTK;
@@ -158,18 +157,15 @@ namespace osu.Framework.Graphics.Audio
             }
         }
 
-        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
+        private Vector2? lastGeneratedDrawSize;
+
+        protected override void Update()
         {
-            bool result = base.OnInvalidate(invalidation, source);
+            base.Update();
 
-            if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)
-            {
-                // We should regenerate when `Scale` changed, but not `Position`.
-                // Unfortunately both of these are grouped together in `MiscGeometry`.
+            // Can't use invalidation for this as RequiredParentSizeToFit is closes, but also triggers on DrawPosition changes.
+            if (lastGeneratedDrawSize != null && DrawSize != lastGeneratedDrawSize)
                 queueRegeneration();
-            }
-
-            return result;
         }
 
         private CancellationTokenSource? cancelSource = new CancellationTokenSource();
@@ -188,6 +184,8 @@ namespace osu.Framework.Graphics.Audio
                 return;
 
             cancelGeneration();
+
+            lastGeneratedDrawSize = DrawSize;
 
             var originalWaveform = Waveform;
 

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.Audio
         {
             base.Update();
 
-            // Can't use invalidation for this as RequiredParentSizeToFit is closes, but also triggers on DrawPosition changes.
+            // Can't use invalidation for this as RequiredParentSizeToFit is closest, but also triggers on DrawPosition changes.
             if (lastGeneratedDrawSize != null && DrawSize != lastGeneratedDrawSize)
                 queueRegeneration();
         }


### PR DESCRIPTION
The previous attempt to fix this (https://github.com/ppy/osu-framework/pull/5197) helped, but there were still some scenarios where invalidation would cause regeneration.

Let's just do our own invalidation for now.

One thing I'm not sure about is whether checking `DrawSize` here is enough (should I be using `ScreenSpaceDrawQuad.Size` instead?).

Closes https://github.com/ppy/osu/issues/24951

| Before | After |
| :---: | :---: |
| ![osu! 2023-09-29 at 10 03 06](https://github.com/ppy/osu-framework/assets/191335/4186ff87-edb5-4491-9637-39ae4f7502b3) | ![osu! 2023-09-29 at 10 02 11](https://github.com/ppy/osu-framework/assets/191335/7caf213f-0642-42bc-9eb1-5593f485627e) |