### PR TITLE
Fix source clock not correctly getting started after a decoupled transition

### DIFF
--- a/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
@@ -397,6 +397,17 @@ namespace osu.Framework.Tests.Clocks
 
             Assert.That(source.CurrentTime, Is.EqualTo(decouplingClock.CurrentTime).Within(30));
             Assert.That(source.IsRunning, Is.True);
+
+            // Subsequently test stop/start works correctly.
+            decouplingClock.Stop();
+            decouplingClock.ProcessFrame();
+            Assert.That(decouplingClock.IsRunning, Is.False);
+            Assert.That(source.IsRunning, Is.False);
+
+            decouplingClock.Start();
+            decouplingClock.ProcessFrame();
+            Assert.That(decouplingClock.IsRunning, Is.True);
+            Assert.That(source.IsRunning, Is.True);
         }
 
         [Test]

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -125,6 +125,7 @@ namespace osu.Framework.Timing
                 {
                     adjustableSourceClock.Seek(currentTime);
                     adjustableSourceClock.Start();
+                    lastSeekFailed = false;
 
                     // Don't use the source's time until next frame, as our decoupled time is likely more accurate
                     // (starting a clock, especially a TrackBass may have slight discrepancies).


### PR DESCRIPTION
Cause is pretty obvious...