### PR TITLE
Simplify `SaturationValueSelector`

### DIFF
--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
@@ -8,10 +8,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
@@ -60,7 +58,10 @@ namespace osu.Framework.Graphics.UserInterface
                     SelectionArea = new Container
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Child = box = new SaturationBox()
+                        Child = box = new SaturationBox
+                        {
+                            Colour = ColourInfo.GradientHorizontal(Color4.White, Color4.Red)
+                        }
                     },
                     marker = CreateMarker().With(d =>
                     {
@@ -148,7 +149,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             private void hueChanged()
             {
-                box.Hue = Hue.Value;
+                box.Colour = ColourInfo.GradientHorizontal(Color4.White, Colour4.FromHSV(Hue.Value, 1f, 1f));
                 updateCurrent();
             }
 
@@ -211,21 +212,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             private partial class SaturationBox : Box
             {
-                private float hue;
-                private ColourInfo gradient = ColourInfo.GradientHorizontal(Color4.White, Color4.Red);
-
-                public float Hue
-                {
-                    set
-                    {
-                        if (hue == value) return;
-
-                        hue = value;
-                        gradient = ColourInfo.GradientHorizontal(Color4.White, Colour4.FromHSV(hue, 1f, 1f));
-                        Invalidate(Invalidation.DrawNode);
-                    }
-                }
-
                 public SaturationBox()
                 {
                     RelativeSizeAxes = Axes.Both;
@@ -235,39 +221,6 @@ namespace osu.Framework.Graphics.UserInterface
                 private void load(ShaderManager shaders)
                 {
                     TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, "SaturationSelectorBackground");
-                }
-
-                protected override DrawNode CreateDrawNode() => new SaturationBoxDrawNode(this);
-
-                private class SaturationBoxDrawNode : SpriteDrawNode
-                {
-                    public new SaturationBox Source => (SaturationBox)base.Source;
-
-                    public SaturationBoxDrawNode(SaturationBox source)
-                        : base(source)
-                    {
-                    }
-
-                    private ColourInfo gradient;
-
-                    public override void ApplyState()
-                    {
-                        base.ApplyState();
-                        gradient = Source.gradient;
-                    }
-
-                    protected override void Blit(IRenderer renderer)
-                    {
-                        if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
-                            return;
-
-                        ColourInfo col = DrawColourInfo.Colour;
-                        col.ApplyChild(gradient);
-
-                        renderer.DrawQuad(Texture, ScreenSpaceDrawQuad, col, null, null,
-                            new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height),
-                            null, TextureCoords);
-                    }
                 }
             }
         }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -9,18 +9,13 @@
 
 layout(location = 2) in highp vec2 v_TexCoord;
 
-layout(std140, set = 0, binding = 0) uniform m_HueData
-{
-    mediump float hue;
-};
-
 layout(location = 0) out vec4 o_Colour;
 
 void main(void)
 {
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     highp vec2 pixelPos = v_TexCoord / resolution;
-    o_Colour = getRoundedColor(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0)), v_TexCoord);
+    o_Colour = getRoundedColor(vec4(vec3(1.0 - pixelPos.y), 1.0), v_TexCoord);
 }
 
 #endif


### PR DESCRIPTION
Hopefully should resolve https://github.com/ppy/osu/issues/24987, however this is based off of [my assumption](https://github.com/ppy/osu/issues/24987#issuecomment-1747750490).

Previously we were passing `hue` to the shader and computing hsv to rgb in there.
Now horizontal gradient (from white to colour) is being passed through the `Colour` property and vertical gradient (from colour to black) is being added on top in the shader.

Visuals/performance are the same.
| master | pr |
|---|---|
| ![master](https://github.com/ppy/osu-framework/assets/22874522/d4fd97e9-106a-4d03-8298-92724d08ed80) | ![pr](https://github.com/ppy/osu-framework/assets/22874522/1bbc03ac-8f8d-4963-8b72-f6562c7f30f0) |