### PR TITLE
Fix incorrect implementation of `TrackVirtual`

### DIFF
--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -320,6 +320,40 @@ namespace osu.Framework.Tests.Audio
             Assert.That(track.CurrentTime, Is.EqualTo(track.Length));
         }
 
+        [Test]
+        public void TestSeekBeyondStartTimeWhenRunning()
+        {
+            bool seekSucceeded = false;
+            startPlaybackAt(0);
+            RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
+
+            Assert.That(seekSucceeded, Is.False);
+            Assert.That(track.IsRunning, Is.False);
+            Assert.That(track.CurrentTime, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestSeekBeyondEndTimeWhenRunning()
+        {
+            bool seekSucceeded = false;
+            startPlaybackAt(0);
+            RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
+
+            Assert.That(seekSucceeded, Is.False);
+            Assert.That(track.IsRunning, Is.False);
+            Assert.That(track.CurrentTime, Is.EqualTo(track.Length));
+        }
+
+        [Test]
+        public void TestStartDoesNotWorkIfTrackAtEnd()
+        {
+            startPlaybackAt(track.Length);
+            track.Start();
+
+            Assert.That(track.IsRunning, Is.False);
+            Assert.That(track.CurrentTime, Is.EqualTo(track.Length));
+        }
+
         private void testPlaybackRate(double expectedRate)
         {
             const double play_time = 1000;

--- a/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
@@ -273,6 +273,36 @@ namespace osu.Framework.Tests.Clocks
             Assert.That(decouplingClock.CurrentTime, Is.EqualTo(1000));
         }
 
+        [Test]
+        public void TestSeekFromNegativeToBeyondLengthWhileDecoupling()
+        {
+            source = new TestStopwatchClockWithRangeLimit
+            {
+                MaxTime = 500
+            };
+
+            decouplingClock.ChangeSource(source);
+            decouplingClock.AllowDecoupling = true;
+
+            decouplingClock.Start();
+
+            Assert.That(decouplingClock.Seek(-1000), Is.True);
+            decouplingClock.ProcessFrame();
+
+            Assert.That(source.CurrentTime, Is.EqualTo(0).Within(30));
+            Assert.That(source.IsRunning, Is.False);
+            Assert.That(decouplingClock.CurrentTime, Is.EqualTo(-1000));
+            Assert.That(decouplingClock.IsRunning, Is.True);
+
+            Assert.That(decouplingClock.Seek(1000), Is.True);
+            decouplingClock.ProcessFrame();
+
+            Assert.That(source.CurrentTime, Is.EqualTo(500));
+            Assert.That(source.IsRunning, Is.False);
+            Assert.That(decouplingClock.CurrentTime, Is.EqualTo(1000).Within(30));
+            Assert.That(decouplingClock.IsRunning, Is.True);
+        }
+
         /// <summary>
         /// In decoupled operation, seeking the source while it's not playing is undefined
         /// behaviour.

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -23,15 +23,17 @@ namespace osu.Framework.Audio.Track
         {
             seekOffset = Math.Clamp(seek, 0, Length);
 
+            bool success = seekOffset == seek;
+
             lock (clock)
             {
-                if (IsRunning)
+                if (success && IsRunning)
                     clock.Restart();
                 else
                     clock.Reset();
             }
 
-            return seekOffset == seek;
+            return success;
         }
 
         public override Task<bool> SeekAsync(double seek)
@@ -53,7 +55,7 @@ namespace osu.Framework.Audio.Track
 
         public override void Start()
         {
-            if (Length == 0)
+            if (Length == 0 || CurrentTime >= Length)
                 return;
 
             lock (clock) clock.Start();

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -124,11 +124,9 @@ namespace osu.Framework.Timing
                 if (lastTime < 0 && currentTime >= 0)
                 {
                     // We still need to check the seek was successful, else we might have already exceeded valid length of the source.
-                    if (adjustableSourceClock.Seek(currentTime))
-                    {
+                    lastSeekFailed = !adjustableSourceClock.Seek(currentTime);
+                    if (!lastSeekFailed)
                         adjustableSourceClock.Start();
-                        lastSeekFailed = false;
-                    }
 
                     // Don't use the source's time until next frame, as our decoupled time is likely more accurate
                     // (starting a clock, especially a TrackBass may have slight discrepancies).

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -123,9 +123,12 @@ namespace osu.Framework.Timing
                 // This could be potentially handled if need be, if we had a notion of what the source's max allowable time is.
                 if (lastTime < 0 && currentTime >= 0)
                 {
-                    adjustableSourceClock.Seek(currentTime);
-                    adjustableSourceClock.Start();
-                    lastSeekFailed = false;
+                    // We still need to check the seek was successful, else we might have already exceeded valid length of the source.
+                    if (adjustableSourceClock.Seek(currentTime))
+                    {
+                        adjustableSourceClock.Start();
+                        lastSeekFailed = false;
+                    }
 
                     // Don't use the source's time until next frame, as our decoupled time is likely more accurate
                     // (starting a clock, especially a TrackBass may have slight discrepancies).


### PR DESCRIPTION
Noticed when going through osu! side test failures.

Also adds safeties and test coverage to `DecouplingFramedClock` against a source which may still start after a failed seek. Better safe than sorry I guess.

Note that the test doesn't fail even without the `TrackVirtual` fix, as it's not using a `TrackVirtual`.