### PR TITLE
Fix `InterpolatingFramedClock` not correctly handling seeks when source clock is stopped

### DIFF
--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -213,6 +213,9 @@ namespace osu.Framework.Tests.Clocks
                 source.CurrentTime += sleep_time;
                 interpolating.ProcessFrame();
 
+                // should be a nooop
+                interpolating.ChangeSource(source);
+
                 Assert.IsTrue(Precision.AlmostEquals(interpolating.CurrentTime, source.CurrentTime, interpolating.AllowableErrorMilliseconds),
                     "Interpolating should be within allowable error bounds.");
 

--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -195,10 +195,12 @@ namespace osu.Framework.Tests.Clocks
             interpolating.ProcessFrame();
             Assert.That(interpolating.IsInterpolating, Is.False);
             Assert.That(interpolating.CurrentTime, Is.EqualTo(-10000).Within(100));
+            Assert.That(interpolating.ElapsedFrameTime, Is.EqualTo(-10000).Within(100));
 
             source.Start();
             interpolating.ProcessFrame();
             Assert.That(interpolating.CurrentTime, Is.EqualTo(-10000).Within(100));
+            Assert.That(interpolating.ElapsedFrameTime, Is.EqualTo(0).Within(100));
         }
 
         [Test]

--- a/osu.Framework.Tests/Clocks/InterpolatingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingFramedClockTest.cs
@@ -10,7 +10,7 @@ using osu.Framework.Timing;
 namespace osu.Framework.Tests.Clocks
 {
     [TestFixture]
-    public class InterpolatingClockTest
+    public class InterpolatingFramedClockTest
     {
         private TestClock source = null!;
         private TestInterpolatingFramedClock interpolating = null!;

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -140,6 +140,7 @@ namespace osu.Framework.Timing
             (source as IAdjustableClock)?.Seek(CurrentTime);
 
             base.ChangeSource(source);
+            base.ProcessFrame();
 
             // the above value transfer may have failed (if the source is not adjustable).
             // in such a case, transfer value in the opposite direction to ensure we are still in sync.

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -61,6 +61,9 @@ namespace osu.Framework.Timing
 
         public virtual void ChangeSource(IClock? source)
         {
+            if (source != null && source == Source)
+                return;
+
             Source = source ?? new StopwatchClock(true);
 
             // We need a frame-based source to correctly process interpolation.

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -85,9 +85,6 @@ namespace osu.Framework.Timing
 
             if (sourceIsRunning)
             {
-                if (sourceHasElapsed)
-                    IsInterpolating = true;
-
                 currentInterpolatedTime += realtimeClock.ElapsedFrameTime * Rate;
 
                 if (!IsInterpolating || Math.Abs(FramedSourceClock.CurrentTime - currentInterpolatedTime) > AllowableErrorMilliseconds)
@@ -109,6 +106,11 @@ namespace osu.Framework.Timing
                 }
 
                 currentTime = currentInterpolatedTime;
+
+                // Of importance, only start interpolating from the next frame.
+                // The first frame after a clock starts may give very incorrect results, ie. due to a seek in the frame before.
+                if (sourceHasElapsed)
+                    IsInterpolating = true;
             }
             else
             {


### PR DESCRIPTION
I'm crossing my fingers that at face value this one is understandable. I'll add inline review notes as to why the changes were made.