### PR TITLE
FFmpeg: Enable MPEG-4 parser and decoder

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get upgrade
-          sudo apt-get install -y make nasm gcc mingw-w64
+          sudo apt-get update
+          sudo apt-get install nasm mingw-w64
 
       - name: Build
         run: osu.Framework.NativeLibs/scripts/ffmpeg/build-win.sh
@@ -111,8 +111,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get upgrade
-          sudo apt-get install -y git curl gcc make nasm pkg-config libva-dev libvdpau-dev
+          sudo apt-get update
+          sudo apt-get install nasm libva-dev libvdpau-dev
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -18,8 +18,8 @@ FFMPEG_FLAGS=(
 
     # File and video formats
     --enable-demuxer='mov,matroska,flv,avi' # mov = mp4, matroska = mkv & webm
-    --enable-parser='h264,hevc,vp8,vp9'
-    --enable-decoder='h264,hevc,vp8,vp9'
+    --enable-parser='mpeg4video,h264,hevc,vp8,vp9'
+    --enable-decoder='mpeg4,h264,hevc,vp8,vp9'
     --enable-protocol=pipe
 )
 

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -19,7 +19,7 @@ FFMPEG_FLAGS=(
     # File and video formats
     --enable-demuxer='mov,matroska,flv,avi' # mov = mp4, matroska = mkv & webm
     --enable-parser='mpeg4video,h264,hevc,vp8,vp9'
-    --enable-decoder='mpeg4,h264,hevc,vp8,vp9'
+    --enable-decoder='flv,mpeg4,h264,hevc,vp8,vp9'
     --enable-protocol=pipe
 )
 


### PR DESCRIPTION
Closes ppy/osu#25086.

[MPEG-4 Part 2](https://en.wikipedia.org/wiki/MPEG-4_Part_2) is a video coding standard that sits "between" H.262 and H.264. Xvid, DivX and some less known formats implement it.

FFmpeg supports these derivative codecs through the `mpeg4` decoder, so to support `xvid` and `divx` (which seems to have been used in some beatmaps), this PR enables it and the according parser.

Note that this does not depend on `libxvid`, which is GPL.