### PR TITLE
Bring back shader workaround to fix blur on iOS

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_Blur.fs
+++ b/osu.Framework/Resources/Shaders/sh_Blur.fs
@@ -44,7 +44,12 @@ lowp vec4 blur(int radius, highp vec2 direction, mediump vec2 texCoord, mediump 
 			break;
 	}
 
-	return sum / totalFactor;
+	// this is supposed to be unnecessary with https://github.com/ppy/veldrid-spirv/pull/4,
+	// but blurring is still broken on some Apple devices when removing it (at least on an M2 iPad Pro and an iPhone 12).
+	// todo: investigate this.
+	float one = g_BackbufferDraw ? 0 : 1;
+
+	return sum / totalFactor * one;
 }
 
 void main(void)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/24960
- Reverts https://github.com/ppy/osu-framework/pull/5979

I could not investigate this as I failed to repro in local builds on neither my iPad nor my phone, but I have confirmed at least that the blur breakage only occurred on the next working release after the [workaround removal PR](https://github.com/ppy/osu-framework/pull/5979) was merged, so I'm going ahead with reverting that for now.

I've made sure at least that blurring still works on all of my devices regardless of its state previously.