### PR TITLE
Disable retrieval of SDL display modes on non-desktop platforms

### DIFF
--- a/osu.Framework/Platform/Display.cs
+++ b/osu.Framework/Platform/Display.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Platform
         public Rectangle Bounds { get; }
 
         /// <summary>
-        /// The available <see cref="DisplayMode"/>s on this display.
+        /// The available <see cref="DisplayMode"/>s on this display, or empty if the display mode cannot be configured (e.g. mobile displays).
         /// </summary>
         public DisplayMode[] DisplayModes { get; }
 

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -350,30 +350,30 @@ namespace osu.Framework.Platform
                 return false;
             }
 
-            int numModes = SDL.SDL_GetNumDisplayModes(displayIndex);
+            DisplayMode[] displayModes = Array.Empty<DisplayMode>();
 
-            if (numModes < 0)
+            if (RuntimeInfo.IsDesktop)
             {
-                Logger.Log($"Failed to get display modes for display at index ({displayIndex}) ({rect.w}x{rect.h}). SDL Error: {SDL.SDL_GetError()} ({numModes})");
-                display = null;
-                return false;
-            }
+                int numModes = SDL.SDL_GetNumDisplayModes(displayIndex);
 
-            if (numModes == 0) Logger.Log($"Display at index ({displayIndex}) ({rect.w}x{rect.h}) has no display modes. Fullscreen might not work.");
+                if (numModes < 0)
+                {
+                    Logger.Log($"Failed to get display modes for display at index ({displayIndex}) ({rect.w}x{rect.h}). SDL Error: {SDL.SDL_GetError()} ({numModes})");
+                    display = null;
+                    return false;
+                }
 
-            var displayModes = Enumerable.Range(0, numModes)
+                if (numModes == 0)
+                    Logger.Log($"Display at index ({displayIndex}) ({rect.w}x{rect.h}) has no display modes. Fullscreen might not work.");
+
+                displayModes = Enumerable.Range(0, numModes)
                                          .Select(modeIndex =>
                                          {
                                              SDL.SDL_GetDisplayMode(displayIndex, modeIndex, out var mode);
                                              return mode.ToDisplayMode(displayIndex);
                                          })
                                          .ToArray();
-
-            // on an iPad, SDL returns a display mode for both portrait and landscape orientations,
-            // but we don't support having both of them in the display modes array (since display modes are usually treated as different resolutions).
-            // for simplicity, do not provide any display modes on iOS regardless of SDL.
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
-                displayModes = Array.Empty<DisplayMode>();
+            }
 
             display = new Display(displayIndex, SDL.SDL_GetDisplayName(displayIndex), new Rectangle(rect.x, rect.y, rect.w, rect.h), displayModes);
             return true;

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -369,6 +369,12 @@ namespace osu.Framework.Platform
                                          })
                                          .ToArray();
 
+            // on an iPad, SDL returns a display mode for both portrait and landscape orientations,
+            // but we don't support having both of them in the display modes array (since display modes are usually treated as different resolutions).
+            // for simplicity, do not provide any display modes on iOS regardless of SDL.
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.iOS)
+                displayModes = Array.Empty<DisplayMode>();
+
             display = new Display(displayIndex, SDL.SDL_GetDisplayName(displayIndex), new Rectangle(rect.x, rect.y, rect.w, rect.h), displayModes);
             return true;
         }


### PR DESCRIPTION
Currently, SDL provides two display modes for an iPad, both of which resemble the same display's resolution, except that the second one is the portrait version of the first one.

![IMG_9F4E6B2C62C4-1](https://github.com/ppy/osu-framework/assets/22781491/fa7150cd-7d92-44a3-9e43-1c8123827abc)

For simplicity, let's not provide any display modes in such case.