### PR TITLE
Correctly handle OTD "multi-reports"

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -108,16 +108,11 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleDeviceReported(object? sender, IDeviceReport report)
         {
-            switch (report)
-            {
-                case ITabletReport tabletReport:
-                    handleTabletReport(tabletReport);
-                    break;
+            if (report is ITabletReport tabletReport)
+                handleTabletReport(tabletReport);
 
-                case IAuxReport auxiliaryReport:
-                    handleAuxiliaryReport(auxiliaryReport);
-                    break;
-            }
+            if (report is IAuxReport auxiliaryReport)
+                handleAuxiliaryReport(auxiliaryReport);
         }
 
         private void updateOutputArea(IWindow window)


### PR DESCRIPTION
Noticed when looking into https://github.com/ppy/osu/issues/5378#issuecomment-1780613477.

Since a single OTD `IDeviceReport` can implement [multiple report interfaces](https://github.com/OpenTabletDriver/OpenTabletDriver/blob/b996c8feb0b3da53ff0599940af550118f6422ca/OpenTabletDriver.Configurations/Parsers/Wacom/Bamboo/BambooTabletReport.cs#L7), a `switch` would handle only one of the report types.