### PR TITLE
Fix releasing mouse buttons outside of window not working in relative mode

### DIFF
--- a/osu.Framework/Platform/SDL2Window_Input.cs
+++ b/osu.Framework/Platform/SDL2Window_Input.cs
@@ -145,16 +145,17 @@ namespace osu.Framework.Platform
         private void pollMouse()
         {
             SDL.SDL_GetGlobalMouseState(out int x, out int y);
-            if (previousPolledPoint.X == x && previousPolledPoint.Y == y)
-                return;
 
-            previousPolledPoint = new Point(x, y);
+            if (previousPolledPoint.X != x || previousPolledPoint.Y != y)
+            {
+                previousPolledPoint = new Point(x, y);
 
-            var pos = WindowMode.Value == Configuration.WindowMode.Windowed ? Position : windowDisplayBounds.Location;
-            int rx = x - pos.X;
-            int ry = y - pos.Y;
+                var pos = WindowMode.Value == Configuration.WindowMode.Windowed ? Position : windowDisplayBounds.Location;
+                int rx = x - pos.X;
+                int ry = y - pos.Y;
 
-            MouseMove?.Invoke(new Vector2(rx * Scale, ry * Scale));
+                MouseMove?.Invoke(new Vector2(rx * Scale, ry * Scale));
+            }
         }
 
         public virtual void StartTextInput(bool allowIme) => ScheduleCommand(SDL.SDL_StartTextInput);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/5788

I originally envisioned the fix to complicate the relative mouse logic further, capturing the cursor when at least one button is held down. That was too hard and not worth the effort. Instead, query the global mouse button state when it's outside the window and release any buttons that should not be held.

It's important that the buttons can only be _released_, not pressed when the cursor is outside the window. Also important (but not that much) is that the buttons are released after the move event is handled so the released events have the most up-to-date position.