### PR TITLE
Allow selecting all text in a `TextBox` programmatically

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
@@ -800,6 +801,33 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select all", () => InputManager.Keys(PlatformAction.SelectAll));
             AddStep("set text via current", () => textBox.Text = "short text");
             AddAssert("nothing selected", () => textBox.SelectedText == string.Empty);
+        }
+
+        [Test]
+        public void TestSelectAll()
+        {
+            TextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new BasicTextBox
+                {
+                    Size = new Vector2(300, 40),
+                    Text = "initial text",
+                });
+            });
+
+            AddAssert("select all method returns false", () => !textBox.SelectAll());
+            AddAssert("no text selected", () => textBox.SelectedText == string.Empty);
+
+            AddStep("click on textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("select all text returns true", () => textBox.SelectAll());
+            AddAssert("all text selected", () => textBox.SelectedText == textBox.Text);
         }
 
         private void prependString(InsertableTextBox textBox, string text)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -265,9 +265,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
 
                 case PlatformAction.SelectAll:
-                    selectionStart = 0;
-                    selectionEnd = text.Length;
-                    cursorAndLayout.Invalidate();
+                    SelectAll();
                     onTextSelectionChanged(TextSelectionType.All, lastSelectionBounds);
                     return true;
 
@@ -356,6 +354,21 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Selects all text in this <see cref="TextBox"/>. Focus *must* be acquired before calling this method.
+        /// </summary>
+        /// <returns>Whether text has been selected successfully. Returns <c>false</c> if the text box does not have focus.</returns>
+        public bool SelectAll()
+        {
+            if (!HasFocus)
+                return false;
+
+            selectionStart = 0;
+            selectionEnd = text.Length;
+            cursorAndLayout.Invalidate();
+            return true;
         }
 
         public virtual void OnReleased(KeyBindingReleaseEvent<PlatformAction> e)


### PR DESCRIPTION
- Supersedes https://github.com/ppy/osu-framework/pull/5823 (only the selection part, ignoring focus acquirement)
- To be used in https://github.com/ppy/osu/issues/24606

I've chose to be as strict as possible with the method, as to not potentially go out of control and backfire on the consumer. I went as far as to make the method throw when the text box is focused, but I lowered it down to returning `false`/`true` instead.

The remaining part of https://github.com/ppy/osu-framework/pull/5823 can be achieved by a `FocusedTextBox` class that overrides `OnFocus` and calls `SelectAll` from inside.