### PR TITLE
Fix `FrameStatisticsViaTouch` to work as described in the wiki

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -23,7 +23,7 @@ namespace osu.Framework
             StartupExecutionMode = Enum.TryParse<ExecutionMode>(Environment.GetEnvironmentVariable("OSU_EXECUTION_MODE"), true, out var mode) ? mode : null;
             NoTestTimeout = Environment.GetEnvironmentVariable("OSU_TESTS_NO_TIMEOUT") == "1";
             ForceTestGC = Environment.GetEnvironmentVariable("OSU_TESTS_FORCED_GC") == "1";
-            FrameStatisticsViaTouch = Environment.GetEnvironmentVariable("OSU_FRAME_STATISTICS_VIA_TOUCH") == "1";
+            FrameStatisticsViaTouch = Environment.GetEnvironmentVariable("OSU_FRAME_STATISTICS_VIA_TOUCH") != "0";
             PreferredGraphicsSurface = Enum.TryParse<GraphicsSurfaceType>(Environment.GetEnvironmentVariable("OSU_GRAPHICS_SURFACE"), true, out var surface) ? surface : null;
             PreferredGraphicsRenderer = Environment.GetEnvironmentVariable("OSU_GRAPHICS_RENDERER")?.ToLowerInvariant();
 

--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Framework
@@ -21,9 +22,9 @@ namespace osu.Framework
         static FrameworkEnvironment()
         {
             StartupExecutionMode = Enum.TryParse<ExecutionMode>(Environment.GetEnvironmentVariable("OSU_EXECUTION_MODE"), true, out var mode) ? mode : null;
-            NoTestTimeout = Environment.GetEnvironmentVariable("OSU_TESTS_NO_TIMEOUT") == "1";
-            ForceTestGC = Environment.GetEnvironmentVariable("OSU_TESTS_FORCED_GC") == "1";
-            FrameStatisticsViaTouch = Environment.GetEnvironmentVariable("OSU_FRAME_STATISTICS_VIA_TOUCH") != "0";
+            NoTestTimeout = parseBool(Environment.GetEnvironmentVariable("OSU_TESTS_NO_TIMEOUT")) ?? false;
+            ForceTestGC = parseBool(Environment.GetEnvironmentVariable("OSU_TESTS_FORCED_GC")) ?? false;
+            FrameStatisticsViaTouch = parseBool(Environment.GetEnvironmentVariable("OSU_FRAME_STATISTICS_VIA_TOUCH")) ?? true;
             PreferredGraphicsSurface = Enum.TryParse<GraphicsSurfaceType>(Environment.GetEnvironmentVariable("OSU_GRAPHICS_SURFACE"), true, out var surface) ? surface : null;
             PreferredGraphicsRenderer = Environment.GetEnvironmentVariable("OSU_GRAPHICS_RENDERER")?.ToLowerInvariant();
 
@@ -33,7 +34,22 @@ namespace osu.Framework
             if (int.TryParse(Environment.GetEnvironmentVariable("OSU_GRAPHICS_STAGING_BUFFER_TYPE"), out int stagingBufferImplementation))
                 StagingBufferType = stagingBufferImplementation;
 
-            NoStructuredBuffers = Environment.GetEnvironmentVariable("OSU_GRAPHICS_NO_SSBO") == "1";
+            NoStructuredBuffers = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_NO_SSBO")) ?? false;
+        }
+
+        private static bool? parseBool(string? value)
+        {
+            switch (value)
+            {
+                case "0":
+                    return false;
+
+                case "1":
+                    return true;
+
+                default:
+                    return bool.TryParse(value, out bool b) ? b : null;
+            }
         }
     }
 }

--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Framework

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -266,7 +266,7 @@ namespace osu.Framework
 
             FrameStatistics.BindValueChanged(e => performanceOverlay.State = e.NewValue, true);
 
-            if (FrameworkEnvironment.FrameStatisticsViaTouch || DebugUtils.IsDebugBuild)
+            if (FrameworkEnvironment.FrameStatisticsViaTouch && DebugUtils.IsDebugBuild)
             {
                 base.AddInternal(new FrameStatisticsTouchReceptor(this)
                 {


### PR DESCRIPTION
https://github.com/ppy/osu-framework/wiki/Environment-variables#osu_frame_statistics_via_touch

I think it makes more sense to have it as described in the wiki. A hybrid solution would be to default to enabled on debug, and disabled on release (the envvar would always override the default in the case).

Currently there's no way to disable touch frame statistics in debug builds (one can only enable them in release builds).