### PR TITLE
Add class for efficiently building B-Splines

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
+++ b/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Tests.MathUtils
             // lagrange of (0,0) (0.5,0.35) (1,1) is equal to 0.6x*x + 0.4x
             Vector2[] points = { new Vector2(0, 0), new Vector2(0.5f, 0.35f), new Vector2(1, 1) };
 
-            List<Vector2> approximated = PathApproximator.ApproximateLagrangePolynomial(points);
+            List<Vector2> approximated = PathApproximator.LagrangePolynomialToPiecewiseLinear(points);
             Assert.Greater(approximated.Count, 10, "Approximated polynomial should have at least 10 points to test");
 
             for (int i = 0; i < approximated.Count; i++)
@@ -34,7 +34,7 @@ namespace osu.Framework.Tests.MathUtils
         {
             Vector2[] points = { new Vector2(0, 0), new Vector2(1, 0), new Vector2(1, -1), new Vector2(-1, -1), new Vector2(-1, 1), new Vector2(3, 2), new Vector2(3, 0) };
 
-            List<Vector2> approximated = PathApproximator.ApproximateBSpline(points, 4);
+            List<Vector2> approximated = PathApproximator.BSplineToPiecewiseLinear(points, 4);
             Assert.AreEqual(approximated.Count, 29, "Approximated path should have 29 points to test");
             Assert.True(Precision.AlmostEquals(approximated[0], points[0], 1e-4f));
             Assert.True(Precision.AlmostEquals(approximated[28], points[6], 1e-4f));

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
@@ -74,7 +74,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 if (copy.Length != 3)
                     return;
 
-                path.Vertices = PathApproximator.ApproximateCircularArc(copy);
+                path.Vertices = PathApproximator.CircularArcToPiecewiseLinear(copy);
 
                 var bounds = PathApproximator.CircularArcBoundingBox(copy);
                 boundingBox.Size = bounds.Size;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneCustomEasingCurve.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneCustomEasingCurve.cs
@@ -165,7 +165,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 vectorPath.AddRange(ordered.Select(p => p.PointPosition.Value));
                 vectorPath.Add(new Vector2(DrawWidth, 0));
 
-                var bezierPath = PathApproximator.ApproximateBezier(vectorPath.ToArray());
+                var bezierPath = PathApproximator.BezierToPiecewiseLinear(vectorPath.ToArray());
                 path.Vertices = bezierPath;
                 path.Position = -path.PositionInBoundingBox(Vector2.Zero);
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             };
 
             updateViz();
-            OnUpdate += _ => updateControlPointsViz();
+            OnUpdate += _ => updateViz();
 
             AddStep("Reset path", () =>
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osuTK.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Input.Events;
+using osuTK.Input;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    [System.ComponentModel.Description("Approximate a hand-drawn path with minimal B-spline control points")]
+    public partial class TestSceneInteractivePathDrawing : FrameworkTestScene
+    {
+        private readonly Path rawDrawnPath;
+        private readonly Path approximatedDrawnPath;
+        private readonly Container controlPointViz;
+
+        private readonly IncrementalBSplineBuilder bSplineBuilder = new IncrementalBSplineBuilder();
+
+        public TestSceneInteractivePathDrawing()
+        {
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    rawDrawnPath = new Path
+                    {
+                        Colour = Color4.DeepPink,
+                        PathRadius = 5,
+                    },
+                    approximatedDrawnPath = new Path
+                    {
+                        Colour = Color4.Blue,
+                        PathRadius = 3,
+                    },
+                    controlPointViz = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0.5f,
+                    },
+                }
+            };
+
+            updateViz();
+            OnUpdate += _ => updateControlPointsViz();
+
+            AddStep("Reset path", () =>
+            {
+                bSplineBuilder.Clear();
+            });
+
+            AddSliderStep($"{nameof(bSplineBuilder.Degree)}", 1, 5, 3, v =>
+            {
+                bSplineBuilder.Degree = v;
+            });
+            AddSliderStep($"{nameof(bSplineBuilder.Tolerance)}", 0f, 1f, 0.1f, v =>
+            {
+                bSplineBuilder.Tolerance = v;
+            });
+        }
+
+        private void updateControlPointsViz()
+        {
+            controlPointViz.Clear();
+
+            foreach (var cp in bSplineBuilder.GetControlPoints())
+            {
+                controlPointViz.Add(new Box
+                {
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(10),
+                    Position = cp,
+                    Colour = Color4.LightGreen,
+                });
+            }
+        }
+
+        protected override bool OnDragStart(DragStartEvent e)
+        {
+            if (e.Button == MouseButton.Left)
+            {
+                bSplineBuilder.Clear();
+                bSplineBuilder.AddLinearPoint(rawDrawnPath.ToLocalSpace(ToScreenSpace(e.MousePosition)));
+                return true;
+            }
+
+            return false;
+        }
+
+        private void updateViz()
+        {
+            rawDrawnPath.Vertices = bSplineBuilder.GetInputPath();
+            approximatedDrawnPath.Vertices = bSplineBuilder.OutputPath;
+
+            updateControlPointsViz();
+        }
+
+        protected override void OnDrag(DragEvent e)
+        {
+            bSplineBuilder.AddLinearPoint(rawDrawnPath.ToLocalSpace(ToScreenSpace(e.MousePosition)));
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Visual.Drawables
     public partial class TestScenePathApproximator : GridTestScene
     {
         public TestScenePathApproximator()
-            : base(2, 3)
+            : base(2, 2)
         {
             Cell(0).AddRange(new[]
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -16,30 +16,30 @@ namespace osu.Framework.Tests.Visual.Drawables
     public partial class TestScenePathApproximator : GridTestScene
     {
         public TestScenePathApproximator()
-            : base(2, 2)
+            : base(2, 3)
         {
             Cell(0).AddRange(new[]
             {
-                createLabel("ApproximateBezier"),
-                new ApproximatedPathTest(PathApproximator.ApproximateBezier),
-            });
-
-            Cell(1).AddRange(new[]
-            {
-                createLabel("ApproximateCatmull"),
-                new ApproximatedPathTest(PathApproximator.ApproximateCatmull),
+                createLabel("BezierToPiecewiseLinear"),
+                new ApproximatedPathTest(PathApproximator.BezierToPiecewiseLinear),
             });
 
             Cell(2).AddRange(new[]
             {
-                createLabel("ApproximateCircularArc"),
-                new ApproximatedPathTest(PathApproximator.ApproximateCircularArc),
+                createLabel("CatmullToPiecewiseLinear"),
+                new ApproximatedPathTest(PathApproximator.CatmullToPiecewiseLinear),
             });
 
             Cell(3).AddRange(new[]
             {
-                createLabel("ApproximateLagrangePolynomial"),
-                new ApproximatedPathTest(PathApproximator.ApproximateLagrangePolynomial),
+                createLabel("CircularArcToPiecewiseLinear"),
+                new ApproximatedPathTest(PathApproximator.CircularArcToPiecewiseLinear),
+            });
+
+            Cell(4).AddRange(new[]
+            {
+                createLabel("LagrangePolynomialToPiecewiseLinear"),
+                new ApproximatedPathTest(PathApproximator.LagrangePolynomialToPiecewiseLinear),
             });
         }
 
@@ -50,10 +50,10 @@ namespace osu.Framework.Tests.Visual.Drawables
             Colour = Color4.White,
         };
 
+        public delegate List<Vector2> ApproximatorFunc(ReadOnlySpan<Vector2> controlPoints);
+
         private partial class ApproximatedPathTest : SmoothPath
         {
-            public delegate List<Vector2> ApproximatorFunc(ReadOnlySpan<Vector2> controlPoints);
-
             public ApproximatedPathTest(ApproximatorFunc approximator)
             {
                 Vector2[] points = new Vector2[5];

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -24,19 +24,19 @@ namespace osu.Framework.Tests.Visual.Drawables
                 new ApproximatedPathTest(PathApproximator.BezierToPiecewiseLinear),
             });
 
-            Cell(2).AddRange(new[]
+            Cell(1).AddRange(new[]
             {
                 createLabel("CatmullToPiecewiseLinear"),
                 new ApproximatedPathTest(PathApproximator.CatmullToPiecewiseLinear),
             });
 
-            Cell(3).AddRange(new[]
+            Cell(2).AddRange(new[]
             {
                 createLabel("CircularArcToPiecewiseLinear"),
                 new ApproximatedPathTest(PathApproximator.CircularArcToPiecewiseLinear),
             });
 
-            Cell(4).AddRange(new[]
+            Cell(3).AddRange(new[]
             {
                 createLabel("LagrangePolynomialToPiecewiseLinear"),
                 new ApproximatedPathTest(PathApproximator.LagrangePolynomialToPiecewiseLinear),

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -20,25 +20,25 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             Cell(0).AddRange(new[]
             {
-                createLabel("BezierToPiecewiseLinear"),
+                createLabel(nameof(PathApproximator.BezierToPiecewiseLinear)),
                 new ApproximatedPathTest(PathApproximator.BezierToPiecewiseLinear),
             });
 
             Cell(1).AddRange(new[]
             {
-                createLabel("CatmullToPiecewiseLinear"),
+                createLabel(nameof(PathApproximator.CatmullToPiecewiseLinear)),
                 new ApproximatedPathTest(PathApproximator.CatmullToPiecewiseLinear),
             });
 
             Cell(2).AddRange(new[]
             {
-                createLabel("CircularArcToPiecewiseLinear"),
+                createLabel(nameof(PathApproximator.CircularArcToPiecewiseLinear)),
                 new ApproximatedPathTest(PathApproximator.CircularArcToPiecewiseLinear),
             });
 
             Cell(3).AddRange(new[]
             {
-                createLabel("LagrangePolynomialToPiecewiseLinear"),
+                createLabel(nameof(PathApproximator.LagrangePolynomialToPiecewiseLinear)),
                 new ApproximatedPathTest(PathApproximator.LagrangePolynomialToPiecewiseLinear),
             });
         }

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
@@ -123,7 +123,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                 shader.Bind();
                 shader.BindUniformBlock("g_ColourBuffer", colourBuffer);
 
-                // Submit vertices, making sure that we don't submit an index which would overflow the SSBO.
+                // Submit rawDrawnPath, making sure that we don't submit an index which would overflow the SSBO.
                 for (int i = 0; i < areas.Count; i++)
                 {
                     vertices.Add(new ColourIndexedVertex

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
@@ -123,7 +123,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                 shader.Bind();
                 shader.BindUniformBlock("g_ColourBuffer", colourBuffer);
 
-                // Submit rawDrawnPath, making sure that we don't submit an index which would overflow the SSBO.
+                // Submit vertices, making sure that we don't submit an index which would overflow the SSBO.
                 for (int i = 0; i < areas.Count; i++)
                 {
                     vertices.Add(new ColourIndexedVertex

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -237,6 +237,16 @@ namespace osu.Framework.Graphics.Lines
             Invalidate(Invalidation.DrawSize);
         }
 
+        public void ReplaceVertex(int index, Vector2 pos)
+        {
+            vertices[index] = pos;
+
+            vertexBoundsCache.Invalidate();
+            segmentsCache.Invalidate();
+
+            Invalidate(Invalidation.DrawSize);
+        }
+
         private readonly List<Line> segmentsBacking = new List<Line>();
         private readonly Cached segmentsCache = new Cached();
         private List<Line> segments => segmentsCache.IsValid ? segmentsBacking : generateSegments();

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -160,7 +160,7 @@ namespace osu.Framework.Utils
             // Determine the alignment between the raw path and control path's momentums.
             // It uses Vector2.Dot which calculates the cosine of the angle between two vectors.
             // This alignment is used to adjust the control points based on the path's direction change.
-            float alignment = MathF.Max(Vector2.Dot(mraw, mcp), 0.01f);
+            float alignment = mraw == Vector2.Zero || mcp == Vector2.Zero ? 1.0f : MathF.Max(Vector2.Dot(mraw, mcp), 0.01f);
 
             // Calculate the distance between the last two control points.
             // This distance is then used, along with alignment, to decide if a new control point is needed.

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Caching;
+using osuTK;
+
+namespace osu.Framework.Utils
+{
+    /// <summary>
+    /// A class for incrementally building B-Spline paths from a series of linear points.
+    /// This can be used to obtain a B-Spline with a minimal number of control points for any
+    /// given set of linear input points, for example, a hand-drawn path.
+    /// </summary>
+    public class IncrementalBSplineBuilder
+    {
+        private readonly List<Vector2> inputPath = new List<Vector2>();
+
+        private readonly Cached<List<Vector2>> outputCache = new Cached<List<Vector2>>
+        {
+            Value = new List<Vector2>()
+        };
+
+        private readonly List<Vector2> controlPoints = new List<Vector2>();
+
+        private int degree;
+
+        /// <summary>
+        /// Gets or sets the degree of the B-Spline. Must not be negative. Default is 3.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
+        public int Degree
+        {
+            get => degree;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Degree must not be negative.");
+
+                degree = value;
+                outputCache.Invalidate();
+            }
+        }
+
+        private float tolerance;
+
+        /// <summary>
+        /// Gets or sets the tolerance for determining when to add a new control point. Must not be negative. Default is 0.1.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
+        public float Tolerance
+        {
+            get => tolerance;
+            set
+            {
+                if (tolerance < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), "Tolerance must not be negative.");
+
+                tolerance = value;
+                outputCache.Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// The piecewise linear approximation of the B-spline created from the input path.
+        /// </summary>
+        public IReadOnlyList<Vector2> OutputPath
+        {
+            get
+            {
+                if (!outputCache.IsValid)
+                    redrawApproximatedPath();
+
+                return outputCache.Value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IncrementalBSplineBuilder"/> class with specified degree and tolerance.
+        /// </summary>
+        /// <param name="degree">The degree of the B-Spline.</param>
+        /// <param name="tolerance">The tolerance for control point addition.</param>
+        public IncrementalBSplineBuilder(int degree = 3, float tolerance = 0.1f)
+        {
+            Degree = degree;
+            Tolerance = tolerance;
+        }
+
+        /// <summary>
+        /// The list of control points of the B-Spline. This is inferred from the input path.
+        /// </summary>
+        public IReadOnlyList<Vector2> GetControlPoints()
+            => controlPoints.ToArray();
+
+        /// <summary>
+        /// The list of input points.
+        /// </summary>
+        public IReadOnlyList<Vector2> GetInputPath()
+            => inputPath.ToArray();
+
+        private void redrawApproximatedPath()
+        {
+            // Set value of output cache to update the cache to be valid.
+            outputCache.Value = new List<Vector2>();
+            if (inputPath.Count == 0)
+                return;
+
+            var oldInputs = inputPath.ToList();
+
+            inputPath.Clear();
+            controlPoints.Clear();
+
+            foreach (var v in oldInputs)
+                AddLinearPoint(v);
+        }
+
+        /// <summary>
+        /// Clears the input path and the B-Spline.
+        /// </summary>
+        public void Clear()
+        {
+            inputPath.Clear();
+            controlPoints.Clear();
+            if (outputCache.IsValid)
+                outputCache.Value.Clear();
+        }
+
+        /// <summary>
+        /// Adds a linear point to the path and updates the B-Spline accordingly.
+        /// </summary>
+        /// <param name="v">The vector representing the point to add.</param>
+        public void AddLinearPoint(Vector2 v)
+        {
+            if (!outputCache.IsValid)
+                redrawApproximatedPath();
+
+            if (inputPath.Count == 0)
+            {
+                inputPath.Add(v);
+                controlPoints.Add(inputPath[0]);
+                controlPoints.Add(inputPath[0]);
+                return;
+            }
+
+            inputPath.Add(v);
+
+            var cps = controlPoints;
+            Debug.Assert(cps.Count >= 2);
+
+            cps[^1] = inputPath[^1];
+
+            // Calculate the normalized momentum vectors for both raw and approximated paths.
+            // Momentum here refers to a direction vector representing the path's direction of movement.
+            var mraw = momentumDirection(inputPath, 3);
+            var mcp = cps.Count > 2 ? momentumDirection(outputCache.Value, 1) : Vector2.Zero;
+
+            // Determine the alignment between the raw path and control path's momentums.
+            // It uses Vector2.Dot which calculates the cosine of the angle between two vectors.
+            // This alignment is used to adjust the control points based on the path's direction change.
+            float alignment = MathF.Max(Vector2.Dot(mraw, mcp), 0.01f);
+
+            // Calculate the distance between the last two control points.
+            // This distance is then used, along with alignment, to decide if a new control point is needed.
+            // The threshold for adding a new control point is based on the alignment and a predefined accuracy factor.
+            float distance = Vector2.Distance(cps[^1], cps[^2]);
+            if (distance / MathF.Pow(alignment, 4) > Tolerance * 1000)
+                cps.Add(cps[^1]);
+
+            outputCache.Value = PathApproximator.BSplineToPiecewiseLinear(cps.ToArray(), degree);
+        }
+
+        private Vector2 momentumDirection(IReadOnlyList<Vector2> vertices, int window)
+        {
+            if (vertices.Count < window + 1)
+                return Vector2.Zero;
+
+            var sum = Vector2.Zero;
+            for (int i = 0; i < window; i++)
+                sum += vertices[^(i + 1)] - vertices[^(i + 2)];
+
+            if (Precision.AlmostEquals(sum.X, 0, 1e-7f) && Precision.AlmostEquals(sum.Y, 0, 1e-7f))
+                return Vector2.Zero;
+
+            return (sum / window).Normalized();
+        }
+    }
+}

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -124,8 +124,7 @@ namespace osu.Framework.Utils
         {
             inputPath.Clear();
             controlPoints.Clear();
-            if (outputCache.IsValid)
-                outputCache.Value.Clear();
+            outputCache.Value = new List<Vector2>();
         }
 
         /// <summary>
@@ -140,6 +139,8 @@ namespace osu.Framework.Utils
             if (inputPath.Count == 0)
             {
                 inputPath.Add(v);
+                // We add the first point twice so we can track the
+                // end point of the raw path using the last control point.
                 controlPoints.Add(inputPath[0]);
                 controlPoints.Add(inputPath[0]);
                 return;
@@ -181,6 +182,8 @@ namespace osu.Framework.Utils
             for (int i = 0; i < window; i++)
                 sum += vertices[^(i + 1)] - vertices[^(i + 2)];
 
+            // We choose a very small acceptable difference here to ensure that
+            // small momenta are not ignored.
             if (Precision.AlmostEquals(sum.X, 0, 1e-7f) && Precision.AlmostEquals(sum.Y, 0, 1e-7f))
                 return Vector2.Zero;
 

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -47,9 +47,9 @@ namespace osu.Framework.Utils
         public static List<Vector2> BSplineToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints, int degree)
         {
             List<Vector2> output = new List<Vector2>();
-            int nPoints = controlPoints.Length - 1;
+            int pointCount = controlPoints.Length - 1;
 
-            if (nPoints < 0)
+            if (pointCount < 0)
                 return output;
 
             Stack<Vector2[]> toFlatten = new Stack<Vector2[]>();
@@ -57,10 +57,10 @@ namespace osu.Framework.Utils
 
             var points = controlPoints.ToArray();
 
-            if (degree > 0 && degree < nPoints)
+            if (degree > 0 && degree < pointCount)
             {
                 // Subdivide B-spline into bezier control points at knots.
-                for (int i = 0; i < nPoints - degree; i++)
+                for (int i = 0; i < pointCount - degree; i++)
                 {
                     var subBezier = new Vector2[degree + 1];
                     subBezier[0] = points[i];
@@ -72,7 +72,7 @@ namespace osu.Framework.Utils
 
                         for (int k = 1; k < degree - j; k++)
                         {
-                            int l = Math.Min(k, nPoints - degree - i);
+                            int l = Math.Min(k, pointCount - degree - i);
                             points[i + k] = (l * points[i + k] + points[i + k + 1]) / (l + 1);
                         }
                     }
@@ -81,14 +81,14 @@ namespace osu.Framework.Utils
                     toFlatten.Push(subBezier);
                 }
 
-                toFlatten.Push(points[(nPoints - degree)..]);
+                toFlatten.Push(points[(pointCount - degree)..]);
                 // Reverse the stack so elements can be accessed in order.
                 toFlatten = new Stack<Vector2[]>(toFlatten);
             }
             else
             {
                 // B-spline subdivision unnecessary, degenerate to single bezier.
-                degree = nPoints;
+                degree = pointCount;
                 toFlatten.Push(points);
             }
             // "toFlatten" contains all the curves which are not yet approximated well enough.
@@ -131,7 +131,7 @@ namespace osu.Framework.Utils
                 toFlatten.Push(parent);
             }
 
-            output.Add(controlPoints[nPoints]);
+            output.Add(controlPoints[pointCount]);
             return output;
         }
 

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -29,27 +29,27 @@ namespace osu.Framework.Utils
         /// </summary>
         /// <param name="controlPoints">The control points.</param>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateBezier(ReadOnlySpan<Vector2> controlPoints)
+        public static List<Vector2> BezierToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
-            return ApproximateBSpline(controlPoints);
+            return BSplineToPiecewiseLinear(controlPoints, 0);
         }
 
         /// <summary>
-        /// Creates a piecewise-linear approximation of a clamped uniform B-spline with polynomial order p,
+        /// Creates a piecewise-linear approximation of a clamped uniform B-spline with polynomial order degree,
         /// by dividing it into a series of bezier control points at its knots, then adaptively repeatedly
         /// subdividing those until their approximation error vanishes below a given threshold.
-        /// Retains previous bezier approximation functionality when p is 0 or too large to create knots.
-        /// Algorithm unsuitable for large values of p with many knots.
+        /// Retains previous bezier approximation functionality when degree is 0 or too large to create knots.
+        /// Algorithm unsuitable for large values of degree with many knots.
         /// </summary>
         /// <param name="controlPoints">The control points.</param>
-        /// <param name="p">The polynomial order.</param>
+        /// <param name="degree">The polynomial order.</param>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateBSpline(ReadOnlySpan<Vector2> controlPoints, int p = 0)
+        public static List<Vector2> BSplineToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints, int degree)
         {
             List<Vector2> output = new List<Vector2>();
-            int n = controlPoints.Length - 1;
+            int nPoints = controlPoints.Length - 1;
 
-            if (n < 0)
+            if (nPoints < 0)
                 return output;
 
             Stack<Vector2[]> toFlatten = new Stack<Vector2[]>();
@@ -57,38 +57,38 @@ namespace osu.Framework.Utils
 
             var points = controlPoints.ToArray();
 
-            if (p > 0 && p < n)
+            if (degree > 0 && degree < nPoints)
             {
                 // Subdivide B-spline into bezier control points at knots.
-                for (int i = 0; i < n - p; i++)
+                for (int i = 0; i < nPoints - degree; i++)
                 {
-                    var subBezier = new Vector2[p + 1];
+                    var subBezier = new Vector2[degree + 1];
                     subBezier[0] = points[i];
 
-                    // Destructively insert the knot p-1 times via Boehm's algorithm.
-                    for (int j = 0; j < p - 1; j++)
+                    // Destructively insert the knot degree-1 times via Boehm's algorithm.
+                    for (int j = 0; j < degree - 1; j++)
                     {
                         subBezier[j + 1] = points[i + 1];
 
-                        for (int k = 1; k < p - j; k++)
+                        for (int k = 1; k < degree - j; k++)
                         {
-                            int l = Math.Min(k, n - p - i);
+                            int l = Math.Min(k, nPoints - degree - i);
                             points[i + k] = (l * points[i + k] + points[i + k + 1]) / (l + 1);
                         }
                     }
 
-                    subBezier[p] = points[i + 1];
+                    subBezier[degree] = points[i + 1];
                     toFlatten.Push(subBezier);
                 }
 
-                toFlatten.Push(points[(n - p)..]);
+                toFlatten.Push(points[(nPoints - degree)..]);
                 // Reverse the stack so elements can be accessed in order.
                 toFlatten = new Stack<Vector2[]>(toFlatten);
             }
             else
             {
                 // B-spline subdivision unnecessary, degenerate to single bezier.
-                p = n;
+                degree = nPoints;
                 toFlatten.Push(points);
             }
             // "toFlatten" contains all the curves which are not yet approximated well enough.
@@ -97,8 +97,8 @@ namespace osu.Framework.Utils
             // <a href="https://en.wikipedia.org/wiki/Depth-first_search">Depth-first search</a>
             // over the tree resulting from the subdivisions we make.)
 
-            var subdivisionBuffer1 = new Vector2[p + 1];
-            var subdivisionBuffer2 = new Vector2[p * 2 + 1];
+            var subdivisionBuffer1 = new Vector2[degree + 1];
+            var subdivisionBuffer2 = new Vector2[degree * 2 + 1];
 
             Vector2[] leftChild = subdivisionBuffer2;
 
@@ -112,7 +112,7 @@ namespace osu.Framework.Utils
                     // an extension to De Casteljau's algorithm to obtain a piecewise-linear approximation
                     // of the bezier curve represented by our control points, consisting of the same amount
                     // of points as there are control points.
-                    bezierApproximate(parent, output, subdivisionBuffer1, subdivisionBuffer2, p + 1);
+                    bezierApproximate(parent, output, subdivisionBuffer1, subdivisionBuffer2, degree + 1);
 
                     freeBuffers.Push(parent);
                     continue;
@@ -120,18 +120,18 @@ namespace osu.Framework.Utils
 
                 // If we do not yet have a sufficiently "flat" (in other words, detailed) approximation we keep
                 // subdividing the curve we are currently operating on.
-                Vector2[] rightChild = freeBuffers.Count > 0 ? freeBuffers.Pop() : new Vector2[p + 1];
-                bezierSubdivide(parent, leftChild, rightChild, subdivisionBuffer1, p + 1);
+                Vector2[] rightChild = freeBuffers.Count > 0 ? freeBuffers.Pop() : new Vector2[degree + 1];
+                bezierSubdivide(parent, leftChild, rightChild, subdivisionBuffer1, degree + 1);
 
                 // We re-use the buffer of the parent for one of the children, so that we save one allocation per iteration.
-                for (int i = 0; i < p + 1; ++i)
+                for (int i = 0; i < degree + 1; ++i)
                     parent[i] = leftChild[i];
 
                 toFlatten.Push(rightChild);
                 toFlatten.Push(parent);
             }
 
-            output.Add(controlPoints[n]);
+            output.Add(controlPoints[nPoints]);
             return output;
         }
 
@@ -139,7 +139,7 @@ namespace osu.Framework.Utils
         /// Creates a piecewise-linear approximation of a Catmull-Rom spline.
         /// </summary>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateCatmull(ReadOnlySpan<Vector2> controlPoints)
+        public static List<Vector2> CatmullToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
             var result = new List<Vector2>((controlPoints.Length - 1) * catmull_detail * 2);
 
@@ -164,11 +164,11 @@ namespace osu.Framework.Utils
         /// Creates a piecewise-linear approximation of a circular arc curve.
         /// </summary>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateCircularArc(ReadOnlySpan<Vector2> controlPoints)
+        public static List<Vector2> CircularArcToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
             CircularArcProperties pr = new CircularArcProperties(controlPoints);
             if (!pr.IsValid)
-                return ApproximateBezier(controlPoints);
+                return BezierToPiecewiseLinear(controlPoints);
 
             // We select the amount of points for the approximation by requiring the discrete curvature
             // to be smaller than the provided tolerance. The exact angle required to meet the tolerance
@@ -244,7 +244,7 @@ namespace osu.Framework.Utils
         /// Basically, returns the input.
         /// </summary>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateLinear(ReadOnlySpan<Vector2> controlPoints)
+        public static List<Vector2> LinearToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
             var result = new List<Vector2>(controlPoints.Length);
 
@@ -258,7 +258,7 @@ namespace osu.Framework.Utils
         /// Creates a piecewise-linear approximation of a lagrange polynomial.
         /// </summary>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
-        public static List<Vector2> ApproximateLagrangePolynomial(ReadOnlySpan<Vector2> controlPoints)
+        public static List<Vector2> LagrangePolynomialToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
             // TODO: add some smarter logic here, chebyshev nodes?
             const int num_steps = 51;


### PR DESCRIPTION
This adds the IncrementalBSplineBuilder class which can be used to build up a B-Spline from a series of linear points efficiently. The class takes special care to keep the number of control points.

This is a preparatory framework side change to implement free-hand drawing of sliders in the osu!lazer editor.

# Breaking changes

## `PathApproximator` method signatures changed

The following `PathApproximator` methods have been renamed:

| old | new |
| :- | :- |
| `ApproximateBezier` | `BezierToPiecewiseLinear` |
| `ApproximateBSpline` | `BSplineToPiecewiseLinear` |
| `ApproximateCatmull` | `CatmullToPiecewiseLinear` |
| `ApproximateCircularArc` | `CircularArcToPiecewiseLinear` |
| `ApproximateLinear` | `LinearToPiecewiseLinear` |
| `ApproximateLagrangePolynomial` | `LagrangePolynomialToPiecewiseLinear` |

Additionally, `ApproximateBSpline`'s polynomial order argument `p` has been renamed to `degree` and lost its default value of 0.