### PR TITLE
PathApproximator: no BSpline degree <1 and better special case handling

### DIFF
--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -35,15 +35,19 @@ namespace osu.Framework.Utils
         }
 
         /// <summary>
-        /// Creates a piecewise-linear approximation of a clamped uniform B-spline with polynomial order degree,
+        /// Creates a piecewise-linear approximation of a clamped uniform B-spline with polynomial order <paramref name="degree"/>,
         /// by dividing it into a series of bezier control points at its knots, then adaptively repeatedly
         /// subdividing those until their approximation error vanishes below a given threshold.
-        /// Retains previous bezier approximation functionality when degree is 0 or too large to create knots.
-        /// Algorithm unsuitable for large values of degree with many knots.
         /// </summary>
+        /// <remarks>
+        /// Does nothing if <paramref name="controlPoints"/> has zero points or one point.
+        /// Generalises to bezier approximation functionality when <paramref name="degree"/> is too large to create knots.
+        /// Algorithm unsuitable for large values of <paramref name="degree"/> with many knots.
+        /// </remarks>
         /// <param name="controlPoints">The control points.</param>
         /// <param name="degree">The polynomial order.</param>
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="degree"/> was less than 1.</exception>
         public static List<Vector2> BSplineToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints, int degree)
         {
             // Zero-th degree splines would be piecewise-constant, which cannot be represented by the piecewise-

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -46,12 +46,20 @@ namespace osu.Framework.Utils
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
         public static List<Vector2> BSplineToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints, int degree)
         {
+            // Zero-th degree splines would be piecewise-constant, which cannot be represented by the picewise-
+            // linear output of this function. Negative degrees would require rational splines which this code
+            // does not support.
             if (degree < 1)
                 throw new ArgumentOutOfRangeException(nameof(degree), $"{nameof(degree)} must be >=1 but was {degree}.");
 
+            // Spline fitting does not make sense when the input contains no points or just one point. In this case
+            // the user likely wants this function to behave like a no-op.
             if (controlPoints.Length < 2)
                 return controlPoints.Length == 0 ? new List<Vector2>() : new List<Vector2> { controlPoints[0] };
 
+            // With fewer control points than the degree, splines can not be unambiguously fitted. Rather than erroring
+            // out, we set the degree to the minimal number that permits a unique fit to avoid special casing in
+            // incremental spline building algorithms that call this function.
             degree = Math.Min(degree, controlPoints.Length - 1);
 
             List<Vector2> output = new List<Vector2>();

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Utils
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
         public static List<Vector2> BSplineToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints, int degree)
         {
-            // Zero-th degree splines would be piecewise-constant, which cannot be represented by the picewise-
+            // Zero-th degree splines would be piecewise-constant, which cannot be represented by the piecewise-
             // linear output of this function. Negative degrees would require rational splines which this code
             // does not support.
             if (degree < 1)


### PR DESCRIPTION
Previously, `PathApproximator.BSplineToPiecewiseLinear` was on one hand too permissive in its input handling (people knowing spline math would scratch their head) and, on the other hand, unintuitively returned an empty spline when given a single control point.

This PR addresses both concerns and adds explanatory comments to the function body.