### PR TITLE
IncrementalBSplineBuilder: rewrite algorithm with many improvements 

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
+++ b/osu.Framework.Tests/MathUtils/TestPathApproximator.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Utils;
 using osuTK;
@@ -39,6 +41,25 @@ namespace osu.Framework.Tests.MathUtils
             Assert.True(Precision.AlmostEquals(approximated[0], points[0], 1e-4f));
             Assert.True(Precision.AlmostEquals(approximated[28], points[6], 1e-4f));
             Assert.True(Precision.AlmostEquals(approximated[10], new Vector2(-0.11415f, -0.69065f), 1e-4f));
+        }
+
+        [Test]
+        public void TestBSplineThrowsOnInvalidDegree()
+        {
+            Vector2[] points = { new Vector2(0, 0), new Vector2(1, 0), new Vector2(1, -1), new Vector2(-1, -1), new Vector2(-1, 1), new Vector2(3, 2), new Vector2(3, 0) };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => PathApproximator.BSplineToPiecewiseLinear(points, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => PathApproximator.BSplineToPiecewiseLinear(points, -5));
+        }
+
+        [TestCase(0)]
+        [TestCase(1)]
+        public void TestBSplineDoesNothingWhenGivenTooFewPoints(int pointCount)
+        {
+            var points = Enumerable.Repeat(new Vector2(), pointCount).ToArray();
+
+            Assert.That(PathApproximator.BSplineToPiecewiseLinear(points, 3), Is.EquivalentTo(points));
+            Assert.That(PathApproximator.BezierToPiecewiseLinear(points), Is.EquivalentTo(points));
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneInteractivePathDrawing.cs
@@ -59,9 +59,13 @@ namespace osu.Framework.Tests.Visual.Drawables
             {
                 bSplineBuilder.Degree = v;
             });
-            AddSliderStep($"{nameof(bSplineBuilder.Tolerance)}", 0f, 1f, 0.1f, v =>
+            AddSliderStep($"{nameof(bSplineBuilder.Tolerance)}", 0f, 3f, 1.5f, v =>
             {
                 bSplineBuilder.Tolerance = v;
+            });
+            AddSliderStep($"{nameof(bSplineBuilder.CornerThreshold)}", 0f, 1f, 0.4f, v =>
+            {
+                bSplineBuilder.CornerThreshold = v;
             });
         }
 
@@ -69,7 +73,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             controlPointViz.Clear();
 
-            foreach (var cp in bSplineBuilder.GetControlPoints())
+            foreach (var cp in bSplineBuilder.ControlPoints)
             {
                 controlPointViz.Add(new Box
                 {

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -308,7 +308,7 @@ namespace osu.Framework.Utils
 
                 var tmp = new List<Vector2>();
                 bool allOnLine = true;
-                float on_line_threshold = 5 * Tolerance * step_size;
+                float onLineThreshold = 5 * Tolerance * step_size;
 
                 if (t1 > t0)
                 {
@@ -331,7 +331,7 @@ namespace osu.Framework.Utils
                         if (currentWinding > controlPointSpacing)
                         {
                             Vector2 p = getPathAt(vertices, distances, t);
-                            if (linearConnection.DistanceSquaredToPoint(p) > on_line_threshold * on_line_threshold)
+                            if (linearConnection.DistanceSquaredToPoint(p) > onLineThreshold * onLineThreshold)
                                 allOnLine = false;
 
                             tmp.Add(p);

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -48,22 +48,7 @@ namespace osu.Framework.Utils
 
         private float inputPathLength => cumulativeInputPathLength.Count == 0 ? 0 : cumulativeInputPathLength[^1];
 
-        public const float FdEpsilon = PathApproximator.BEZIER_TOLERANCE * 8f;
-
-        /// <summary>
-        /// Get the tangent at a given point on the path.
-        /// </summary>
-        /// <param name="path">The path to get the tangent from.</param>
-        /// <param name="cumulativeDistances">The cumulative distances of the path.</param>
-        /// <param name="t">The point on the path to get the tangent from.</param>
-        /// <returns>The tangent at the given point on the path.</returns>
-        private static Vector2 getTangentAt(List<Vector2> path, List<float> cumulativeDistances, float t)
-        {
-            Vector2 xminus = getPathAt(path, cumulativeDistances, t - FdEpsilon);
-            Vector2 xplus = getPathAt(path, cumulativeDistances, t + FdEpsilon);
-
-            return xplus == xminus ? Vector2.Zero : (xplus - xminus).Normalized();
-        }
+        public const float FD_EPSILON = PathApproximator.BEZIER_TOLERANCE * 8f;
 
         /// <summary>
         /// Get the amount of rotation (in radians) at a given point on the path.
@@ -74,9 +59,9 @@ namespace osu.Framework.Utils
         /// <returns>The amount of rotation (in radians) at the given point on the path.</returns>
         private static float getWindingAt(List<Vector2> path, List<float> cumulativeDistances, float t)
         {
-            Vector2 xminus = getPathAt(path, cumulativeDistances, t - FdEpsilon);
+            Vector2 xminus = getPathAt(path, cumulativeDistances, t - FD_EPSILON);
             Vector2 x = getPathAt(path, cumulativeDistances, t);
-            Vector2 xplus = getPathAt(path, cumulativeDistances, t + FdEpsilon);
+            Vector2 xplus = getPathAt(path, cumulativeDistances, t + FD_EPSILON);
             Vector2 tminus = x == xminus ? Vector2.Zero : (x - xminus).Normalized();
             Vector2 tplus = xplus == x ? Vector2.Zero : (xplus - x).Normalized();
             return MathF.Abs(MathF.Acos(Math.Clamp(Vector2.Dot(tminus, tplus), -1f, 1f)));
@@ -135,7 +120,7 @@ namespace osu.Framework.Utils
         private float cornerThreshold;
 
         /// <summary>
-        /// Gets or sets the corner threshold for determining when to add a new control point. Must not be negative. Default is 0.1.
+        /// Gets or sets the corner threshold for determining when to add a new control point. Must not be negative. Default is 0.4.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the value is negative.</exception>
         public float CornerThreshold
@@ -165,7 +150,7 @@ namespace osu.Framework.Utils
                 return outputCache.Value;
             }
         }
-        ///
+
         /// <summary>
         /// The list of control points of the B-Spline. This is inferred from the input path.
         /// </summary>
@@ -185,6 +170,7 @@ namespace osu.Framework.Utils
         /// </summary>
         /// <param name="degree">The degree of the B-Spline.</param>
         /// <param name="tolerance">The tolerance for control point addition.</param>
+        /// <param name="cornerThreshold">The threshold to use for inserting sharp control points at corners.</param>
         public IncrementalBSplineBuilder(int degree = 3, float tolerance = 1.5f, float cornerThreshold = 0.4f)
         {
             Degree = degree;
@@ -205,15 +191,16 @@ namespace osu.Framework.Utils
         /// <returns>A tuple containing the smoothed vertices and the cumulative distances of the smoothed path.</returns>
         private (List<Vector2> vertices, List<float> distances) computeSmoothedInputPath()
         {
-            var controlPoints = new Vector2[(int)(inputPathLength / FdEpsilon)];
-            for (int i = 0; i < controlPoints.Length; ++i)
-                controlPoints[i] = getPathAt(inputPath, cumulativeInputPathLength, i * FdEpsilon);
+            var cps = new Vector2[(int)(inputPathLength / FD_EPSILON)];
+            for (int i = 0; i < cps.Length; ++i)
+                cps[i] = getPathAt(inputPath, cumulativeInputPathLength, i * FD_EPSILON);
 
             // Empirically, degree 7 works really well as a good tradeoff for smoothing vs sharpness here.
-            int smoothedInputPathDegree = 7;
-            var vertices = PathApproximator.BSplineToPiecewiseLinear(controlPoints, smoothedInputPathDegree);
+            const int smoothed_input_path_degree = 7;
+            var vertices = PathApproximator.BSplineToPiecewiseLinear(cps, smoothed_input_path_degree);
             var distances = new List<float>();
             float cumulativeLength = 0;
+
             for (int i = 1; i < vertices.Count; ++i)
             {
                 cumulativeLength += Vector2.Distance(vertices[i], vertices[i - 1]);
@@ -232,39 +219,38 @@ namespace osu.Framework.Utils
         /// <returns>A list of t values at which corners occur.</returns>
         private List<float> detectCorners(List<Vector2> vertices, List<float> distances)
         {
-            var corners = new List<Vector2>();
             var cornerT = new List<float> { 0f };
 
-            float threshold = cornerThreshold / FdEpsilon;
+            float threshold = cornerThreshold / FD_EPSILON;
 
-            float stepSize = FdEpsilon;
-            int nSteps = (int)(distances[^1] / stepSize);
+            const float step_size = FD_EPSILON;
+            int nSteps = (int)(distances[^1] / step_size);
 
             // Empirically, averaging the winding rate over a neighborgood of 32 samples seems to be
             // a good representation of the neighborhood of the curve.
-            const int nAvgSamples = 32;
+            const int n_avg_samples = 32;
             float avgCurvature = 0.0f;
 
             for (int i = 0; i < nSteps; ++i)
             {
                 // Update average curvature by adding the new winding rate and subtracting the old one from
                 // nAvgSamples steps ago.
-                float newt = i * stepSize;
+                float newt = i * step_size;
                 float newWinding = MathF.Abs(getWindingAt(vertices, distances, newt));
 
-                float oldt = (i - nAvgSamples) * stepSize;
+                float oldt = (i - n_avg_samples) * step_size;
                 float oldWinding = oldt < 0 ? 0 : MathF.Abs(getWindingAt(vertices, distances, oldt));
 
-                avgCurvature = avgCurvature + (newWinding - oldWinding) / nAvgSamples;
+                avgCurvature += (newWinding - oldWinding) / n_avg_samples;
 
                 // Check whether the current winding rate is a local maximum and whether it exceeds the
                 // threshold as well as the surrounding average curvature. If so, we have found a corner.
                 // Also prohibit marking new corners that are too close to the previous one.
-                float midt = (i - nAvgSamples / 2f) * stepSize;
+                float midt = (i - n_avg_samples / 2f) * step_size;
                 float midWinding = midt < 0 ? 0 : MathF.Abs(getWindingAt(vertices, distances, midt));
 
                 float distToPrevCorner = cornerT.Count == 0 ? float.MaxValue : newt - cornerT[^1];
-                if (midWinding > threshold && midWinding > avgCurvature * 4 && distToPrevCorner > nAvgSamples * stepSize)
+                if (midWinding > threshold && midWinding > avgCurvature * 4 && distToPrevCorner > n_avg_samples * step_size)
                     cornerT.Add(midt);
             }
 
@@ -282,7 +268,10 @@ namespace osu.Framework.Utils
             //  2. Detect corners by thresholding local curvature maxima and place sharp control points at these corners.
             //  3. Place additional control points inbetween the sharp ones with density proportional to the product
             //     of Tolerance and curvature.
+            //  4. Additionally, we special case linear segments: if the path does not deviate more
+            //     than some threshold from a straight line, we do not add additional control points.
             var (vertices, distances) = computeSmoothedInputPath();
+
             if (vertices.Count < 2)
             {
                 controlPoints.Value = vertices;
@@ -299,13 +288,14 @@ namespace osu.Framework.Utils
 
             // Populate each segment between corners with control points that have density proportional to the
             // product of Tolerance and curvature.
-            float stepSize = FdEpsilon;
+            const float step_size = FD_EPSILON;
+
             for (int i = 1; i < cornerTs.Count; ++i)
             {
                 float totalAngle = 0;
 
-                float t0 = cornerTs[i - 1] + stepSize * 2;
-                float t1 = cornerTs[i] - stepSize * 2;
+                float t0 = cornerTs[i - 1] + step_size * 2;
+                float t1 = cornerTs[i] - step_size * 2;
 
                 Vector2 c0 = getPathAt(vertices, distances, cornerTs[i - 1]);
                 Vector2 c1 = getPathAt(vertices, distances, cornerTs[i]);
@@ -313,27 +303,30 @@ namespace osu.Framework.Utils
 
                 var tmp = new List<Vector2>();
                 bool allOnLine = true;
-                float onLineThreshold = 10 * stepSize;
+                const float on_line_threshold = 10 * step_size;
 
                 if (t1 > t0)
                 {
-                    int nSteps = (int)((t1 - t0) / stepSize);
+                    int nSteps = (int)((t1 - t0) / step_size);
+
                     for (int j = 0; j < nSteps; ++j)
                     {
-                        float t = t0 + j * stepSize;
+                        float t = t0 + j * step_size;
                         totalAngle += getWindingAt(vertices, distances, t);
                     }
 
                     int nControlPoints = (int)(totalAngle / Tolerance);
                     float controlPointSpacing = totalAngle / nControlPoints;
                     float currentAngle = 0;
+
                     for (int j = 0; j < nSteps; ++j)
                     {
-                        float t = t0 + j * stepSize;
+                        float t = t0 + j * step_size;
+
                         if (currentAngle > controlPointSpacing)
                         {
                             Vector2 p = getPathAt(vertices, distances, t);
-                            if (linearConnection.DistanceSquaredToPoint(p) > onLineThreshold * onLineThreshold)
+                            if (linearConnection.DistanceSquaredToPoint(p) > on_line_threshold * on_line_threshold)
                                 allOnLine = false;
 
                             tmp.Add(p);
@@ -354,8 +347,7 @@ namespace osu.Framework.Utils
                 if (i == cornerTs.Count - 1)
                     cps.Add(c1);
                 else
-                    for (int j = 0; j < degree; ++j)
-                        cps.Add(c1);
+                    cps.AddRange(Enumerable.Repeat(c1, degree));
             }
         }
 
@@ -392,7 +384,7 @@ namespace osu.Framework.Utils
             }
 
             float inputDistance = Vector2.Distance(v, inputPath[^1]);
-            if (inputDistance < FdEpsilon * 2)
+            if (inputDistance < FD_EPSILON * 2)
                 return;
 
             inputPath.Add(v);

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -308,7 +308,7 @@ namespace osu.Framework.Utils
 
                 var tmp = new List<Vector2>();
                 bool allOnLine = true;
-                const float on_line_threshold = 10 * step_size;
+                float on_line_threshold = 5 * Tolerance * step_size;
 
                 if (t1 > t0)
                 {

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Utils
     /// </summary>
     public static class PathApproximator
     {
-        private const float bezier_tolerance = 0.25f;
+        public const float BEZIER_TOLERANCE = 0.25f;
 
         /// <summary>
         /// The amount of pieces to calculate for each control point quadruplet.
@@ -313,7 +313,7 @@ namespace osu.Framework.Utils
         {
             for (int i = 1; i < controlPoints.Length - 1; i++)
             {
-                if ((controlPoints[i - 1] - 2 * controlPoints[i] + controlPoints[i + 1]).LengthSquared > bezier_tolerance * bezier_tolerance * 4)
+                if ((controlPoints[i - 1] - 2 * controlPoints[i] + controlPoints[i + 1]).LengthSquared > BEZIER_TOLERANCE * BEZIER_TOLERANCE * 4)
                     return false;
             }
 

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Utils
         /// <returns>A list of vectors representing the piecewise-linear approximation.</returns>
         public static List<Vector2> BezierToPiecewiseLinear(ReadOnlySpan<Vector2> controlPoints)
         {
-            return BSplineToPiecewiseLinear(controlPoints, controlPoints.Length - 1);
+            return BSplineToPiecewiseLinear(controlPoints, Math.Max(1, controlPoints.Length - 1));
         }
 
         /// <summary>

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Utils
     /// </summary>
     public static class PathApproximator
     {
-        public const float BEZIER_TOLERANCE = 0.25f;
+        internal const float BEZIER_TOLERANCE = 0.25f;
 
         /// <summary>
         /// The amount of pieces to calculate for each control point quadruplet.


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6045

- The BSpline builder now smoothens the input curve before processing it, making it more reliable.
- Corners are detected explicitly based on local maxima of winding rate. To be automatically converted to red control points on osu!'s end.
- The density of control points is also determined by winding rate.

Fixes https://github.com/ppy/osu-framework/issues/6046 and addresses comments in https://github.com/ppy/osu/pull/25409


https://github.com/ppy/osu-framework/assets/4923655/aa025169-8d57-4571-9d74-d6095d30f924

