### PR TITLE
Use better `RunOnAudioThread()` logic in audio tests

### DIFF
--- a/osu.Framework.Tests/Audio/AudioCollectionManagerTest.cs
+++ b/osu.Framework.Tests/Audio/AudioCollectionManagerTest.cs
@@ -15,7 +15,6 @@ namespace osu.Framework.Tests.Audio
         {
             var manager = new TestAudioCollectionManager();
 
-            var threadExecutionFinished = new ManualResetEventSlim();
             var updateLoopStarted = new ManualResetEventSlim();
 
             // add a huge amount of items to the queue
@@ -23,24 +22,20 @@ namespace osu.Framework.Tests.Audio
                 manager.AddItem(new TestingAdjustableAudioComponent());
 
             // in a separate thread start processing the queue
-            var thread = new Thread(() =>
+            var thread = AudioTestHelper.StartNewAudioThread(() =>
             {
                 while (!manager.IsDisposed)
                 {
                     updateLoopStarted.Set();
                     manager.Update();
                 }
-
-                threadExecutionFinished.Set();
             });
-
-            thread.Start();
 
             Assert.IsTrue(updateLoopStarted.Wait(10000));
 
             Assert.DoesNotThrow(() => manager.Dispose());
 
-            Assert.IsTrue(threadExecutionFinished.Wait(10000));
+            thread.Dispose();
         }
 
         private class TestAudioCollectionManager : AudioCollectionManager<AdjustableAudioComponent>

--- a/osu.Framework.Tests/Audio/AudioTestHelper.cs
+++ b/osu.Framework.Tests/Audio/AudioTestHelper.cs
@@ -13,13 +13,14 @@ namespace osu.Framework.Tests.Audio
     internal static class AudioTestHelper
     {
         /// <summary>
-        /// Runs an <paramref name="action"/> on a newly created audio thread.
+        /// Runs an <paramref name="action"/> on a newly created audio thread, and blocks until it has been run to completion.
         /// </summary>
         /// <param name="action">The action to run on the audio thread.</param>
         public static void RunOnAudioThread(Action action)
         {
-            var thread = StartNewAudioThread(action);
-            thread.Dispose();
+            using (var _ = StartNewAudioThread(action))
+            {
+            }
         }
 
         /// <summary>

--- a/osu.Framework.Tests/Audio/AudioTestHelper.cs
+++ b/osu.Framework.Tests/Audio/AudioTestHelper.cs
@@ -10,7 +10,7 @@ using osu.Framework.Threading;
 
 namespace osu.Framework.Tests.Audio
 {
-    public static class AudioTestHelper
+    internal static class AudioTestHelper
     {
         /// <summary>
         /// Runs an <paramref name="action"/> on a newly created audio thread.

--- a/osu.Framework.Tests/Audio/AudioTestHelper.cs
+++ b/osu.Framework.Tests/Audio/AudioTestHelper.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Development;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    public static class AudioTestHelper
+    {
+        /// <summary>
+        /// Runs an <paramref name="action"/> on a newly created audio thread.
+        /// </summary>
+        /// <param name="action">The action to run on the audio thread.</param>
+        public static void RunOnAudioThread(Action action)
+        {
+            var thread = StartNewAudioThread(action);
+            thread.Dispose();
+        }
+
+        /// <summary>
+        /// Runs an <paramref name="action"/> on a newly created audio thread.
+        /// </summary>
+        /// <param name="action">The action to run on the audio thread.</param>
+        /// <returns>An <see cref="InvokeOnDisposal"/> that waits for the thread to stop and rethrows any unhandled exceptions thrown by the <paramref name="action"/>.</returns>
+        public static IDisposable StartNewAudioThread(Action action)
+        {
+            var resetEvent = new ManualResetEvent(false);
+            Exception? threadException = null;
+
+            new Thread(() =>
+            {
+                ThreadSafety.IsAudioThread = true;
+
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    threadException = e;
+                }
+
+                resetEvent.Set();
+            })
+            {
+                Name = GameThread.SuffixedThreadNameFor("Audio")
+            }.Start();
+
+            return new InvokeOnDisposal(() =>
+            {
+                if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                    throw new TimeoutException();
+
+                if (threadException != null)
+                    ExceptionDispatchInfo.Throw(threadException);
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -2,14 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Runtime.ExceptionServices;
-using System.Threading;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
-using osu.Framework.Development;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
 
@@ -70,36 +67,7 @@ namespace osu.Framework.Tests.Audio
             RunOnAudioThread(() => allComponents.Update());
         }
 
-        public void RunOnAudioThread(Action action)
-        {
-            var resetEvent = new ManualResetEvent(false);
-            Exception? threadException = null;
-
-            new Thread(() =>
-            {
-                ThreadSafety.IsAudioThread = true;
-
-                try
-                {
-                    action();
-                }
-                catch (Exception e)
-                {
-                    threadException = e;
-                }
-
-                resetEvent.Set();
-            })
-            {
-                Name = GameThread.SuffixedThreadNameFor("Audio")
-            }.Start();
-
-            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
-                throw new TimeoutException();
-
-            if (threadException != null)
-                ExceptionDispatchInfo.Throw(threadException);
-        }
+        public void RunOnAudioThread(Action action) => AudioTestHelper.RunOnAudioThread(action);
 
         internal TrackBass GetTrack() => (TrackBass)TrackStore.Get("Resources.Tracks.sample-track.mp3");
         internal SampleBass GetSample() => (SampleBass)SampleStore.Get("Resources.Tracks.sample-track.mp3");

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -67,6 +67,10 @@ namespace osu.Framework.Tests.Audio
             RunOnAudioThread(() => allComponents.Update());
         }
 
+        /// <summary>
+        /// Runs an <paramref name="action"/> on a newly created audio thread, and blocks until it has been run to completion.
+        /// </summary>
+        /// <param name="action">The action to run on the audio thread.</param>
         public void RunOnAudioThread(Action action) => AudioTestHelper.RunOnAudioThread(action);
 
         internal TrackBass GetTrack() => (TrackBass)TrackStore.Get("Resources.Tracks.sample-track.mp3");

--- a/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
@@ -3,12 +3,8 @@
 
 #nullable disable
 
-using System;
-using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Development;
-using osu.Framework.Threading;
 
 namespace osu.Framework.Tests.Audio
 {
@@ -56,31 +52,6 @@ namespace osu.Framework.Tests.Audio
             Assert.IsTrue(channel.HasCompleted);
         }
 
-        private void updateSample() => RunOnAudioThread(() => sample.Update());
-
-        /// <summary>
-        /// Certain actions are invoked on the audio thread.
-        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        public static void RunOnAudioThread(Action action)
-        {
-            var resetEvent = new ManualResetEvent(false);
-
-            new Thread(() =>
-            {
-                ThreadSafety.IsAudioThread = true;
-
-                action();
-
-                resetEvent.Set();
-            })
-            {
-                Name = GameThread.SuffixedThreadNameFor("Audio")
-            }.Start();
-
-            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
-                throw new TimeoutException();
-        }
+        private void updateSample() => AudioTestHelper.RunOnAudioThread(() => sample.Update());
     }
 }

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -10,8 +10,6 @@ using NUnit.Framework;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
-using osu.Framework.Threading;
 
 namespace osu.Framework.Tests.Audio
 {
@@ -399,24 +397,6 @@ namespace osu.Framework.Tests.Audio
         /// Here we simulate this process on a correctly named thread to avoid endless blocking.
         /// </summary>
         /// <param name="action">The action to perform.</param>
-        public static void RunOnAudioThread(Action action)
-        {
-            var resetEvent = new ManualResetEvent(false);
-
-            new Thread(() =>
-            {
-                ThreadSafety.IsAudioThread = true;
-
-                action();
-
-                resetEvent.Set();
-            })
-            {
-                Name = GameThread.SuffixedThreadNameFor("Audio")
-            }.Start();
-
-            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
-                throw new TimeoutException();
-        }
+        public static void RunOnAudioThread(Action action) => AudioTestHelper.RunOnAudioThread(action);
     }
 }

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -381,7 +381,7 @@ namespace osu.Framework.Tests.Audio
             updateTrack();
         }
 
-        private void updateTrack() => AudioTestHelper.RunOnAudioThread((() => track.Update()));
+        private void updateTrack() => AudioTestHelper.RunOnAudioThread(() => track.Update());
 
         private void restartTrack()
         {

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -282,7 +282,7 @@ namespace osu.Framework.Tests.Audio
             track.Start();
             updateTrack();
 
-            RunOnAudioThread(() => track.Seek(20000));
+            AudioTestHelper.RunOnAudioThread(() => track.Seek(20000));
             Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
         }
 
@@ -292,7 +292,7 @@ namespace osu.Framework.Tests.Audio
             track.Seek(5000);
 
             bool seekSucceeded = false;
-            RunOnAudioThread(() => seekSucceeded = track.Seek(track.CurrentTime));
+            AudioTestHelper.RunOnAudioThread(() => seekSucceeded = track.Seek(track.CurrentTime));
 
             Assert.That(seekSucceeded, Is.True);
             Assert.That(track.CurrentTime, Is.EqualTo(5000));
@@ -302,7 +302,7 @@ namespace osu.Framework.Tests.Audio
         public void TestSeekBeyondStartTime()
         {
             bool seekSucceeded = false;
-            RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
+            AudioTestHelper.RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
 
             Assert.That(seekSucceeded, Is.False);
             Assert.That(track.CurrentTime, Is.EqualTo(0));
@@ -312,7 +312,7 @@ namespace osu.Framework.Tests.Audio
         public void TestSeekBeyondEndTime()
         {
             bool seekSucceeded = false;
-            RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
+            AudioTestHelper.RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
 
             Assert.That(seekSucceeded, Is.False);
             Assert.That(track.CurrentTime, Is.EqualTo(track.Length));
@@ -323,7 +323,7 @@ namespace osu.Framework.Tests.Audio
         {
             bool seekSucceeded = false;
             startPlaybackAt(0);
-            RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
+            AudioTestHelper.RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
 
             Assert.That(seekSucceeded, Is.False);
             Assert.That(track.IsRunning, Is.False);
@@ -335,7 +335,7 @@ namespace osu.Framework.Tests.Audio
         {
             bool seekSucceeded = false;
             startPlaybackAt(0);
-            RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
+            AudioTestHelper.RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
 
             Assert.That(seekSucceeded, Is.False);
             Assert.That(track.IsRunning, Is.False);
@@ -381,22 +381,15 @@ namespace osu.Framework.Tests.Audio
             updateTrack();
         }
 
-        private void updateTrack() => RunOnAudioThread(() => track.Update());
+        private void updateTrack() => AudioTestHelper.RunOnAudioThread((() => track.Update()));
 
         private void restartTrack()
         {
-            RunOnAudioThread(() =>
+            AudioTestHelper.RunOnAudioThread(() =>
             {
                 track.Restart();
                 track.Update();
             });
         }
-
-        /// <summary>
-        /// Certain actions are invoked on the audio thread.
-        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
-        /// </summary>
-        /// <param name="action">The action to perform.</param>
-        public static void RunOnAudioThread(Action action) => AudioTestHelper.RunOnAudioThread(action);
     }
 }


### PR DESCRIPTION
Noticed the problem in https://discord.com/channels/188630481301012481/589331078574112768/1174627793221472276.

Updates all audio tests that start a new audio thread to use the `RunOnAudioThread()` logic from #5946.
Previously, some tests had custom logic that would silence exceptions.