### PR TITLE
Update some inspections to (mostly) satisfy latest rider EAP

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -826,6 +826,7 @@ See the LICENCE file in the repository root for full licence text.&#xD;
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ENumerics_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=System_002ESecurity_002ECryptography_002ERSA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/AutoImport2/=CSHARP/BlackLists/=TagLib_002EMpeg4_002EBox/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>

--- a/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
+++ b/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
@@ -41,16 +41,22 @@ namespace osu.Framework.Benchmarks
         [Benchmark]
         public void BenchmarkRawCachingReuse()
         {
-            using (var store = new RawCachingGlyphStore(baseResources, font_name) { CacheStorage = sharedTemp })
+            using (var store = new RawCachingGlyphStore(baseResources, font_name))
+            {
+                store.CacheStorage = sharedTemp;
                 runFor(store);
+            }
         }
 
         [Benchmark(Baseline = true)]
         public void BenchmarkRawCaching()
         {
             using (var temp = new TemporaryNativeStorage("fontstore-test" + Guid.NewGuid()))
-            using (var store = new RawCachingGlyphStore(baseResources, font_name) { CacheStorage = temp })
+            using (var store = new RawCachingGlyphStore(baseResources, font_name))
+            {
+                store.CacheStorage = temp;
                 runFor(store);
+            }
         }
 
         [Benchmark]

--- a/osu.Framework.Tests/IO/FontStoreTest.cs
+++ b/osu.Framework.Tests/IO/FontStoreTest.cs
@@ -47,13 +47,17 @@ namespace osu.Framework.Tests.IO
         [Test]
         public void TestNoCrashOnMissingResources()
         {
-            using (var glyphStore = new RawCachingGlyphStore(fontResourceStore, "DoesntExist") { CacheStorage = storage })
-            using (var fontStore = new FontStore(new DummyRenderer(), glyphStore, 100))
+            using (var glyphStore = new RawCachingGlyphStore(fontResourceStore, "DoesntExist"))
             {
-                Assert.That(glyphStore.Get('a'), Is.Null);
+                glyphStore.CacheStorage = storage;
 
-                Assert.That(fontStore.Get("DoesntExist", 'a'), Is.Null);
-                Assert.That(fontStore.Get("OtherAttempt", 'a'), Is.Null);
+                using (var fontStore = new FontStore(new DummyRenderer(), glyphStore, 100))
+                {
+                    Assert.That(glyphStore.Get('a'), Is.Null);
+
+                    Assert.That(fontStore.Get("DoesntExist", 'a'), Is.Null);
+                    Assert.That(fontStore.Get("OtherAttempt", 'a'), Is.Null);
+                }
             }
         }
 

--- a/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneAudioMixer.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Tests.Visual.Audio
                 currentContainer.Remove(this, false);
                 targetContainer.Add(this);
 
-                Position = Parent.ToLocalSpace(centre);
+                Position = Parent!.ToLocalSpace(centre);
 
                 currentContainer = targetContainer;
             }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableScale.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableScale.cs
@@ -76,11 +76,11 @@ namespace osu.Framework.Tests.Visual.Drawables
             });
 
             AddAssert("passed through input X position is correct",
-                () => box.ToParentSpace(box.ToLocalSpace(box.Parent.ToScreenSpace(Vector2.Zero))).X,
+                () => box.ToParentSpace(box.ToLocalSpace(box.Parent!.ToScreenSpace(Vector2.Zero))).X,
                 () => Is.Zero.Within(1));
 
             AddAssert("passed through input Y position is correct",
-                () => box.ToParentSpace(box.ToLocalSpace(box.Parent.ToScreenSpace(Vector2.Zero))).Y,
+                () => box.ToParentSpace(box.ToLocalSpace(box.Parent!.ToScreenSpace(Vector2.Zero))).Y,
                 () => Is.Zero.Within(1));
         }
     }

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -25,16 +25,19 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).
         /// </summary>
+        [CanBeNull]
         public event Action<ValueChangedEvent<T>> ValueChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Disabled"/> has changed (or manually via <see cref="TriggerDisabledChange"/>).
         /// </summary>
+        [CanBeNull]
         public event Action<bool> DisabledChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Default"/> has changed (or manually via <see cref="TriggerDefaultChange"/>).
         /// </summary>
+        [CanBeNull]
         public event Action<ValueChangedEvent<T>> DefaultChanged;
 
         private T value;
@@ -245,7 +248,7 @@ namespace osu.Framework.Bindables
         /// An object deriving T can be parsed, or a string can be parsed if T is an enum type.
         /// </summary>
         /// <param name="input">The input which is to be parsed.</param>
-        public virtual void Parse(object input)
+        public virtual void Parse([CanBeNull] object input)
         {
             switch (input)
             {

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString(string? format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
+        public override string ToString(string? format, IFormatProvider? formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<double> CreateInstance() => new BindableDouble();
     }

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Bindables
         {
         }
 
-        public override string ToString(string? format, IFormatProvider formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
+        public override string ToString(string? format, IFormatProvider? formatProvider) => base.ToString(format ?? "0.0###", formatProvider);
 
         protected override Bindable<float> CreateInstance() => new BindableFloat();
     }

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Caching;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Lists;
@@ -24,6 +25,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="triggerDisabledChange(bool)"/>).
         /// </summary>
+        [CanBeNull]
         public event Action<bool> DisabledChanged;
 
         private readonly List<T> collection = new List<T>();
@@ -417,7 +419,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="input">The input which is to be parsed.</param>
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
-        public void Parse(object input)
+        public void Parse([CanBeNull] object input)
         {
             ensureMutationAllowed();
 

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
         {
             base.Update();
 
-            Vector2 drawSizeRatio = Vector2.Divide(Parent.ChildSize, TargetDrawSize);
+            Vector2 drawSizeRatio = Vector2.Divide(Parent!.ChildSize, TargetDrawSize);
 
             switch (Strategy)
             {

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -2,8 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -427,7 +427,13 @@ namespace osu.Framework.Graphics.Veldrid
             maxTextureSize = (int)properties.limits.maxImageDimension2D;
 
             string vulkanName = RuntimeInfo.IsApple ? "MoltenVK" : "Vulkan";
-            string extensions = string.Join(" ", instanceExtensions.Concat(deviceExtensions).Select(e => Marshal.PtrToStringUTF8((IntPtr)e.extensionName)));
+
+            List<string?> extensionNames = new List<string?>();
+
+            foreach (var ext in instanceExtensions)
+                extensionNames.Add(Marshal.PtrToStringUTF8((IntPtr)ext.extensionName));
+            foreach (var ext in deviceExtensions)
+                extensionNames.Add(Marshal.PtrToStringUTF8((IntPtr)ext.extensionName));
 
             string apiVersion = $"{properties.apiVersion >> 22}.{(properties.apiVersion >> 12) & 0x3FFU}.{properties.apiVersion & 0xFFFU}";
             string driverVersion;
@@ -444,7 +450,7 @@ namespace osu.Framework.Graphics.Veldrid
                                     {vulkanName} API Version:    {apiVersion}
                                     {vulkanName} Driver Version: {driverVersion}
                                     {vulkanName} Device:         {Marshal.PtrToStringUTF8((IntPtr)properties.deviceName)}
-                                    {vulkanName} Extensions:     {extensions}");
+                                    {vulkanName} Extensions:     {string.Join(',', extensionNames)}");
         }
 
         public static void LogMetal(this GraphicsDevice device, out int maxTextureSize)

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -6,6 +6,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
@@ -131,7 +132,7 @@ namespace osu.Framework.IO.Stores
             base.RemoveStore(store);
         }
 
-        public ITexturedCharacterGlyph Get(string fontName, char character)
+        public ITexturedCharacterGlyph Get([CanBeNull] string fontName, char character)
         {
             var key = (fontName, character);
 

--- a/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
+++ b/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
@@ -33,12 +33,17 @@ namespace osu.Framework.IO.Stores
                 return stream?.ReadAllBytesToArray();
         }
 
-        public virtual Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
+        public virtual async Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(name);
 
             using (Stream stream = storage.GetStream(name))
-                return stream?.ReadAllBytesToArrayAsync(cancellationToken);
+            {
+                if (stream == null)
+                    return null;
+
+                return await stream.ReadAllBytesToArrayAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         public Stream GetStream(string name)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -117,6 +117,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public event Func<Exception, bool> ExceptionThrown;
 
+        [CanBeNull]
         public event Func<IpcMessage, IpcMessage> MessageReceived;
 
         /// <summary>


### PR DESCRIPTION
- Rewrite veldrid extension logging code to avoid fixed-in-delegate inspection
- Fix multiple cases of using objects which may be disposed
- Add some missing nullability markers
- Add new migration flag

A couple of inspections are still flagging warning, but are r# bugs:

https://youtrack.jetbrains.com/issue/RSRP-494840/Incorrect-Conditional-access-qualifier-expression-is-known-to-be-not-null 
https://youtrack.jetbrains.com/issue/RSRP-494839/Resharper-asks-to-dispose-IEnumerator-which-does-not-implement-IDisposable