### PR TITLE
Don't draw when the window is minimised

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -487,6 +487,9 @@ namespace osu.Framework.Platform
             if (ExecutionState != ExecutionState.Running)
                 return;
 
+            if (Window?.WindowState == WindowState.Minimised)
+                return;
+
             Renderer.AllowTearing = windowMode.Value == WindowMode.Fullscreen;
 
             ObjectUsage<DrawNode> buffer;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -481,13 +481,15 @@ namespace osu.Framework.Platform
 
         protected virtual void DrawFrame()
         {
+            Debug.Assert(Window != null);
+
             if (Root == null)
                 return;
 
             if (ExecutionState != ExecutionState.Running)
                 return;
 
-            if (Window?.WindowState == WindowState.Minimised)
+            if (Window.WindowState == WindowState.Minimised)
                 return;
 
             Renderer.AllowTearing = windowMode.Value == WindowMode.Fullscreen;


### PR DESCRIPTION
Original [discord thread](https://discord.com/channels/188630481301012481/589331078574112768/1175771698814013520) that sparked this change.

When the window is restored from minimised state, it'll show the old frame (with DX11) until a new frame is rendered.

This change visibly reduced the CPU and GPU usage (GPU goes to 0%) when the window is minimised, previously I'd only see a small reduction in GPU usage.