### PR TITLE
Fix android pack action failing due to missing OpenJDK

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,6 +25,12 @@
       "commands": [
         "CodeFileSanity"
       ]
+    },
+    "java.openjdk": {
+      "version": "11.0.1-beta001",
+      "commands": [
+        "Java.OpenJDK"
+      ]
     }
   }
 }


### PR DESCRIPTION
Not sure what broke this.

Failure: https://github.com/ppy/osu-framework/actions/runs/6924828290/job/18836758832
Fix reference: https://discord.com/channels/188630481301012481/589331078574112768/1176026954965729321

Testing: https://github.com/peppy/osu-framework/actions/runs/6926220112/job/18838045454
