### PR TITLE
Improve incremental bspline builder

### DIFF
--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -320,22 +320,25 @@ namespace osu.Framework.Utils
                         totalWinding += getAbsWindingAt(vertices, distances, t);
                     }
 
-                    int nControlPoints = (int)(totalWinding / Tolerance);
-                    float controlPointSpacing = totalWinding / nControlPoints;
                     float currentWinding = 0;
-
                     for (int j = 0; j < nSteps; ++j)
                     {
                         float t = t0 + j * step_size;
 
-                        if (currentWinding > controlPointSpacing)
+                        // Don't permit control points too close to the next corner as they are redundant.
+                        // However, ignore this limitation on the last segment of the path as we would like
+                        // it to follow the user's drawing as closely as possible.
+                        if (currentWinding + tmp.Count * Tolerance > totalWinding - Tolerance * 0.5f && i < cornerTs.Count - 1)
+                            break;
+
+                        if (currentWinding > Tolerance)
                         {
                             Vector2 p = getPathAt(vertices, distances, t);
                             if (linearConnection.DistanceSquaredToPoint(p) > onLineThreshold * onLineThreshold)
                                 allOnLine = false;
 
                             tmp.Add(p);
-                            currentWinding -= controlPointSpacing;
+                            currentWinding -= Tolerance;
                         }
 
                         currentWinding += getAbsWindingAt(vertices, distances, t);

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -321,6 +321,7 @@ namespace osu.Framework.Utils
                     }
 
                     float currentWinding = 0;
+
                     for (int j = 0; j < nSteps; ++j)
                     {
                         float t = t0 + j * step_size;

--- a/osu.Framework/Utils/IncrementalBSplineBuilder.cs
+++ b/osu.Framework/Utils/IncrementalBSplineBuilder.cs
@@ -94,6 +94,9 @@ namespace osu.Framework.Utils
                 if (value < 0)
                     throw new ArgumentOutOfRangeException(nameof(value), "Degree must not be negative.");
 
+                if (value == degree)
+                    return;
+
                 degree = value;
                 outputCache.Invalidate();
                 controlPoints.Invalidate();
@@ -114,6 +117,9 @@ namespace osu.Framework.Utils
                 if (tolerance < 0)
                     throw new ArgumentOutOfRangeException(nameof(value), "Tolerance must not be negative.");
 
+                if (value == tolerance)
+                    return;
+
                 tolerance = value;
                 outputCache.Invalidate();
                 controlPoints.Invalidate();
@@ -133,6 +139,9 @@ namespace osu.Framework.Utils
             {
                 if (cornerThreshold < 0)
                     throw new ArgumentOutOfRangeException(nameof(value), "CornerThreshold must not be negative.");
+
+                if (value == cornerThreshold)
+                    return;
 
                 cornerThreshold = value;
                 outputCache.Invalidate();


### PR DESCRIPTION
This PR makes the following improvements to the incremental BSpline builder:
1. the last vertex of the BSpline now follows the mouse perfectly without any jitter. Vertices are still inserted with `FD_EPSILON * 2` spacing to ensure derivatives are computed stably; only the currently last vertex is affected by this change.
2. the control point spacing algorithm has been tweaked to prevent global dependencies along the path. This gets rid of jittering that the previous batch of "improvements" introduced. See comparison videos below.

Before this PR:
https://github.com/ppy/osu-framework/assets/4923655/69f60092-f24f-4f62-a296-143a3058fe2c

After this PR:
https://github.com/ppy/osu-framework/assets/4923655/8d8c72d0-0822-4364-8929-1c2e9598c6d2