### PR TITLE
Attempt to fix android compile failures due to invalid java version again

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,12 +25,6 @@
       "commands": [
         "CodeFileSanity"
       ]
-    },
-    "java.openjdk": {
-      "version": "11.0.1-beta001",
-      "commands": [
-        "Java.OpenJDK"
-      ]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: microsoft
+          java-version: 11
+
       - name: Install .NET 6.0.x
         uses: actions/setup-dotnet@v3
         with:

--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -124,6 +124,12 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
+      - name: Setup JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: microsoft
+          java-version: 11
+
       - name: Restore .NET workloads
         run: dotnet workload install android
 


### PR DESCRIPTION
The previous fix in reality did nothing because the [two](https://github.com/peppy/osu-framework/actions/runs/6926220112/job/18838045454) [runs](https://github.com/ppy/osu-framework/actions/runs/6927288952/job/18840885827) that passed happened to run on the version of the runner that was _not_ broken, namely 20231029.1.0. Today's run [ran on 20231115.2.0](https://github.com/ppy/osu-framework/actions/runs/6939325341/job/18876480850#step:1:9) and thus broke again.

[Attempt at evidence that this time it will be fixed.](https://github.com/bdach/osu-framework/actions/runs/6941641330/job/18882900940#step:1:9)

This will need to be done game-side too, but I will do that after the framework tag is fixed, because right now game-side builds are failing due to the nuget package not existing (which it doesn't, because it didn't build).