### PR TITLE
Allow using custom `ITexturedGlyphLookupStore`s as texture sources

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Benchmarks
 
         private class TestStore : ITexturedGlyphLookupStore
         {
-            public ITexturedCharacterGlyph Get(string fontName, char character) => new TexturedCharacterGlyph(
+            public ITexturedCharacterGlyph Get(string? fontName, char character) => new TexturedCharacterGlyph(
                 new CharacterGlyph(character, character, character, character, character, null),
                 new DummyRenderer().CreateTexture(1, 1));
 

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -6,7 +6,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
@@ -20,7 +19,7 @@ namespace osu.Framework.IO.Stores
     {
         private readonly List<IGlyphStore> glyphStores = new List<IGlyphStore>();
 
-        private readonly List<FontStore> nestedFontStores = new List<FontStore>();
+        private readonly List<ITexturedGlyphLookupStore> nestedFontStores = new List<ITexturedGlyphLookupStore>();
 
         private Storage cacheStorage;
 
@@ -77,12 +76,18 @@ namespace osu.Framework.IO.Stores
 
         public override void AddStore(ITextureStore store)
         {
-            if (store is FontStore fs)
+            switch (store)
             {
-                // if null, share the main store's atlas.
-                fs.Atlas ??= Atlas;
-                fs.cacheStorage ??= cacheStorage;
-                nestedFontStores.Add(fs);
+                case FontStore fs:
+                    // if null, share the main store's atlas.
+                    fs.Atlas ??= Atlas;
+                    fs.cacheStorage ??= cacheStorage;
+                    nestedFontStores.Add(fs);
+                    break;
+
+                case ITexturedGlyphLookupStore gs:
+                    nestedFontStores.Add(gs);
+                    break;
             }
 
             base.AddStore(store);
@@ -132,7 +137,7 @@ namespace osu.Framework.IO.Stores
             base.RemoveStore(store);
         }
 
-        public ITexturedCharacterGlyph Get([CanBeNull] string fontName, char character)
+        public ITexturedCharacterGlyph Get(string fontName, char character)
         {
             var key = (fontName, character);
 

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.IO.Stores
             AssetName = assetName;
             TextureLoader = textureLoader;
 
-            FontName = assetName?.Split('/').Last();
+            FontName = assetName?.Split('/').Last() ?? string.Empty;
         }
 
         private Task fontLoadTask;

--- a/osu.Framework/Text/ITexturedGlyphLookupStore.cs
+++ b/osu.Framework/Text/ITexturedGlyphLookupStore.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Text
         /// <param name="fontName">The name of the font.</param>
         /// <param name="character">The character to retrieve.</param>
         /// <returns>The character glyph.</returns>
-        ITexturedCharacterGlyph? Get(string fontName, char character);
+        ITexturedCharacterGlyph? Get(string? fontName, char character);
 
         /// <summary>
         /// Retrieves a glyph from the store asynchronously.


### PR DESCRIPTION
Offers a bit more flexibility for custom implementations of font lookups. To be used osu! side to allow lookups of raw sprites. I may consider bringing that functionality over to the framework side after it has been proved reliable.

Probably best to wait for the osu! side PR to see how this works.