### PR TITLE
FFmpeg: Enable Microsoft MPEG-4 v1-3 decoders

### DIFF
--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -19,7 +19,7 @@ FFMPEG_FLAGS=(
     # File and video formats
     --enable-demuxer='mov,matroska,flv,avi' # mov = mp4, matroska = mkv & webm
     --enable-parser='mpeg4video,h264,hevc,vp8,vp9'
-    --enable-decoder='flv,mpeg4,h264,hevc,vp8,vp9'
+    --enable-decoder='flv,msmpeg4v1,msmpeg4v2,msmpeg4v3,mpeg4,h264,hevc,vp8,vp9'
     --enable-protocol=pipe
 )
 

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -430,7 +430,7 @@ namespace osu.Framework.Graphics.Video
             }
 
             if (!openSuccessful)
-                throw new InvalidOperationException("No usable decoder found");
+                throw new InvalidOperationException($"No usable decoder found for codec ID {codecParams.codec_id}");
         }
 
         private void decodingLoop(CancellationToken cancellationToken)


### PR DESCRIPTION
It's a bit hard to find information on these codec versions, but they do exist in the [Microsoft docs](https://learn.microsoft.com/en-us/windows/win32/medfound/windowsmediampeg4decoder) and (fairly technical) [FFmpeg docs](https://www.ffmpeg.org/~michael/msmpeg4.txt). The codec is similar to other MPEG-4 codecs, but was de-facto standardized by Microsoft before the official ISO standard for MPEG-4 Part 2 existed, from what I can tell.

Fixes ppy/osu#25604.

Build artifacts available on [my fork](https://github.com/FreezyLemon/osu-framework/actions/runs/7047974393).

I added all three versions because the file size barely increases over enabling just one of them.

Also added the codec ID when logging that no suitable decoder was found. This should make it easier to debug in the future just from the logs.