### PR TITLE
Fix visual tests crashing when using `params` and `TestCase` attribute

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
@@ -104,6 +104,17 @@ namespace osu.Framework.Tests.Visual.Testing
         [Repeat(2)]
         public void TestTestCase(int _) => TestTest();
 
+        [TestCase(0)]
+        [TestCase(1, "one")]
+        [TestCase(3, "one", "two", "three")]
+        [TestCase(2, new[] { "test", "two" })]
+        public void TestParamsTestCase(int length, params string[] p)
+        {
+            TestTest();
+            AddAssert("params is array", () => p, Is.TypeOf<string[]>);
+            AddAssert("length is expected", () => p, () => Has.Length.EqualTo(length));
+        }
+
         protected override ITestSceneTestRunner CreateRunner() => new TestRunner();
 
         private partial class TestRunner : TestSceneTestRunner

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -468,7 +468,7 @@ namespace osu.Framework.Testing
                         hadTestAttributeTest = true;
                         CurrentTest.AddLabel($"{name}({string.Join(", ", tc.Arguments)}){repeatSuffix}");
 
-                        handleTestMethod(m, tc.Arguments);
+                        handleTestMethod(m, tc.BuildFrom(methodWrapper, null).Single().Arguments);
                     }
 
                     foreach (var tcs in m.GetCustomAttributes(typeof(TestCaseSourceAttribute), false).OfType<TestCaseSourceAttribute>())


### PR DESCRIPTION
Would crash with:
```cs
2023-11-30 23:15:59 [error]: System.Reflection.TargetParameterCountException: Parameter count mismatch.
2023-11-30 23:15:59 [error]: at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
2023-11-30 23:15:59 [error]: at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
2023-11-30 23:15:59 [error]: at osu.Framework.Testing.TestBrowser.<>c__DisplayClass33_0.<finishLoad>g__handleTestMethod|1(MethodInfo methodInfo, Object[] arguments) in C:\...\osu-framework\osu.Framework\Testing\TestBrowser.cs:line 533
2023-11-30 23:15:59 [error]: at osu.Framework.Testing.TestBrowser.finishLoad(TestScene newTest, Action onCompletion) in C:\...\osu-framework\osu.Framework\Testing\TestBrowser.cs:line 471
2023-11-30 23:15:59 [error]: at osu.Framework.Testing.TestBrowser.<>c__DisplayClass31_0.<LoadTest>b__1() in C:\...\osu-framework\osu.Framework\Testing\TestBrowser.cs:line 368
```

Instead of using the raw arguments, this will now use `BuildFrom()` to build the proper arguments for the test method.

xmldoc for NUnit [`TestCase.BuildFrom()`](https://github.com/nunit/nunit/blob/cfcbc97847c9e08b720ffb3b961c48cae5af6199/src/NUnitFramework/framework/Attributes/TestCaseAttribute.cs#L424-L429) says:
> Builds a single test from the specified method and context.
