### PR TITLE
Request `READ_EXTERNAL_STORAGE` permission on older android versions

### DIFF
--- a/osu.Framework.Tests.Android/AndroidManifest.xml
+++ b/osu.Framework.Tests.Android/AndroidManifest.xml
@@ -6,4 +6,5 @@
 	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 	<uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
 </manifest>


### PR DESCRIPTION
Reported in https://discord.com/channels/188630481301012481/1097318920991559880/1179849444032790589.

Documented (badly) in https://developer.android.com/reference/android/Manifest.permission#READ_MEDIA_IMAGES
> For apps with a targetSdkVersion of Build.VERSION_CODES.S_V2 or lower, the READ_EXTERNAL_STORAGE permission is required, instead, to read image files.

They actually meant to say "for apps that will run on Build.VERSION_CODES.S_V2 or lower [...]"