### PR TITLE
Cleanup `DrawNode` drawing methods

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -113,8 +113,8 @@ namespace osu.Framework.Tests.Visual.Containers
             if (drawNode != null)
             {
                 labelDrawables.Text = $"boxes: {Cell(1).Children.Count * cell_count:N0}";
-                labelFrag.Text = $"samples ({nameof(DrawNode.Draw)}): {drawNode.DrawSamples:N0}";
-                labelFrag2.Text = $"samples ({nameof(DrawNode.DrawOpaqueInteriorSubTree)}): {drawNode.DrawOpaqueInteriorSubTreeSamples:N0}";
+                labelFrag.Text = $"samples (Draw): {drawNode.DrawSamples:N0}";
+                labelFrag2.Text = $"samples (DrawOpaqueInterior): {drawNode.DrawOpaqueInteriorSubTreeSamples:N0}";
             }
         }
 
@@ -151,16 +151,16 @@ namespace osu.Framework.Tests.Visual.Containers
             {
             }
 
-            internal override void DrawOpaqueInteriorSubTree(IRenderer renderer, DepthValue depthValue)
+            protected override void DrawOpaqueInterior(IRenderer renderer)
             {
                 if (renderer is VeldridRenderer)
                 {
-                    base.DrawOpaqueInteriorSubTree(renderer, depthValue);
+                    base.DrawOpaqueInterior(renderer);
                     return;
                 }
 
                 startQuery();
-                base.DrawOpaqueInteriorSubTree(renderer, depthValue);
+                base.DrawOpaqueInterior(renderer);
                 DrawOpaqueInteriorSubTreeSamples = endQuery();
             }
 
@@ -171,7 +171,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 base.ApplyState();
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 if (renderer is VeldridRenderer)
                 {

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
@@ -102,7 +102,7 @@ namespace osu.Framework.Tests.Visual.Graphics
             private IShaderStorageBufferObject<ColourData>? colourBuffer;
             private IVertexBatch<ColourIndexedVertex>? vertices;
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 
@@ -192,7 +192,7 @@ namespace osu.Framework.Tests.Visual.Graphics
             private ShaderStorageBufferObjectStack<ColourData>? colourBuffer;
             private IVertexBatch<ColourIndexedVertex>? vertices;
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
@@ -131,7 +131,7 @@ namespace osu.Framework.Tests.Visual.Graphics
             {
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 
@@ -164,7 +164,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                     DestinationAlpha = BlendingType.One,
                 });
 
-                drawNode.Draw(renderer);
+                DrawOther(drawNode, renderer);
 
                 renderer.PopStencilInfo();
                 renderer.SetBlend(DrawColourInfo.Blending);
@@ -182,7 +182,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                     passed: StencilOperation.Keep
                 ));
 
-                drawNode.Draw(renderer);
+                DrawOther(drawNode, renderer);
 
                 renderer.PopStencilInfo();
             }

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneVertexBatching.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneVertexBatching.cs
@@ -88,7 +88,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                 {
                 }
 
-                public override void Draw(IRenderer renderer)
+                protected override void Draw(IRenderer renderer)
                 {
                     base.Draw(renderer);
                     renderer.FlushCurrentBatch(null);

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -317,7 +317,7 @@ namespace osu.Framework.Graphics.Audio
 
             private IVertexBatch<TexturedVertex2D>? vertexBatch;
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Graphics
         /// <returns>A version representing this <see cref="DrawNode"/>'s state.</returns>
         protected virtual long GetDrawVersion() => InvalidationID;
 
-        public sealed override void Draw(IRenderer renderer)
+        protected sealed override void Draw(IRenderer renderer)
         {
             if (!SharedData.IsInitialised)
                 SharedData.Initialise(renderer);
@@ -101,7 +101,7 @@ namespace osu.Framework.Graphics
                         renderer.PushOrtho(screenSpaceDrawRectangle);
                         renderer.Clear(new ClearInfo(backgroundColour));
 
-                        Child.Draw(renderer);
+                        DrawOther(Child, renderer);
 
                         renderer.PopOrtho();
                     }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Shaders;
 using osuTK;
 using osu.Framework.Graphics.Colour;
 using System;
-using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -177,7 +176,7 @@ namespace osu.Framework.Graphics.Containers
                     quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(100, 1000);
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 updateQuadBatch(renderer);
 
@@ -201,7 +200,7 @@ namespace osu.Framework.Graphics.Containers
                 if (Children != null)
                 {
                     for (int i = 0; i < Children.Count; i++)
-                        Children[i].Draw(renderer);
+                        DrawOther(Children[i], renderer);
                 }
 
                 if (maskingInfo != null)
@@ -211,21 +210,11 @@ namespace osu.Framework.Graphics.Containers
                     renderer.PopQuadBatch();
             }
 
-            internal override void DrawOpaqueInteriorSubTree(IRenderer renderer, DepthValue depthValue)
+            protected override void DrawOpaqueInterior(IRenderer renderer)
             {
-                DrawChildrenOpaqueInteriors(renderer, depthValue);
-                base.DrawOpaqueInteriorSubTree(renderer, depthValue);
-            }
+                base.DrawOpaqueInterior(renderer);
 
-            /// <summary>
-            /// Performs <see cref="DrawOpaqueInteriorSubTree"/> on all children of this <see cref="CompositeDrawableDrawNode"/>.
-            /// </summary>
-            /// <param name="renderer">The renderer to draw with.</param>
-            /// <param name="depthValue">The previous depth value.</param>
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            protected virtual void DrawChildrenOpaqueInteriors(IRenderer renderer, DepthValue depthValue)
-            {
-                bool canIncrement = depthValue.CanIncrement;
+                bool canIncrement = renderer.BackbufferDepthValue.CanIncrement;
 
                 // Assume that if we can't increment the depth value, no child can, thus nothing will be drawn.
                 if (canIncrement)
@@ -244,7 +233,7 @@ namespace osu.Framework.Graphics.Containers
                 if (Children != null)
                 {
                     for (int i = Children.Count - 1; i >= 0; i--)
-                        Children[i].DrawOpaqueInteriorSubTree(renderer, depthValue);
+                        DrawOtherOpaqueInterior(Children[i], renderer);
                 }
 
                 // Assume that if we can't increment the depth value, no child can, thus nothing will be drawn.

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 base.DrawOpaqueInterior(renderer);
 
-                bool canIncrement = renderer.BackbufferDepthValue.CanIncrement;
+                bool canIncrement = renderer.BackbufferDepth.CanIncrement;
 
                 // Assume that if we can't increment the depth value, no child can, thus nothing will be drawn.
                 if (canIncrement)
@@ -246,6 +246,9 @@ namespace osu.Framework.Graphics.Containers
                         renderer.PopQuadBatch();
                 }
             }
+
+            protected internal override bool CanDrawOpaqueInterior => true;
+            protected override bool HasOwnOpaqueInterior => false;
 
             protected override void Dispose(bool isDisposing)
             {

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -130,6 +130,10 @@ namespace osu.Framework.Graphics
             renderer.SetDrawDepth(drawDepth);
         }
 
+        protected void DrawOther(DrawNode node, IRenderer renderer) => node.Draw(renderer);
+
+        protected void DrawOtherOpaqueInterior(DrawNode node, IRenderer renderer) => node.DrawOpaqueInterior(renderer);
+
         /// <summary>
         /// Whether this <see cref="DrawNode"/> can draw a opaque interior. <see cref="DrawOpaqueInterior"/> will only be invoked if this value is <code>true</code>.
         /// Should not return <code>true</code> if <see cref="DrawOpaqueInterior"/> will result in a no-op.

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -70,6 +70,9 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Draws this <see cref="DrawNode"/> to the screen.
         /// </summary>
+        /// <remarks>
+        /// Subclasses must invoke <code>base.Draw()</code> prior to drawing vertices.
+        /// </remarks>
         /// <param name="renderer">The renderer to draw with.</param>
         protected virtual void Draw(IRenderer renderer)
         {
@@ -82,9 +85,14 @@ namespace osu.Framework.Graphics
         /// The opaque interior must be a fully-opaque, non-blended area of this <see cref="DrawNode"/>, clipped to the current masking area via <code>DrawClipped()</code>.
         /// See <see cref="Sprites.SpriteDrawNode"/> for an example implementation.
         /// </summary>
+        /// <remarks>
+        /// Subclasses must invoke <code>base.DrawOpaqueInterior()</code> prior to drawing vertices.
+        /// </remarks>
         /// <param name="renderer">The renderer to draw with.</param>
         protected virtual void DrawOpaqueInterior(IRenderer renderer)
         {
+            if (HasOwnOpaqueInterior)
+                renderer.BackbufferDepth.Increment();
         }
 
         protected internal static void DrawOther(DrawNode node, IRenderer renderer)
@@ -103,9 +111,6 @@ namespace osu.Framework.Graphics
 
             if (!renderer.BackbufferDepth.CanIncrement || !node.CanDrawOpaqueInterior)
                 return;
-
-            if (node.HasOwnOpaqueInterior)
-                renderer.BackbufferDepth.Increment();
 
             node.DrawOpaqueInterior(renderer);
         }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -73,6 +73,7 @@ namespace osu.Framework.Graphics
         /// <param name="renderer">The renderer to draw with.</param>
         protected virtual void Draw(IRenderer renderer)
         {
+            renderer.SetBlend(DrawColourInfo.Blending);
         }
 
         /// <summary>
@@ -87,9 +88,7 @@ namespace osu.Framework.Graphics
 
         protected internal static void DrawOther(DrawNode node, IRenderer renderer)
         {
-            renderer.SetBlend(node.DrawColourInfo.Blending);
             renderer.BackbufferDepth.Set(node.drawDepth);
-
             node.Draw(renderer);
         }
 

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -74,6 +74,7 @@ namespace osu.Framework.Graphics
         protected virtual void Draw(IRenderer renderer)
         {
             renderer.SetBlend(DrawColourInfo.Blending);
+            renderer.BackbufferDepth.Set(drawDepth);
         }
 
         /// <summary>
@@ -88,7 +89,6 @@ namespace osu.Framework.Graphics
 
         protected internal static void DrawOther(DrawNode node, IRenderer renderer)
         {
-            renderer.BackbufferDepth.Set(node.drawDepth);
             node.Draw(renderer);
         }
 

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -88,11 +88,17 @@ namespace osu.Framework.Graphics
                 {
                 }
 
-                internal override void DrawOpaqueInteriorSubTree(IRenderer renderer, DepthValue depthValue)
-                    => getCurrentFrameSource()?.DrawOpaqueInteriorSubTree(renderer, depthValue);
+                protected override void DrawOpaqueInterior(IRenderer renderer)
+                {
+                    if (getCurrentFrameSource() != null)
+                        DrawOtherOpaqueInterior(getCurrentFrameSource(), renderer);
+                }
 
-                public override void Draw(IRenderer renderer)
-                    => getCurrentFrameSource()?.Draw(renderer);
+                protected override void Draw(IRenderer renderer)
+                {
+                    if (getCurrentFrameSource() != null)
+                        DrawOther(getCurrentFrameSource(), renderer);
+                }
 
                 protected internal override bool CanDrawOpaqueInterior => getCurrentFrameSource()?.CanDrawOpaqueInterior ?? false;
 

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Lines
                 pathShader = Source.pathShader;
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 

--- a/osu.Framework/Graphics/Rendering/DepthValue.cs
+++ b/osu.Framework/Graphics/Rendering/DepthValue.cs
@@ -56,6 +56,16 @@ namespace osu.Framework.Graphics.Rendering
         }
 
         /// <summary>
+        /// Sets the depth to a given value. After this, the depth value can no longer be incremented.
+        /// </summary>
+        /// <param name="value">The new depth value.</param>
+        public void Set(float value)
+        {
+            count = max_count;
+            depth = value;
+        }
+
+        /// <summary>
         /// Whether the depth value can be incremented.
         /// </summary>
         internal bool CanIncrement

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -41,10 +41,9 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public WrapMode CurrentWrapModeS => WrapMode.None;
         public WrapMode CurrentWrapModeT => WrapMode.None;
         public bool IsMaskingActive => false;
-        public float BackbufferDrawDepth => 0;
         public bool UsingBackbuffer => false;
         public Texture WhitePixel { get; }
-        public DepthValue BackbufferDepth { get; } = new DepthValue();
+        DepthValue IRenderer.BackbufferDepth { get; } = new DepthValue();
 
         public bool IsInitialised { get; private set; }
 

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -44,6 +44,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public float BackbufferDrawDepth => 0;
         public bool UsingBackbuffer => false;
         public Texture WhitePixel { get; }
+        public DepthValue BackbufferDepthValue { get; } = new DepthValue();
 
         public bool IsInitialised { get; private set; }
 
@@ -217,10 +218,6 @@ namespace osu.Framework.Graphics.Rendering.Dummy
             => new DummyShaderStorageBufferObject<TData>(ssboSize);
 
         void IRenderer.SetUniform<T>(IUniformWithValue<T> uniform)
-        {
-        }
-
-        void IRenderer.SetDrawDepth(float drawDepth)
         {
         }
 

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         public float BackbufferDrawDepth => 0;
         public bool UsingBackbuffer => false;
         public Texture WhitePixel { get; }
-        public DepthValue BackbufferDepthValue { get; } = new DepthValue();
+        public DepthValue BackbufferDepth { get; } = new DepthValue();
 
         public bool IsInitialised { get; private set; }
 

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         Texture WhitePixel { get; }
 
-        DepthValue BackbufferDepth { get; }
+        internal DepthValue BackbufferDepth { get; }
 
         /// <summary>
         /// Whether this <see cref="IRenderer"/> has been initialised using <see cref="Initialise"/>.

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -144,11 +144,6 @@ namespace osu.Framework.Graphics.Rendering
         bool IsMaskingActive { get; }
 
         /// <summary>
-        /// The current backbuffer depth.
-        /// </summary>
-        float BackbufferDrawDepth { get; }
-
-        /// <summary>
         /// Whether the currently bound framebuffer is the backbuffer.
         /// </summary>
         bool UsingBackbuffer { get; }
@@ -157,6 +152,8 @@ namespace osu.Framework.Graphics.Rendering
         /// The texture for a white pixel.
         /// </summary>
         Texture WhitePixel { get; }
+
+        DepthValue BackbufferDepthValue { get; }
 
         /// <summary>
         /// Whether this <see cref="IRenderer"/> has been initialised using <see cref="Initialise"/>.
@@ -440,13 +437,6 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         /// <param name="uniform">The uniform to set.</param>
         internal void SetUniform<T>(IUniformWithValue<T> uniform) where T : unmanaged, IEquatable<T>;
-
-        /// <summary>
-        /// Sets the current draw depth.
-        /// The draw depth is written to every vertex added to <see cref="IVertexBuffer"/>s.
-        /// </summary>
-        /// <param name="drawDepth">The draw depth.</param>
-        internal void SetDrawDepth(float drawDepth);
 
         internal IVertexBatch<TexturedVertex2D> DefaultQuadBatch { get; }
 

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -153,6 +153,9 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         Texture WhitePixel { get; }
 
+        /// <summary>
+        /// The current depth of <see cref="TexturedVertex2D"/> vertices when drawn to the backbuffer.
+        /// </summary>
         internal DepthValue BackbufferDepth { get; }
 
         /// <summary>

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         Texture WhitePixel { get; }
 
-        DepthValue BackbufferDepthValue { get; }
+        DepthValue BackbufferDepth { get; }
 
         /// <summary>
         /// Whether this <see cref="IRenderer"/> has been initialised using <see cref="Initialise"/>.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics.Rendering
         public bool IsMaskingActive => maskingStack.Count > 1;
         public bool UsingBackbuffer => frameBufferStack.Count == 0;
         public Texture WhitePixel => whitePixel.Value;
-        public DepthValue BackbufferDepthValue { get; } = new DepthValue();
+        public DepthValue BackbufferDepth { get; } = new DepthValue();
 
         public bool IsInitialised { get; private set; }
 
@@ -199,6 +199,8 @@ namespace osu.Framework.Graphics.Rendering
             Debug.Assert(defaultQuadBatch != null);
 
             FrameIndex++;
+
+            BackbufferDepth.Reset();
 
             resetScheduler.Update();
 

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -69,9 +69,9 @@ namespace osu.Framework.Graphics.Rendering
         public WrapMode CurrentWrapModeS { get; private set; }
         public WrapMode CurrentWrapModeT { get; private set; }
         public bool IsMaskingActive => maskingStack.Count > 1;
-        public float BackbufferDrawDepth { get; private set; }
         public bool UsingBackbuffer => frameBufferStack.Count == 0;
         public Texture WhitePixel => whitePixel.Value;
+        public DepthValue BackbufferDepthValue { get; } = new DepthValue();
 
         public bool IsInitialised { get; private set; }
 
@@ -323,13 +323,6 @@ namespace osu.Framework.Graphics.Rendering
         /// Returns an image containing the current content of the backbuffer, i.e. takes a screenshot.
         /// </summary>
         protected internal abstract Image<Rgba32> TakeScreenshot();
-
-        /// <summary>
-        /// Sets the current draw depth.
-        /// The draw depth is written to every vertex added to <see cref="IVertexBuffer"/>s.
-        /// </summary>
-        /// <param name="drawDepth">The draw depth.</param>
-        internal void SetDrawDepth(float drawDepth) => BackbufferDrawDepth = drawDepth;
 
         /// <summary>
         /// Performs a once-off initialisation of this <see cref="Renderer"/>.
@@ -1151,7 +1144,6 @@ namespace osu.Framework.Graphics.Rendering
         void IRenderer.MakeCurrent() => MakeCurrent();
         void IRenderer.ClearCurrent() => ClearCurrent();
         void IRenderer.SetUniform<T>(IUniformWithValue<T> uniform) => SetUniform(uniform);
-        void IRenderer.SetDrawDepth(float drawDepth) => SetDrawDepth(drawDepth);
         void IRenderer.PushQuadBatch(IVertexBatch<TexturedVertex2D> quadBatch) => PushQuadBatch(quadBatch);
         void IRenderer.PopQuadBatch() => PopQuadBatch();
         Image<Rgba32> IRenderer.TakeScreenshot() => TakeScreenshot();

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics.Rendering
         public bool IsMaskingActive => maskingStack.Count > 1;
         public bool UsingBackbuffer => frameBufferStack.Count == 0;
         public Texture WhitePixel => whitePixel.Value;
-        public DepthValue BackbufferDepth { get; } = new DepthValue();
+        DepthValue IRenderer.BackbufferDepth => backBufferDepth;
 
         public bool IsInitialised { get; private set; }
 
@@ -107,6 +107,8 @@ namespace osu.Framework.Graphics.Rendering
         private readonly RendererDisposalQueue disposalQueue = new RendererDisposalQueue();
 
         private readonly Scheduler resetScheduler = new Scheduler(() => ThreadSafety.IsDrawThread, new StopwatchClock(true)); // force no thread set until we are actually on the draw thread.
+
+        private readonly DepthValue backBufferDepth = new DepthValue();
 
         private readonly Stack<IVertexBatch<TexturedVertex2D>> quadBatches = new Stack<IVertexBatch<TexturedVertex2D>>();
         private readonly List<IVertexBuffer> vertexBuffersInUse = new List<IVertexBuffer>();
@@ -200,7 +202,7 @@ namespace osu.Framework.Graphics.Rendering
 
             FrameIndex++;
 
-            BackbufferDepth.Reset();
+            backBufferDepth.Reset();
 
             resetScheduler.Update();
 

--- a/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public TexturedVertex2D(IRenderer renderer)
         {
             this = default; // explicitly initialise all members to default values
-            backbufferDrawDepth = renderer.BackbufferDepthValue;
+            backbufferDrawDepth = renderer.BackbufferDepth;
         }
 
         public readonly bool Equals(TexturedVertex2D other) =>

--- a/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public TexturedVertex2D(IRenderer renderer)
         {
             this = default; // explicitly initialise all members to default values
-            backbufferDrawDepth = renderer.BackbufferDrawDepth;
+            backbufferDrawDepth = renderer.BackbufferDepthValue;
         }
 
         public readonly bool Equals(TexturedVertex2D other) =>

--- a/osu.Framework/Graphics/Sprites/BufferedContainerView.cs
+++ b/osu.Framework/Graphics/Sprites/BufferedContainerView.cs
@@ -132,7 +132,7 @@ namespace osu.Framework.Graphics.Sprites
                 sourceEffectPlacement = Source.container.EffectPlacement;
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 base.Draw(renderer);
 

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics.Sprites
                 renderer.DrawQuad(Texture, ConservativeScreenSpaceDrawQuad, DrawColourInfo.Colour, textureCoords: TextureCoords);
         }
 
-        public override void Draw(IRenderer renderer)
+        protected override void Draw(IRenderer renderer)
         {
             base.Draw(renderer);
 

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Sprites
                 }
             }
 
-            public override void Draw(IRenderer renderer)
+            protected override void Draw(IRenderer renderer)
             {
                 Debug.Assert(parts != null);
 

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -237,7 +237,7 @@ namespace osu.Framework.Graphics.Visualisation
                     visualisedMipLevel = Source.visualisedMipLevel.Value;
                 }
 
-                public override void Draw(IRenderer renderer)
+                protected override void Draw(IRenderer renderer)
                 {
                     if (!textureReference.TryGetTarget(out var texture))
                         return;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -528,7 +528,7 @@ namespace osu.Framework.Platform
                     Renderer.PushDepthInfo(DepthInfo.Default);
 
                     // Front pass
-                    buffer.Object.DrawOpaqueInteriorSubTree(Renderer, depthValue);
+                    buffer.Object.InternalDrawOpaqueInterior(Renderer);
 
                     Renderer.PopDepthInfo();
                     Renderer.SetBlendMask(BlendingMask.All);
@@ -543,7 +543,7 @@ namespace osu.Framework.Platform
                 }
 
                 // Back pass
-                buffer.Object.Draw(Renderer);
+                buffer.Object.InternalDraw(Renderer);
 
                 Renderer.PopDepthInfo();
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -475,8 +475,6 @@ namespace osu.Framework.Platform
                 buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false);
         }
 
-        private readonly DepthValue depthValue = new DepthValue();
-
         private bool didRenderFrame;
 
         protected virtual void DrawFrame()
@@ -520,15 +518,13 @@ namespace osu.Framework.Platform
 
                 if (!bypassFrontToBackPass.Value)
                 {
-                    depthValue.Reset();
-
                     Renderer.SetBlend(BlendingParameters.None);
 
                     Renderer.SetBlendMask(BlendingMask.None);
                     Renderer.PushDepthInfo(DepthInfo.Default);
 
                     // Front pass
-                    buffer.Object.InternalDrawOpaqueInterior(Renderer);
+                    DrawNode.DrawOtherOpaqueInterior(buffer.Object, Renderer);
 
                     Renderer.PopDepthInfo();
                     Renderer.SetBlendMask(BlendingMask.All);
@@ -543,7 +539,7 @@ namespace osu.Framework.Platform
                 }
 
                 // Back pass
-                buffer.Object.InternalDraw(Renderer);
+                DrawNode.DrawOther(buffer.Object, Renderer);
 
                 Renderer.PopDepthInfo();
 


### PR DESCRIPTION
Curious what people's thoughts are on this.

Right now, we have a dichotomy between the implementations of `Draw()` and `DrawOpaqueInternal()` where one batches everything including children inside `Draw()` but the other exposes `DrawOpaqueInternalSubtree()` for this purpose. 

This results in other weirdness, like `Draw()` being `public` and `DrawOpaqueInternal()` being protected. As a consumer of the framework, there is no way to correctly implement `DrawOpaqueInternal()` if needing to draw a child, prior to this PR.

My eventual goal is to be able to wrap both of these draw functions in some way that indicates to the renderer what `DrawNode` is currently being drawn, for example something like...
```csharp
class DrawNode
{
    protected internal static void DrawOther(DrawNode node, IRenderer renderer)
    {
        using (renderer.BeginDrawNode(node))
            node.Draw();
    }
}
```

This is a breaking change.

# vNext

## `DrawNode.Draw()` has been made `protected`

In order to match the signature of `DrawOpaqueInternal()`, `Draw()` has been made `protected`.

`DrawNode`s which draw others from within themselves need to make use of helper methods:

```diff
- public override void Draw(IRenderer renderer)
+ protected override void Draw(IRenderer renderer)
{
    base.Draw(renderer);

-   other.Draw(renderer);
+   DrawOther(other, renderer);
}
```