### PR TITLE
FFmpeg: Add VP6 and WMV2 video formats

### DIFF
--- a/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/common.sh
@@ -16,10 +16,15 @@ FFMPEG_FLAGS=(
     --enable-avformat
     --enable-swscale
 
-    # File and video formats
-    --enable-demuxer='mov,matroska,flv,avi' # mov = mp4, matroska = mkv & webm
-    --enable-parser='mpeg4video,h264,hevc,vp8,vp9'
-    --enable-decoder='flv,msmpeg4v1,msmpeg4v2,msmpeg4v3,mpeg4,h264,hevc,vp8,vp9'
+    # Legacy video formats
+    --enable-demuxer='avi,flv,asf'
+    --enable-parser='mpeg4video'
+    --enable-decoder='flv,msmpeg4v1,msmpeg4v2,msmpeg4v3,mpeg4,vp6,vp6f,wmv2'
+
+    # Modern video formats
+    --enable-demuxer='mov,matroska' # mov = mp4, matroska = mkv & webm
+    --enable-parser='h264,hevc,vp8,vp9'
+    --enable-decoder='h264,hevc,vp8,vp9'
     --enable-protocol=pipe
 )
 


### PR DESCRIPTION
As mentioned [here](https://github.com/ppy/osu/discussions/25604#discussioncomment-7740686), there are some beatmaps with WMV2 and VP6 video.

WMV2 is the shorthand (fourcc) for [Windows Media Video 8](https://en.wikipedia.org/wiki/Windows_Media_Video#Versions). [VP6](https://en.wikipedia.org/wiki/VP6) was often used in Flash. A new demuxer is also needed (`asf`) to decode .wmv files.

As per usual, build artifacts available on [my fork](https://github.com/FreezyLemon/osu-framework/actions/runs/7087395991).