### PR TITLE
Simple localisation for framework-side strings

### DIFF
--- a/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Extensions.LocalisationExtensions;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation.Strings;
+
+namespace osu.Framework.Tests.Visual.Localisation
+{
+    public partial class TestSceneFrameworkStringLocalisation : LocalisationTestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Manager.AddLanguage("en-US", new TestLocalisationStore("en-US", new Dictionary<string, string>
+            {
+                // no translations, use the fallback value
+            }));
+
+            Manager.AddLanguage("en-GB", new TestLocalisationStore("en-GB", new Dictionary<string, string>
+            {
+                [WindowModeStrings.Windowed.GetKey()] = "Windowed",
+                [WindowModeStrings.Borderless.GetKey()] = "Borderless",
+                [WindowModeStrings.Fullscreen.GetKey()] = "Full screen",
+            }));
+
+            Manager.AddLanguage("hr-HR", new TestLocalisationStore("hr-HR", new Dictionary<string, string>
+            {
+                [WindowModeStrings.Windowed.GetKey()] = "Prozor",
+                [WindowModeStrings.Borderless.GetKey()] = "Bez ruba",
+                [WindowModeStrings.Fullscreen.GetKey()] = "Puni zaslon",
+            }));
+        }
+
+        [Test]
+        public void TestDropdown()
+        {
+            AddStep("add dropdown", () =>
+            {
+                Child = new BasicDropdown<WindowMode>
+                {
+                    Width = 200,
+                    Items = Enum.GetValues<WindowMode>()
+                };
+            });
+
+            SetLocale("en-US");
+            SetLocale("en-GB");
+            SetLocale("hr-HR");
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
@@ -38,17 +38,19 @@ namespace osu.Framework.Tests.Visual.Localisation
         }
 
         [Test]
-        public void TestDropdown()
+        public void TestEnumDropdown()
         {
+            BasicDropdown<WindowMode> dropdown = null!;
+
             AddStep("add dropdown", () =>
             {
-                Child = new BasicDropdown<WindowMode>
+                Child = dropdown = new BasicDropdown<WindowMode>
                 {
                     Width = 200,
                     Items = Enum.GetValues<WindowMode>()
                 };
             });
-
+            AddStep("open dropdown", () => dropdown.Menu.Open());
             SetLocale("en-US");
             SetLocale("en-GB");
             SetLocale("hr-HR");

--- a/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneFrameworkStringLocalisation.cs
@@ -24,16 +24,16 @@ namespace osu.Framework.Tests.Visual.Localisation
 
             Manager.AddLanguage("en-GB", new TestLocalisationStore("en-GB", new Dictionary<string, string>
             {
-                [WindowModeStrings.Windowed.GetKey()] = "Windowed",
-                [WindowModeStrings.Borderless.GetKey()] = "Borderless",
-                [WindowModeStrings.Fullscreen.GetKey()] = "Full screen",
+                [WindowModeStrings.Windowed.GetTranslationKey()] = "Windowed",
+                [WindowModeStrings.Borderless.GetTranslationKey()] = "Borderless",
+                [WindowModeStrings.Fullscreen.GetTranslationKey()] = "Full screen",
             }));
 
             Manager.AddLanguage("hr-HR", new TestLocalisationStore("hr-HR", new Dictionary<string, string>
             {
-                [WindowModeStrings.Windowed.GetKey()] = "Prozor",
-                [WindowModeStrings.Borderless.GetKey()] = "Bez ruba",
-                [WindowModeStrings.Fullscreen.GetKey()] = "Puni zaslon",
+                [WindowModeStrings.Windowed.GetTranslationKey()] = "Prozor",
+                [WindowModeStrings.Borderless.GetTranslationKey()] = "Bez ruba",
+                [WindowModeStrings.Fullscreen.GetTranslationKey()] = "Puni zaslon",
             }));
         }
 

--- a/osu.Framework/Configuration/WindowMode.cs
+++ b/osu.Framework/Configuration/WindowMode.cs
@@ -1,12 +1,20 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
+using osu.Framework.Localisation.Strings;
+
 namespace osu.Framework.Configuration
 {
     public enum WindowMode
     {
+        [LocalisableDescription(typeof(WindowModeStrings), nameof(WindowModeStrings.Windowed))]
         Windowed = 0,
+
+        [LocalisableDescription(typeof(WindowModeStrings), nameof(WindowModeStrings.Borderless))]
         Borderless = 1,
+
+        [LocalisableDescription(typeof(WindowModeStrings), nameof(WindowModeStrings.Fullscreen))]
         Fullscreen = 2
     }
 }

--- a/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
+++ b/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
@@ -70,5 +70,22 @@ namespace osu.Framework.Extensions.LocalisationExtensions
         /// <param name="data">The string data.</param>
         /// <returns>A case transformable string with its string data transformed to sentence case.</returns>
         public static CaseTransformableString ToSentence(this ILocalisableStringData data) => new LocalisableString(data).ToSentence();
+
+        /// <summary>
+        /// Returns the <see cref="TranslatableString.Key"/> of the <see cref="TranslatableString"/> that is the underlying data of this <see cref="LocalisableString"/>.
+        /// </summary>
+        /// <param name="str">
+        /// The <see cref="LocalisableString"/> whose underlying data is the <see cref="TranslatableString"/>.
+        /// This is usually a static property of a "strings" class containing translation definitions.
+        /// </param>
+        /// <returns>The <see cref="TranslatableString.Key"/> of the underlying <see cref="TranslatableString"/>.</returns>
+        /// <exception cref="ArgumentException">Thrown if this <see cref="LocalisableString"/> doesn't have underlying <see cref="TranslatableString"/> data.</exception>
+        public static string GetKey(this LocalisableString str)
+        {
+            if (str.Data is not TranslatableString translatable)
+                throw new ArgumentException($"The {nameof(LocalisableString)} doesn't have underlying {nameof(TranslatableString)} data.", nameof(str));
+
+            return translatable.Key;
+        }
     }
 }

--- a/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
+++ b/osu.Framework/Extensions/LocalisationExtensions/LocalisableStringExtensions.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Extensions.LocalisationExtensions
         /// </param>
         /// <returns>The <see cref="TranslatableString.Key"/> of the underlying <see cref="TranslatableString"/>.</returns>
         /// <exception cref="ArgumentException">Thrown if this <see cref="LocalisableString"/> doesn't have underlying <see cref="TranslatableString"/> data.</exception>
-        public static string GetKey(this LocalisableString str)
+        public static string GetTranslationKey(this LocalisableString str)
         {
             if (str.Data is not TranslatableString translatable)
                 throw new ArgumentException($"The {nameof(LocalisableString)} doesn't have underlying {nameof(TranslatableString)} data.", nameof(str));

--- a/osu.Framework/Localisation/Strings/WindowModeStrings.cs
+++ b/osu.Framework/Localisation/Strings/WindowModeStrings.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Localisation.Strings
+{
+    public static class WindowModeStrings
+    {
+        private const string prefix = "osu.Framework.Resources.Localisation.WindowMode";
+
+        /// <summary>
+        /// "Windowed"
+        /// </summary>
+        public static LocalisableString Windowed => new TranslatableString(getKey("windowed"), "Windowed");
+
+        /// <summary>
+        /// "Borderless"
+        /// </summary>
+        public static LocalisableString Borderless => new TranslatableString(getKey("borderless"), "Borderless");
+
+        /// <summary>
+        /// "Fullscreen"
+        /// </summary>
+        public static LocalisableString Fullscreen => new TranslatableString(getKey("fullscreen"), "Fullscreen");
+
+        private static string getKey(string key) => $"{prefix}:{key}";
+    }
+}


### PR DESCRIPTION
- Idea initially described in https://github.com/ppy/osu/issues/6526#issuecomment-1836621664
- Part of the solution for https://github.com/ppy/osu/discussions/22226
- Would solve https://github.com/ppy/osu/pull/24184#issuecomment-1630684895

RFC

This shows an idea for how to allow games to provide translation and customisation of framework-side strings. The idea is to provide static `*Strings.cs` classes that have static `LocalisableString`/`TranslatableString` properties ([like how osu! does it]). Framework would use these strings where applicable. Only English fallback strings are provided, translations in framework are not currently considered.

Consumers then have a stable way of getting the lookup key of framework strings and can do _whatever_ with them in `ILocalisationStore.Get()`.

Some examples of what consumers could do:

- change framework strings to their liking, eg. "Joystick {0}" → "🎮 {0}"
   - for osu! crowdin: we need to consider how is the source strings displayed to translators, we'd want it to be the changed text, not the framework fallback
- remap strings/keys to existing strings that are translated in the game
- consume the framework `*Strings.cs` files in their own translation tooling to provide translations

Example implementation of remapping framework strings to existing osu! strings:

```diff
diff --git a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
index 3fa86c188c..0e4ba369ee 100644
--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -11,6 +11,7 @@
 using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 
 namespace osu.Game.Localisation
@@ -19,6 +20,12 @@ public class ResourceManagerLocalisationStore : ILocalisationStore
     {
         private readonly Dictionary<string, ResourceManager> resourceManagers = new Dictionary<string, ResourceManager>();
 
+        private static readonly Dictionary<string, string> framework_remapping = new Dictionary<LocalisableString, LocalisableString>
+        {
+            [Framework.Localisation.Strings.CommonStrings.Paste] = CommonStrings.Paste,
+            [Framework.Localisation.Strings.CommonStrings.Copy] = CommonStrings.Copy,
+        }.ToDictionary(p => p.Key.GetTranslationKey(), p => p.Value.GetTranslationKey());
+
         public ResourceManagerLocalisationStore(string cultureCode)
         {
             EffectiveCulture = new CultureInfo(cultureCode);
@@ -30,6 +37,9 @@ public void Dispose()
 
         public string Get(string lookup)
         {
+            if (lookup.StartsWith(@"osu.Framework", StringComparison.Ordinal) && framework_remapping.TryGetValue(lookup, out string newLookup))
+                lookup = newLookup;
+
             string[] split = lookup.Split(':');
 
             if (split.Length < 2)
```

# Future work

## framework

- use [ppy/osu-localisation-analyser] to make it easier to add new localisations
- add simple localisations for more strings
- localise inputkey/keycombination

## osu!

- figure out how to get the strings to [crowdin] and [osu-resources]

[like how osu! does it]: https://github.com/ppy/osu/blob/f0364f01eae911c8272fcfeb86de9129dc52ffb8/osu.Game/Localisation/CommonStrings.cs
[ppy/osu-localisation-analyser]: https://github.com/ppy/osu-localisation-analyser
[crowdin]: https://crowdin.com/project/osu-web
[osu-resources]: https://github.com/ppy/osu-resources/