### PR TITLE
Implement ability to get `Texture`'s average colour

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureAverageColour.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureAverageColour.cs
@@ -1,0 +1,105 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public partial class TestSceneTextureAverageColour : FrameworkTestScene
+    {
+        public TestSceneTextureAverageColour()
+        {
+            Add(new TextureStoreProvider());
+        }
+
+        private partial class TextureStoreProvider : FillFlowContainer
+        {
+            private DependencyContainer dependencies = null!;
+
+            [BackgroundDependencyLoader]
+            private void load(IRenderer renderer, GameHost host, Game game)
+            {
+                dependencies.CacheAs(new TextureStore(renderer, host.CreateTextureLoaderStore(new NamespacedResourceStore<byte[]>(game.Resources, "Textures"))));
+
+                AutoSizeAxes = Axes.Y;
+                RelativeSizeAxes = Axes.X;
+                Direction = FillDirection.Full;
+                Spacing = new Vector2(10);
+                Children = new[]
+                {
+                    new Cell("d3-colour-interpolation"),
+                    new Cell("figma-colour-interpolation"),
+                    new Cell("sample-texture"),
+                    new Cell("sample-texture-2"),
+                };
+            }
+
+            protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+                => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+        }
+
+        private partial class Cell : CompositeDrawable
+        {
+            private readonly string textureName;
+            private Sprite sprite = null!;
+            private Box coloredBox = null!;
+
+            public Cell(string textureName)
+            {
+                this.textureName = textureName;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures)
+            {
+                Size = new Vector2(200);
+                InternalChild = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    RowDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, 30)
+                    },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.Relative, 1f)
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            sprite = new Sprite
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Texture = textures.Get(textureName)
+                            }
+                        },
+                        new Drawable[]
+                        {
+                            coloredBox = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                coloredBox.Colour = sprite.Texture.AverageColour;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -8,6 +8,8 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Visualisation;
 using osuTK;
+using osuTK.Graphics;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -47,6 +49,11 @@ namespace osu.Framework.Graphics.Textures
         /// The texture opacity.
         /// </summary>
         public Opacity Opacity { get; protected set; } = Opacity.Mixed;
+
+        /// <summary>
+        /// The texture average colour.
+        /// </summary>
+        public Color4 AverageColour { get; protected set; } = Color4.Black;
 
         /// <summary>
         /// The texture wrap mode in horizontal direction.
@@ -180,7 +187,7 @@ namespace osu.Framework.Graphics.Textures
         /// The provided upload will be disposed after the upload is completed.
         /// </summary>
         /// <param name="upload">The texture data to upload.</param>
-        public void SetData(ITextureUpload upload) => SetData(upload, WrapModeS, WrapModeT, null);
+        public void SetData(ITextureUpload upload) => SetData(upload, WrapModeS, WrapModeT, null, null);
 
         /// <summary>
         /// Queue a <see cref="TextureUpload"/> to be uploaded on the draw thread.
@@ -188,9 +195,10 @@ namespace osu.Framework.Graphics.Textures
         /// </summary>
         /// <param name="upload">The texture data to upload.</param>
         /// <param name="opacity">The texture's opacity, if known.</param>
-        public void SetData(ITextureUpload upload, Opacity opacity) => SetData(upload, WrapModeS, WrapModeT, opacity);
+        /// <param name="averageColour">The texture's average colour, if known.</param>
+        public void SetData(ITextureUpload upload, Opacity opacity, Color4 averageColour) => SetData(upload, WrapModeS, WrapModeT, opacity, averageColour);
 
-        internal virtual void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity)
+        internal virtual void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity, Color4? averageColour)
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not set data of a disposed texture.");
@@ -210,7 +218,7 @@ namespace osu.Framework.Graphics.Textures
             }
 
             UpdateOpacity(upload, ref opacity);
-
+            UpdateAverageColour(upload, ref averageColour);
             NativeTexture.SetData(upload);
         }
 
@@ -242,6 +250,39 @@ namespace osu.Framework.Graphics.Textures
             // return firstPixelValue == 0 ? Opacity.Transparent : Opacity.Opaque;
         }
 
+        protected static Color4 ComputeAverageColour(ITextureUpload upload)
+        {
+            ReadOnlySpan<Rgba32> data = upload.Data;
+
+            if (data.Length == 0)
+                return Color4.Black;
+
+            int nonTransparentCount = 0;
+            int rSum = 0;
+            int gSum = 0;
+            int bSum = 0;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i].A == 0)
+                    continue;
+
+                rSum += data[i].R;
+                gSum += data[i].G;
+                bSum += data[i].B;
+                nonTransparentCount++;
+            }
+
+            if (nonTransparentCount == 0)
+                return Color4.Black;
+
+            rSum /= nonTransparentCount;
+            gSum /= nonTransparentCount;
+            bSum /= nonTransparentCount;
+
+            return new Color4((byte)rSum, (byte)gSum, (byte)bSum, 255);
+        }
+
         protected void UpdateOpacity(ITextureUpload upload, ref Opacity? uploadOpacity)
         {
             // Compute opacity if it doesn't have a value yet
@@ -256,6 +297,13 @@ namespace osu.Framework.Graphics.Textures
                 Opacity = uploadOpacity.Value;
             else if (uploadOpacity.Value != Opacity)
                 Opacity = Opacity.Mixed;
+        }
+
+        protected void UpdateAverageColour(ITextureUpload upload, ref Color4? uploadAverageColour)
+        {
+            // Compute colour if it doesn't have a value yet
+            uploadAverageColour ??= ComputeAverageColour(upload);
+            AverageColour = uploadAverageColour.Value;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Textures/TextureAtlas_BackingAtlasTexture.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas_BackingAtlasTexture.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.Textures
                 IsAtlasTexture = parent.IsAtlasTexture = true;
             }
 
-            internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity)
+            internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity, Color4? averageColour)
             {
                 // Can only perform padding when the bounds are a sub-part of the texture
                 RectangleI middleBounds = upload.Bounds;
@@ -55,7 +55,8 @@ namespace osu.Framework.Graphics.Textures
                 {
                     // For a texture atlas, we don't care about opacity, so we avoid
                     // any computations related to it by assuming it to be mixed.
-                    base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
+                    // Same goes for average colour.
+                    base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed, Color4.Black);
                     return;
                 }
 
@@ -70,7 +71,8 @@ namespace osu.Framework.Graphics.Textures
                 // Upload the middle part of the texture
                 // For a texture atlas, we don't care about opacity, so we avoid
                 // any computations related to it by assuming it to be mixed.
-                base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
+                // Same goes for average colour.
+                base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed, Color4.Black);
             }
 
             private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
@@ -115,7 +117,8 @@ namespace osu.Framework.Graphics.Textures
                         {
                             // For a texture atlas, we don't care about opacity, so we avoid
                             // any computations related to it by assuming it to be mixed.
-                            base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                            // Same goes for average colour.
+                            base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed, Color4.Black);
                         }
                     }
                 }
@@ -166,7 +169,8 @@ namespace osu.Framework.Graphics.Textures
                         {
                             // For a texture atlas, we don't care about opacity, so we avoid
                             // any computations related to it by assuming it to be mixed.
-                            base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                            // Same goes for average colour.
+                            base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed, Color4.Black);
                         }
                     }
                 }
@@ -207,7 +211,8 @@ namespace osu.Framework.Graphics.Textures
 
                         // For a texture atlas, we don't care about opacity, so we avoid
                         // any computations related to it by assuming it to be mixed.
-                        base.SetData(cornerUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                        // Same goes for average colour.
+                        base.SetData(cornerUpload, WrapMode.None, WrapMode.None, Opacity.Mixed, Color4.Black);
                     }
                 }
             }

--- a/osu.Framework/Graphics/Textures/TextureRegion.cs
+++ b/osu.Framework/Graphics/Textures/TextureRegion.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics.Primitives;
+using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -32,7 +33,7 @@ namespace osu.Framework.Graphics.Textures
 
         public override int Height => bounds.Height;
 
-        internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity)
+        internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? opacity, Color4? averageColour)
         {
             if (upload.Bounds.Width > bounds.Width || upload.Bounds.Height > bounds.Height)
             {
@@ -54,7 +55,8 @@ namespace osu.Framework.Graphics.Textures
             }
 
             UpdateOpacity(upload, ref opacity);
-            parent.SetData(upload, wrapModeS, wrapModeT, opacity);
+            UpdateAverageColour(upload, ref averageColour);
+            parent.SetData(upload, wrapModeS, wrapModeT, opacity, averageColour);
         }
 
         private RectangleF boundsInParent(RectangleF? area)

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -24,6 +24,7 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Platform.Linux.Native;
+using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Video
 {
@@ -645,7 +646,8 @@ namespace osu.Framework.Graphics.Video
                 var upload = new VideoTextureUpload(frame);
 
                 // We do not support videos with transparency at this point, so the upload's opacity as well as the texture's opacity is always opaque.
-                tex.SetData(upload, Opacity.Opaque);
+                // Average colour doesn't make sense for videos.
+                tex.SetData(upload, Opacity.Opaque, Color4.Black);
                 decodedFrames.Enqueue(new DecodedFrame { Time = frameTime, Texture = tex });
             }
         }


### PR DESCRIPTION
Some design elements require sampling colour from the texture. This implementation covers this functionality in the simplest way possible - getting average colour of non-transparent pixels.

However I'm marking this as a draft due to this issue https://github.com/ppy/osu/issues/9307. Basically looks like iterating over pixel data may cause performance issues.