### PR TITLE
Make `ToTriangle` in `Sharps.Triangle` overrideable

### DIFF
--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -30,19 +30,21 @@ namespace osu.Framework.Graphics.Shapes
             Texture ??= renderer.WhitePixel;
         }
 
-        public override RectangleF BoundingBox => toTriangle(ToParentSpace(LayoutRectangle)).AABBFloat;
+        public override RectangleF BoundingBox => ToTriangle(ToParentSpace(LayoutRectangle)).AABBFloat;
 
-        private static Primitives.Triangle toTriangle(Quad q) => new Primitives.Triangle(
+        protected Primitives.Triangle ToTriangle(Quad q) => new Primitives.Triangle(
             (q.TopLeft + q.TopRight) / 2,
             q.BottomLeft,
             q.BottomRight);
 
-        public override bool Contains(Vector2 screenSpacePos) => toTriangle(ScreenSpaceDrawQuad).Contains(screenSpacePos);
+        public override bool Contains(Vector2 screenSpacePos) => ToTriangle(ScreenSpaceDrawQuad).Contains(screenSpacePos);
 
         protected override DrawNode CreateDrawNode() => new TriangleDrawNode(this);
 
         private class TriangleDrawNode : SpriteDrawNode
         {
+            protected new Triangle Source => (Triangle)base.Source;
+
             public TriangleDrawNode(Triangle source)
                 : base(source)
             {
@@ -53,7 +55,7 @@ namespace osu.Framework.Graphics.Shapes
                 if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
                     return;
 
-                renderer.DrawTriangle(Texture, toTriangle(ScreenSpaceDrawQuad), DrawColourInfo.Colour, null, null,
+                renderer.DrawTriangle(Texture, Source.ToTriangle(ScreenSpaceDrawQuad), DrawColourInfo.Colour, null, null,
                     new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height), TextureCoords);
             }
 
@@ -62,7 +64,7 @@ namespace osu.Framework.Graphics.Shapes
                 if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
                     return;
 
-                var triangle = toTriangle(ConservativeScreenSpaceDrawQuad);
+                var triangle = Source.ToTriangle(ConservativeScreenSpaceDrawQuad);
 
                 if (renderer.IsMaskingActive)
                     renderer.DrawClipped(ref triangle, Texture, DrawColourInfo.Colour);

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -32,6 +32,11 @@ namespace osu.Framework.Graphics.Shapes
 
         public override RectangleF BoundingBox => ToTriangle(ToParentSpace(LayoutRectangle)).AABBFloat;
 
+        /// <summary>
+        /// Converts a <see cref="Quad"/> and its vertex to a <see cref="Primitives.Triangle"/>.
+        /// </summary>
+        /// <param name="q">A quadrilateral boundary, providing four vertices.</param>
+        /// <returns>Converted triangle.</returns>
         protected Primitives.Triangle ToTriangle(Quad q) => new Primitives.Triangle(
             (q.TopLeft + q.TopRight) / 2,
             q.BottomLeft,

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Graphics.Shapes
         /// </summary>
         /// <param name="q">A quadrilateral boundary, providing four vertices.</param>
         /// <returns>Converted triangle.</returns>
-        protected Primitives.Triangle ToTriangle(Quad q) => new Primitives.Triangle(
+        protected virtual Primitives.Triangle ToTriangle(Quad q) => new Primitives.Triangle(
             (q.TopLeft + q.TopRight) / 2,
             q.BottomLeft,
             q.BottomRight);


### PR DESCRIPTION
As a practical and useful example. In some cases, the user needs to change the orientation of the triangle. But simple rotation does not meet the needs, as an example:

```cs
this.InternalChildren = [
  new Box {
    RelativeSizeAxes = Axes.Both,
    Width = 0.8f,
    Height = 0.25f,
    Anchor = Anchor.Centre,
    Origin = Anchor.Centre,
    Colour = Color4.Blue,
  },
  new Triangle {
    RelativeSizeAxes = Axes.Both,
    Rotation = 90,
    Width = 0.8f,
    Height = 0.25f,
    // Width = 0.25f, Height = 0.8f, // Also not working properly.
    Anchor = Anchor.Centre,
    Origin = Anchor.Centre,
    Colour = Color4.Yellow,
  },
];
```

| ` Width = 0.8f, Height = 0.25f,` | `Width = 0.25f, Height = 0.8f,` |
| - | - |
| ![image](https://github.com/ppy/osu-framework/assets/29837738/5415d3d8-9c02-4d00-a83a-23420989e35c) | ![image](https://github.com/ppy/osu-framework/assets/29837738/569f6c15-b4b1-450d-85db-5418ed6eb27e) |

It is not possible to obtain a `Triangle` with the same length and width as the `Box`. Currently, modifying this behavior to make it work as expected would require writing a lot of code, and most of logic would be duplicated with what is already in the `Triangle` class.

The easiest way to override `Triangle` and make it behave as expected is to override the `ToTriangle` method. After modification you can easily change its orientation and it will behave as expected:

```cs
internal partial class RightTriangle : Triangle {
  protected override Primitives.Triangle ToTriangle(Quad q) => new Primitives.Triangle(
    (q.TopRight + q.BottomRight) / 2,
    q.TopLeft,
    q.BottomLeft);
}
// And then...
this.InternalChildren = [
  new Box {
    RelativeSizeAxes = Axes.Both,
    Width = 0.8f,
    Height = 0.25f,
    Anchor = Anchor.Centre,
    Origin = Anchor.Centre,
    Colour = Color4.Blue,
  },
  new RightTriangle {
    RelativeSizeAxes = Axes.Both,
    Width = 0.8f,
    Height = 0.25f,
    Anchor = Anchor.Centre,
    Origin = Anchor.Centre,
    Colour = Color4.Yellow,
  },
];
```

![image](https://github.com/ppy/osu-framework/assets/29837738/d71dfe8e-2274-4dc2-abfe-8638ca3104c6)
