### PR TITLE
Fix dropdown/menu components not providing items in correct order

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             bool itemClicked = false;
             bool actionReceived = false;
 
-            AddStep("set item action", () => Menus.GetSubMenu(0).Items[0].Items[0].Action.Value = () => itemClicked = true);
+            AddStep("set item action", () => Menus.GetSubMenu(0).Items.ElementAt(0).Items[0].Action.Value = () => itemClicked = true);
             AddStep("add mouse handler", () => Add(new MouseHandlingLayer
             {
                 Action = () => actionReceived = true,

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -320,7 +320,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             return result == expected;
         });
 
-        private void assertMenuItems(int expectedCount) => AddAssert($"menu contains {expectedCount} item(s)", () => contextMenuContainer.CurrentMenu.Items.Count == expectedCount);
+        private void assertMenuItems(int expectedCount) => AddAssert($"menu contains {expectedCount} item(s)", () => contextMenuContainer.CurrentMenu.Items.Count() == expectedCount);
 
         private partial class BoxWithContextMenu : Box, IHasContextMenu
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("click item 2", () =>
             {
-                InputManager.MoveMouseTo(testDropdown.Menu.Children[2]);
+                InputManager.MoveMouseTo(testDropdown.Menu.Children.ElementAt(2));
                 InputManager.Click(MouseButton.Left);
             });
 
@@ -176,7 +176,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("click item 4", () =>
             {
-                InputManager.MoveMouseTo(testDropdown.Menu.Children[4]);
+                InputManager.MoveMouseTo(testDropdown.Menu.Children.ElementAt(4));
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -181,7 +181,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             IReadOnlyList<MenuItem> currentItems = null;
             AddStep("Click item", () => { ClickItem(0, 0); });
 
-            AddStep("Get items", () => { currentItems = Menus.GetSubMenu(1).Items; });
+            AddStep("Get items", () => { currentItems = Menus.GetSubMenu(1).Items.ToList(); });
 
             AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
             AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(0).GetMenuItems()[1]));

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -60,12 +60,14 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected IEnumerable<DropdownMenuItem<T>> MenuItems => itemMap.Values;
 
+        private readonly List<T> orderedItems = new List<T>();
+
         /// <summary>
         /// Enumerate all values in the dropdown.
         /// </summary>
         public IEnumerable<T> Items
         {
-            get => MenuItems.Select(i => i.Value);
+            get => orderedItems;
             set
             {
                 if (boundItemSource != null)
@@ -127,7 +129,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (itemMap.ContainsKey(value))
                 throw new ArgumentException($"The item {value} already exists in this {nameof(Dropdown<T>)}.");
 
-            var item = new DropdownMenuItem<T>(value, () =>
+            var menuItem = new DropdownMenuItem<T>(value, () =>
             {
                 if (!Current.Disabled)
                     Current.Value = value;
@@ -137,14 +139,20 @@ namespace osu.Framework.Graphics.UserInterface
 
             // inheritors expect that `virtual GenerateItemText` is only called when this dropdown's BDL has run to completion.
             if (LoadState >= LoadState.Ready)
-                item.Text.Value = GenerateItemText(value);
+                menuItem.Text.Value = GenerateItemText(value);
 
             if (position != null)
-                Menu.Insert(position.Value, item);
+            {
+                Menu.Insert(position.Value, menuItem);
+                orderedItems.Insert(position.Value, value);
+            }
             else
-                Menu.Add(item);
+            {
+                Menu.Add(menuItem);
+                orderedItems.Add(value);
+            }
 
-            itemMap[value] = item;
+            itemMap[value] = menuItem;
         }
 
         /// <summary>
@@ -169,6 +177,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             Menu.Remove(item);
             itemMap.Remove(value);
+            orderedItems.Remove(value);
             return true;
         }
 
@@ -405,7 +414,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (Current.Value == null || !itemMap.ContainsKey(Current.Value))
             {
-                Current.Value = itemMap.Keys.FirstOrDefault();
+                Current.Value = orderedItems.FirstOrDefault();
                 return;
             }
 
@@ -442,6 +451,7 @@ namespace osu.Framework.Graphics.UserInterface
         private void clearItems()
         {
             itemMap.Clear();
+            orderedItems.Clear();
             Menu.Clear();
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Gets the item representations contained by this <see cref="Menu"/>.
         /// </summary>
-        protected internal IReadOnlyList<DrawableMenuItem> Children => itemsFlow.Children;
+        protected internal IEnumerable<DrawableMenuItem> Children => itemsFlow.Children.OrderBy(c => itemsFlow.GetLayoutPosition(c));
 
         protected readonly Direction Direction;
 
@@ -142,9 +142,9 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Gets or sets the <see cref="MenuItem"/>s contained within this <see cref="Menu"/>.
         /// </summary>
-        public IReadOnlyList<MenuItem> Items
+        public IEnumerable<MenuItem> Items
         {
-            get => itemsFlow.Select(r => r.Item).ToList();
+            get => Children.Select(r => r.Item);
             set
             {
                 Clear();


### PR DESCRIPTION
The change in `Dropdown` is quite ugly, I would rather let the component always store a bindable list and get away with the extra list storage, but I'm not fully confident about pushing such change any time soon.