### PR TITLE
Bump OpenTabletDriver to 0.6.4.0

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.3.0" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
## Tablets

### Added support

- Gaomon GM116HD
- Huion Kamvas 22
- VEIKK VK1060PRO
- Wacom CTC-4110WL
- Wacom CTC-6110WL
- Wacom DTH-1320
- Wacom PTU-600U
- XP-Pen Deco M

### Improved detection

- Artisul A1201
- Gaomon 1060 Pro 
- Huion H1060P
- Huion H420x
- Huion H950P
- Huion Kamvas 20
- Huion Kamvas Pro 24 (4K)
- Kamvas Pro 13 (2.5k)
- UGEE S640

### Other

- Huion Q11K: Fix digitizer specifications
- XP-Pen Star 05 V3: Fix digitizer specifications