### PR TITLE
Add low latency initialisation support on windows by directly interacting with WASAPI

### DIFF
--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Tests.Audio
 
         internal BassAudioMixer CreateMixer()
         {
-            var mixer = new BassAudioMixer(Mixer, "Test mixer");
+            var mixer = new BassAudioMixer(null, Mixer, "Test mixer");
             mixerComponents.AddItem(mixer);
             return mixer;
         }

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -162,7 +162,8 @@ namespace osu.Framework.Audio
 
             thread.RegisterManager(this);
 
-            AudioDevice.ValueChanged += onDeviceChanged;
+            AudioDevice.ValueChanged += _ => onDeviceChanged();
+            GlobalMixerHandle.ValueChanged += _ => onDeviceChanged();
 
             AddItem(TrackMixer = createAudioMixer(null, nameof(TrackMixer)));
             AddItem(SampleMixer = createAudioMixer(null, nameof(SampleMixer)));
@@ -221,9 +222,9 @@ namespace osu.Framework.Audio
             base.Dispose(disposing);
         }
 
-        private void onDeviceChanged(ValueChangedEvent<string> args)
+        private void onDeviceChanged()
         {
-            scheduler.Add(() => setAudioDevice(args.NewValue));
+            scheduler.Add(() => setAudioDevice(AudioDevice.Value));
         }
 
         private void onDevicesChanged()

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -394,7 +394,7 @@ namespace osu.Framework.Audio
                 return true;
 
             // this likely doesn't help us but also doesn't seem to cause any issues or any cpu increase.
-            Bass.UpdatePeriod = 5;
+            Bass.UpdatePeriod = 1;
 
             // reduce latency to a known sane minimum.
             Bass.DeviceBufferLength = 10;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -108,6 +108,12 @@ namespace osu.Framework.Audio
             MaxValue = 1
         };
 
+        /// <summary>
+        /// If a global mixer is being used, this will be the BASS handle for it.
+        /// If non-null, all game mixers should be added to this mixer.
+        /// </summary>
+        internal readonly Bindable<int?> GlobalMixerHandle = new Bindable<int?>();
+
         public override bool IsLoaded => base.IsLoaded &&
                                          // bass default device is a null device (-1), not the actual system default.
                                          Bass.CurrentDevice != Bass.DefaultDevice;
@@ -236,7 +242,7 @@ namespace osu.Framework.Audio
 
         private AudioMixer createAudioMixer(AudioMixer fallbackMixer, string identifier)
         {
-            var mixer = new BassAudioMixer(fallbackMixer, identifier);
+            var mixer = new BassAudioMixer(this, fallbackMixer, identifier);
             AddItem(mixer);
             return mixer;
         }
@@ -390,7 +396,10 @@ namespace osu.Framework.Audio
             // See https://www.un4seen.com/forum/?topic=19601 for more information.
             Bass.Configure((ManagedBass.Configuration)70, false);
 
-            return AudioThread.InitDevice(device);
+            if (!thread.InitDevice(device))
+                return false;
+
+            return true;
         }
 
         private void syncAudioDevices()

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Audio
         /// If a global mixer is being used, this will be the BASS handle for it.
         /// If non-null, all game mixers should be added to this mixer.
         /// </summary>
-        internal readonly Bindable<int?> GlobalMixerHandle = new Bindable<int?>();
+        internal readonly IBindable<int?> GlobalMixerHandle = new Bindable<int?>();
 
         public override bool IsLoaded => base.IsLoaded &&
                                          // bass default device is a null device (-1), not the actual system default.

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -312,7 +312,7 @@ namespace osu.Framework.Audio
             if (setAudioDevice(Bass.NoSoundDevice))
                 return true;
 
-            //we're fucked. even "No sound" device won't initialise.
+            // we're boned. even "No sound" device won't initialise.
             return false;
         }
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -112,6 +112,16 @@ namespace osu.Framework.Audio
         /// If a global mixer is being used, this will be the BASS handle for it.
         /// If non-null, all game mixers should be added to this mixer.
         /// </summary>
+        /// <remarks>
+        /// When this is non-null, all mixers created via <see cref="CreateAudioMixer"/>
+        /// will themselves be added to the global mixer, which will handle playback itself.
+        ///
+        /// In this mode of operation, nested mixers will be created with the <see cref="BassFlags.Decode"/>
+        /// flag, meaning they no longer handle playback directly.
+        ///
+        /// An eventual goal would be to use a global mixer across all platforms as it can result
+        /// in more control and better playback performance.
+        /// </remarks>
         internal readonly IBindable<int?> GlobalMixerHandle = new Bindable<int?>();
 
         public override bool IsLoaded => base.IsLoaded &&

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -109,6 +109,14 @@ namespace osu.Framework.Audio
         };
 
         /// <summary>
+        /// Whether a global mixer is being used for audio routing.
+        /// For now, this is only the case on Windows when using shared mode WASAPI initialisation.
+        /// </summary>
+        public IBindable<bool> UsingGlobalMixer => usingGlobalMixer;
+
+        private readonly Bindable<bool> usingGlobalMixer = new BindableBool();
+
+        /// <summary>
         /// If a global mixer is being used, this will be the BASS handle for it.
         /// If non-null, all game mixers should be added to this mixer.
         /// </summary>
@@ -163,7 +171,11 @@ namespace osu.Framework.Audio
             thread.RegisterManager(this);
 
             AudioDevice.ValueChanged += _ => onDeviceChanged();
-            GlobalMixerHandle.ValueChanged += _ => onDeviceChanged();
+            GlobalMixerHandle.ValueChanged += handle =>
+            {
+                onDeviceChanged();
+                usingGlobalMixer.Value = handle.NewValue.HasValue;
+            };
 
             AddItem(TrackMixer = createAudioMixer(null, nameof(TrackMixer)));
             AddItem(SampleMixer = createAudioMixer(null, nameof(SampleMixer)));

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -14,6 +14,7 @@ using osu.Framework.Development;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Statistics;
+using osu.Framework.Threading;
 
 namespace osu.Framework.Audio.Mixing.Bass
 {
@@ -277,7 +278,9 @@ namespace osu.Framework.Audio.Mixing.Bass
             if (!ManagedBass.Bass.GetDeviceInfo(ManagedBass.Bass.CurrentDevice, out var deviceInfo) || !deviceInfo.IsInitialized)
                 return;
 
-            Handle = BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop);
+            Handle = AudioThread.WasapiMixer != 0
+                ? BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop | BassFlags.Decode)
+                : BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop);
 
             if (Handle == 0)
                 return;
@@ -293,6 +296,7 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             Effects.BindCollectionChanged(onEffectsChanged, true);
 
+            BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
             ManagedBass.Bass.ChannelPlay(Handle);
         }
 

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -252,8 +252,8 @@ namespace osu.Framework.Audio.Mixing.Bass
             {
                 ManagedBass.Bass.ChannelSetDevice(Handle, deviceIndex);
 
-                if (AudioThread.WasapiMixer != 0)
-                    BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
+                if (AudioThread.GlobalMixer != 0)
+                    BassMix.MixerAddChannel(AudioThread.GlobalMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
             }
         }
 
@@ -283,7 +283,7 @@ namespace osu.Framework.Audio.Mixing.Bass
             if (!ManagedBass.Bass.GetDeviceInfo(ManagedBass.Bass.CurrentDevice, out var deviceInfo) || !deviceInfo.IsInitialized)
                 return;
 
-            Handle = AudioThread.WasapiMixer != 0
+            Handle = AudioThread.GlobalMixer != 0
                 ? BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop | BassFlags.Decode)
                 : BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop);
 
@@ -301,8 +301,8 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             Effects.BindCollectionChanged(onEffectsChanged, true);
 
-            if (AudioThread.WasapiMixer != 0)
-                BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
+            if (AudioThread.GlobalMixer != 0)
+                BassMix.MixerAddChannel(AudioThread.GlobalMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
 
             ManagedBass.Bass.ChannelPlay(Handle);
         }

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -249,7 +249,12 @@ namespace osu.Framework.Audio.Mixing.Bass
             if (Handle == 0)
                 createMixer();
             else
+            {
                 ManagedBass.Bass.ChannelSetDevice(Handle, deviceIndex);
+
+                if (AudioThread.WasapiMixer != 0)
+                    BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
+            }
         }
 
         protected override void UpdateState()
@@ -296,7 +301,9 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             Effects.BindCollectionChanged(onEffectsChanged, true);
 
-            BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
+            if (AudioThread.WasapiMixer != 0)
+                BassMix.MixerAddChannel(AudioThread.WasapiMixer, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);
+
             ManagedBass.Bass.ChannelPlay(Handle);
         }
 

--- a/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
@@ -4,7 +4,9 @@
 using System;
 using ManagedBass;
 using ManagedBass.Mix;
+using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
@@ -28,6 +30,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         private float maxPeak = float.MinValue;
         private double lastMaxPeakTime;
         private readonly bool isOutputChannel;
+        private IBindable<bool> usingGlobalMixer = null!;
 
         public AudioChannelDisplay(int channelHandle, bool isOutputChannel = false)
         {
@@ -100,13 +103,19 @@ namespace osu.Framework.Graphics.Visualisation.Audio
             };
         }
 
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audioManager)
+        {
+            usingGlobalMixer = audioManager.UsingGlobalMixer.GetBoundCopy();
+        }
+
         protected override void Update()
         {
             base.Update();
 
             float[] levels = new float[2];
 
-            if (isOutputChannel)
+            if (isOutputChannel && !usingGlobalMixer.Value)
                 Bass.ChannelGetLevel(ChannelHandle, levels, 1 / 1000f * sample_window, LevelRetrievalFlags.Stereo);
             else
                 BassMix.ChannelGetLevel(ChannelHandle, levels, 1 / 1000f * sample_window, LevelRetrievalFlags.Stereo);

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Threading
 
         #region BASS Initialisation
 
-        // TODO: All this bass init stuff should proably not be in this class.
+        // TODO: All this bass init stuff should probably not be in this class.
 
         private WasapiProcedure? wasapiProcedure;
 

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -115,6 +115,8 @@ namespace osu.Framework.Threading
                 FreeDevice(d);
         }
 
+        // TODO: All this bass init stuff should proably not be in this class.
+
         internal static bool InitDevice(int deviceId)
         {
             Debug.Assert(ThreadSafety.IsAudioThread);

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -236,7 +236,7 @@ namespace osu.Framework.Threading
                 }
             });
 
-            bool initialised = BassWasapi.Init(wasapiDevice, Procedure: wasapiProcedure, Buffer: 0.02f, Period: 0.005f);
+            bool initialised = BassWasapi.Init(wasapiDevice, Procedure: wasapiProcedure, Buffer: 0.001f, Period: 0.001f);
 
             if (!initialised)
                 return;

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -187,7 +187,13 @@ namespace osu.Framework.Threading
 
             // This is intentionally initialised inline and stored to a field.
             // If we don't do this, it gets GC'd away.
-            wasapiProcedure = (buffer, length, _) => Bass.ChannelGetData(globalMixerHandle.Value!.Value, buffer, length);
+            wasapiProcedure = (buffer, length, _) =>
+            {
+                if (globalMixerHandle.Value == null)
+                    return 0;
+
+                return Bass.ChannelGetData(globalMixerHandle.Value!.Value, buffer, length);
+            };
 
             if (BassWasapi.Init(wasapiDevice, Procedure: wasapiProcedure, Buffer: 0.02f, Period: 0.005f))
             {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -43,7 +43,7 @@
 
     <!-- DO NOT use ProjectReference for native packaging project.
          See https://github.com/NuGet/Home/issues/4514 and https://github.com/dotnet/sdk/issues/765 . -->
-    <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2023.1205.0-nativelibs" />
+    <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2023.1225.0-nativelibs" />
 
     <!-- Any version ahead of this will cause AOT issues with iOS
          See https://github.com/mono/mono/issues/21188 -->

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
+    <PackageReference Include="ppy.ManagedBass.Wasapi" Version="2022.1216.0" />
     <PackageReference Include="ppy.Veldrid" Version="4.9.3-g91ce5a6cda" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gca6cec7843" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />


### PR DESCRIPTION
This reduces latency from perceivable (25-40ms) to non-perceivable (5-15ms). With this change, the latency on windows actually becomes limited by the update thread rate.

Pushing this as a draft for those interested in testing it ahead of time. I hope to clean up the single `static` usage.

If you wish to test in the mean time, please checkout this PR, build osu! after running `UseLocalFramework.ps1`.

- [x] Depends on https://github.com/ppy/osu-framework/pull/6090 (for initialisation sanity)
- [x] Depends on https://github.com/ppy/osu-framework/pull/6091