### PR TITLE
Fix audio device names not being populated in time for bass device initialisation

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -169,7 +169,8 @@ namespace osu.Framework.Audio
 
             CancellationToken token = cancelSource.Token;
 
-            scheduler.Add(() =>
+            syncAudioDevices();
+            scheduler.AddDelayed(() =>
             {
                 // sync audioDevices every 1000ms
                 new Thread(() =>
@@ -189,7 +190,7 @@ namespace osu.Framework.Audio
                 {
                     IsBackground = true
                 }.Start();
-            });
+            }, 1000);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Without this, at least on my PC, the BASS device initialisation happens twice. The first time, device matching fails because the first run of `syncAudioDevices` has not occurred yet (scheduled and thread). This causes initialisation to fail matching by name:

https://github.com/ppy/osu-framework/blob/e5a0e4ec0e9a030dbc83ae3fb375a9ebd2e8963b/osu.Framework/Audio/AudioManager.cs#L303-L305

.. and initialise the BASS "no sound" or "default" device unnecessarily.

Then a second callback happens which brings the device into a good state.

Basically, this PR reduces the number of BASS device initialisations on startup from 2 to 1 in many cases.