### PR TITLE
Rename concept of "global" mixer with "fallback"

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -234,9 +234,9 @@ namespace osu.Framework.Audio
         public AudioMixer CreateAudioMixer(string identifier = default) =>
             createAudioMixer(SampleMixer, !string.IsNullOrEmpty(identifier) ? identifier : $"user #{Interlocked.Increment(ref userMixerID)}");
 
-        private AudioMixer createAudioMixer(AudioMixer globalMixer, string identifier)
+        private AudioMixer createAudioMixer(AudioMixer fallbackMixer, string identifier)
         {
-            var mixer = new BassAudioMixer(globalMixer, identifier);
+            var mixer = new BassAudioMixer(fallbackMixer, identifier);
             AddItem(mixer);
             return mixer;
         }

--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -14,17 +14,17 @@ namespace osu.Framework.Audio.Mixing
     {
         public readonly string Identifier;
 
-        private readonly AudioMixer? globalMixer;
+        private readonly AudioMixer? fallbackMixer;
 
         /// <summary>
         /// Creates a new <see cref="AudioMixer"/>.
         /// </summary>
-        /// <param name="globalMixer">The global <see cref="AudioMixer"/>, which <see cref="IAudioChannel"/>s are moved to if removed from this one.
-        /// A <c>null</c> value indicates this is the global <see cref="AudioMixer"/>.</param>
+        /// <param name="fallbackMixer">A fallback <see cref="AudioMixer"/>, which <see cref="IAudioChannel"/>s are moved to if removed from this one.
+        /// A <c>null</c> value indicates this is the fallback <see cref="AudioMixer"/>.</param>
         /// <param name="identifier">An identifier displayed on the audio mixer visualiser.</param>
-        protected AudioMixer(AudioMixer? globalMixer, string identifier)
+        protected AudioMixer(AudioMixer? fallbackMixer, string identifier)
         {
-            this.globalMixer = globalMixer;
+            this.fallbackMixer = fallbackMixer;
             Identifier = identifier;
         }
 
@@ -56,7 +56,7 @@ namespace osu.Framework.Audio.Mixing
         protected void Remove(IAudioChannel channel, bool returnToDefault)
         {
             // If this is the default mixer, prevent removal.
-            if (returnToDefault && globalMixer == null)
+            if (returnToDefault && fallbackMixer == null)
                 return;
 
             channel.EnqueueAction(() =>
@@ -69,7 +69,7 @@ namespace osu.Framework.Audio.Mixing
 
                 // Add the channel back to the default mixer so audio can always be played.
                 if (returnToDefault)
-                    globalMixer.AsNonNull().Add(channel);
+                    fallbackMixer.AsNonNull().Add(channel);
             });
         }
 

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -42,10 +42,10 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// <summary>
         /// Creates a new <see cref="BassAudioMixer"/>.
         /// </summary>
-        /// <param name="globalMixer"><inheritdoc /></param>
+        /// <param name="fallbackMixer"><inheritdoc /></param>
         /// <param name="identifier">An identifier displayed on the audio mixer visualiser.</param>
-        public BassAudioMixer(AudioMixer? globalMixer, string identifier)
-            : base(globalMixer, identifier)
+        public BassAudioMixer(AudioMixer? fallbackMixer, string identifier)
+            : base(fallbackMixer, identifier)
         {
             EnqueueAction(createMixer);
         }
@@ -278,6 +278,7 @@ namespace osu.Framework.Audio.Mixing.Bass
                 return;
 
             Handle = BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop);
+
             if (Handle == 0)
                 return;
 


### PR DESCRIPTION
Hopefully this makes immediate sense.

Splitting this out from WASAPI changes to allow me to use the term "global mixer" more correctly.