### PR TITLE
Add setting to control automatic minimising on focus loss in fullscreen mode

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
             SetDefault(FrameworkSetting.HardwareVideoDecoder, HardwareVideoDecoder.Any);
             SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
-            SetDefault(FrameworkSetting.MinimiseOnFocusLossInFullscreen, true);
+            SetDefault(FrameworkSetting.MinimiseOnFocusLossInFullscreen, RuntimeInfo.IsDesktop);
             SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
             SetDefault(FrameworkSetting.Renderer, RendererType.Automatic);

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -37,6 +37,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
             SetDefault(FrameworkSetting.HardwareVideoDecoder, HardwareVideoDecoder.Any);
             SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
+            SetDefault(FrameworkSetting.MinimiseOnFocusLossInFullscreen, true);
             SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
             SetDefault(FrameworkSetting.Renderer, RendererType.Automatic);
@@ -90,6 +91,11 @@ namespace osu.Framework.Configuration
         LastDisplayDevice,
 
         SizeFullscreen,
+
+        /// <summary>
+        /// Whether the window will be minimised when losing focus in <see cref="Framework.Configuration.WindowMode.Fullscreen"/> mode.
+        /// </summary>
+        MinimiseOnFocusLossInFullscreen,
 
         Renderer,
         WindowMode,

--- a/osu.Framework/Platform/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2Window.cs
@@ -230,7 +230,6 @@ namespace osu.Framework.Platform
             flags |= graphicsSurface.Type.ToFlags();
 
             SDL.SDL_SetHint(SDL.SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4, "1");
-            SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_IME_SHOW_UI, "1");
             SDL.SDL_SetHint(SDL.SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, "0");
             SDL.SDL_SetHint(SDL.SDL_HINT_TOUCH_MOUSE_EVENTS, "0"); // disable touch events generating synthetic mouse events on desktop platforms

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -21,6 +21,12 @@ namespace osu.Framework.Platform
     {
         private void setupWindowing(FrameworkConfigManager config)
         {
+            config.BindWith(FrameworkSetting.MinimiseOnFocusLossInFullscreen, minimiseOnFocusLoss);
+            minimiseOnFocusLoss.BindValueChanged(e =>
+            {
+                ScheduleCommand(() => SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, e.NewValue ? "1" : "0"));
+            }, true);
+
             fetchDisplays();
 
             DisplaysChanged += _ => CurrentDisplayBindable.Default = PrimaryDisplay;
@@ -429,6 +435,8 @@ namespace osu.Framework.Platform
         /// Bound to <see cref="FrameworkSetting.LastDisplayDevice"/>.
         /// </summary>
         private readonly Bindable<DisplayIndex> windowDisplayIndexBindable = new Bindable<DisplayIndex>();
+
+        private readonly BindableBool minimiseOnFocusLoss = new BindableBool();
 
         /// <summary>
         /// Updates <see cref="Size"/> and <see cref="Scale"/> according to SDL state.


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/discussions/17172

Uses `SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS` on desktop (and iOS, but I'm not sure if it does anything).
Mobile isn't really a consideration here, as the OS has full control over "minimising a window".

Added tests that require manually alt-tabbing. Tested on windows 11 with DirectX (seamless transition) and OpenGL legacy (black screen flicker).