### PR TITLE
Fix dropdown header handling platform actions when not hovered

### DIFF
--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -143,11 +143,10 @@ namespace osu.Framework.Graphics.UserInterface
             Background.Colour = IsHovered && Enabled.Value ? BackgroundColourHover : BackgroundColour;
         }
 
+        public override bool HandleNonPositionalInput => IsHovered;
+
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (!IsHovered)
-                return false;
-
             if (!Enabled.Value)
                 return true;
 


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/26175
- Resolves https://github.com/ppy/osu/issues/26211

Regressed in https://github.com/ppy/osu-framework/commit/6d215cf9303c547f57056b69d7f6afcd12f0b66a. Not sure why the change was made in the first place, but it has been reverted here. No signs of breakage as far as I tried.

To briefly explain the issue in the linked thread above, disabled dropdowns handle any platform action received, regardless of whether the dropdown is hovered or not. When pressing left/right arrows anywhere, the actions `MoveBackwardChar`/`MoveForwardChar` are propagated first, and any disabled dropdown present in the scene will handle them, therefore blocking the slider from receiving the key event.