### PR TITLE
Ignore input while `KeyBindingContainer` is not in a loaded state

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
@@ -48,7 +49,7 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
-        public void TestPressKeyBeforeKeyBindingContainerAdded()
+        public void TestPressHalfCombinationBeforeKeyBindingContainerAdded()
         {
             List<TestAction> pressedActions = new List<TestAction>();
             List<TestAction> releasedActions = new List<TestAction>();
@@ -66,6 +67,77 @@ namespace osu.Framework.Tests.Visual.Input
                     {
                         Pressed = a => pressedActions.Add(a),
                         Released = a => releasedActions.Add(a)
+                    }
+                };
+            });
+
+            AddStep("press key A", () => InputManager.PressKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA triggered", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionA));
+            AddAssert("no actions released", () => releasedActions, () => Is.Empty);
+
+            AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("only one action released", () => releasedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
+        }
+
+        [Test]
+        public void TestPressKeyBeforeKeyBindingContainerAdded()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new TestKeyBindingContainer(mode: SimultaneousBindingMode.All)
+                {
+                    Child = new TestKeyBindingReceptor
+                    {
+                        Pressed = a => pressedActions.Add(a),
+                        Released = a => releasedActions.Add(a)
+                    }
+                };
+            });
+
+            AddStep("press key A", () => InputManager.PressKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA triggered", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionA));
+            AddAssert("no actions released", () => releasedActions, () => Is.Empty);
+
+            AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("only one action released", () => releasedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
+        }
+
+        [Test]
+        public void TestPressKeyBeforeKeyBindingContainerAdded_WithPassThroughInputManager()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new PassThroughInputManager
+                {
+                    Child = new TestKeyBindingContainer(mode: SimultaneousBindingMode.All)
+                    {
+                        Child = new TestKeyBindingReceptor
+                        {
+                            Pressed = a => pressedActions.Add(a),
+                            Released = a => releasedActions.Add(a)
+                        },
                     }
                 };
             });
@@ -419,7 +491,8 @@ namespace osu.Framework.Tests.Visual.Input
 
             public Func<TestAction, bool>? Pressed;
 
-            public TestKeyBindingContainer(bool prioritised = false)
+            public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None)
+                : base(mode)
             {
                 Prioritised = prioritised;
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -204,6 +204,12 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, Vector2? scrollDelta = null, bool isPrecise = false)
         {
+            if (!IsLoaded)
+                // If a KeyBindingContainer resides inside of a PassThroughInputManager,
+                // then the first input sync will propagate events while KeyBindingContainer is not fully loaded yet (in a ready state).
+                // since it's not loaded yet, KeyBindings will also be null because ReloadMappings isn't called, therefore ignore input in this stage.
+                return false;
+
             pressedInputKeys.Add(newKey);
 
             float scrollAmount = getScrollAmount(newKey, scrollDelta);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23555

This issue is occurring due to the presence of a `PassThroughInputManager` layer above the key binding container. All input managers process input on `Update`, so even if a drawable has not received its first update frame, the input manager may propagate input changes to such drawable.

`KeyBindingContainer` gets into a weird state when handling input while it's not loaded. Since it's not loaded, `KeyBindings` would be null since it only gets populated in `LoadComplete`, so no press/release events are propagated to children for the first key. However, the key gets stored in `pressedInputKeys`, and later on, when the next key is pressed, the old key incorrectly becomes processed as a new binding as well, causing the double-press issue.

For simplicity, I've made `handleNewPressed` return early if the key binding container is not loaded yet. 

That being said, it should be taken into consideration that a drawable receiving input events before it's loaded is highly unexpected, and may need to be iterated upon at a later point.