### PR TITLE
Standardise logging calls

### DIFF
--- a/osu.Framework.Tests/IO/TestLogging.cs
+++ b/osu.Framework.Tests/IO/TestLogging.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -77,6 +78,71 @@ namespace osu.Framework.Tests.IO
 
             Assert.IsNotNull(resolvedException, "exception wasn't forwarded by logger");
             Logger.NewEntry -= logTest;
+        }
+
+        [Test]
+        public void TestClassNameLogging()
+        {
+            void logTest(LogEntry entry)
+            {
+                Assert.That(entry.Message, Does.StartWith(nameof(TestLogging)));
+            }
+
+            using (var storage = new TemporaryNativeStorage(nameof(TestExceptionLogging)))
+            {
+                Logger.Storage = storage;
+                Logger.Enabled = true;
+
+                Logger.NewEntry += logTest;
+                Logger.Error(new TestException(), "message");
+                Logger.Error(new TestException(), "message", "test");
+                Logger.Log("message");
+                Logger.Log("message", "test");
+                Logger.LogPrint("message");
+                Logger.LogPrint("message", "test");
+                Logger.NewEntry -= logTest;
+
+                Logger.Enabled = false;
+                Logger.Flush();
+            }
+        }
+
+        [Test]
+        public void TestValueLogging()
+        {
+            Dictionary<object, object> valueChanges = new Dictionary<object, object>() { [""] = "osu!", ["EnteringMode"] = "TopLevel" };
+            Dictionary<string, object> values = new Dictionary<string, object>() { ["beatmap"] = 186, ["ruleset"] = 0, };
+
+            void logTest(LogEntry entry)
+            {
+                foreach (var valueChange in valueChanges)
+                {
+                    Assert.That(entry.Message, Contains.Substring($"from: \"{valueChange.Key}\" to: \"{valueChange.Value}\""));
+                }
+
+                foreach (var value in values)
+                {
+                    Assert.That(entry.Message, Contains.Substring($"{value.Key}:{value.Value}"));
+                }
+            }
+
+            using (var storage = new TemporaryNativeStorage(nameof(TestExceptionLogging)))
+            {
+                Logger.Storage = storage;
+                Logger.Enabled = true;
+
+                Logger.NewEntry += logTest;
+                Logger.Error(new TestException(), "message", valueChanges: valueChanges, values: values);
+                Logger.Error(new TestException(), "message", "test", valueChanges: valueChanges, values: values);
+                Logger.Log("message", valueChanges: valueChanges, values: values);
+                Logger.Log("message", "test", valueChanges: valueChanges, values: values);
+                Logger.LogPrint("message", valueChanges: valueChanges, values: values);
+                Logger.LogPrint("message", "test", valueChanges: valueChanges, values: values);
+                Logger.NewEntry -= logTest;
+
+                Logger.Enabled = false;
+                Logger.Flush();
+            }
         }
 
         [Test]

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -155,9 +156,11 @@ namespace osu.Framework.Logging
         /// <param name="description">The description of the error that should be logged with the exception.</param>
         /// <param name="target">The logging target (file).</param>
         /// <param name="recursive">Whether the inner exceptions of the given exception <paramref name="e"/> should be logged recursively.</param>
-        public static void Error(Exception e, string description, LoggingTarget target = LoggingTarget.Runtime, bool recursive = false)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void Error(Exception e, string description, LoggingTarget target = LoggingTarget.Runtime, bool recursive = false, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
-            error(e, description, target, null, recursive);
+            error(e, description, target, null, recursive, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -167,17 +170,29 @@ namespace osu.Framework.Logging
         /// <param name="description">The description of the error that should be logged with the exception.</param>
         /// <param name="name">The logger name (file).</param>
         /// <param name="recursive">Whether the inner exceptions of the given exception <paramref name="e"/> should be logged recursively.</param>
-        public static void Error(Exception e, string description, string name, bool recursive = false)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void Error(Exception e, string description, string name, bool recursive = false, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
-            error(e, description, null, name, recursive);
+            error(e, description, null, name, recursive, valueChanges: valueChanges, values: values);
         }
 
-        private static void error(Exception e, string description, LoggingTarget? target, string name, bool recursive)
+        /// <summary>
+        /// Logs the given exception with the given description to the logger with the given name.
+        /// </summary>
+        /// <param name="e">The exception that should be logged.</param>
+        /// <param name="description">The description of the error that should be logged with the exception.</param>
+        /// <param name="target">The logging target (file).</param>
+        /// <param name="name">The logger name (file).</param>
+        /// <param name="recursive">Whether the inner exceptions of the given exception <paramref name="e"/> should be logged recursively.</param>
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        private static void error(Exception e, string description, LoggingTarget? target, string name, bool recursive, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
-            log($@"{description}", target, name, LogLevel.Error, e);
+            log($@"{description}", target, name, LogLevel.Error, e, valueChanges: valueChanges, values: values);
 
             if (recursive && e.InnerException != null)
-                error(e.InnerException, $"{description} (inner)", target, name, true);
+                error(e.InnerException, $"{description} (inner)", target, name, true, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -187,9 +202,11 @@ namespace osu.Framework.Logging
         /// <param name="target">The logging target (file).</param>
         /// <param name="level">The verbosity level.</param>
         /// <param name="outputToListeners">Whether the message should be sent to listeners of <see cref="Debug"/> and <see cref="Console"/>. True by default.</param>
-        public static void Log(string message, LoggingTarget target = LoggingTarget.Runtime, LogLevel level = LogLevel.Verbose, bool outputToListeners = true)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void Log(string message, LoggingTarget target = LoggingTarget.Runtime, LogLevel level = LogLevel.Verbose, bool outputToListeners = true, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
-            log(message, target, null, level, outputToListeners: outputToListeners);
+            log(message, target, null, level, outputToListeners: outputToListeners, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -199,19 +216,32 @@ namespace osu.Framework.Logging
         /// <param name="name">The logger name (file).</param>
         /// <param name="level">The verbosity level.</param>
         /// <param name="outputToListeners">Whether the message should be sent to listeners of <see cref="Debug"/> and <see cref="Console"/>. True by default.</param>
-        public static void Log(string message, string name, LogLevel level = LogLevel.Verbose, bool outputToListeners = true)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void Log(string message, string name, LogLevel level = LogLevel.Verbose, bool outputToListeners = true, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
-            log(message, null, name, level, outputToListeners: outputToListeners);
+            log(message, null, name, level, outputToListeners: outputToListeners, valueChanges: valueChanges, values: values);
         }
 
-        private static void log(string message, LoggingTarget? target, string loggerName, LogLevel level, Exception exception = null, bool outputToListeners = true)
+        /// <summary>
+        /// Log an arbitrary string to the specified logging target.
+        /// </summary>
+        /// <param name="message">The message to log. Can include newline (\n) characters to split into multiple lines.</param>
+        /// <param name="target">The logging target (file).</param>
+        /// <param name="loggerName">The logger name (file).</param>
+        /// <param name="level">The verbosity level.</param>
+        /// <param name="exception">An optional related exception.</param>
+        /// <param name="outputToListeners">Whether the message should be sent to listeners of <see cref="Debug"/> and <see cref="Console"/>. True by default.</param>
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        private static void log(string message, LoggingTarget? target, string loggerName, LogLevel level, Exception exception = null, bool outputToListeners = true, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
             try
             {
                 if (target.HasValue)
-                    GetLogger(target.Value).Add(message, level, exception, outputToListeners);
+                    GetLogger(target.Value).Add(message, level, exception, outputToListeners, valueChanges, values);
                 else
-                    GetLogger(loggerName).Add(message, level, exception, outputToListeners);
+                    GetLogger(loggerName).Add(message, level, exception, outputToListeners, valueChanges, values);
             }
             catch
             {
@@ -224,12 +254,14 @@ namespace osu.Framework.Logging
         /// <param name="message">The message to log. Can include newline (\n) characters to split into multiple lines.</param>
         /// <param name="target">The logging target (file).</param>
         /// <param name="level">The verbosity level.</param>
-        public static void LogPrint(string message, LoggingTarget target = LoggingTarget.Runtime, LogLevel level = LogLevel.Verbose)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void LogPrint(string message, LoggingTarget target = LoggingTarget.Runtime, LogLevel level = LogLevel.Verbose, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
             if (Enabled && DebugUtils.IsDebugBuild)
                 System.Diagnostics.Debug.Print(message);
 
-            Log(message, target, level);
+            Log(message, target, level, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -238,12 +270,14 @@ namespace osu.Framework.Logging
         /// <param name="message">The message to log. Can include newline (\n) characters to split into multiple lines.</param>
         /// <param name="name">The logger name (file).</param>
         /// <param name="level">The verbosity level.</param>
-        public static void LogPrint(string message, string name, LogLevel level = LogLevel.Verbose)
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public static void LogPrint(string message, string name, LogLevel level = LogLevel.Verbose, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
             if (Enabled && DebugUtils.IsDebugBuild)
                 System.Diagnostics.Debug.Print(message);
 
-            Log(message, name, level);
+            Log(message, name, level, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -275,12 +309,14 @@ namespace osu.Framework.Logging
         /// Logs a new message with the <see cref="LogLevel.Debug"/> and will only be logged if your project is built in the Debug configuration. Please note that the default setting for <see cref="Level"/> is <see cref="LogLevel.Verbose"/> so unless you increase the <see cref="Level"/> to <see cref="LogLevel.Debug"/> messages printed with this method will not appear in the output.
         /// </summary>
         /// <param name="message">The message that should be logged.</param>
-        public void Debug(string message = @"")
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public void Debug(string message = @"", Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
             if (!DebugUtils.IsDebugBuild)
                 return;
 
-            Add(message, LogLevel.Debug);
+            Add(message, LogLevel.Debug, valueChanges: valueChanges, values: values);
         }
 
         /// <summary>
@@ -290,14 +326,16 @@ namespace osu.Framework.Logging
         /// <param name="level">The verbosity level.</param>
         /// <param name="exception">An optional related exception.</param>
         /// <param name="outputToListeners">Whether the message should be sent to listeners of <see cref="Debug"/> and <see cref="Console"/>. True by default.</param>
-        public void Add(string message = @"", LogLevel level = LogLevel.Verbose, Exception exception = null, bool outputToListeners = true) =>
-            add(message, level, exception, outputToListeners && OutputToListeners);
+        /// <param name="valueChanges">Value changes to be indicated in the logs</param>
+        /// <param name="values">Value to be shown in the logs</param>
+        public void Add(string message = @"", LogLevel level = LogLevel.Verbose, Exception exception = null, bool outputToListeners = true, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null) =>
+            add(message, level, exception, outputToListeners && OutputToListeners, valueChanges, values);
 
         private readonly RollingTime debugOutputRollingTime = new RollingTime(50, 10000);
 
         private readonly Queue<string> pendingFileOutput = new Queue<string>();
 
-        private void add(string message = @"", LogLevel level = LogLevel.Verbose, Exception exception = null, bool outputToListeners = true)
+        private void add(string message = @"", LogLevel level = LogLevel.Verbose, Exception exception = null, bool outputToListeners = true, Dictionary<object, object> valueChanges = null, Dictionary<string, object> values = null)
         {
             if (!Enabled || level < Level)
                 return;
@@ -307,6 +345,23 @@ namespace osu.Framework.Logging
             logCount.Value++;
 
             message = ApplyFilters(message);
+
+            Type callingClass = new StackTrace().GetFrames().Where(sf => sf.HasMethod()).Select(sf => sf.GetMethod()).FirstOrDefault(m => m != null && m.DeclaringType != typeof(Logger))?.DeclaringType;
+
+            if (callingClass != null)
+            {
+                message = $"{callingClass.Name}, {message}";
+            }
+
+            if (valueChanges != null)
+            {
+                message = $"{message}, {string.Join(" ", valueChanges.Select(kvp => $"from: \"{kvp.Key}\" to: \"{kvp.Value}\""))}";
+            }
+
+            if (values != null)
+            {
+                message = $"{message}, {string.Join(" ", values.Select(kvp => $"{kvp.Key}:{kvp.Value}"))}";
+            }
 
             string logOutput = message;
 


### PR DESCRIPTION
Addressing ppy/osu#10682

The requirement is that we will try to standardise logs in the following format:

`<timestamp> <log level> <calling class>, <event>, <key>:<value> <key>:<value> ...`

The calling class is now recorded, though if required we can make this optional.

The `<key>:<value>` examples shown have two different variations:

1. SongSelect, updating selection, **beatmap:"186" ruleset:"0**
2. ButtonSystem, state changed, **from: "EnteringMode" to: "TopLevel"**

As a result, I've added two separate dictionaries respectively to support both; the first variation will be a `string`/`object `dictionary for a `name:value` input while the second variation will use `object`/`object` to allow support for `value changes` (e.g two integers, two strings, etc.).

The `working beatmap: "Some beatmap name"` example was ignored (Even though it includes a little space after the `:`) as it was probably meant to fall under the first variation.

If both are specified into the log, then `from/to` takes precedence.

This PR is currently to implement the functionality, but does not _yet_ replace all instances where these two new optional parameters are to be used. I've added them to all methods and their overloads that uses the `add` method.