### PR TITLE
Fix android storage path on .NET 8

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Android
             // The default current directory on android is '/'.
             // On some devices '/' maps to the app data directory. On others it maps to the root of the internal storage.
             // In order to have a consistent current directory on all devices the full path of the app data directory is set as the current directory.
-            System.Environment.CurrentDirectory = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
+            System.Environment.CurrentDirectory = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 
             base.OnCreate(savedInstanceState);
 


### PR DESCRIPTION
As per https://github.com/dotnet/runtime/pull/76250 and https://github.com/dotnet/docs/issues/31423, `System.Environment.SpecialFolder.Profile` since .NET 8 points to `$HOME/Documents` instead of `$HOME`, causing
```
android.runtime.JavaProxyThrowable: [System.IO.DirectoryNotFoundException]: IO_PathNotFound_Path, /data/user/0/com.test.app/files/Documents
```
on startup.
This PR changes it to always target `$HOME`.

Similar change was previously done in https://github.com/ppy/osu-framework/pull/5909/commits/d7ff5d6478ada5017518aa19843f3fdca0d174cf, but android was skipped.