### PR TITLE
Fix `InputManager` including non-loaded direct children in input queue

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
@@ -48,7 +49,7 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
-        public void TestPressKeyBeforeKeyBindingContainerAdded()
+        public void TestPressHalfCombinationBeforeKeyBindingContainerAdded()
         {
             List<TestAction> pressedActions = new List<TestAction>();
             List<TestAction> releasedActions = new List<TestAction>();
@@ -66,6 +67,77 @@ namespace osu.Framework.Tests.Visual.Input
                     {
                         Pressed = a => pressedActions.Add(a),
                         Released = a => releasedActions.Add(a)
+                    }
+                };
+            });
+
+            AddStep("press key A", () => InputManager.PressKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA triggered", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionA));
+            AddAssert("no actions released", () => releasedActions, () => Is.Empty);
+
+            AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("only one action released", () => releasedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
+        }
+
+        [Test]
+        public void TestPressKeyBeforeKeyBindingContainerAdded()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new TestKeyBindingContainer(mode: SimultaneousBindingMode.All)
+                {
+                    Child = new TestKeyBindingReceptor
+                    {
+                        Pressed = a => pressedActions.Add(a),
+                        Released = a => releasedActions.Add(a)
+                    }
+                };
+            });
+
+            AddStep("press key A", () => InputManager.PressKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA triggered", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionA));
+            AddAssert("no actions released", () => releasedActions, () => Is.Empty);
+
+            AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("only one action released", () => releasedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
+        }
+
+        [Test]
+        public void TestPressKeyBeforeKeyBindingContainerAdded_WithPassThroughInputManager()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new PassThroughInputManager
+                {
+                    Child = new TestKeyBindingContainer(mode: SimultaneousBindingMode.All)
+                    {
+                        Child = new TestKeyBindingReceptor
+                        {
+                            Pressed = a => pressedActions.Add(a),
+                            Released = a => releasedActions.Add(a)
+                        },
                     }
                 };
             });
@@ -419,7 +491,8 @@ namespace osu.Framework.Tests.Visual.Input
 
             public Func<TestAction, bool>? Pressed;
 
-            public TestKeyBindingContainer(bool prioritised = false)
+            public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None)
+                : base(mode)
             {
                 Prioritised = prioritised;
             }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -624,8 +624,12 @@ namespace osu.Framework.Input
                 FrameStatistics.Increment(StatisticsCounterType.PositionalIQ);
 
             var children = AliveInternalChildren;
+
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildPositionalInputQueue(screenSpacePos, positionalInputQueue);
+            {
+                if (ShouldBeConsideredForInput(children[i]))
+                    children[i].BuildPositionalInputQueue(screenSpacePos, positionalInputQueue);
+            }
 
             positionalInputQueue.Reverse();
             return positionalInputQueue.AsSlimReadOnly();

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -593,8 +593,12 @@ namespace osu.Framework.Input
                 FrameStatistics.Increment(StatisticsCounterType.InputQueue);
 
             var children = AliveInternalChildren;
+
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildNonPositionalInputQueue(inputQueue);
+            {
+                if (ShouldBeConsideredForInput(children[i]))
+                    children[i].BuildNonPositionalInputQueue(inputQueue);
+            }
 
             if (!unfocusIfNoLongerValid())
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/23555

`KeyBindingContainer` gets into a weird state when handling input while it's not loaded. Since it's not loaded, `KeyBindings` would be null since it only gets populated in `LoadComplete`, so no press/release events are propagated to children for the first key. However, the key gets stored in `pressedInputKeys`, and later on, when the next key is pressed, the old key incorrectly becomes processed as a new binding as well, causing the double-press issue.

`KeyBindingContainer` was not supposed to enter the input queue if it's not fully loaded in the first place, but turns out `InputManager` was incorrectly adding it (by bypassing `ShouldBeConsideredForInput`).