### PR TITLE
Set process priority of framework window to high when focused

### DIFF
--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -112,6 +112,32 @@ namespace osu.Framework.Platform
             return ipcProvider.SendMessageAsync(message);
         }
 
+        protected override void OnActivated()
+        {
+            setGamePriority(true);
+            base.OnActivated();
+        }
+
+        protected override void OnDeactivated()
+        {
+            setGamePriority(false);
+            base.OnDeactivated();
+        }
+
+        private void setGamePriority(bool active)
+        {
+            try
+            {
+                // We set process priority after the window becomes active, because for whatever reason windows will
+                // reset this when the window becomes active after being inactive when game mode is enabled.
+                Process.GetCurrentProcess().PriorityClass = active ? ProcessPriorityClass.High : ProcessPriorityClass.Normal;
+            }
+            catch
+            {
+                // This doesn't work on all operating systems.
+            }
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             ipcProvider?.Dispose();

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -112,32 +112,6 @@ namespace osu.Framework.Platform
             return ipcProvider.SendMessageAsync(message);
         }
 
-        protected override void OnActivated()
-        {
-            setGamePriority(true);
-            base.OnActivated();
-        }
-
-        protected override void OnDeactivated()
-        {
-            setGamePriority(false);
-            base.OnDeactivated();
-        }
-
-        private void setGamePriority(bool active)
-        {
-            try
-            {
-                // We set process priority after the window becomes active, because for whatever reason windows will
-                // reset this when the window becomes active after being inactive when game mode is enabled.
-                Process.GetCurrentProcess().PriorityClass = active ? ProcessPriorityClass.High : ProcessPriorityClass.Normal;
-            }
-            catch
-            {
-                // This doesn't work on all operating systems.
-            }
-        }
-
         protected override void Dispose(bool isDisposing)
         {
             ipcProvider?.Dispose();

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -93,13 +94,29 @@ namespace osu.Framework.Platform.Windows
         protected override void OnActivated()
         {
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous | Execution.ExecutionState.SystemRequired | Execution.ExecutionState.DisplayRequired);
+            setGamePriority(true);
             base.OnActivated();
         }
 
         protected override void OnDeactivated()
         {
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous);
+            setGamePriority(false);
             base.OnDeactivated();
+        }
+
+        private void setGamePriority(bool active)
+        {
+            try
+            {
+                // We set process priority after the window becomes active, because for whatever reason windows will
+                // reset this when the window becomes active after being inactive when game mode is enabled.
+                Process.GetCurrentProcess().PriorityClass = active ? ProcessPriorityClass.High : ProcessPriorityClass.Normal;
+            }
+            catch
+            {
+                // This doesn't work on all operating systems.
+            }
         }
     }
 }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Platform.Windows
             }
             catch
             {
-                // This doesn't work on all operating systems.
+                // Failure to set priority is not critical.
             }
         }
     }


### PR DESCRIPTION
This is something we do on osu!stable and has large gains (for some users) on desktop systems, especially when shared with other heavy applications.

Tested on windows and macOS. Windows works as expected, macOS fails due to lack of permissions. Would appreciate linux testing.

If deemed more appropriate, can be moved to `WindowsGameHost`.