### PR TITLE
Reduce allocs when setting value on `BindableNumber` with precision

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableNumber.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableNumber.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkBindableNumber
+    {
+        private readonly BindableInt bindableNoPrecision = new BindableInt();
+        private readonly BindableInt bindableWithPrecision = new BindableInt { Precision = 5 };
+
+        [Benchmark]
+        public void SetValueNoPrecision()
+        {
+            for (int i = 0; i < 1000; i++)
+                bindableNoPrecision.Value = i;
+        }
+
+        [Benchmark]
+        public void SetValueWithPrecision()
+        {
+            for (int i = 0; i < 1000; i++)
+                bindableWithPrecision.Value = i;
+        }
+    }
+}

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -78,10 +78,34 @@ namespace osu.Framework.Bindables
                 double doubleValue = ClampValue(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
                 doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
 
-                base.Value = (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
+                base.Value = convertFromDouble(doubleValue);
             }
             else
                 base.Value = value;
+        }
+
+        private T convertFromDouble(double value)
+        {
+            if (typeof(T) == typeof(sbyte))
+                return (T)(object)Convert.ToSByte(value);
+            if (typeof(T) == typeof(byte))
+                return (T)(object)Convert.ToByte(value);
+            if (typeof(T) == typeof(short))
+                return (T)(object)Convert.ToInt16(value);
+            if (typeof(T) == typeof(ushort))
+                return (T)(object)Convert.ToUInt16(value);
+            if (typeof(T) == typeof(int))
+                return (T)(object)Convert.ToInt32(value);
+            if (typeof(T) == typeof(uint))
+                return (T)(object)Convert.ToUInt32(value);
+            if (typeof(T) == typeof(long))
+                return (T)(object)Convert.ToInt64(value);
+            if (typeof(T) == typeof(ulong))
+                return (T)(object)Convert.ToUInt64(value);
+            if (typeof(T) == typeof(float))
+                return (T)(object)Convert.ToSingle(value);
+
+            return (T)(object)value;
         }
 
         protected override T DefaultMinValue


### PR DESCRIPTION
BenchmarkDotNet isn't outputting a summary table, so I'll leave it up to @peppy to provide before/after tales. But the optimisation is pretty standard (see other cases of the same being done in this file).