### PR TITLE
Expose `RunTestsFromNUnit` as `public`

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneNestedGame.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneNestedGame.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Tests.Visual.Testing
             AddStep("mark host running", () => hostWasRunningAfterNestedExit = true);
         }
 
-        protected override void RunTestsFromNUnit()
+        public override void RunTestsFromNUnit()
         {
             base.RunTestsFromNUnit();
 

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -491,7 +491,7 @@ namespace osu.Framework.Testing
         }
 
         [TearDown]
-        protected virtual void RunTestsFromNUnit()
+        public virtual void RunTestsFromNUnit()
         {
             RunTearDownSteps();
 


### PR DESCRIPTION
This allows running tests from a headless/benchmark context much easier.

Used in https://github.com/ppy/osu/pull/26422