### PR TITLE
Change `ValueChangedEvent` to a `struct`

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -492,8 +492,8 @@ namespace osu.Framework.Tests.Bindables
 
             bindable2.BindTo(bindable1);
 
-            ValueChangedEvent<int> event1 = null;
-            ValueChangedEvent<int> event2 = null;
+            ValueChangedEvent<int> event1 = default;
+            ValueChangedEvent<int> event2 = default;
 
             bindable1.BindValueChanged(e => event1 = e);
             bindable2.BindValueChanged(e => event2 = e);

--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Audio
 
         private bool invalidationPending;
 
-        internal void InvalidateState(ValueChangedEvent<double>? valueChangedEvent = null)
+        internal void InvalidateState(ValueChangedEvent<double> valueChangedEvent = default)
         {
             if (CanPerformInline)
                 OnStateChanged();

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Bindables
             return null;
         }
 
-        private void recalculateAggregate(ValueChangedEvent<T> obj = null)
+        private void recalculateAggregate(ValueChangedEvent<T> obj = default)
         {
             T calculated = initialValue;
 

--- a/osu.Framework/Bindables/ValueChangedEvent.cs
+++ b/osu.Framework/Bindables/ValueChangedEvent.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Bindables
     /// An event fired when a value changes, providing the old and new value for reference.
     /// </summary>
     /// <typeparam name="T">The type of bindable.</typeparam>
-    public struct ValueChangedEvent<T>
+    public readonly struct ValueChangedEvent<T>
     {
         /// <summary>
         /// The old value.

--- a/osu.Framework/Bindables/ValueChangedEvent.cs
+++ b/osu.Framework/Bindables/ValueChangedEvent.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Bindables
     /// An event fired when a value changes, providing the old and new value for reference.
     /// </summary>
     /// <typeparam name="T">The type of bindable.</typeparam>
-    public class ValueChangedEvent<T>
+    public struct ValueChangedEvent<T>
     {
         /// <summary>
         /// The old value.


### PR DESCRIPTION
There's very little reason for this to be a class.

It is constructed by each bindable locally when it has listeners, and generally never modified or passed further. Changing to a struct reduces GC overhead.

(honestly we shouldn't be firing these enough for it to be an issue in the first place, but there's some egregious usage of bindables in the game which needs further consideration to fix, and this may alleviate things somewhat).

Not sure whether this needs profiling. A well structured benchmark may show lower GC counts, but allocations should not change.

osu!-side changes:

```diff
diff --git a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
index 2cd8e45d28..d9c7ee3ffd 100644
--- a/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Match/RoomSubScreen.cs
@@ -493,7 +493,7 @@ private void endHandlingTrack()
             cancelTrackLooping();
         }
 
-        private void applyLoopingToTrack(ValueChangedEvent<WorkingBeatmap> _ = null)
+        private void applyLoopingToTrack(ValueChangedEvent<WorkingBeatmap> _ = default)
         {
             if (!this.IsCurrentScreen())
                 return;
diff --git a/osu.Game/Screens/Select/SongSelect.cs b/osu.Game/Screens/Select/SongSelect.cs
index 2d5c44e5a5..6b229936d5 100644
--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -493,9 +493,9 @@ public void FinaliseSelection(BeatmapInfo? beatmapInfo = null, RulesetInfo? rule
 
         private ScheduledDelegate? selectionChangedDebounce;
 
-        private void updateCarouselSelection(ValueChangedEvent<WorkingBeatmap>? e = null)
+        private void updateCarouselSelection(ValueChangedEvent<WorkingBeatmap> e = default)
         {
-            var beatmap = e?.NewValue ?? Beatmap.Value;
+            var beatmap = e.NewValue ?? Beatmap.Value;
             if (beatmap is DummyWorkingBeatmap || !this.IsCurrentScreen()) return;
 
             Logger.Log($"Song select working beatmap updated to {beatmap}");

```