### PR TITLE
Remove alloc overhead for `NormalizedValue`

### DIFF
--- a/osu.Framework/Bindables/RangeConstrainedBindable.cs
+++ b/osu.Framework/Bindables/RangeConstrainedBindable.cs
@@ -74,6 +74,47 @@ namespace osu.Framework.Bindables
             setValue(defaultValue);
         }
 
+        public float NormalizedValue
+        {
+            get
+            {
+                float min = convertToSingle(MinValue);
+                float max = convertToSingle(MaxValue);
+
+                if (max - min == 0)
+                    return 1;
+
+                float val = convertToSingle(Value);
+                return (val - min) / (max - min);
+            }
+        }
+
+        private static float convertToSingle(T val)
+        {
+            if (typeof(T) == typeof(sbyte))
+                return Convert.ToSingle((sbyte)(object)val);
+            if (typeof(T) == typeof(byte))
+                return Convert.ToSingle((byte)(object)val);
+            if (typeof(T) == typeof(short))
+                return Convert.ToSingle((short)(object)val);
+            if (typeof(T) == typeof(ushort))
+                return Convert.ToSingle((ushort)(object)val);
+            if (typeof(T) == typeof(int))
+                return Convert.ToSingle((int)(object)val);
+            if (typeof(T) == typeof(uint))
+                return Convert.ToSingle((uint)(object)val);
+            if (typeof(T) == typeof(long))
+                return Convert.ToSingle((long)(object)val);
+            if (typeof(T) == typeof(ulong))
+                return Convert.ToSingle((ulong)(object)val);
+            if (typeof(T) == typeof(double))
+                return Convert.ToSingle((double)(object)val);
+            if (typeof(T) == typeof(float))
+                return (float)(object)val;
+
+            throw new InvalidOperationException();
+        }
+
         /// <summary>
         /// Sets the minimum value. This method does no equality comparisons.
         /// </summary>

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -91,14 +91,7 @@ namespace osu.Framework.Graphics.UserInterface
                                                         + $" and {nameof(BindableNumber<T>.MaxValue)} to produce a valid {nameof(NormalizedValue)}.");
                 }
 
-                float min = Convert.ToSingle(currentNumberInstantaneous.MinValue);
-                float max = Convert.ToSingle(currentNumberInstantaneous.MaxValue);
-
-                if (max - min == 0)
-                    return 1;
-
-                float val = Convert.ToSingle(currentNumberInstantaneous.Value);
-                return (val - min) / (max - min);
+                return currentNumberInstantaneous.NormalizedValue;
             }
         }
 


### PR DESCRIPTION
Was ~200KB/s during gameplay.

Not even going to provide a benchmark, should be obvious.