### PR TITLE
Avoid creating a new texture in `SmoothPath` if the existing one is already the correct size

### DIFF
--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -78,9 +78,16 @@ namespace osu.Framework.Graphics.Lines
                 raw[i, 0] = new Rgba32(colour.R, colour.G, colour.B, colour.A * Math.Min(progress / aa_portion, 1));
             }
 
-            var texture = new DisposableTexture(renderer.CreateTexture(textureWidth, 1, true));
-            texture.SetData(new TextureUpload(raw));
-            Texture = texture;
+            if (Texture?.Width == textureWidth)
+            {
+                Texture.SetData(new TextureUpload(raw));
+            }
+            else
+            {
+                var texture = new DisposableTexture(renderer.CreateTexture(textureWidth, 1, true));
+                texture.SetData(new TextureUpload(raw));
+                Texture = texture;
+            }
 
             if (customBackgroundColour == null)
                 base.BackgroundColour = ColourAt(0).Opacity(0);


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| ![2024-01-11 00 29 16@2x](https://github.com/ppy/osu-framework/assets/191335/39bf2567-0e07-4243-8326-6ac5633e182b) | ![2024-01-11 00 29 24@2x](https://github.com/ppy/osu-framework/assets/191335/3e1cde0e-dd4c-4073-9f2d-dc0169f9ecfa) |

Could go further and reuse the `Image` but it may cause the unsafe read to get half of the new and old pixels, so I didn't go down that path.