### PR TITLE
Reduce input processing overheads in `PassThroughInputManager`

### DIFF
--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -95,7 +95,8 @@ namespace osu.Framework.Input
             switch (e)
             {
                 case MouseMoveEvent mouseMove:
-                    new MousePositionAbsoluteInput { Position = mouseMove.ScreenSpaceMousePosition }.Apply(CurrentState, this);
+                    if (mouseMove.ScreenSpaceMousePosition != CurrentState.Mouse.Position)
+                        new MousePositionAbsoluteInput { Position = mouseMove.ScreenSpaceMousePosition }.Apply(CurrentState, this);
                     break;
 
                 case MouseDownEvent mouseDown:

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -172,9 +172,6 @@ namespace osu.Framework.Input
         /// <param name="state">The state to synchronise current with. If this is null, it is regarded as an empty state.</param>
         protected virtual void SyncInputState(InputState state)
         {
-            // TODO: THIS IS ALL VERY HEAVY ALLOCATION AND NEEDS TO BE REMOVED.
-            // Using this class outside of a testing situation is not recommended...
-
             // invariant: if mouse button is currently pressed, then it has been pressed in parent (but not the converse)
             // therefore, mouse up events are always synced from parent
             // mouse down events are not synced to prevent false clicks

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -182,8 +182,10 @@ namespace osu.Framework.Input
             new KeyboardKeyInput(state?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
 
             var touchStateDifference = (state?.Touch ?? new TouchState()).EnumerateDifference(CurrentState.Touch);
-            new TouchInput(touchStateDifference.deactivated, false).Apply(CurrentState, this);
-            new TouchInput(touchStateDifference.activated, true).Apply(CurrentState, this);
+            if (touchStateDifference.deactivated.Length > 0)
+                new TouchInput(touchStateDifference.deactivated, false).Apply(CurrentState, this);
+            if (touchStateDifference.activated.Length > 0)
+                new TouchInput(touchStateDifference.activated, true).Apply(CurrentState, this);
 
             new JoystickButtonInput(state?.Joystick?.Buttons ?? new ButtonStates<JoystickButton>(), CurrentState.Joystick.Buttons).Apply(CurrentState, this);
             new JoystickAxisInput(state?.Joystick?.GetAxes() ?? Array.Empty<JoystickAxis>()).Apply(CurrentState, this);

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;
+using JoystickState = osu.Framework.Input.States.JoystickState;
 
 namespace osu.Framework.Input
 {
@@ -176,24 +177,56 @@ namespace osu.Framework.Input
             // invariant: if mouse button is currently pressed, then it has been pressed in parent (but not the converse)
             // therefore, mouse up events are always synced from parent
             // mouse down events are not synced to prevent false clicks
-            var mouseButtonDifference = (state?.Mouse?.Buttons ?? new ButtonStates<MouseButton>()).EnumerateDifference(CurrentState.Mouse.Buttons);
-            new MouseButtonInput(mouseButtonDifference.Released.Select(button => new ButtonInputEntry<MouseButton>(button, false))).Apply(CurrentState, this);
+            var mouseDiff = (state?.Mouse?.Buttons ?? new ButtonStates<MouseButton>()).EnumerateDifference(CurrentState.Mouse.Buttons);
+            if (mouseDiff.Released.Length > 0)
+                new MouseButtonInput(mouseDiff.Released.Select(button => new ButtonInputEntry<MouseButton>(button, false))).Apply(CurrentState, this);
 
-            new KeyboardKeyInput(state?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
+            var keyDiff = (state?.Keyboard.Keys ?? new ButtonStates<Key>()).EnumerateDifference(CurrentState.Keyboard.Keys);
+            foreach (var key in keyDiff.Released)
+                new KeyboardKeyInput(key, false).Apply(CurrentState, this);
+            foreach (var key in keyDiff.Pressed)
+                new KeyboardKeyInput(key, true).Apply(CurrentState, this);
 
-            var touchStateDifference = (state?.Touch ?? new TouchState()).EnumerateDifference(CurrentState.Touch);
-            if (touchStateDifference.deactivated.Length > 0)
-                new TouchInput(touchStateDifference.deactivated, false).Apply(CurrentState, this);
-            if (touchStateDifference.activated.Length > 0)
-                new TouchInput(touchStateDifference.activated, true).Apply(CurrentState, this);
+            var touchDiff = (state?.Touch ?? new TouchState()).EnumerateDifference(CurrentState.Touch);
+            if (touchDiff.deactivated.Length > 0)
+                new TouchInput(touchDiff.deactivated, false).Apply(CurrentState, this);
+            if (touchDiff.activated.Length > 0)
+                new TouchInput(touchDiff.activated, true).Apply(CurrentState, this);
 
-            new JoystickButtonInput(state?.Joystick?.Buttons ?? new ButtonStates<JoystickButton>(), CurrentState.Joystick.Buttons).Apply(CurrentState, this);
-            new JoystickAxisInput(state?.Joystick?.GetAxes() ?? Array.Empty<JoystickAxis>()).Apply(CurrentState, this);
+            var joyButtonDiff = (state?.Joystick?.Buttons ?? new ButtonStates<JoystickButton>()).EnumerateDifference(CurrentState.Joystick.Buttons);
+            foreach (var button in joyButtonDiff.Released)
+                new JoystickButtonInput(button, false).Apply(CurrentState, this);
+            foreach (var button in joyButtonDiff.Pressed)
+                new JoystickButtonInput(button, true).Apply(CurrentState, this);
 
-            new MidiKeyInput(state?.Midi ?? new MidiState(), CurrentState.Midi).Apply(CurrentState, this);
+            // Basically only perform the full state diff if we have found that any axis changed.
+            // This avoids unnecessary alloc overhead.
+            for (int i = 0; i < JoystickState.MAX_AXES; i++)
+            {
+                if (state?.Joystick?.AxesValues[i] != CurrentState.Joystick.AxesValues[i])
+                {
+                    new JoystickAxisInput(state?.Joystick?.GetAxes() ?? Array.Empty<JoystickAxis>()).Apply(CurrentState, this);
+                    break;
+                }
+            }
 
-            new TabletPenButtonInput(state?.Tablet.PenButtons ?? new ButtonStates<TabletPenButton>(), CurrentState.Tablet.PenButtons).Apply(CurrentState, this);
-            new TabletAuxiliaryButtonInput(state?.Tablet.AuxiliaryButtons ?? new ButtonStates<TabletAuxiliaryButton>(), CurrentState.Tablet.AuxiliaryButtons).Apply(CurrentState, this);
+            var midiDiff = (state?.Midi?.Keys ?? new ButtonStates<MidiKey>()).EnumerateDifference(CurrentState.Midi.Keys);
+            foreach (var key in midiDiff.Released)
+                new MidiKeyInput(key, CurrentState.Midi.Velocities[key], false).Apply(CurrentState, this);
+            foreach (var key in midiDiff.Pressed)
+                new MidiKeyInput(key, state!.Midi!.Velocities[key], true).Apply(CurrentState, this);
+
+            var tabletPenDiff = (state?.Tablet?.PenButtons ?? new ButtonStates<TabletPenButton>()).EnumerateDifference(CurrentState.Tablet.PenButtons);
+            foreach (var button in tabletPenDiff.Released)
+                new TabletPenButtonInput(button, false).Apply(CurrentState, this);
+            foreach (var button in tabletPenDiff.Pressed)
+                new TabletPenButtonInput(button, true).Apply(CurrentState, this);
+
+            var tabletAuxiliaryDiff = (state?.Tablet?.AuxiliaryButtons ?? new ButtonStates<TabletAuxiliaryButton>()).EnumerateDifference(CurrentState.Tablet.AuxiliaryButtons);
+            foreach (var button in tabletAuxiliaryDiff.Released)
+                new TabletAuxiliaryButtonInput(button, false).Apply(CurrentState, this);
+            foreach (var button in tabletAuxiliaryDiff.Pressed)
+                new TabletAuxiliaryButtonInput(button, true).Apply(CurrentState, this);
         }
     }
 }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -210,9 +210,9 @@ namespace osu.Framework.Input
 
             var midiDiff = (state?.Midi?.Keys ?? new ButtonStates<MidiKey>()).EnumerateDifference(CurrentState.Midi.Keys);
             foreach (var key in midiDiff.Released)
-                new MidiKeyInput(key, state?.Midi?.Velocities[key] ?? 0, false).Apply(CurrentState, this);
+                new MidiKeyInput(key, state?.Midi?.Velocities.GetValueOrDefault(key) ?? 0, false).Apply(CurrentState, this);
             foreach (var key in midiDiff.Pressed)
-                new MidiKeyInput(key, state?.Midi?.Velocities[key] ?? 0, true).Apply(CurrentState, this);
+                new MidiKeyInput(key, state?.Midi?.Velocities.GetValueOrDefault(key) ?? 0, true).Apply(CurrentState, this);
 
             var tabletPenDiff = (state?.Tablet?.PenButtons ?? new ButtonStates<TabletPenButton>()).EnumerateDifference(CurrentState.Tablet.PenButtons);
             foreach (var button in tabletPenDiff.Released)

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -210,9 +210,9 @@ namespace osu.Framework.Input
 
             var midiDiff = (state?.Midi?.Keys ?? new ButtonStates<MidiKey>()).EnumerateDifference(CurrentState.Midi.Keys);
             foreach (var key in midiDiff.Released)
-                new MidiKeyInput(key, CurrentState.Midi.Velocities[key], false).Apply(CurrentState, this);
+                new MidiKeyInput(key, state?.Midi?.Velocities[key] ?? 0, false).Apply(CurrentState, this);
             foreach (var key in midiDiff.Pressed)
-                new MidiKeyInput(key, state!.Midi!.Velocities[key], true).Apply(CurrentState, this);
+                new MidiKeyInput(key, state?.Midi?.Velocities[key] ?? 0, true).Apply(CurrentState, this);
 
             var tabletPenDiff = (state?.Tablet?.PenButtons ?? new ButtonStates<TabletPenButton>()).EnumerateDifference(CurrentState.Tablet.PenButtons);
             foreach (var button in tabletPenDiff.Released)

--- a/osu.Framework/Input/States/TouchState.cs
+++ b/osu.Framework/Input/States/TouchState.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using osuTK;
 
 namespace osu.Framework.Input.States
@@ -46,15 +44,33 @@ namespace osu.Framework.Input.States
         /// Enumerates the difference between this state and a <param ref="previous"/> state.
         /// </summary>
         /// <param name="previous">The previous state.</param>
-        public (IEnumerable<Touch> deactivated, IEnumerable<Touch> activated) EnumerateDifference(TouchState previous)
+        public (Touch[] deactivated, Touch[] activated) EnumerateDifference(TouchState previous)
         {
-            var activityDifference = ActiveSources.EnumerateDifference(previous.ActiveSources);
+            var diff = ActiveSources.EnumerateDifference(previous.ActiveSources);
 
-            return
-            (
-                activityDifference.Released.Select(s => new Touch(s, previous.TouchPositions[(int)s])),
-                activityDifference.Pressed.Select(s => new Touch(s, TouchPositions[(int)s]))
-            );
+            int pressedCount = diff.Pressed.Length;
+            int releasedCount = diff.Released.Length;
+
+            if (pressedCount == 0 && releasedCount == 0)
+                return (Array.Empty<Touch>(), Array.Empty<Touch>());
+
+            Touch[] pressedTouches = new Touch[pressedCount];
+
+            for (int i = 0; i < pressedCount; i++)
+            {
+                var s = diff.Pressed[i];
+                pressedTouches[i] = new Touch(s, TouchPositions[(int)s]);
+            }
+
+            Touch[] releasedTouches = new Touch[releasedCount];
+
+            for (int i = 0; i < releasedCount; i++)
+            {
+                var s = diff.Released[i];
+                releasedTouches[i] = new Touch(s, previous.TouchPositions[(int)s]);
+            }
+
+            return (releasedTouches, pressedTouches);
         }
     }
 }


### PR DESCRIPTION
This one's a bit fiddly, but mostly copying existing examples.

41b7c32cc01fa3a3831e1333cbde3a313f9104c7

| Before | After |
| :---: | :---: |
| ![2024-01-11 01 08 58@2x](https://github.com/ppy/osu-framework/assets/191335/c6972d7c-c240-48bc-b35b-81d5450b3df3) | ![2024-01-11 01 09 12@2x](https://github.com/ppy/osu-framework/assets/191335/6f25eea7-9b59-402c-94d5-5b547d6ab71d) |

de5ad34538620a8f1b671251295d6c192182ea0c

| Before | After |
| :---: | :---: |
| ![2024-01-11 02 11 24@2x](https://github.com/ppy/osu-framework/assets/191335/afd87dc0-d7f9-4996-a867-7ceae6418d14) | ![2024-01-11 02 11 35@2x](https://github.com/ppy/osu-framework/assets/191335/2d98f13d-da7c-4eb4-a320-2b8da3b3050b) |

91185b1a504d8a93a5a7c1081e6ffb88deda3f4b

| Before | After |
| :---: | :---: |
| ![2024-01-11 02 14 21@2x](https://github.com/ppy/osu-framework/assets/191335/029358a4-d004-4046-8e47-3156dab20122) | ![2024-01-11 02 16 50@2x](https://github.com/ppy/osu-framework/assets/191335/d011c2ee-ec85-48a5-9ffc-8761faa6b7fb) |

