### PR TITLE
Remove delegate allocation in jitter calculation in `FramedClock`

### DIFF
--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Extensions.TypeExtensions;
 using System;
 using System.Diagnostics;
-using System.Linq;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Timing
 {
@@ -85,12 +84,18 @@ namespace osu.Framework.Timing
                     FramesPerSecond = (int)Math.Ceiling(framesSinceLastCalculation * 1000f / timeSinceLastCalculation);
 
                     // simple stddev
-                    double avg = betweenFrameTimes.Average();
-                    double sumVariance = 0;
+                    double sum = 0;
+                    double sumOfSquares = 0;
+
                     foreach (double v in betweenFrameTimes)
-                        sumVariance += Math.Pow(v - avg, 2);
-                    double stddev = Math.Sqrt(sumVariance / betweenFrameTimes.Length);
-                    Jitter = stddev;
+                    {
+                        sum += v;
+                        sumOfSquares += v * v;
+                    }
+
+                    double avg = sum / betweenFrameTimes.Length;
+                    double variance = (sumOfSquares / betweenFrameTimes.Length) - (avg * avg);
+                    Jitter = Math.Sqrt(variance);
                 }
 
                 timeSinceLastCalculation = framesSinceLastCalculation = 0;

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -86,7 +86,10 @@ namespace osu.Framework.Timing
 
                     // simple stddev
                     double avg = betweenFrameTimes.Average();
-                    double stddev = Math.Sqrt(betweenFrameTimes.Average(v => Math.Pow(v - avg, 2)));
+                    double sumVariance = 0;
+                    foreach (double v in betweenFrameTimes)
+                        sumVariance += Math.Pow(v - avg, 2);
+                    double stddev = Math.Sqrt(sumVariance / betweenFrameTimes.Length);
                     Jitter = stddev;
                 }
 


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| ![2024-01-11 05 33 07@2x](https://github.com/ppy/osu-framework/assets/191335/2397e34a-0222-459d-84a0-de4fa148f87b) | ![2024-01-11 05 40 58@2x](https://github.com/ppy/osu-framework/assets/191335/de51549d-f9ac-4537-848f-a14a41d68226) |