### PR TITLE
Remove allocations during bass device sync polling operation

### DIFF
--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using ManagedBass;
 using osu.Framework.Audio;
@@ -40,12 +40,20 @@ namespace osu.Framework.Tests.Audio
             }
         }
 
-        protected override IEnumerable<DeviceInfo> EnumerateAllDevices()
+        protected override bool CheckForDeviceChanges(ImmutableArray<DeviceInfo> previousDevices)
         {
-            var devices = base.EnumerateAllDevices();
+            if (simulateLoss)
+                return true;
+
+            return base.CheckForDeviceChanges(previousDevices);
+        }
+
+        protected override ImmutableArray<DeviceInfo> GetAllDevices()
+        {
+            var devices = base.GetAllDevices();
 
             if (simulateLoss)
-                devices = devices.Take(BASS_INTERNAL_DEVICE_COUNT);
+                devices = devices.Take(BASS_INTERNAL_DEVICE_COUNT).ToImmutableArray();
 
             return devices;
         }

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -644,7 +644,9 @@ namespace osu.Framework.Input.Bindings
 
             Debug.Assert(!keys.Contains(InputKey.None)); // Having None in pressed keys will break IsPressed
             keys.Sort();
-            return new KeyCombination(keys.ToImmutable());
+
+            // Can't use `MoveToImmutable` here as we don't provide accurate capacity.
+            return new KeyCombination(keys.ToImmutableList());
         }
     }
 

--- a/osu.Framework/Platform/SDL2Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL2Window_Windowing.cs
@@ -341,7 +341,7 @@ namespace osu.Framework.Platform
                     Logger.Log($"Failed to retrieve SDL display at index ({i})", level: LogLevel.Error);
             }
 
-            return builder.ToImmutable();
+            return builder.MoveToImmutable();
         }
 
         private static bool tryGetDisplayFromSDL(int displayIndex, [NotNullWhen(true)] out Display? display)


### PR DESCRIPTION
Minor gains because this is just a one second poll, but is what it is.

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-11 at 05 48 29](https://github.com/ppy/osu-framework/assets/191335/33cf934d-61b4-4e0d-9593-7a7788b575a3) | ![CleanShot 2024-01-11 at 05 47 48](https://github.com/ppy/osu-framework/assets/191335/72674e5d-f2c5-488d-ac02-29f52c5229f4) |

Also fixed a couple of incorrect calls on array building. Check underlying implementation for reasoning (one allocates, other doesn't).