### PR TITLE
Reduce allocation overhead for keyboard / binding / button handling

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -202,6 +202,8 @@ namespace osu.Framework.Input.Bindings
             return drawables.FirstOrDefault(d => triggerKeyBindingEvent(d, pressEvent)) != null;
         }
 
+        private readonly List<IKeyBinding> newlyPressed = new List<IKeyBinding>();
+
         private bool handleNewPressed(InputState state, InputKey newKey, Vector2? scrollDelta = null, bool isPrecise = false)
         {
             pressedInputKeys.Add(newKey);
@@ -210,10 +212,20 @@ namespace osu.Framework.Input.Bindings
             var pressedCombination = new KeyCombination(pressedInputKeys);
 
             bool handled = false;
-            var bindings = KeyBindings?.Except(pressedBindings) ?? Enumerable.Empty<IKeyBinding>();
 
-            var newlyPressed = bindings.Where(m =>
-                m.KeyCombination.IsPressed(pressedCombination, matchingMode));
+            newlyPressed.Clear();
+
+            if (KeyBindings != null)
+            {
+                foreach (IKeyBinding binding in KeyBindings)
+                {
+                    if (pressedBindings.Contains(binding))
+                        continue;
+
+                    if (binding.KeyCombination.IsPressed(pressedCombination, matchingMode))
+                        newlyPressed.Add(binding);
+                }
+            }
 
             if (KeyCombination.IsModifierKey(newKey))
             {
@@ -221,11 +233,15 @@ namespace osu.Framework.Input.Bindings
                 // lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
                 // TODO: remove when we switch to .NET 7.
                 // ReSharper disable once ConvertClosureToMethodGroup
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
+                for (int i = 0; i < newlyPressed.Count; i++)
+                {
+                    if (!newlyPressed[i].KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)))
+                        newlyPressed.RemoveAt(i--);
+                }
             }
 
             // we want to always handle bindings with more keys before bindings with less.
-            newlyPressed = newlyPressed.OrderByDescending(b => b.KeyCombination.Keys.Length).ToList();
+            newlyPressed.Sort(static (a, b) => b.KeyCombination.Keys.Length.CompareTo(a.KeyCombination.Keys.Length));
 
             pressedBindings.AddRange(newlyPressed);
 
@@ -343,14 +359,13 @@ namespace osu.Framework.Input.Bindings
             // we don't want to consider exact matching here as we are dealing with bindings, not actions.
             var pressedCombination = new KeyCombination(pressedInputKeys);
 
-            var newlyReleased = pressedInputKeys.Count == 0
-                ? pressedBindings.ToList()
-                : pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
-
-            foreach (var binding in newlyReleased)
+            for (int i = 0; i < pressedBindings.Count; i++)
             {
-                pressedBindings.Remove(binding);
+                var binding = pressedBindings[i];
 
+                if (binding.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)) continue;
+
+                pressedBindings.RemoveAt(i--);
                 PropagateReleased(getInputQueue(binding).Where(d => d.IsRootedAt(this)), state, binding.GetAction<T>());
                 keyBindingQueues[binding].Clear();
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -211,6 +211,7 @@ namespace osu.Framework.Input.Bindings
 
             bool handled = false;
             var bindings = KeyBindings?.Except(pressedBindings) ?? Enumerable.Empty<IKeyBinding>();
+
             var newlyPressed = bindings.Where(m =>
                 m.KeyCombination.IsPressed(pressedCombination, matchingMode));
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -363,11 +363,12 @@ namespace osu.Framework.Input.Bindings
             {
                 var binding = pressedBindings[i];
 
-                if (binding.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)) continue;
-
-                pressedBindings.RemoveAt(i--);
-                PropagateReleased(getInputQueue(binding).Where(d => d.IsRootedAt(this)), state, binding.GetAction<T>());
-                keyBindingQueues[binding].Clear();
+                if (pressedInputKeys.Count == 0 || !binding.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any))
+                {
+                    pressedBindings.RemoveAt(i--);
+                    PropagateReleased(getInputQueue(binding).Where(d => d.IsRootedAt(this)), state, binding.GetAction<T>());
+                    keyBindingQueues[binding].Clear();
+                }
             }
         }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -39,7 +39,12 @@ namespace osu.Framework.Input.Bindings
 
             var keyBuilder = ImmutableArray.CreateBuilder<InputKey>(keys.Count);
 
-            keyBuilder.AddRange(keys);
+            foreach (var key in keys)
+            {
+                if (!keyBuilder.Contains(key))
+                    keyBuilder.Add(key);
+            }
+
             keyBuilder.Sort();
 
             Keys = keyBuilder.MoveToImmutable();

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -29,10 +29,20 @@ namespace osu.Framework.Input.Bindings
         /// Construct a new instance.
         /// </summary>
         /// <param name="keys">The keys.</param>
-        /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(IEnumerable<InputKey>? keys)
         {
-            Keys = keys?.Any() == true ? keys.Distinct().OrderBy(k => (int)k).ToImmutableArray() : none;
+            if (keys == null || !keys.Any())
+            {
+                Keys = ImmutableArray<InputKey>.Empty;
+                return;
+            }
+
+            var keyBuilder = ImmutableArray.CreateBuilder<InputKey>(keys.Count());
+
+            keyBuilder.AddRange(keys);
+            keyBuilder.Sort();
+
+            Keys = keyBuilder.MoveToImmutable();
         }
 
         /// <summary>
@@ -643,8 +653,7 @@ namespace osu.Framework.Input.Bindings
             }
 
             Debug.Assert(!keys.Contains(InputKey.None)); // Having None in pressed keys will break IsPressed
-            keys.Sort();
-            return new KeyCombination(keys.ToImmutable());
+            return new KeyCombination(keys);
         }
     }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -33,11 +33,11 @@ namespace osu.Framework.Input.Bindings
         {
             if (keys == null || !keys.Any())
             {
-                Keys = ImmutableArray<InputKey>.Empty;
+                Keys = none;
                 return;
             }
 
-            var keyBuilder = ImmutableArray.CreateBuilder<InputKey>(keys.Count());
+            var keyBuilder = ImmutableArray.CreateBuilder<InputKey>(keys.Count);
 
             keyBuilder.AddRange(keys);
             keyBuilder.Sort();

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Input.Bindings
         /// Construct a new instance.
         /// </summary>
         /// <param name="keys">The keys.</param>
-        public KeyCombination(IEnumerable<InputKey>? keys)
+        public KeyCombination(ICollection<InputKey>? keys)
         {
             if (keys == null || !keys.Any())
             {
@@ -51,7 +51,7 @@ namespace osu.Framework.Input.Bindings
         /// <param name="keys">The keys.</param>
         /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(params InputKey[] keys)
-            : this(keys.AsEnumerable())
+            : this((ICollection<InputKey>)keys)
         {
         }
 
@@ -61,7 +61,7 @@ namespace osu.Framework.Input.Bindings
         /// <param name="keys">A comma-separated (KeyCode in integer) string representation of the keys.</param>
         /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(string keys)
-            : this(keys.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => (InputKey)int.Parse(s)))
+            : this(keys.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => (InputKey)int.Parse(s)).ToArray())
         {
         }
 

--- a/osu.Framework/Input/ButtonEventManager.cs
+++ b/osu.Framework/Input/ButtonEventManager.cs
@@ -121,7 +121,16 @@ namespace osu.Framework.Input
         /// <returns>The drawable which handled the event or null if none.</returns>
         protected Drawable? PropagateButtonEvent(IEnumerable<Drawable> drawables, UIEvent e)
         {
-            var handledBy = drawables.FirstOrDefault(target => target.TriggerEvent(e));
+            Drawable? handledBy = null;
+
+            foreach (Drawable target in drawables)
+            {
+                if (target.TriggerEvent(e))
+                {
+                    handledBy = target;
+                    break;
+                }
+            }
 
             if (handledBy != null)
                 Logger.Log($"{e} handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);


### PR DESCRIPTION
Overall gains are pretty substantial. All testing done with 13 keystrokes. Ignore overall allocations as the runtime of tests was significantly different.

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-11 at 07 44 09](https://github.com/ppy/osu-framework/assets/191335/4862e994-fb54-44a1-91d6-5265bb541897) | ![CleanShot 2024-01-11 at 07 44 17](https://github.com/ppy/osu-framework/assets/191335/1574e0e3-1c05-490e-b167-db842dca03ed) |

---

94b4b2435aa692d79274fae680b31ceb1dfc8ecb Remove allocation overhead in button propagation flow

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-11 at 07 40 36](https://github.com/ppy/osu-framework/assets/191335/3d99afd4-a2aa-408e-87b7-c552205b4cdf) | ![CleanShot 2024-01-11 at 07 41 14](https://github.com/ppy/osu-framework/assets/191335/0fb117e5-cd0c-4563-b654-676c4b721749) |

d16d899a67415dff193f5eb11a272cd99265916a Remove allocation overhead from `KeyBindingContainer` key handling

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-11 at 07 35 00](https://github.com/ppy/osu-framework/assets/191335/be3dea65-6a97-4e09-9aac-4d1437662dbc) | ![CleanShot 2024-01-11 at 07 35 54](https://github.com/ppy/osu-framework/assets/191335/fd8bcc18-b608-45fd-83d0-9392bf3eecc9) |

7641f7021ef606f0e68ac28f5078b869648f8edd Reduce allocation overhead of `KeyCombination` constructor

| Before | After |
| :---: | :---: |
| ![CleanShot 2024-01-11 at 07 30 23](https://github.com/ppy/osu-framework/assets/191335/85afc530-0369-42e1-ac2a-8c1b272f7598) | ![CleanShot 2024-01-11 at 07 30 28](https://github.com/ppy/osu-framework/assets/191335/fbc6ad66-5cd5-4015-84d1-bcfc746b0188) |