### PR TITLE
Make IPC port configurable via `HostOptions`

### DIFF
--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -89,8 +89,8 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void TestIpc()
         {
-            using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { BindIPC = true }))
-            using (var client = new HeadlessGameHost(@"client", new HostOptions { BindIPC = true }))
+            using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPort = 45356 }))
+            using (var client = new HeadlessGameHost(@"client", new HostOptions { IPCPort = 45356 }))
             {
                 Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
                 Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void IsAliveTest()
         {
-            using (var client = new TestHeadlessGameHost(@"client", true))
+            using (var client = new TestHeadlessGameHost(@"client", 45356))
             {
                 var testGame = new TestTestGame();
                 client.Run(testGame);
@@ -25,8 +25,8 @@ namespace osu.Framework.Tests.Platform
         {
             public Drawable CurrentRoot => Root;
 
-            public TestHeadlessGameHost(string gameName, bool bindIPC)
-                : base(gameName, new HostOptions { BindIPC = bindIPC })
+            public TestHeadlessGameHost(string gameName, int? ipcPort)
+                : base(gameName, new HostOptions { IPCPort = ipcPort })
             {
             }
         }

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -11,7 +11,9 @@ namespace osu.Framework
     public class HostOptions
     {
         /// <summary>
-        /// The IPC port to bind. See <see cref="IIpcHost"/> for more details on usage.
+        /// The IPC port to bind. This port should be between 1024 and 49151,
+        /// and should be unique to avoid conflicts with other osu!framework apps.
+        /// See <see cref="IIpcHost"/> for more details on usage.
         /// </summary>
         public int? IPCPort { get; set; }
 

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -12,7 +12,8 @@ namespace osu.Framework
     {
         /// <summary>
         /// The IPC port to bind. This port should be between 1024 and 49151,
-        /// and should be unique to avoid conflicts with other osu!framework apps.
+        /// should be shared by all instances of a given osu!framework app,
+        /// but be distinct from IPC ports specified by other osu!framework apps.
         /// See <see cref="IIpcHost"/> for more details on usage.
         /// </summary>
         public int? IPCPort { get; set; }

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -11,14 +11,9 @@ namespace osu.Framework
     public class HostOptions
     {
         /// <summary>
-        /// Whether to bind the IPC port. See <see cref="IIpcHost"/> for more details on usage.
-        /// </summary>
-        public bool BindIPC { get; set; }
-
-        /// <summary>
         /// The IPC port to bind. See <see cref="IIpcHost"/> for more details on usage.
         /// </summary>
-        public int IPCPort { get; set; } = 45356;
+        public int? IPCPort { get; set; }
 
         /// <summary>
         /// Whether this is a portable installation. Will cause all game files to be placed alongside the executable, rather than in the standard data directory.

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -16,6 +16,11 @@ namespace osu.Framework
         public bool BindIPC { get; set; }
 
         /// <summary>
+        /// The IPC port to bind. See <see cref="IIpcHost"/> for more details on usage.
+        /// </summary>
+        public int IPCPort { get; set; } = 45356;
+
+        /// <summary>
         /// Whether this is a portable installation. Will cause all game files to be placed alongside the executable, rather than in the standard data directory.
         /// </summary>
         public bool PortableInstallation { get; set; }

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -15,15 +15,15 @@ namespace osu.Framework.Platform
 {
     public abstract class DesktopGameHost : SDL2GameHost
     {
-        public const int IPC_PORT = 45356;
-
         private TcpIpcProvider ipcProvider;
         private readonly bool bindIPCPort;
+        private readonly int ipcPort;
 
         protected DesktopGameHost(string gameName, HostOptions options = null)
             : base(gameName, options)
         {
             bindIPCPort = Options.BindIPC;
+            ipcPort = Options.IPCPort;
             IsPortableInstallation = Options.PortableInstallation;
         }
 
@@ -63,7 +63,7 @@ namespace osu.Framework.Platform
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new TcpIpcProvider(IPC_PORT);
+            ipcProvider = new TcpIpcProvider(ipcPort);
             ipcProvider.MessageReceived += OnMessageReceived;
 
             IsPrimaryInstance = ipcProvider.Bind();

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -16,13 +16,11 @@ namespace osu.Framework.Platform
     public abstract class DesktopGameHost : SDL2GameHost
     {
         private TcpIpcProvider ipcProvider;
-        private readonly bool bindIPCPort;
-        private readonly int ipcPort;
+        private readonly int? ipcPort;
 
         protected DesktopGameHost(string gameName, HostOptions options = null)
             : base(gameName, options)
         {
-            bindIPCPort = Options.BindIPC;
             ipcPort = Options.IPCPort;
             IsPortableInstallation = Options.PortableInstallation;
         }
@@ -57,13 +55,13 @@ namespace osu.Framework.Platform
 
         private void ensureIPCReady()
         {
-            if (!bindIPCPort)
+            if (ipcPort == null)
                 return;
 
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new TcpIpcProvider(ipcPort);
+            ipcProvider = new TcpIpcProvider(ipcPort.Value);
             ipcProvider.MessageReceived += OnMessageReceived;
 
             IsPrimaryInstance = ipcProvider.Bind();


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/6127

# Breaking changes

## `HostOptions.BindIPC` has been superseded by `HostOptions.IPCPort`

Previously, the IPC port used for multiple instances of a single osu!framework app was hardcoded in the IPC host itself, effectively making it so that _all osu!framework apps_ would share the same IPC port, which obviously cannot work.

To allow multiple osu!framework apps to utilise IPC concurrently, `BindIPC` has thus been replaced by `IPCPort`.

- Setting `IPCPort = null` is equivalent to `BindIPC = false`.
- Setting `IPCPort` to a non-null value is equivalent to `BindIPC = true` *and* will force the use the specific port provided.

Note that it is advised to use a "user port" (in the range of 1024-49151) as per RFC 6335.