### PR TITLE
Fix `KeyCombination` throwing when duplicates are fed in

### DIFF
--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -7,7 +7,7 @@ using osu.Framework.Input.Bindings;
 namespace osu.Framework.Tests.Input
 {
     [TestFixture]
-    public class KeyCombinationModifierTest
+    public class KeyCombinationTest
     {
         private static readonly object[][] key_combination_display_test_cases =
         {
@@ -50,5 +50,23 @@ namespace osu.Framework.Tests.Input
         [TestCaseSource(nameof(key_combination_display_test_cases))]
         public void TestLeftRightModifierHandling(KeyCombination candidate, KeyCombination pressed, KeyCombinationMatchingMode matchingMode, bool shouldContain)
             => Assert.AreEqual(shouldContain, KeyCombination.ContainsAll(candidate.Keys, pressed.Keys, matchingMode));
+
+        [Test]
+        public void TestCreationNoDuplicates()
+        {
+            var keyCombination = new KeyCombination(InputKey.A, InputKey.Control);
+
+            Assert.That(keyCombination.Keys[0], Is.EqualTo(InputKey.Control));
+            Assert.That(keyCombination.Keys[1], Is.EqualTo(InputKey.A));
+        }
+
+        [Test]
+        public void TestCreationWithDuplicates()
+        {
+            var keyCombination = new KeyCombination(InputKey.A, InputKey.Control, InputKey.A);
+
+            Assert.That(keyCombination.Keys[0], Is.EqualTo(InputKey.Control));
+            Assert.That(keyCombination.Keys[1], Is.EqualTo(InputKey.A));
+        }
     }
 }

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Input.Bindings
 
             keyBuilder.Sort();
 
-            Keys = hadDuplicates ? keys.ToImmutableArray() : keyBuilder.MoveToImmutable();
+            Keys = hadDuplicates ? keyBuilder.ToImmutableArray() : keyBuilder.MoveToImmutable();
         }
 
         /// <summary>

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -39,15 +39,23 @@ namespace osu.Framework.Input.Bindings
 
             var keyBuilder = ImmutableArray.CreateBuilder<InputKey>(keys.Count);
 
+            bool hadDuplicates = false;
+
             foreach (var key in keys)
             {
-                if (!keyBuilder.Contains(key))
-                    keyBuilder.Add(key);
+                if (keyBuilder.Contains(key))
+                {
+                    // This changes the expected count meaning we can't use the optimised MoveToImmutable() method.
+                    hadDuplicates = true;
+                    continue;
+                }
+
+                keyBuilder.Add(key);
             }
 
             keyBuilder.Sort();
 
-            Keys = keyBuilder.MoveToImmutable();
+            Keys = hadDuplicates ? keys.ToImmutableArray() : keyBuilder.MoveToImmutable();
         }
 
         /// <summary>


### PR DESCRIPTION
This class may require some test coverage. Just pushing out for immediate visibility.