### PR TITLE
Fix incorrect implementation of `OsuTKWindow.Displays`

### DIFF
--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.Platform
 
         public abstract IBindable<bool> IsActive { get; }
 
-        public virtual ImmutableArray<Display> Displays => new ImmutableArray<Display> { DisplayDevice.GetDisplay(DisplayIndex.Primary).ToDisplay() };
+        public virtual ImmutableArray<Display> Displays => ImmutableArray.Create(DisplayDevice.GetDisplay(DisplayIndex.Primary).ToDisplay());
 
 #pragma warning disable CS0067
         public event Action<IEnumerable<Display>> DisplaysChanged;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26506.

See https://github.com/dotnet/runtime/issues/26880 for description of why the previous reasonable-looking code was in fact a footgun.