### PR TITLE
Fix runaway texture uploads when window is minimised with frame statistics visible

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -12,6 +12,7 @@ using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
@@ -188,6 +189,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
             lock (uploadQueue)
             {
+                if (uploadQueue.Count >= 100 && uploadQueue.Count % 100 == 0)
+                    Logger.Log($"Texture {Identifier}'s upload queue is large ({uploadQueue.Count})");
+
                 bool requireUpload = uploadQueue.Count == 0;
                 uploadQueue.Enqueue(upload);
 

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -404,9 +404,9 @@ namespace osu.Framework.Graphics.Performance
         {
             // Don't process frames when minimised, as the draw thread may not be running and texture uploads
             // from the graph displays will get out of hand.
-            bool isMinimised = host.Window.WindowState != WindowState.Minimised;
+            bool isMinimised = host.Window.WindowState == WindowState.Minimised;
 
-            if (state == FrameStatisticsMode.Full && isMinimised)
+            if (state == FrameStatisticsMode.Full && !isMinimised)
             {
                 applyFrameGC(frame);
                 applyFrameTime(frame);

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -20,9 +20,11 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Platform;
 using osuTK;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using WindowState = osu.Framework.Platform.WindowState;
 
 namespace osu.Framework.Graphics.Performance
 {
@@ -395,9 +397,16 @@ namespace osu.Framework.Graphics.Performance
             }
         }
 
+        [Resolved]
+        private GameHost host { get; set; }
+
         private void applyFrame(FrameStatistics frame)
         {
-            if (state == FrameStatisticsMode.Full)
+            // Don't process frames when minimised, as the draw thread may not be running and texture uploads
+            // from the graph displays will get out of hand.
+            bool isMinimised = host.Window.WindowState != WindowState.Minimised;
+
+            if (state == FrameStatisticsMode.Full && isMinimised)
             {
                 applyFrameGC(frame);
                 applyFrameTime(frame);

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -11,6 +11,7 @@ using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
@@ -188,6 +189,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         {
             lock (uploadQueue)
             {
+                if (uploadQueue.Count >= 100 && uploadQueue.Count % 100 == 0)
+                    Logger.Log($"Texture {Identifier}'s upload queue is large ({uploadQueue.Count})");
+
                 bool requireUpload = uploadQueue.Count == 0;
                 uploadQueue.Enqueue(upload);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/6131.

Tried to think of a way to avoid this at a higher level but not really sure we can.