### PR TITLE
Fix DragStart and TouchMove input events possibly being handled by unrooted drawables

### DIFF
--- a/.idea/.idea.osu-framework/.idea/vcs.xml
+++ b/.idea/.idea.osu-framework/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/.idea/.idea.osu-framework/.idea/vcs.xml
+++ b/.idea/.idea.osu-framework/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/osu.Framework.Tests/Input/KeyboardInputTest.cs
+++ b/osu.Framework.Tests/Input/KeyboardInputTest.cs
@@ -6,6 +6,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
@@ -83,6 +84,50 @@ namespace osu.Framework.Tests.Input
             AddStep("remove receptor 0 & reset repeat", () =>
             {
                 Remove(receptors[0], true);
+                receptors[0].RepeatReceived = false;
+                receptors[1].RepeatReceived = false;
+            });
+
+            AddUntilStep("wait for repeat on receptor 1", () => receptors[1].RepeatReceived);
+            AddAssert("receptor 0 did not receive repeat", () => !receptors[0].RepeatReceived);
+        }
+
+        /// <summary>
+        /// Tests that a drawable whose parent is removed from the hierarchy (or is otherwise removed from the input queues) won't receive OnKeyDown() events for every subsequent repeat.
+        /// </summary>
+        [Test]
+        public void TestNoLongerValidChildDrawableDoesNotReceiveRepeat()
+        {
+            var receptors = new InputReceptor[2];
+            var receptorParents = new Container[2];
+
+            AddStep("create hierarchy", () =>
+            {
+                Children = new Drawable[]
+                {
+                    receptorParents[0] = new Container
+                    {
+                        Children = new Drawable[]
+                        {
+                            receptors[0] = new InputReceptor { Size = new Vector2(100) }
+                        }
+                    },
+                    receptorParents[1] = new Container
+                    {
+                        Children = new Drawable[]
+                        {
+                            receptors[1] = new InputReceptor { Size = new Vector2(100) }
+                        }
+                    }
+                };
+            });
+
+            AddStep("press key", () => InputManager.PressKey(Key.A));
+            AddUntilStep("wait for repeat on receptor 0", () => receptors[0].RepeatReceived);
+
+            AddStep("remove receptor parent 0 & reset repeat", () =>
+            {
+                Remove(receptorParents[0], true);
                 receptors[0].RepeatReceived = false;
                 receptors[1].RepeatReceived = false;
             });

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -108,6 +108,7 @@ namespace osu.Framework.Tests.Input
         {
             InputReceptor receptor = null;
             Container receptorParent = null;
+            Vector2 lastPosition = Vector2.Zero;
 
             AddStep("create hierarchy", () =>
             {
@@ -123,12 +124,16 @@ namespace osu.Framework.Tests.Input
                 };
             });
 
-            AddStep("move mouse to receptor", () => InputManager.MoveMouseTo(receptor));
+            AddStep("move mouse to receptor", () =>
+            {
+                lastPosition = receptor.ToScreenSpace(receptor.LayoutRectangle.Centre);
+                InputManager.MoveMouseTo(lastPosition);
+            });
             AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
 
             AddStep("remove receptor parent", () => Remove(receptorParent, true));
 
-            AddStep("drag mouse", () => InputManager.MoveMouseTo(receptor, new Vector2(10)));
+            AddStep("drag mouse", () => InputManager.MoveMouseTo(lastPosition + new Vector2(10)));
             AddAssert("receptor did not receive drag start", () => !receptor.DragStartReceived);
         }
 

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -6,6 +6,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
@@ -99,10 +100,43 @@ namespace osu.Framework.Tests.Input
             AddAssert("receptor did not receive double click", () => !receptor.DoubleClickReceived);
         }
 
+        /// <summary>
+        /// Tests that a drawable whose parent is removed from the hierarchy (or is otherwise removed from the input queues) does not receive an OnDragStart() event.
+        /// </summary>
+        [Test]
+        public void TestNoLongerValidChildDrawableDoesNotReceiveDragStart()
+        {
+            InputReceptor receptor = null;
+            Container receptorParent = null;
+
+            AddStep("create hierarchy", () =>
+            {
+                Children = new Drawable[]
+                {
+                    receptorParent = new Container
+                    {
+                        Children = new Drawable[]
+                        {
+                            receptor = new InputReceptor { Size = new Vector2(100) }
+                        }
+                    }
+                };
+            });
+
+            AddStep("move mouse to receptor", () => InputManager.MoveMouseTo(receptor));
+            AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("remove receptor parent", () => Remove(receptorParent, true));
+
+            AddStep("drag mouse", () => InputManager.MoveMouseTo(receptor, new Vector2(10)));
+            AddAssert("receptor did not receive drag start", () => !receptor.DragStartReceived);
+        }
+
         private partial class InputReceptor : Box
         {
             public bool ClickReceived { get; set; }
             public bool DoubleClickReceived { get; set; }
+            public bool DragStartReceived { get; set; }
 
             public Func<bool> Click;
 
@@ -115,6 +149,12 @@ namespace osu.Framework.Tests.Input
             protected override bool OnDoubleClick(DoubleClickEvent e)
             {
                 DoubleClickReceived = true;
+                return true;
+            }
+
+            protected override bool OnDragStart(DragStartEvent e)
+            {
+                DragStartReceived = true;
                 return true;
             }
         }

--- a/osu.Framework.Tests/Input/TouchInputTest.cs
+++ b/osu.Framework.Tests/Input/TouchInputTest.cs
@@ -25,6 +25,7 @@ namespace osu.Framework.Tests.Input
         {
             InputReceptor receptor = null;
             Container receptorParent = null;
+            Vector2 lastPosition = Vector2.Zero;
 
             AddStep("create hierarchy", () =>
             {
@@ -40,11 +41,15 @@ namespace osu.Framework.Tests.Input
                 };
             });
 
-            AddStep("begin touch on receptor", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, receptor.ToScreenSpace(receptor.Position))));
+            AddStep("begin touch on receptor", () =>
+            {
+                lastPosition = receptor.ToScreenSpace(receptor.LayoutRectangle.Centre);
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, lastPosition));
+            });
 
             AddStep("remove receptor parent", () => Remove(receptorParent, true));
 
-            AddStep("move touch", () => InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, receptor.ToScreenSpace(receptor.Position + new Vector2(10)))));
+            AddStep("move touch", () => InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, lastPosition + new Vector2(10))));
             AddAssert("receptor did not receive touch move", () => !receptor.TouchMoveReceived);
         }
 

--- a/osu.Framework.Tests/Input/TouchInputTest.cs
+++ b/osu.Framework.Tests/Input/TouchInputTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Testing;
+using osuTK;
+
+namespace osu.Framework.Tests.Input
+{
+    [HeadlessTest]
+    public partial class TouchInputTest : ManualInputManagerTestScene
+    {
+        /// <summary>
+        /// Tests that a drawable whose parent is removed from the hierarchy (or is otherwise removed from the input queues) does not receive an OnDragStart() event.
+        /// </summary>
+        [Test]
+        public void TestNoLongerValidChildDrawableDoesNotReceiveTouchMove()
+        {
+            InputReceptor receptor = null;
+            Container receptorParent = null;
+
+            AddStep("create hierarchy", () =>
+            {
+                Children = new Drawable[]
+                {
+                    receptorParent = new Container
+                    {
+                        Children = new Drawable[]
+                        {
+                            receptor = new InputReceptor { Size = new Vector2(100) }
+                        }
+                    }
+                };
+            });
+
+            AddStep("begin touch on receptor", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, receptor.ToScreenSpace(receptor.Position))));
+
+            AddStep("remove receptor parent", () => Remove(receptorParent, true));
+
+            AddStep("move touch", () => InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, receptor.ToScreenSpace(receptor.Position + new Vector2(10)))));
+            AddAssert("receptor did not receive touch move", () => !receptor.TouchMoveReceived);
+        }
+
+        private partial class InputReceptor : Box
+        {
+            public bool TouchMoveReceived { get; set; }
+
+            protected override void OnTouchMove(TouchMoveEvent e)
+            {
+                TouchMoveReceived = true;
+            }
+        }
+    }
+}

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Input
         public void HandleRepeat(InputState state)
         {
             // Only drawables that can still handle input should handle the repeat
-            var drawables = ButtonDownInputQueue.AsNonNull().Intersect(InputQueue).Where(t => t.IsAlive && t.IsPresent);
+            var drawables = ButtonDownInputQueue.AsNonNull().Intersect(InputQueue);
 
             PropagateButtonEvent(drawables, new KeyDownEvent(state, Button, true));
         }

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Input
         public void HandleRepeat(InputState state)
         {
             // Only drawables that can still handle input should handle the repeat
-            var drawables = ButtonDownInputQueue.AsNonNull().Intersect(InputQueue);
+            var drawables = ButtonDownInputQueue.AsNonNull().Intersect(InputQueue).Where(t => t.IsAlive && t.IsPresent);
 
             PropagateButtonEvent(drawables, new KeyDownEvent(state, Button, true));
         }

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -195,7 +195,7 @@ namespace osu.Framework.Input
             DragStarted = true;
 
             // also the laziness of IEnumerable here
-            var drawables = ButtonDownInputQueue.AsNonNull().Where(t => t.IsAlive && t.IsPresent);
+            var drawables = ButtonDownInputQueue.AsNonNull().Where(d => d.IsRootedAt(InputManager));
 
             var draggable = PropagateButtonEvent(drawables, new DragStartEvent(state, Button, MouseDownPosition));
             if (draggable != null)

--- a/osu.Framework/Input/TouchEventManager.cs
+++ b/osu.Framework/Input/TouchEventManager.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
@@ -36,7 +37,7 @@ namespace osu.Framework.Input
 
         private void handleTouchMove(InputState state, Vector2 position, Vector2 lastPosition)
         {
-            PropagateButtonEvent(ButtonDownInputQueue!, new TouchMoveEvent(state, new Touch(Button, position), TouchDownPosition, lastPosition));
+            PropagateButtonEvent(ButtonDownInputQueue!.Where(d => d.IsRootedAt(InputManager)), new TouchMoveEvent(state, new Touch(Button, position), TouchDownPosition, lastPosition));
         }
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets)


### PR DESCRIPTION
Drawables in the `ButtonDownInputQueue` could become unrooted between the button down event and a drag start event or touch move event. 
If a parent of a drawable gets removed, the children will keep `IsAlive` true forever, so checking for `IsAlive` is not sufficient.

Failing tests included. The test for the key repeat input does not fail before my fixes, but I added it for good measure.