### PR TITLE
Add the ability to solo a test in visual testing using `[Solo]` attribute

### DIFF
--- a/osu.Framework/Testing/SoloAttribute.cs
+++ b/osu.Framework/Testing/SoloAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+
+namespace osu.Framework.Testing
+{
+    /// <summary>
+    /// Denotes a single test method which will be "solo"ed during visual execution.
+    /// This implies all other tests will be ignored.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    [MeansImplicitUse]
+    public class SoloAttribute : Attribute
+    {
+    }
+}

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -400,7 +400,13 @@ namespace osu.Framework.Testing
 
             bool hadTestAttributeTest = false;
 
-            foreach (var m in newTest.GetType().GetMethods())
+            var methods = newTest.GetType().GetMethods();
+
+            var solo = methods.FirstOrDefault(m => m.GetCustomAttribute(typeof(SoloAttribute), false) != null);
+            if (solo != null)
+                methods = new[] { solo };
+
+            foreach (var m in methods)
             {
                 string name = m.Name;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -402,9 +402,9 @@ namespace osu.Framework.Testing
 
             var methods = newTest.GetType().GetMethods();
 
-            var solo = methods.FirstOrDefault(m => m.GetCustomAttribute(typeof(SoloAttribute), false) != null);
-            if (solo != null)
-                methods = new[] { solo };
+            var soloTests = methods.Where(m => m.GetCustomAttribute(typeof(SoloAttribute), false) != null).ToArray();
+            if (soloTests.Any())
+                methods = soloTests;
 
             foreach (var m in methods)
             {


### PR DESCRIPTION
I've been wanting this for years. Discussed implementation details recently with smoogi and agreed that getting something very simple implemented would be beneficial to test development efficiency.

Basically, rather than commenting out 100 tests in a method where you want to test one specific test repeatedly (commonly using hot reload), you can now add `[Solo]` to the test in question and the runner will ignore the rest.

This has no effect when tests are run from nunit, as you may expect.