### PR TITLE
Write log header later to ensure game identifiers are present

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -302,8 +302,6 @@ namespace osu.Framework.Logging
             if (!Enabled || level < Level)
                 return;
 
-            ensureHeader();
-
             logCount.Value++;
 
             message = ApplyFilters(message);
@@ -394,6 +392,17 @@ namespace osu.Framework.Logging
                 using (var stream = Storage.GetStream(Filename, FileAccess.Write, FileMode.Append))
                 using (var writer = new StreamWriter(stream))
                 {
+                    if (!headerAdded)
+                    {
+                        writer.WriteLine("----------------------------------------------------------");
+                        writer.WriteLine($"{Name} Log for {UserIdentifier} (LogLevel: {Level})");
+                        writer.WriteLine($"Running {GameIdentifier} {VersionIdentifier} on .NET {Environment.Version}");
+                        writer.WriteLine($"Environment: {RuntimeInfo.OS} ({Environment.OSVersion}), {Environment.ProcessorCount} cores ");
+                        writer.WriteLine("----------------------------------------------------------");
+
+                        headerAdded = true;
+                    }
+
                     foreach (string line in lines)
                         writer.WriteLine(line);
                 }
@@ -433,19 +442,6 @@ namespace osu.Framework.Logging
             {
                 Log($"Cycling logs failed ({e})");
             }
-        }
-
-        private void ensureHeader()
-        {
-            if (headerAdded) return;
-
-            headerAdded = true;
-
-            add("----------------------------------------------------------", outputToListeners: false);
-            add($"{Name} Log for {UserIdentifier} (LogLevel: {Level})", outputToListeners: false);
-            add($"Running {GameIdentifier} {VersionIdentifier} on .NET {Environment.Version}", outputToListeners: false);
-            add($"Environment: {RuntimeInfo.OS} ({Environment.OSVersion}), {Environment.ProcessorCount} cores ", outputToListeners: false);
-            add("----------------------------------------------------------", outputToListeners: false);
         }
 
         private static readonly List<string> filters = new List<string>();


### PR DESCRIPTION
The flow in `GameHost` ensures that the game/version identifiers are set before `Logger.Storage` is set. Unfortunately, until now any call to the static `Logger.Log` would immediately materialise the headers into their final string form. A stray log call before `GameHost.Run` could result in less-than-optimal headers.

This can be seen in osu!'s runtime log from an [early log call](https://github.com/ppy/osu/blob/1e3c332658a320fb2dbf49e4a97e2927cafc4dcc/osu.Desktop/Program.cs#L124).

Before:

```
2024-01-17 15:34:40 [verbose]: ----------------------------------------------------------
2024-01-17 15:34:40 [verbose]: runtime Log for dean (LogLevel: Debug)
2024-01-17 15:34:40 [verbose]: Running game unknown on .NET 6.0.25
2024-01-17 15:34:40 [verbose]: Environment: macOS (Unix 14.3.0), 8 cores
2024-01-17 15:34:40 [verbose]: ----------------------------------------------------------
2024-01-17 15:34:40 [verbose]: Starting legacy IPC provider...
```


After:

```
----------------------------------------------------------
runtime Log for dean (LogLevel: Debug)
Running osu-development 0.0.0.0 on .NET 6.0.25
Environment: macOS (Unix 14.3.0), 8 cores 
----------------------------------------------------------
2024-01-17 15:27:24 [verbose]: Starting legacy IPC provider...
```

Note that timestamps are not prefixed to the header now, but I think this is probably for the best.