### PR TITLE
Add adjustment step setting for `SliderBar`

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -60,6 +60,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
                         KeyboardStep = 1,
+                        AdjustmentStep = 0.25f,
                         Current = sliderBarValue
                     },
                     new SpriteText
@@ -272,7 +273,65 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkValue(0);
         }
 
-        private void checkValue(int expected) =>
+        [Test]
+        public void TestAdjustmentStepRelativeClick()
+        {
+            checkValue(0);
+            AddStep("Move Cursor",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.799f, 0.5f))); });
+            AddStep("Click", () => { InputManager.PressButton(MouseButton.Left); });
+            AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
+            checkValue(6);
+
+            AddStep("Move Cursor",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.801f, 0.5f))); });
+            AddStep("Click", () => { InputManager.PressButton(MouseButton.Left); });
+            AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
+            checkValue(6);
+
+            AddStep("Move Cursor",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.81f, 0.5f))); });
+            AddStep("Click", () => { InputManager.PressButton(MouseButton.Left); });
+            AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
+            checkValue(6.25f);
+
+            AddStep("Move Cursor",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.79f, 0.5f))); });
+            AddStep("Click", () => { InputManager.PressButton(MouseButton.Left); });
+            AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
+            checkValue(5.75f);
+        }
+
+        [Test]
+        public void TestAdjustmentStepKeyboardFromWeirdValue()
+        {
+            AddStep("set value to non-tick value", () => sliderBar.Current.Value = 6.01);
+
+            AddStep("move mouse inside", () =>
+            {
+                InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.25f, 0.5f)));
+            });
+
+            AddStep("Press right arrow key", () =>
+            {
+                InputManager.PressKey(Key.Right);
+                InputManager.ReleaseKey(Key.Right);
+            });
+
+            checkValue(7);
+
+            AddStep("set value to non-tick value", () => sliderBar.Current.Value = 6.05);
+
+            AddStep("Press left arrow key", () =>
+            {
+                InputManager.PressKey(Key.Left);
+                InputManager.ReleaseKey(Key.Left);
+            });
+
+            checkValue(5);
+        }
+
+        private void checkValue(float expected) =>
             AddAssert($"Value == {expected}", () => sliderBarValue.Value, () => Is.EqualTo(expected).Within(Precision.FLOAT_EPSILON));
 
         private void sliderBarValueChanged(ValueChangedEvent<double> args)

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A custom step value for each key press which actuates a change on this control.
         /// </summary>
-        public float KeyboardStep { get; set; }
+        public double KeyboardStep { get; set; }
 
         /// <summary>
         /// A custom step value for all user adjustments. This will apply as a final limiting factor, even after <see cref="KeyboardStep"/>.
@@ -186,8 +186,8 @@ namespace osu.Framework.Graphics.UserInterface
             if (!IsHovered)
                 return false;
 
-            float step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToSingle(currentNumberInstantaneous.MaxValue) - Convert.ToSingle(currentNumberInstantaneous.MinValue)) / 20;
-            if (currentNumberInstantaneous.IsInteger) step = MathF.Ceiling(step);
+            double step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToDouble(currentNumberInstantaneous.MaxValue) - Convert.ToDouble(currentNumberInstantaneous.MinValue)) / 20;
+            if (currentNumberInstantaneous.IsInteger) step = Math.Ceiling(step);
 
             switch (e.Key)
             {


### PR DESCRIPTION
Picture this scenario: you have a bindable which you want to bind to a slider bar control to allow user adjustment. Generally, when adjusting via a slider bar, adjustments should be sane values, but a user might want to override with a textbox input also bound the to the same bindable.

Using precision becomes non-feasible because it will limit the bindable across all usages (foreshadowing https://github.com/ppy/osu/issues/25862). Like with other UI frameworks, we want to set a tick/step value which governs inputs made via the slider bar.

There's an argument for "fix this locally" but I guarantee we will run into this scenario more and more, especially after we make textbox input for slider config settings more common and users ask for higher precision.