### PR TITLE
Include rounded corner radius in android safe area implementation

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -245,6 +245,22 @@ namespace osu.Framework.Android
                     usableScreenArea = usableScreenArea.Shrink(cutout.SafeInsetLeft, cutout.SafeInsetRight, cutout.SafeInsetTop, cutout.SafeInsetBottom);
             }
 
+            if (OperatingSystem.IsAndroidVersionAtLeast(31) && RootWindowInsets != null)
+            {
+                var topLeftCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopLeft);
+                var topRightCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopRight);
+                var bottomLeftCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomLeft);
+                var bottomRightCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomRight);
+
+                int cornerInsetLeft = Math.Max(topLeftCorner?.Radius ?? 0, bottomLeftCorner?.Radius ?? 0);
+                int cornerInsetRight = Math.Max(topRightCorner?.Radius ?? 0, bottomRightCorner?.Radius ?? 0);
+                int cornerInsetTop = Math.Max(topLeftCorner?.Radius ?? 0, topRightCorner?.Radius ?? 0);
+                int cornerInsetBottom = Math.Max(bottomLeftCorner?.Radius ?? 0, bottomRightCorner?.Radius ?? 0);
+
+                var radiusInsetArea = screenArea.Shrink(cornerInsetLeft, cornerInsetRight, cornerInsetTop, cornerInsetBottom);
+                usableScreenArea = usableScreenArea.Intersect(radiusInsetArea);
+            }
+
             if (OperatingSystem.IsAndroidVersionAtLeast(24) && Activity.IsInMultiWindowMode)
             {
                 // if we are in multi-window mode, the status bar is always visible (even if we request to hide it) and could be obstructing our view.

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -273,8 +273,6 @@ namespace osu.Framework.Android
                 usableScreenArea = usableScreenArea.Intersect(screenArea.Shrink(0, 0, statusBarHeight, 0));
             }
 
-            // TODO: add rounded corners support (Android 12): https://developer.android.com/guide/topics/ui/look-and-feel/rounded-corners
-
             // compute the location/area of this view on the screen.
 
             int[] location = new int[2];

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -257,7 +257,10 @@ namespace osu.Framework.Android
                 int cornerInsetTop = Math.Max(topLeftCorner?.Radius ?? 0, topRightCorner?.Radius ?? 0);
                 int cornerInsetBottom = Math.Max(bottomLeftCorner?.Radius ?? 0, bottomRightCorner?.Radius ?? 0);
 
-                var radiusInsetArea = screenArea.Shrink(cornerInsetLeft, cornerInsetRight, cornerInsetTop, cornerInsetBottom);
+                var radiusInsetArea = screenArea.Width >= screenArea.Height
+                    ? screenArea.Shrink(cornerInsetLeft, cornerInsetRight, 0, 0)
+                    : screenArea.Shrink(0, 0, cornerInsetTop, cornerInsetBottom);
+
                 usableScreenArea = usableScreenArea.Intersect(radiusInsetArea);
             }
 


### PR DESCRIPTION
Android apparently has a [separate API for "window cutouts"](https://developer.android.com/develop/ui/views/layout/display-cutout), i.e. for cameras and the like, and a [separate API for "rounded corners"](https://developer.android.com/develop/ui/views/layout/insets/rounded-corners), i.e. devices where the rounded corners of the display will cause some areas of the theoretically-rectangular display to be obscured. Because there is no engineering like overengineering, right? Bonus points for them being usable at different API levels, too.

Disclaimer that this does absolutely nothing on my one test device that has a rounded display and a high enough API level, but honestly it may be a device issue since it's not even returning `true` for `WindowInsets.IsRound`. Maybe it'll help someone, no idea.