### PR TITLE
Ignore autogenerated .idea android file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,4 @@ inspectcodereport.xml
 inspectcode
 
 .idea/.idea.osu-framework.Desktop/.idea/misc.xml
+.idea/.idea.osu-framework.Android/.idea/deploymentTargetDropDown.xml


### PR DESCRIPTION
This file just shows the last selected android device:

## `deploymentTargetDropDown.xml`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project version="4">
  <component name="deploymentTargetDropDown">
    <value>
      <entry key="osu.Framework.Android">
        <State />
      </entry>
      <entry key="osu.Framework.Tests.Android">
        <State>
          <runningDeviceTargetSelectedWithDropDown>
            <Target>
              <type value="RUNNING_DEVICE_TARGET" />
              <deviceKey>
                <Key>
                  <type value="SERIAL_NUMBER" />
                  <value value="***" />
                </Key>
              </deviceKey>
            </Target>
          </runningDeviceTargetSelectedWithDropDown>
          <timeTargetWasSelectedWithDropDown value="2024-01-18T17:26:25.696017100Z" />
        </State>
      </entry>
    </value>
  </component>
</project>
```