### PR TITLE
Fix `TemplateGameTestScene` showing up in test browser

### DIFF
--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TemplateGameTestScene.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TemplateGameTestScene.cs
@@ -2,7 +2,7 @@ using osu.Framework.Testing;
 
 namespace TemplateGame.Game.Tests.Visual
 {
-    public partial class TemplateGameTestScene : TestScene
+    public abstract partial class TemplateGameTestScene : TestScene
     {
         protected override ITestSceneTestRunner CreateRunner() => new TemplateGameTestSceneTestRunner();
 

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/FlappyDonTestScene.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/FlappyDonTestScene.cs
@@ -2,7 +2,7 @@ using osu.Framework.Testing;
 
 namespace FlappyDon.Game.Tests.Visual
 {
-    public partial class FlappyDonTestScene : TestScene
+    public abstract partial class FlappyDonTestScene : TestScene
     {
         protected override ITestSceneTestRunner CreateRunner() => new FlappyDonTestSceneTestRunner();
 


### PR DESCRIPTION
Noticed after making a template. Same fix as https://github.com/ppy/osu-framework/commit/e08c8827ed6914ed0257c5af5f77eab443310fe3.