### PR TITLE
Fix allocation overhead in `TabFillFlowContainer` when it can't fit all the items

### DIFF
--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -218,10 +218,7 @@ namespace osu.Framework.Graphics.Containers
             base.UpdateAfterChildren();
 
             if (!childLayout.IsValid)
-            {
                 InvalidateLayout();
-                childLayout.Validate();
-            }
 
             if (!layout.IsValid)
             {

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -227,6 +227,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 performLayout();
                 layout.Validate();
+                childLayout.Validate();
             }
         }
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -223,7 +223,9 @@ namespace osu.Framework.Graphics.Containers
             if (!layout.IsValid)
             {
                 performLayout();
+
                 layout.Validate();
+                // It's important to only validate childLayout after performLayout() is called to ensure it doesn't get re-invalidated.
                 childLayout.Validate();
             }
         }


### PR DESCRIPTION
The issue was caused [by this](https://github.com/ppy/osu-framework/blob/f6feea4b08de3a5182fa15f6913edfcffeceb267/osu.Framework/Graphics/UserInterface/TabControl.cs#L503).

So as far as my understanding goes: `FlowContainer` was never expecting it's children to be invalidated during validation process and at the end it was validating every frame.

Timeline of events:
1. `FlowContainer.UpdateAfterChildren` checking if it needs validation
2. `childLayout` invalidated? validate it and invalidate `layout`
3. `layout` is invalidated - call `performLayout()`
4. `performLayout()` calls `ComputeLayoutPositions()` down the line
5. `ComputeLayoutPositions()` is overriden by `TabFillFlowContainer` and changes children Y, which triggers `childLayout` to be invalidated again (even if it was validated in 2)
6. validate `layout` and go to the next frame with still invalidated `childLayout`
7. repeat

This is confirmed by the fact that it happens only if TabControl can't fit all the items. Thus hidden items will have Y != 0 and the issue occurs.
For long enough controls (in big enough screens/small enough UI scale) all the tabs already at Y=0, so setting their position to Y=0 won't trigger layout invalidation and they are fine.

||master|pr|
|---|---|---|
|TabControlTestScene|![tests-master](https://github.com/ppy/osu-framework/assets/22874522/241fedcf-922e-4e3f-9c21-7601cfd38682)|![tests-pr](https://github.com/ppy/osu-framework/assets/22874522/ba340d9c-622d-4605-b6ea-c3d839165c73)|
|song-select|![master](https://github.com/ppy/osu-framework/assets/22874522/f406f286-bc2f-4b30-b97d-94b479dee608)|![pr](https://github.com/ppy/osu-framework/assets/22874522/c10dfc4d-b7fb-4f44-b4ce-f73371ee4bc4)|