### PR TITLE
Implement Linux clipboard with support for images

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxClipboard.cs
+++ b/osu.Framework/Platform/Linux/LinuxClipboard.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using NuGet.Packaging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
+
+namespace osu.Framework.Platform.Linux
+{
+    public class LinuxClipboard : Clipboard
+    {
+        protected Process Xclip(IEnumerable<string> args)
+        {
+            Process xclip = new Process();
+            xclip.StartInfo.FileName = "xclip";
+            xclip.StartInfo.UseShellExecute = false;
+            xclip.StartInfo.RedirectStandardInput = true;
+            xclip.StartInfo.RedirectStandardError = true;
+            xclip.StartInfo.RedirectStandardOutput = true;
+            xclip.StartInfo.ArgumentList.AddRange(args);
+            return xclip;
+        }
+
+        protected bool HasTarget(string target)
+        {
+            using Process xclip = Xclip(new[] { "-selection", "clipboard", "-t", "TARGETS", "-o" });
+            xclip.Start();
+
+            bool hasTarget = false;
+
+            try
+            {
+                string? line;
+                while ((line = xclip.StandardOutput.ReadLine()) != null)
+                {
+                    if (line == target)
+                    {
+                        hasTarget = true;
+                        break;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            xclip.StandardInput.Close();
+            xclip.WaitForExit();
+
+            return hasTarget;
+        }
+
+        public override Image<TPixel>? GetImage<TPixel>()
+        {
+            if (!HasTarget("image/png"))
+                return null;
+
+            using Process xclip = Xclip(new[] { "-selection", "clipboard", "-t", "image/png", "-o" });
+            xclip.Start();
+
+            // reserve 5 MB because it's a bit above a typical png size
+            using MemoryStream xclipStdout = new MemoryStream(5 * 1024 * 1024);
+
+            // If we don't read stdout before waiting, the process might hang because some internal buffer got full.
+            // I know, weird...
+            xclip.StandardOutput.BaseStream.CopyTo(xclipStdout);
+            xclipStdout.Position = 0;
+
+            xclip.StandardInput.Close();
+            xclip.WaitForExit();
+
+            if (xclip.ExitCode == 0)
+                return Image.Load<TPixel>(xclipStdout);
+            else
+                return null;
+        }
+
+        public override string? GetText()
+        {
+            if (!HasTarget("text/plain"))
+                return null;
+
+            using Process xclip = Xclip(new[] { "-selection", "clipboard", "-t", "text/plain", "-o" });
+            xclip.Start();
+
+            string? stdout = null;
+            try
+            {
+                stdout = xclip.StandardOutput.ReadToEnd();
+            }
+            catch (Exception)
+            {
+            }
+
+            xclip.StandardInput.Close();
+            xclip.WaitForExit();
+
+            if (xclip.ExitCode == 0)
+                return stdout;
+            else
+                return null;
+        }
+
+        public override bool SetImage(Image image)
+        {
+            using Process xclip = Xclip(new[] { "-selection", "clipboard", "-t", "image/png", "-i" });
+            xclip.Start();
+
+            image.Save(xclip.StandardInput.BaseStream, PngFormat.Instance);
+
+            xclip.StandardInput.Close();
+            xclip.WaitForExit();
+
+            return xclip.ExitCode == 0;
+        }
+
+        public override void SetText(string text)
+        {
+            using Process xclip = Xclip(new[] { "-selection", "clipboard", "-t", "text/plain", "-i" });
+            xclip.Start();
+
+            xclip.StandardInput.Write(text);
+
+            xclip.StandardInput.Close();
+            xclip.WaitForExit();
+        }
+    }
+}

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -51,6 +51,8 @@ namespace osu.Framework.Platform.Linux
             }
         }
 
+        protected override Clipboard CreateClipboard() => new LinuxClipboard();
+
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new SDL2DesktopWindow(preferredSurface);
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new LinuxReadableKeyCombinationProvider();


### PR DESCRIPTION
This is a followup to my recent comment on this discussion about being able to copy a screenshot in osu!: https://github.com/ppy/osu/discussions/16775#discussioncomment-8248801

This is an implementation of a Linux clipboard by spawning an `xclip` process. It should work on all X11 systems.
I tested in the clipboard visual test scene and all tests pass, so there shouldn't be a problem!

However, I haven't implemented anything for Wayland yet. At least as it stands, if it fails to find `xclip`, it'll fallback on the SDL2 clipboard via inheritance. That means that images won't work on Wayland yet, but I'll look into a way I can potentially implement that.