### PR TITLE
Fix Waveform not disposing Stream

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkWaveform.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWaveform.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Benchmarks
     [MemoryDiagnoser]
     public class BenchmarkWaveform : BenchmarkTest
     {
-        private Stream data = null!;
+        private byte[] data = null!;
         private Waveform preloadedWaveform = null!;
 
         public override void SetUp()
@@ -27,11 +27,11 @@ namespace osu.Framework.Benchmarks
 
             var store = new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(FrameworkTestScene).Assembly), "Resources");
 
-            data = store.GetStream("Tracks/sample-track.mp3");
+            data = store.Get("Tracks/sample-track.mp3");
 
             Debug.Assert(data != null);
 
-            preloadedWaveform = new Waveform(data);
+            preloadedWaveform = new Waveform(new MemoryStream(data));
             // wait for load
             preloadedWaveform.GetPoints();
         }
@@ -40,7 +40,7 @@ namespace osu.Framework.Benchmarks
         [Test]
         public async Task TestCreate()
         {
-            var waveform = new Waveform(data);
+            var waveform = new Waveform(new MemoryStream(data));
 
             var originalPoints = await waveform.GetPointsAsync().ConfigureAwait(false);
             Debug.Assert(originalPoints.Length > 0);

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -72,7 +72,11 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Constructs a new <see cref="Waveform"/> from provided audio data.
         /// </summary>
-        /// <param name="data">The sample data stream. If null, an empty waveform is constructed.</param>
+        /// <param name="data">
+        /// The sample data stream.
+        /// The <see cref="Waveform"/> will take ownership of this stream and dispose it when done reading track data.
+        /// If null, an empty waveform is constructed.
+        /// </param>
         public Waveform(Stream? data)
         {
             this.data = data;


### PR DESCRIPTION
I found this issue a bit back while testing performance of Waveform implementation of #6002.
Having `data.Dispose()` in my code hindered the benchmarks from running, and it seemed that the benchmarks used a single stream through its entire session.

I assumed that the stream gets disposed somewhere else, but I couldn't find any code for that. This could be my oversight, but writing this PR didn't take much time anyway...