### PR TITLE
FFmpeg Linux binaries: Include version in file name

### DIFF
--- a/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
@@ -27,9 +27,8 @@ build_ffmpeg
 popd > /dev/null
 
 # gcc creates multiple symlinks per .so file for versioning.
-# We want to delete the symlinks to prevent weird behaviour with GitHub actions.
+# We delete the symlinks and rename the real files to include the major library version
 rm linux-x64/*.so
 for f in linux-x64/*.so.*.*.*; do
-    mv -v "$f" "${f%.*.*.*}"
+    mv -vf "$f" "${f%.*.*}"
 done
-rm linux-x64/*.so.*

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
@@ -19,6 +19,10 @@ FFMPEG_FLAGS+=(
 
 pushd . > /dev/null
 prep_ffmpeg linux-x64
+# Apply patch from upstream to fix errors with new binutils versions:
+# Ticket: https://fftrac-bg.ffmpeg.org/ticket/10405
+# This patch should be removed when FFmpeg is updated to >=6.1
+patch -p1 < "$SCRIPT_PATH/fix-binutils-2.41.patch"
 build_ffmpeg
 popd > /dev/null
 

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/fix-binutils-2.41.patch
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/fix-binutils-2.41.patch
@@ -1,0 +1,76 @@
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?utf8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed19..ca7e2dffc1 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+-- 
+2.30.2
+


### PR DESCRIPTION
I explain the rationale behind this change in #6154.

The included patch is necessary for local builds on some distros, and it will become necessary on more distros (and CI) as binutils gets updated (ver 2.41 breaks the ffmpeg build).

Note that the new NativeLibs version will cause the current logic to not find the new libraries. See the linked PR for the required logic change.