### PR TITLE
Fix `IBindableList.GetEnumerator()` boxing and allocating

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -10,6 +10,7 @@ namespace osu.Framework.Benchmarks
     public class BenchmarkBindableList
     {
         private readonly BindableList<int> list = new BindableList<int>();
+        private IBindableList<int> iList => list;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -26,6 +27,20 @@ namespace osu.Framework.Benchmarks
             for (int i = 0; i < 100; i++)
             {
                 foreach (int val in list)
+                    result += val;
+            }
+
+            return result;
+        }
+
+        [Benchmark]
+        public int EnumerateInterface()
+        {
+            int result = 0;
+
+            for (int i = 0; i < 100; i++)
+            {
+                foreach (int val in iList)
                     result += val;
             }
 

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -37,5 +37,7 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindableList<T> GetBoundCopy();
+
+        new List<T>.Enumerator GetEnumerator();
     }
 }


### PR DESCRIPTION
Saw this one come up off-hand, and I think it's a pretty easy gun to shoot yourself in the foot given that we advise exposing as `IBindableList<T>` for read-only usages. It's simple enough to fix in this case since the hierarchy is pretty concrete.

Before:

|             Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|------------------- |---------:|----------:|----------:|-------:|----------:|
|          Enumerate | 1.225 us | 0.0028 us | 0.0023 us |      - |         - |
| EnumerateInterface | 6.546 us | 0.0156 us | 0.0138 us | 1.9073 |    4000 B |

After:

|             Method |     Mean |     Error |    StdDev | Allocated |
|------------------- |---------:|----------:|----------:|----------:|
|          Enumerate | 1.241 us | 0.0107 us | 0.0089 us |         - |
| EnumerateInterface | 1.696 us | 0.0048 us | 0.0037 us |         - |
