### PR TITLE
Fix build warning

### DIFF
--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Statistics
         [StructLayout(LayoutKind.Sequential)]
         private struct TypedReferenceAccess
         {
-            public IntPtr Value;
+            public readonly IntPtr Value;
             public IntPtr Type;
         }
 

--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;
 
@@ -132,21 +133,20 @@ namespace osu.Framework.Statistics
         // ReSharper disable once UnusedParameter.Local
         private static unsafe Type getTypeFromHandle(IntPtr handle)
         {
-            // This is super unsafe code which is dependent upon internal CLR structures.
+#pragma warning disable CS8500
             TypedReferenceAccess tr = new TypedReferenceAccess { Type = handle };
-            return __reftype(*(TypedReference*)&tr);
+            return TypedReference.GetTargetType(*(TypedReference*)&tr);
+#pragma warning restore CS8500
         }
 
         /// <summary>
         /// Matches the internal layout of <see cref="TypedReference"/>.
         /// See: https://source.dot.net/#System.Private.CoreLib/src/System/TypedReference.cs
         /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
         private struct TypedReferenceAccess
         {
-            [JetBrains.Annotations.UsedImplicitly]
             public IntPtr Value;
-
-            [JetBrains.Annotations.UsedImplicitly]
             public IntPtr Type;
         }
 


### PR DESCRIPTION
```
1>DotNetRuntimeListener.cs(137,32): Warning CS8500 : This takes the address of, gets the size of, or declares a pointer to a managed type ('TypedReference')
```

I'd use `Unsafe.Cast<>` but it can't be done because `TypedReference` contains a `ByReference<T>` where `T` is not marked as `unmanaged`, even though the specific usage in the class is a `byte` which is unmanaged.

`TypedReference.GetTargetType()` is equivalent to `__reftype` internally. Just cleaning this up to not use undocumented features.