### PR TITLE
Rework dependencies to allow value types

### DIFF
--- a/osu.Framework.Tests/Dependencies/Reflection/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/CachedAttributeTest.cs
@@ -51,11 +51,13 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         }
 
         [Test]
-        public void TestAttemptToCacheStruct()
+        public void TestCacheStruct()
         {
             var provider = new Provider4();
 
-            Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.IsNotNull(dependencies.Get<int?>());
         }
 
         [Test]
@@ -136,7 +138,9 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         {
             var provider = new Provider12();
 
-            Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.IsNotNull(dependencies.Get<IProvidedInterface1>());
         }
 
         /// <summary>
@@ -149,13 +153,13 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
-            Assert.AreEqual(provider.CachedObject.Value, dependencies.GetValue<CachedStructProvider.Struct>().Value);
+            Assert.AreEqual(provider.CachedObject.Value, dependencies.Get<CachedStructProvider.Struct>().Value);
         }
 
         [Test]
-        public void TestGetValueNullInternal()
+        public void TestGetNullInternal()
         {
-            Assert.AreEqual(default(int), new DependencyContainer().GetValue<int>());
+            Assert.AreEqual(default(int), new DependencyContainer().Get<int>());
         }
 
         /// <summary>
@@ -171,7 +175,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
-            Assert.AreEqual(testValue, dependencies.GetValue<int?>());
+            Assert.AreEqual(testValue, dependencies.Get<int?>());
         }
 
         [Test]
@@ -460,9 +464,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             public object Provided1
             {
                 get => null;
-                set
-                {
-                }
+                set { }
             }
         }
 
@@ -471,9 +473,7 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             [Cached]
             public object Provided1
             {
-                set
-                {
-                }
+                set { }
             }
         }
 

--- a/osu.Framework.Tests/Dependencies/Reflection/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/DependencyContainerTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
-using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
@@ -137,22 +136,22 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             Assert.Throws<TypeAlreadyCachedException>(() => dependencies.Cache(testObject2));
         }
 
-        /// <summary>
-        /// Special case because "where T : class" also allows interfaces.
-        /// </summary>
         [Test]
-        public void TestAttemptCacheStruct()
+        public void TestCacheStruct()
         {
-            Assert.Throws<ArgumentException>(() => new DependencyContainer().Cache(new BaseStructObject()));
+            var dependencies = new DependencyContainer();
+            dependencies.Cache(new BaseStructObject());
+
+            Assert.IsNotNull(dependencies.Get<BaseStructObject?>());
         }
 
-        /// <summary>
-        /// Special case because "where T : class" also allows interfaces.
-        /// </summary>
         [Test]
-        public void TestAttemptCacheAsStruct()
+        public void TestCacheAsStruct()
         {
-            Assert.Throws<ArgumentException>(() => new DependencyContainer().CacheAs<IBaseInterface>(new BaseStructObject()));
+            var dependencies = new DependencyContainer();
+            dependencies.CacheAs<IBaseInterface>(new BaseStructObject());
+
+            Assert.IsNotNull(dependencies.Get<IBaseInterface>());
         }
 
         /// <summary>
@@ -166,9 +165,9 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
             var dependencies = new DependencyContainer();
 
-            Assert.DoesNotThrow(() => dependencies.CacheValue(token));
+            Assert.DoesNotThrow(() => dependencies.Cache(token));
 
-            var retrieved = dependencies.GetValue<CancellationToken>();
+            var retrieved = dependencies.Get<CancellationToken>();
 
             source.Cancel();
 
@@ -238,16 +237,19 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         }
 
         [Test]
-        public void TestCacheNullInternal()
+        public void TestAttemptCacheNullInternal()
         {
-            Assert.DoesNotThrow(() => new DependencyContainer().CacheValue(null));
-            Assert.DoesNotThrow(() => new DependencyContainer().CacheValueAs<object>(null));
+            Assert.Throws<ArgumentNullException>(() => new DependencyContainer().Cache(null!));
+            Assert.Throws<ArgumentNullException>(() => new DependencyContainer().CacheAs<object>(null!));
         }
 
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
+            var receiver = new Receiver12();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.TestObject);
         }
 
         [Test]
@@ -265,60 +267,43 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             int? testObject = 5;
 
             var dependencies = new DependencyContainer();
-            dependencies.CacheValueAs(testObject);
+            dependencies.CacheAs(testObject);
 
-            Assert.AreEqual(testObject, dependencies.GetValue<int>());
-            Assert.AreEqual(testObject, dependencies.GetValue<int?>());
+            Assert.AreEqual(testObject, dependencies.Get<int>());
+            Assert.AreEqual(testObject, dependencies.Get<int?>());
         }
 
-        [Test]
-        public void TestCacheWithDependencyInfo()
+        [TestCase(null, null)]
+        [TestCase("name", null)]
+        [TestCase(null, typeof(object))]
+        [TestCase("name", typeof(object))]
+        public void TestCacheWithDependencyInfo(string name, Type parent)
         {
-            var cases = new[]
-            {
-                default,
-                new CacheInfo("name"),
-                new CacheInfo(parent: typeof(object)),
-                new CacheInfo("name", typeof(object))
-            };
+            CacheInfo info = new CacheInfo(name, parent);
 
             var dependencies = new DependencyContainer();
+            dependencies.CacheAs(1, info);
 
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(i, cases[i]);
-
-            Assert.Multiple(() =>
-            {
-                for (int i = 0; i < cases.Length; i++)
-                    Assert.AreEqual(i, dependencies.GetValue<int>(cases[i]));
-            });
+            Assert.AreEqual(1, dependencies.Get<int>(info));
         }
 
-        [Test]
-        public void TestDependenciesOverrideParent()
+        [TestCase(null, null)]
+        [TestCase("name", null)]
+        [TestCase(null, typeof(object))]
+        [TestCase("name", typeof(object))]
+        public void TestDependenciesOverrideParent(string name, Type parent)
         {
-            var cases = new[]
-            {
-                default,
-                new CacheInfo("name"),
-                new CacheInfo(parent: typeof(object)),
-                new CacheInfo("name", typeof(object))
-            };
+            CacheInfo info = new CacheInfo(name, parent);
 
             var dependencies = new DependencyContainer();
-
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(i, cases[i]);
+            dependencies.CacheAs(1, info);
 
             dependencies = new DependencyContainer(dependencies);
-
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(cases.Length + i, cases[i]);
+            dependencies.CacheAs(2, info);
 
             Assert.Multiple(() =>
             {
-                for (int i = 0; i < cases.Length; i++)
-                    Assert.AreEqual(cases.Length + i, dependencies.GetValue<int>(cases[i]));
+                Assert.AreEqual(2, dependencies.Get<int>(info));
             });
         }
 
@@ -334,6 +319,18 @@ namespace osu.Framework.Tests.Dependencies.Reflection
             // Cache the non-nullable dependency.
             dependencies.CacheAs(new BaseObject());
             Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+        }
+
+        [Test]
+        public void TestResolveDefaultStruct()
+        {
+            Assert.That(new DependencyContainer().Get<CancellationToken>(), Is.EqualTo(default(CancellationToken)));
+        }
+
+        [Test]
+        public void TestResolveNullStruct()
+        {
+            Assert.That(new DependencyContainer().Get<CancellationToken?>(), Is.Null);
         }
 
         private interface IBaseInterface
@@ -439,11 +436,10 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
         private class Receiver12 : IDependencyInjectionCandidate
         {
-            [UsedImplicitly] // param used implicitly
+            public int TestObject { get; private set; } = 1;
+
             [BackgroundDependencyLoader]
-            private void load(int testObject)
-            {
-            }
+            private void load(int testObject) => TestObject = testObject;
         }
 
         private class Receiver13 : IDependencyInjectionCandidate

--- a/osu.Framework.Tests/Dependencies/Reflection/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/Reflection/ResolvedAttributeTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -160,7 +161,10 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver14()));
+            var receiver = new Receiver14();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.Obj);
         }
 
         [Test]
@@ -210,6 +214,26 @@ namespace osu.Framework.Tests.Dependencies.Reflection
 
             // Does not throw with the non-nullable dependency cached.
             Assert.DoesNotThrow(() => createDependencies(new Bindable<int>(10)).Inject(receiver));
+        }
+
+        [Test]
+        public void TestResolveDefaultStruct()
+        {
+            var receiver = new Receiver19();
+
+            createDependencies().Inject(receiver);
+
+            Assert.That(receiver.Token, Is.EqualTo(default(CancellationToken)));
+        }
+
+        [Test]
+        public void TestResolveNullStruct()
+        {
+            var receiver = new Receiver20();
+
+            createDependencies().Inject(receiver);
+
+            Assert.That(receiver.Token, Is.Null);
         }
 
         private DependencyContainer createDependencies(params object[] toCache)
@@ -341,6 +365,18 @@ namespace osu.Framework.Tests.Dependencies.Reflection
         {
             [Resolved]
             public Bindable<int> Obj { get; private set; } = null!;
+        }
+
+        private class Receiver19 : IDependencyInjectionCandidate
+        {
+            [Resolved]
+            public CancellationToken Token { get; private set; }
+        }
+
+        private class Receiver20 : IDependencyInjectionCandidate
+        {
+            [Resolved]
+            public CancellationToken? Token { get; private set; }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/CachedAttributeTest.cs
@@ -48,11 +48,13 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         }
 
         [Test]
-        public void TestAttemptToCacheStruct()
+        public void TestCacheStruct()
         {
             var provider = new Provider4();
 
-            Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.IsNotNull(dependencies.Get<int?>());
         }
 
         [Test]
@@ -133,7 +135,9 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         {
             var provider = new Provider12();
 
-            Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.IsNotNull(dependencies.Get<IProvidedInterface1>());
         }
 
         /// <summary>
@@ -146,13 +150,13 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
-            Assert.AreEqual(provider.CachedObject.Value, dependencies.GetValue<PartialCachedStructProvider.Struct>().Value);
+            Assert.AreEqual(provider.CachedObject.Value, dependencies.Get<PartialCachedStructProvider.Struct>().Value);
         }
 
         [Test]
         public void TestGetValueNullInternal()
         {
-            Assert.AreEqual(default(int), new DependencyContainer().GetValue<int>());
+            Assert.AreEqual(default(int), new DependencyContainer().Get<int>());
         }
 
         /// <summary>
@@ -168,7 +172,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
             var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
 
-            Assert.AreEqual(testValue, dependencies.GetValue<int?>());
+            Assert.AreEqual(testValue, dependencies.Get<int?>());
         }
 
         [Test]
@@ -457,9 +461,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             {
                 get => null;
                 // ReSharper disable once ValueParameterNotUsed
-                set
-                {
-                }
+                set { }
             }
         }
 

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/CachedModelDependenciesTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/CachedModelDependenciesTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -83,7 +81,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
             Assert.AreEqual(2, resolver.Model.Bindable.Value);
 
-            dependencies.Model.Value.Bindable.Value = 3;
+            dependencies.Model.Value!.Bindable.Value = 3;
 
             Assert.AreEqual(3, resolver.Model.Bindable.Value);
         }
@@ -109,7 +107,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             Assert.AreEqual(2, resolver.Model.Bindable.Value);
             Assert.AreEqual("2", resolver.Model.BindableString.Value);
 
-            dependencies.Model.Value.Bindable.Value = 3;
+            dependencies.Model.Value!.Bindable.Value = 3;
             dependencies.Model.Value.BindableString.Value = "3";
 
             Assert.AreEqual(3, resolver.Model.Bindable.Value);
@@ -283,15 +281,15 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
         private partial class NonReadOnlyFieldModel : IDependencyInjectionCandidate
         {
-#pragma warning disable 649
-            public Bindable<int> Bindable;
-#pragma warning restore 649
+#pragma warning disable CS0414 // Field is assigned but its value is never used
+            public Bindable<int> Bindable = null!;
+#pragma warning restore CS0414 // Field is assigned but its value is never used
         }
 
         private partial class PropertyModel : IDependencyInjectionCandidate
         {
             // ReSharper disable once UnusedMember.Local
-            public Bindable<int> Bindable { get; private set; }
+            public Bindable<int> Bindable { get; private set; } = null!;
         }
 
         private partial class FieldModel : IDependencyInjectionCandidate
@@ -309,22 +307,22 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         private partial class FieldModelResolver : IDependencyInjectionCandidate
         {
             [Resolved]
-            public FieldModel Model { get; private set; }
+            public FieldModel Model { get; private set; } = null!;
         }
 
         private partial class DerivedFieldModelResolver : IDependencyInjectionCandidate
         {
             [Resolved]
-            public DerivedFieldModel Model { get; private set; }
+            public DerivedFieldModel Model { get; private set; } = null!;
         }
 
         private partial class DerivedFieldModelPropertyResolver : IDependencyInjectionCandidate
         {
             [Resolved(typeof(DerivedFieldModel))]
-            public Bindable<int> Bindable { get; private set; }
+            public Bindable<int> Bindable { get; private set; } = null!;
 
             [Resolved(typeof(DerivedFieldModel))]
-            public Bindable<string> BindableString { get; private set; }
+            public Bindable<string> BindableString { get; private set; } = null!;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/DependencyContainerTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
-using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
@@ -136,22 +135,22 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             Assert.Throws<TypeAlreadyCachedException>(() => dependencies.Cache(testObject2));
         }
 
-        /// <summary>
-        /// Special case because "where T : class" also allows interfaces.
-        /// </summary>
         [Test]
-        public void TestAttemptCacheStruct()
+        public void TestCacheStruct()
         {
-            Assert.Throws<ArgumentException>(() => new DependencyContainer().Cache(new BaseStructObject()));
+            var dependencies = new DependencyContainer();
+            dependencies.Cache(new BaseStructObject());
+
+            Assert.IsNotNull(dependencies.Get<BaseStructObject?>());
         }
 
-        /// <summary>
-        /// Special case because "where T : class" also allows interfaces.
-        /// </summary>
         [Test]
-        public void TestAttemptCacheAsStruct()
+        public void TestCacheAsStruct()
         {
-            Assert.Throws<ArgumentException>(() => new DependencyContainer().CacheAs<IBaseInterface>(new BaseStructObject()));
+            var dependencies = new DependencyContainer();
+            dependencies.CacheAs<IBaseInterface>(new BaseStructObject());
+
+            Assert.IsNotNull(dependencies.Get<IBaseInterface>());
         }
 
         /// <summary>
@@ -165,9 +164,9 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
             var dependencies = new DependencyContainer();
 
-            Assert.DoesNotThrow(() => dependencies.CacheValue(token));
+            Assert.DoesNotThrow(() => dependencies.Cache(token));
 
-            var retrieved = dependencies.GetValue<CancellationToken>();
+            var retrieved = dependencies.Get<CancellationToken>();
 
             source.Cancel();
 
@@ -241,16 +240,19 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         }
 
         [Test]
-        public void TestCacheNullInternal()
+        public void TestAttemptCacheNullInternal()
         {
-            Assert.DoesNotThrow(() => new DependencyContainer().CacheValue(null));
-            Assert.DoesNotThrow(() => new DependencyContainer().CacheValueAs<object>(null));
+            Assert.Throws<ArgumentNullException>(() => new DependencyContainer().Cache(null!));
+            Assert.Throws<ArgumentNullException>(() => new DependencyContainer().CacheAs<object>(null!));
         }
 
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
+            var receiver = new Receiver12();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.TestObject);
         }
 
         [Test]
@@ -268,60 +270,43 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             int? testObject = 5;
 
             var dependencies = new DependencyContainer();
-            dependencies.CacheValueAs(testObject);
+            dependencies.CacheAs(testObject);
 
-            Assert.AreEqual(testObject, dependencies.GetValue<int>());
-            Assert.AreEqual(testObject, dependencies.GetValue<int?>());
+            Assert.AreEqual(testObject, dependencies.Get<int>());
+            Assert.AreEqual(testObject, dependencies.Get<int?>());
         }
 
-        [Test]
-        public void TestCacheWithDependencyInfo()
+        [TestCase(null, null)]
+        [TestCase("name", null)]
+        [TestCase(null, typeof(object))]
+        [TestCase("name", typeof(object))]
+        public void TestCacheWithDependencyInfo(string name, Type parent)
         {
-            var cases = new[]
-            {
-                default,
-                new CacheInfo("name"),
-                new CacheInfo(parent: typeof(object)),
-                new CacheInfo("name", typeof(object))
-            };
+            CacheInfo info = new CacheInfo(name, parent);
 
             var dependencies = new DependencyContainer();
+            dependencies.CacheAs(1, info);
 
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(i, cases[i]);
-
-            Assert.Multiple(() =>
-            {
-                for (int i = 0; i < cases.Length; i++)
-                    Assert.AreEqual(i, dependencies.GetValue<int>(cases[i]));
-            });
+            Assert.AreEqual(1, dependencies.Get<int>(info));
         }
 
-        [Test]
-        public void TestDependenciesOverrideParent()
+        [TestCase(null, null)]
+        [TestCase("name", null)]
+        [TestCase(null, typeof(object))]
+        [TestCase("name", typeof(object))]
+        public void TestDependenciesOverrideParent(string name, Type parent)
         {
-            var cases = new[]
-            {
-                default,
-                new CacheInfo("name"),
-                new CacheInfo(parent: typeof(object)),
-                new CacheInfo("name", typeof(object))
-            };
+            CacheInfo info = new CacheInfo(name, parent);
 
             var dependencies = new DependencyContainer();
-
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(i, cases[i]);
+            dependencies.CacheAs(1, info);
 
             dependencies = new DependencyContainer(dependencies);
-
-            for (int i = 0; i < cases.Length; i++)
-                dependencies.CacheValueAs(cases.Length + i, cases[i]);
+            dependencies.CacheAs(2, info);
 
             Assert.Multiple(() =>
             {
-                for (int i = 0; i < cases.Length; i++)
-                    Assert.AreEqual(cases.Length + i, dependencies.GetValue<int>(cases[i]));
+                Assert.AreEqual(2, dependencies.Get<int>(info));
             });
         }
 
@@ -337,6 +322,18 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
             // Cache the non-nullable dependency.
             dependencies.CacheAs(new BaseObject());
             Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+        }
+
+        [Test]
+        public void TestResolveDefaultStruct()
+        {
+            Assert.That(new DependencyContainer().Get<CancellationToken>(), Is.EqualTo(default(CancellationToken)));
+        }
+
+        [Test]
+        public void TestResolveNullStruct()
+        {
+            Assert.That(new DependencyContainer().Get<CancellationToken?>(), Is.Null);
         }
 
         private interface IBaseInterface
@@ -443,11 +440,10 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
         private partial class Receiver12 : IDependencyInjectionCandidate
         {
-            [UsedImplicitly] // param used implicitly
+            public int TestObject { get; private set; } = 1;
+
             [BackgroundDependencyLoader]
-            private void load(int testObject)
-            {
-            }
+            private void load(int testObject) => TestObject = testObject;
         }
 
         private partial class Receiver13 : IDependencyInjectionCandidate

--- a/osu.Framework.Tests/Dependencies/SourceGeneration/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/SourceGeneration/ResolvedAttributeTest.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -157,7 +158,10 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver14()));
+            var receiver = new Receiver14();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.Obj);
         }
 
         [Test]
@@ -207,6 +211,26 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
 
             // Does not throw with the non-nullable dependency cached.
             Assert.DoesNotThrow(() => createDependencies(new Bindable<int>(10)).Inject(receiver));
+        }
+
+        [Test]
+        public void TestResolveDefaultStruct()
+        {
+            var receiver = new Receiver19();
+
+            createDependencies().Inject(receiver);
+
+            Assert.That(receiver.Token, Is.EqualTo(default(CancellationToken)));
+        }
+
+        [Test]
+        public void TestResolveNullStruct()
+        {
+            var receiver = new Receiver20();
+
+            createDependencies().Inject(receiver);
+
+            Assert.That(receiver.Token, Is.Null);
         }
 
         private DependencyContainer createDependencies(params object[] toCache)
@@ -303,7 +327,7 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         private partial class Receiver14 : IDependencyInjectionCandidate
         {
             [Resolved]
-            public int Obj { get; private set; }
+            public int Obj { get; private set; } = 1;
         }
 
         private partial class Receiver15 : IDependencyInjectionCandidate
@@ -332,6 +356,18 @@ namespace osu.Framework.Tests.Dependencies.SourceGeneration
         {
             [Resolved]
             public Bindable<int> Obj { get; private set; } = null!;
+        }
+
+        private partial class Receiver19 : IDependencyInjectionCandidate
+        {
+            [Resolved]
+            public CancellationToken Token { get; private set; }
+        }
+
+        private partial class Receiver20 : IDependencyInjectionCandidate
+        {
+            [Resolved]
+            public CancellationToken? Token { get; private set; }
         }
     }
 }

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
@@ -17,141 +14,84 @@ namespace osu.Framework.Allocation
     {
         private readonly Dictionary<CacheInfo, object> cache = new Dictionary<CacheInfo, object>();
 
-        private readonly IReadOnlyDependencyContainer parentContainer;
+        private readonly IReadOnlyDependencyContainer? parentContainer;
 
         /// <summary>
         /// Create a new DependencyContainer instance.
         /// </summary>
         /// <param name="parent">An optional parent container which we should use as a fallback for cache lookups.</param>
-        public DependencyContainer(IReadOnlyDependencyContainer parent = null)
+        public DependencyContainer(IReadOnlyDependencyContainer? parent = null)
         {
             parentContainer = parent;
         }
 
         /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get{T}()"/>.
         /// </summary>
         /// <param name="instance">The instance to cache.</param>
         public void Cache(object instance)
             => Cache(instance, default);
 
         /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get{T}()"/>.
         /// </summary>
         /// <param name="instance">The instance to cache.</param>
         /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
         public void Cache(object instance, CacheInfo info)
-            => CacheAs(instance.GetType(), info, instance, false);
-
-        /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
-        public void CacheAs<T>(T instance) where T : class
-            => CacheAs(instance, default);
-
-        /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
-        /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
-        public void CacheAs<T>(T instance, CacheInfo info) where T : class
-            => CacheAs(typeof(T), info, instance, false);
-
-        /// <summary>
-        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
-        /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
-        public void CacheAs<T>(Type type, T instance) where T : class
-            => CacheAs(type, instance, default);
-
-        /// <summary>
-        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
-        /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
-        /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
-        public void CacheAs<T>(Type type, T instance, CacheInfo info) where T : class
-            => CacheAs(type, info, instance, false);
-
-        /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <remarks>
-        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
-        /// (e.g. <see cref="CancellationToken"/> or reference types).
-        /// </remarks>
-        /// <param name="instance">The instance to cache.</param>
-        internal void CacheValue(object instance)
-            => CacheValue(instance, default);
-
-        /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
-        /// </summary>
-        /// <remarks>
-        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
-        /// (e.g. <see cref="CancellationToken"/> or reference types).
-        /// </remarks>
-        /// <param name="instance">The instance to cache.</param>
-        /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
-        internal void CacheValue(object instance, CacheInfo info)
         {
             if (instance == null)
-                return;
+                throw new ArgumentNullException(nameof(instance));
 
-            CacheAs(instance.GetType(), info, instance, true);
+            CacheAs(instance.GetType(), info, instance);
         }
 
         /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get{T}()"/>.
         /// </summary>
-        /// <remarks>
-        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
-        /// (e.g. <see cref="CancellationToken"/> or reference types).
-        /// </remarks>
         /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
-        internal void CacheValueAs<T>(T instance)
-            => CacheValueAs(instance, default);
+        public void CacheAs<T>(T instance)
+            => CacheAs(instance, default);
 
         /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get{T}()"/>.
         /// </summary>
-        /// <remarks>
-        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
-        /// (e.g. <see cref="CancellationToken"/> or reference types).
-        /// </remarks>
         /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
         /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
-        internal void CacheValueAs<T>(T instance, CacheInfo info)
-            => CacheAs(typeof(T), info, instance, true);
+        public void CacheAs<T>(T instance, CacheInfo info)
+            => CacheAs(typeof(T), info, instance);
 
         /// <summary>
-        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get{T}()"/>.
+        /// </summary>
+        /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
+        /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
+        public void CacheAs<T>(Type type, T instance)
+            => CacheAs(type, instance, default);
+
+        /// <summary>
+        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get{T}()"/>.
+        /// </summary>
+        /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
+        /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
+        /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
+        public void CacheAs<T>(Type type, T instance, CacheInfo info)
+            => CacheAs(type, info, instance);
+
+        /// <summary>
+        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get{T}()"/>.
         /// </summary>
         /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
         /// <param name="info">Extra information to identify <paramref name="instance"/> in the cache.</param>
         /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
-        /// <param name="allowValueTypes">Whether value types are allowed to be cached.
-        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
-        /// (e.g. <see cref="CancellationToken"/> or reference types).</param>
-        internal void CacheAs(Type type, CacheInfo info, object instance, bool allowValueTypes)
+        internal void CacheAs(Type type, CacheInfo info, object? instance)
         {
             if (instance == null)
-            {
-                if (allowValueTypes)
-                    return;
-
                 throw new ArgumentNullException(nameof(instance));
-            }
 
             info = info.WithType(type.GetUnderlyingNullableType() ?? type);
 
             var instanceType = instance.GetType();
             instanceType = instanceType.GetUnderlyingNullableType() ?? instanceType;
-
-            if (instanceType.IsValueType && !allowValueTypes)
-                throw new ArgumentException($"{instanceType.ReadableName()} must be a class to be cached as a dependency.", nameof(instance));
 
             if (!info.Type.IsInstanceOfType(instance))
                 throw new ArgumentException($"{instanceType.ReadableName()} must be a subclass of {info.Type.ReadableName()}.", nameof(instance));
@@ -164,14 +104,38 @@ namespace osu.Framework.Allocation
             cache[info] = instance;
         }
 
-        public object Get(Type type)
-            => Get(type, default);
+        public T Get<T>() => Get<T>(default);
 
-        public object Get(Type type, CacheInfo info)
+        public T Get<T>(CacheInfo info)
+        {
+            TryGet(out T value, info);
+            return value;
+        }
+
+        public bool TryGet<T>(out T value) => TryGet(out value, default);
+
+        public bool TryGet<T>(out T value, CacheInfo info)
+        {
+            object? obj = Get(typeof(T), info);
+
+            if (obj == null)
+            {
+                // `(int)(object)null` throws a NRE, so `default` is used instead.
+                value = default!;
+                return false;
+            }
+
+            value = (T)obj;
+            return true;
+        }
+
+        public object? Get(Type type) => Get(type, default);
+
+        public object? Get(Type type, CacheInfo info)
         {
             info = info.WithType(type.GetUnderlyingNullableType() ?? type);
 
-            if (cache.TryGetValue(info, out object existing))
+            if (cache.TryGetValue(info, out object? existing))
                 return existing;
 
             return parentContainer?.Get(type, info);

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Allocation
@@ -14,19 +12,40 @@ namespace osu.Framework.Allocation
     public interface IReadOnlyDependencyContainer
     {
         /// <summary>
-        /// Retrieves a cached dependency of <paramref name="type"/> if it exists and null otherwise.
+        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and null otherwise.
         /// </summary>
-        /// <param name="type">The dependency type to query for.</param>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
         /// <returns>The requested dependency, or null if not found.</returns>
-        object Get(Type type);
+        T Get<T>();
 
         /// <summary>
-        /// Retrieves a cached dependency of <paramref name="type"/> if it exists and null otherwise.
+        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and null otherwise.
         /// </summary>
-        /// <param name="type">The dependency type to query for.</param>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
         /// <param name="info">Extra information that identifies the cached dependency.</param>
         /// <returns>The requested dependency, or null if not found.</returns>
-        object Get(Type type, CacheInfo info);
+        T Get<T>(CacheInfo info);
+
+        /// <summary>
+        /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="value">The requested dependency, or null if not found.</param>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
+        /// <returns>Whether the requested dependency existed.</returns>
+        bool TryGet<T>(out T value);
+
+        /// <summary>
+        /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="value">The requested dependency, or null if not found.</param>
+        /// <param name="info">Extra information that identifies the cached dependency.</param>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
+        /// <returns>Whether the requested dependency existed.</returns>
+        bool TryGet<T>(out T value, CacheInfo info);
+
+        object? Get(Type type);
+
+        object? Get(Type type, CacheInfo info);
 
         /// <summary>
         /// Injects dependencies into the given instance.
@@ -34,79 +53,5 @@ namespace osu.Framework.Allocation
         /// <typeparam name="T">The type of the instance to inject dependencies into.</typeparam>
         /// <param name="instance">The instance to inject dependencies into.</param>
         void Inject<T>(T instance) where T : class, IDependencyInjectionCandidate;
-    }
-
-    public static class ReadOnlyDependencyContainerExtensions
-    {
-        /// <summary>
-        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and null otherwise.
-        /// </summary>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <returns>The requested dependency, or null if not found.</returns>
-        public static T Get<T>(this IReadOnlyDependencyContainer container)
-            where T : class
-            => Get<T>(container, default);
-
-        /// <summary>
-        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and null otherwise.
-        /// </summary>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <param name="info">Extra information that identifies the cached dependency.</param>
-        /// <returns>The requested dependency, or null if not found.</returns>
-        public static T Get<T>(this IReadOnlyDependencyContainer container, CacheInfo info)
-            where T : class
-            => (T)container.Get(typeof(T), info);
-
-        /// <summary>
-        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and default(<typeparamref name="T"/>) otherwise.
-        /// </summary>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <returns>The requested dependency, or default(<typeparamref name="T"/>) if not found.</returns>
-        internal static T GetValue<T>(this IReadOnlyDependencyContainer container)
-            => GetValue<T>(container, default);
-
-        /// <summary>
-        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and default(<typeparamref name="T"/>) otherwise.
-        /// </summary>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <param name="info">Extra information that identifies the cached dependency.</param>
-        /// <returns>The requested dependency, or default(<typeparamref name="T"/>) if not found.</returns>
-        internal static T GetValue<T>(this IReadOnlyDependencyContainer container, CacheInfo info)
-        {
-            if (container.Get(typeof(T), info) is T value)
-                return value;
-
-            return default;
-        }
-
-        /// <summary>
-        /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <param name="value">The requested dependency, or null if not found.</param>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <returns>Whether the requested dependency existed.</returns>
-        public static bool TryGet<T>(this IReadOnlyDependencyContainer container, out T value)
-            where T : class
-            => TryGet(container, out value, default);
-
-        /// <summary>
-        /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
-        /// <param name="value">The requested dependency, or null if not found.</param>
-        /// <param name="info">Extra information that identifies the cached dependency.</param>
-        /// <typeparam name="T">The dependency type to query for.</typeparam>
-        /// <returns>Whether the requested dependency existed.</returns>
-        public static bool TryGet<T>(this IReadOnlyDependencyContainer container, out T value, CacheInfo info)
-            where T : class
-        {
-            value = container.Get<T>(info);
-            return value != null;
-        }
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.Containers
             var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(disposalCancellationSource.Token, cancellation);
 
             var deps = new DependencyContainer(Dependencies);
-            deps.CacheValueAs(linkedSource.Token);
+            deps.CacheAs(linkedSource.Token);
 
             loadingComponents ??= new WeakList<Drawable>();
 

--- a/osu.Framework/Utils/SourceGeneratorUtils.cs
+++ b/osu.Framework/Utils/SourceGeneratorUtils.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Framework.Graphics;
 
 namespace osu.Framework.Utils
 {
@@ -27,15 +26,8 @@ namespace osu.Framework.Utils
         /// <exception cref="NullDependencyException">If <paramref name="obj"/> is <c>null</c>.</exception>
         public static void CacheDependency(DependencyContainer container, Type callerType, object? obj, CacheInfo info, Type? asType, string? cachedName, string? propertyName)
         {
-            bool allowValueTypes = callerType.Assembly == typeof(Drawable).Assembly;
-
             if (obj == null)
-            {
-                if (allowValueTypes)
-                    return;
-
                 throw new NullDependencyException($"Attempted to cache a null value: {callerType.ReadableName()}.{propertyName}.");
-            }
 
             CacheInfo cacheInfo = new CacheInfo(info.Name ?? cachedName);
 
@@ -45,7 +37,7 @@ namespace osu.Framework.Utils
                 cacheInfo = new CacheInfo(cacheInfo.Name ?? propertyName, info.Parent);
             }
 
-            container.CacheAs(asType ?? obj.GetType(), cacheInfo, obj, allowValueTypes);
+            container.CacheAs(asType ?? obj.GetType(), cacheInfo, obj);
         }
 
         /// <summary>
@@ -84,7 +76,7 @@ namespace osu.Framework.Utils
         {
             object? val = container.Get(type, new CacheInfo(cachedName, cachedParent));
 
-            if (val == null && !allowNulls)
+            if (val == null && !type.IsValueType && !allowNulls)
                 throw new DependencyNotRegisteredException(callerType, type);
 
             if (rebindBindables && val is IBindable bindableVal)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/6157

Consider this an RFC.

The way structs are handled right now is a mess. If I (as the person who wrote all of this) can't understand how they're handled, then I don't think anyone can. And my confusion is the result of two conflicting thought processes:
- `CancellationToken` is somehow a special type. How is it so?
- The way I view structs is as always being initialised, whether in a "zeroed" state or otherwise (unless they're nullable).

Every value type is a special type that can only be cached by osu!framework. `CancellationToken` is doubly special because it _sometimes_ arrives in `load()`, and _sometimes_ doesn't, depending on whether you're in an async-load context. So the **only proper way** to use BDL with `CancellationToken` is to make it nullable.

In my opinion, if you want to cache and resolve a value-type dependency and accept whatever footguns that comes with (by-val copies, you can't cache multiple `int`s, etc), then you should be able to do so. But the framework should retain predictable semantics, which for me means matching the C# spec - `ValueType = default!` is a zero-initialised struct. This is a simplification of semantics to me.

New semantics:
```
Get<int>() => 0;               // Allowed
Get<int?>() => null;           // Allowed
Cache<int>(0);                 // Allowed
Cache<int>(null);              // Disallowed
Cache<int?>(0);                // Warning in NRT contexts
CacheAs<IInterface>(MyStruct); // Allowed - boxed.
Cache<object>(null);           // Exception
Cache<object?>(null);          // Exception + warning in NRT contexts
```

Is this something I foresee being used? No. It's just for the sake of clarifying semantics.