### PR TITLE
Revert "Fix `IBindableList.GetEnumerator()` boxing and allocating"

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -10,6 +10,7 @@ namespace osu.Framework.Benchmarks
     public class BenchmarkBindableList
     {
         private readonly BindableList<int> list = new BindableList<int>();
+        private IBindableList<int> iList => list;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -26,6 +27,20 @@ namespace osu.Framework.Benchmarks
             for (int i = 0; i < 100; i++)
             {
                 foreach (int val in list)
+                    result += val;
+            }
+
+            return result;
+        }
+
+        [Benchmark]
+        public int EnumerateInterface()
+        {
+            int result = 0;
+
+            for (int i = 0; i < 100; i++)
+            {
+                foreach (int val in iList)
                     result += val;
             }
 

--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -10,7 +10,6 @@ namespace osu.Framework.Benchmarks
     public class BenchmarkBindableList
     {
         private readonly BindableList<int> list = new BindableList<int>();
-        private IBindableList<int> iList => list;
 
         [GlobalSetup]
         public void GlobalSetup()
@@ -27,20 +26,6 @@ namespace osu.Framework.Benchmarks
             for (int i = 0; i < 100; i++)
             {
                 foreach (int val in list)
-                    result += val;
-            }
-
-            return result;
-        }
-
-        [Benchmark]
-        public int EnumerateInterface()
-        {
-            int result = 0;
-
-            for (int i = 0; i < 100; i++)
-            {
-                foreach (int val in iList)
                     result += val;
             }
 

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -37,5 +37,10 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindableList<T> GetBoundCopy();
+
+        // We want this enumerator to reduce enumeration overhead, but it causes mono / android crashes for silly reasons.
+        // See https://sentry.ppy.sh/share/issue/c7cda39d8ab94897a2bb350059fd3652/
+
+        // new List<T>.Enumerator GetEnumerator();
     }
 }

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -37,7 +37,5 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindableList<T> GetBoundCopy();
-
-        new List<T>.Enumerator GetEnumerator();
     }
 }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/26809

Android [decided it didn't like this optimisation](https://sentry.ppy.sh/organizations/ppy/issues/?end=2024-01-30T17%3A11%3A59&groupStatsPeriod=auto&project=2&query=firstRelease%3Aosu%402024.130.2+os.name%3AAndroid&referrer=issue-list&sort=freq&start=2024-01-30T11%3A10%3A00). Not exactly surprised given the track record we have with these sorts of tricky changes (something inside mono _reeeeeally_ doesn't like interface level trickery).