### PR TITLE
Add readonly dictionary wrapper that removes enumerator alloc

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyDictionary.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyDictionary.cs
@@ -1,0 +1,156 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Extensions.ListExtensions;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkSlimReadOnlyDictionary
+    {
+        private readonly Dictionary<int, int> dictionary = new Dictionary<int, int>();
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            int[] values = { 0, 1, 2, 3, 4, 5, 3, 2, 3, 1, 4, 5, -1 };
+            for (int i = 0; i < values.Length; i++)
+                dictionary[i] = values[i];
+        }
+
+        [Benchmark]
+        public int Dictionary()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach ((_, int v) in dictionary)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int DictionaryAsReadOnly()
+        {
+            int sum = 0;
+
+            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach ((_, int v) in readOnlyDictionary)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int DictionaryAsSlimReadOnly()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach ((_, int v) in dictionary.AsSlimReadOnly())
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int Keys()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in dictionary.Keys)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int KeysAsReadOnly()
+        {
+            int sum = 0;
+
+            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in readOnlyDictionary.Keys)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int KeysAsSlimReadOnly()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in dictionary.AsSlimReadOnly().Keys)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int Values()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in dictionary.Values)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ValuesAsReadOnly()
+        {
+            int sum = 0;
+
+            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in readOnlyDictionary.Values)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ValuesAsSlimReadOnly()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (int v in dictionary.AsSlimReadOnly().Values)
+                    sum += v;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyDictionary.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyDictionary.cs
@@ -12,10 +12,13 @@ namespace osu.Framework.Benchmarks
     public class BenchmarkSlimReadOnlyDictionary
     {
         private readonly Dictionary<int, int> dictionary = new Dictionary<int, int>();
+        private ReadOnlyDictionary<int, int> readOnlyDictionary = null!;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
+            readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
+
             int[] values = { 0, 1, 2, 3, 4, 5, 3, 2, 3, 1, 4, 5, -1 };
             for (int i = 0; i < values.Length; i++)
                 dictionary[i] = values[i];
@@ -39,8 +42,6 @@ namespace osu.Framework.Benchmarks
         public int DictionaryAsReadOnly()
         {
             int sum = 0;
-
-            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
 
             for (int i = 0; i < 1000; i++)
             {
@@ -84,8 +85,6 @@ namespace osu.Framework.Benchmarks
         {
             int sum = 0;
 
-            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
-
             for (int i = 0; i < 1000; i++)
             {
                 foreach (int v in readOnlyDictionary.Keys)
@@ -127,8 +126,6 @@ namespace osu.Framework.Benchmarks
         public int ValuesAsReadOnly()
         {
             int sum = 0;
-
-            ReadOnlyDictionary<int, int> readOnlyDictionary = new ReadOnlyDictionary<int, int>(dictionary);
 
             for (int i = 0; i < 1000; i++)
             {

--- a/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyList.cs
@@ -8,7 +8,7 @@ using osu.Framework.Extensions.ListExtensions;
 namespace osu.Framework.Benchmarks
 {
     [MemoryDiagnoser]
-    public class BenchmarkSlimReadOnlyCollection
+    public class BenchmarkSlimReadOnlyList
     {
         private readonly List<int> list = new List<int> { 0, 1, 2, 3, 4, 5, 3, 2, 3, 1, 4, 5, -1 };
 

--- a/osu.Framework/Extensions/ListExtensions/ListExtensions.cs
+++ b/osu.Framework/Extensions/ListExtensions/ListExtensions.cs
@@ -17,5 +17,17 @@ namespace osu.Framework.Extensions.ListExtensions
         /// <returns>The read-only view.</returns>
         public static SlimReadOnlyListWrapper<T> AsSlimReadOnly<T>(this List<T> list)
             => new SlimReadOnlyListWrapper<T>(list);
+
+        /// <summary>
+        /// Creates a new read-only view into a <see cref="Dictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <remarks>Enumeration does not allocate the enumerator.</remarks>
+        /// <param name="dictionary">The dictionary to create the view of.</param>
+        /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+        /// <returns>The read-only view.</returns>
+        public static SlimReadOnlyDictionaryWrapper<TKey, TValue> AsSlimReadOnly<TKey, TValue>(this Dictionary<TKey, TValue> dictionary)
+            where TKey : notnull
+            => new SlimReadOnlyDictionaryWrapper<TKey, TValue>(dictionary);
     }
 }

--- a/osu.Framework/Lists/SlimReadOnlyDictionaryWrapper.cs
+++ b/osu.Framework/Lists/SlimReadOnlyDictionaryWrapper.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace osu.Framework.Lists
+{
+    public readonly struct SlimReadOnlyDictionaryWrapper<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        where TKey : notnull
+    {
+        private readonly Dictionary<TKey, TValue> dict;
+
+        public SlimReadOnlyDictionaryWrapper(Dictionary<TKey, TValue> dict)
+        {
+            this.dict = dict;
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+            => dict.GetEnumerator();
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+            => dict.GetEnumerator();
+
+        public Dictionary<TKey, TValue>.KeyCollection Keys
+            => dict.Keys;
+
+        public Dictionary<TKey, TValue>.ValueCollection Values
+            => dict.Values;
+
+        public bool ContainsKey(TKey key)
+            => dict.ContainsKey(key);
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+            => dict.TryGetValue(key, out value);
+
+        public TValue this[TKey key]
+            => dict[key];
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+            => dict.Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+            => dict.Values;
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public int Count
+            => dict.Count;
+    }
+}


### PR DESCRIPTION
I find it pretty silly that this is still a thing even going into .NET 8. Hoping to use this for https://github.com/ppy/osu/pull/26863.

|                   Method |     Mean |    Error |   StdDev |    Gen0 | Allocated |
|------------------------- |---------:|---------:|---------:|--------:|----------:|
|               Dictionary | 35.05 us | 0.692 us | 1.035 us |       - |         - |
|     DictionaryAsReadOnly | 91.75 us | 1.833 us | 4.212 us | 22.9492 |   48000 B |
| DictionaryAsSlimReadOnly | 34.67 us | 0.690 us | 1.345 us |       - |         - |
|                     Keys | 28.73 us | 0.079 us | 0.074 us |       - |         - |
|           KeysAsReadOnly | 81.24 us | 0.101 us | 0.095 us | 19.0430 |   40000 B |
|       KeysAsSlimReadOnly | 28.75 us | 0.056 us | 0.052 us |       - |         - |
|                   Values | 28.50 us | 0.083 us | 0.074 us |       - |         - |
|         ValuesAsReadOnly | 81.41 us | 1.241 us | 0.969 us | 19.0430 |   40000 B |
|     ValuesAsSlimReadOnly | 28.58 us | 0.074 us | 0.058 us |       - |         - |

In contrast to `SlimReadOnlyListWrapper<T>`, the only thing gained by implementing any of the other interfaces is `CopyTo()`, so I've taken the liberty of not implementing every dictionary interface in existence here.