### PR TITLE
Add ability to manage output area of tablet handler

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -23,6 +23,16 @@ namespace osu.Framework.Input.Handlers.Tablet
         Bindable<Vector2> AreaSize { get; }
 
         /// <summary>
+        /// Position of output area inside game window, 0 is top-left position, 1 is bottom-right.
+        /// </summary>
+        Bindable<Vector2> OutputAreaPosition { get; }
+
+        /// <summary>
+        /// Relative size of output area inside game window.
+        /// </summary>
+        Bindable<Vector2> OutputAreaSize { get; }
+
+        /// <summary>
         /// Information on the currently connected tablet device. May be null if no tablet is detected.
         /// </summary>
         IBindable<TabletInfo> Tablet { get; }

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -38,6 +38,10 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
 
+        public Bindable<Vector2> OutputAreaPosition { get; } = new Bindable<Vector2>();
+
+        public Bindable<Vector2> OutputAreaSize { get; } = new Bindable<Vector2>(new Vector2(1f, 1f));
+
         public Bindable<float> Rotation { get; } = new Bindable<float>();
 
         public IBindable<TabletInfo> Tablet => tablet;
@@ -57,6 +61,11 @@ namespace osu.Framework.Input.Handlers.Tablet
             AreaOffset.BindValueChanged(_ => updateInputArea(device));
             AreaSize.BindValueChanged(_ => updateInputArea(device), true);
             Rotation.BindValueChanged(_ => updateInputArea(device), true);
+
+            OutputAreaPosition.BindValueChanged(_ => updateOutputArea(host.Window));
+            OutputAreaSize.BindValueChanged(_ => updateOutputArea(host.Window));
+
+            updateOutputArea(host.Window);
 
             Enabled.BindValueChanged(enabled =>
             {
@@ -126,14 +135,26 @@ namespace osu.Framework.Input.Handlers.Tablet
             {
                 case AbsoluteOutputMode absoluteOutputMode:
                 {
-                    float outputWidth, outputHeight;
+                    // window size & pos
+                    float outputWidth = window.ClientSize.Width;
+                    float outputHeight = window.ClientSize.Height;
+                    float posX = outputWidth / 2;
+                    float posY = outputHeight / 2;
+
+                    // applying "output area"
+                    float areaOffsX = (1f - OutputAreaSize.Value.X) * (OutputAreaPosition.Value.X - 0.5f) * outputWidth;
+                    float areaOffsY = (1f - OutputAreaSize.Value.Y) * (OutputAreaPosition.Value.Y - 0.5f) * outputHeight;
+                    outputWidth *= OutputAreaSize.Value.X;
+                    outputHeight *= OutputAreaSize.Value.Y;
+                    posX += areaOffsX;
+                    posY += areaOffsY;
 
                     // Set output area in pixels
                     absoluteOutputMode.Output = new Area
                     {
-                        Width = outputWidth = window.ClientSize.Width,
-                        Height = outputHeight = window.ClientSize.Height,
-                        Position = new System.Numerics.Vector2(outputWidth / 2, outputHeight / 2)
+                        Width = outputWidth,
+                        Height = outputHeight,
+                        Position = new System.Numerics.Vector2(posX, posY)
                     };
                     break;
                 }


### PR DESCRIPTION
Partially does #6150 .

Exposes area position / size bindables, implements their application.

Manually tested this in different scaling modes with different window sizes/positions on display, seems to work as expected.

Ad-hoc diff for osu!:

```diff
diff --git a/osu.Game/OsuGame.cs b/osu.Game/OsuGame.cs
index c244708385..e82abc233e 100644
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -68,6 +68,7 @@
 using osu.Game.Updater;
 using osu.Game.Users;
 using osu.Game.Utils;
+using osuTK;
 using osuTK.Graphics;
 using Sentry;
 
@@ -1134,10 +1135,46 @@ protected override void LoadComplete()
                 if (mode.NewValue != OverlayActivation.All) CloseAllOverlays();
             };
 
+            {
+                var tablet = Host.AvailableInputHandlers.OfType<ITabletHandler>().FirstOrDefault();
+
+                if (tablet != null)
+                {
+                    scalingMode = LocalConfig.GetBindable<ScalingMode>(OsuSetting.Scaling);
+                    scalingSizeX = LocalConfig.GetBindable<float>(OsuSetting.ScalingSizeX);
+                    scalingSizeY = LocalConfig.GetBindable<float>(OsuSetting.ScalingSizeY);
+                    scalingPositionX = LocalConfig.GetBindable<float>(OsuSetting.ScalingPositionX);
+                    scalingPositionY = LocalConfig.GetBindable<float>(OsuSetting.ScalingPositionY);
+
+                    void updateAreaSize(ValueChangedEvent<float> _)
+                    {
+                        if (scalingMode.Value == ScalingMode.Everything)
+                            tablet.OutputAreaSize.Value = new Vector2(scalingSizeX.Value, scalingSizeY.Value);
+                        else
+                            tablet.OutputAreaSize.Value = new Vector2(1, 1);
+                    }
+
+                    scalingMode.ValueChanged += _ => updateAreaSize(null!);
+                    scalingSizeX.ValueChanged += updateAreaSize;
+                    scalingSizeY.ValueChanged += updateAreaSize;
+                    scalingPositionX.ValueChanged += _ => tablet.OutputAreaPosition.Value = new Vector2(scalingPositionX.Value, scalingPositionY.Value);
+                    scalingPositionY.ValueChanged += _ => tablet.OutputAreaPosition.Value = new Vector2(scalingPositionX.Value, scalingPositionY.Value);
+
+                    updateAreaSize(null!);
+                    tablet.OutputAreaPosition.Value = new Vector2(scalingPositionX.Value, scalingPositionY.Value);
+                }
+            }
+
             // Importantly, this should be run after binding PostNotification to the import handlers so they can present the import after game startup.
             handleStartupImport();
         }
 
+        private Bindable<ScalingMode> scalingMode = null!;
+        private Bindable<float> scalingPositionX = null!;
+        private Bindable<float> scalingPositionY = null!;
+        private Bindable<float> scalingSizeX = null!;
+        private Bindable<float> scalingSizeY = null!;
+
         private void handleStartupImport()
         {
             if (args?.Length > 0)
```