### PR TITLE
Allow to customize popover blocker

### DIFF
--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Cursor
     public partial class PopoverContainer : Container
     {
         private readonly Container content;
-        private readonly Container dismissOnMouseDownContainer;
+        private readonly Container<Drawable> dismissOnMouseDownContainer;
 
         private IHasPopover? target;
         private Popover? currentPopover;
@@ -177,7 +177,7 @@ namespace osu.Framework.Graphics.Cursor
             return availableSize;
         }
 
-        private partial class DismissOnMouseDownContainer : Container
+        private partial class DismissOnMouseDownContainer : Container<Drawable>
         {
             protected override bool OnMouseDown(MouseDownEvent e)
             {

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -31,10 +31,7 @@ namespace osu.Framework.Graphics.Cursor
                 {
                     RelativeSizeAxes = Axes.Both,
                 },
-                dismissOnMouseDownContainer = new DismissOnMouseDownContainer
-                {
-                    RelativeSizeAxes = Axes.Both
-                }
+                dismissOnMouseDownContainer = CreateInternalPopoverContainer().With(x => x.RelativeSizeAxes = Axes.Both)
             };
         }
 
@@ -176,6 +173,11 @@ namespace osu.Framework.Graphics.Cursor
             // the final size is the intersection of the X/Y areas.
             return availableSize;
         }
+
+        /// <summary>
+        /// Creates a container where <see cref="Popover"/>s will be placed. This container is expected to dismiss popovers on mouse clicks.
+        /// </summary>
+        protected virtual Container<Drawable> CreateInternalPopoverContainer() => new DismissOnMouseDownContainer();
 
         private partial class DismissOnMouseDownContainer : Container<Drawable>
         {


### PR DESCRIPTION
In my project I need to skip all non-left mouse buttons through popover container. I also use custom logic that has conditions not to close popovers on outside clicks. To do this i had to copy-paste out the whole popover subsystem just to set my own `DismissOnMouseDownContainer`. I want to switch to built-in one again so proposing this.

This allows to override component that handles outside clicks in `PopoverContainer`. This is no-op change for existing usages.