### PR TITLE
Fix tablet events being enqueued when window is inactive

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -203,7 +203,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void enqueueInput(IInput input)
         {
-            PendingInputs.Enqueue(input);
+            if(host.IsActive.Value) {
+                PendingInputs.Enqueue(input);
+            }
             FrameStatistics.Increment(StatisticsCounterType.TabletEvents);
             statistic_total_events.Value++;
         }


### PR DESCRIPTION
This is a simple fix for ppy/osu#26284 (at least on my system). Maybe adding this check should be considered for other input handlers.