### PR TITLE
Set UTF-8 console encoding on windows

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Text;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Rendering;
@@ -36,6 +37,13 @@ namespace osu.Framework.Platform.Windows
         internal WindowsGameHost(string gameName, HostOptions? options)
             : base(gameName, options)
         {
+            try
+            {
+                Console.OutputEncoding = Encoding.UTF8;
+            }
+            catch
+            {
+            }
         }
 
         public override bool OpenFileExternally(string filename)


### PR DESCRIPTION
This is in a try/catch because it can fail, and is only set on windows because UTF-8 is not the default there. Emoji already works fine when running unit tests from Rider, so setting this in `DesktopGameHost` is not needed.

Before (Rider Run/Debug on Windows):

![image](https://github.com/ppy/osu-framework/assets/16479013/1fc182b0-36a4-43f0-981d-eb680c47f44f)

After:

![image](https://github.com/ppy/osu-framework/assets/16479013/97da5abc-b81c-4ef3-ac9e-f38c6198f765)
