### PR TITLE
Fix some .NET 8 CA1416 android inspections

### DIFF
--- a/osu.Framework.Android/Input/AndroidMouseHandler.cs
+++ b/osu.Framework.Android/Input/AndroidMouseHandler.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Android.Input
         /// <remarks>
         /// Only available in Android 8.0 Oreo (<see cref="BuildVersionCodes.O"/>) and up.
         /// </remarks>
-        public BindableBool UseRelativeMode { get; } = new BindableBool(true)
+        public BindableBool UseRelativeMode { get; } = new BindableBool(false)
         {
             Description = "Allows for sensitivity adjustment and tighter control of input",
         };
@@ -44,7 +44,10 @@ namespace osu.Framework.Android.Input
 
         public override bool IsActive => true;
 
-        protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.Mouse, InputSourceType.MouseRelative, InputSourceType.Touchpad };
+        protected override IEnumerable<InputSourceType> HandledEventSources =>
+            OperatingSystem.IsAndroidVersionAtLeast(26)
+                ? new[] { InputSourceType.Mouse, InputSourceType.MouseRelative, InputSourceType.Touchpad }
+                : new[] { InputSourceType.Mouse, InputSourceType.Touchpad };
 
         private AndroidGameWindow window = null!;
 

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using Android.Views;
 using osu.Framework.Input;
@@ -19,7 +20,10 @@ namespace osu.Framework.Android.Input
 
         public override bool IsActive => true;
 
-        protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.BluetoothStylus, InputSourceType.Stylus, InputSourceType.Touchscreen };
+        protected override IEnumerable<InputSourceType> HandledEventSources =>
+            OperatingSystem.IsAndroidVersionAtLeast(23)
+                ? new[] { InputSourceType.BluetoothStylus, InputSourceType.Stylus, InputSourceType.Touchscreen }
+                : new[] { InputSourceType.Stylus, InputSourceType.Touchscreen };
 
         public AndroidTouchHandler(AndroidGameView view)
             : base(view)
@@ -81,7 +85,9 @@ namespace osu.Framework.Android.Input
         protected override bool OnHover(MotionEvent hoverEvent)
         {
             hoverEvent.HandleHistorically(apply);
-            enqueueInput(new MouseButtonInput(MouseButton.Right, hoverEvent.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
+
+            if (OperatingSystem.IsAndroidVersionAtLeast(23))
+                enqueueInput(new MouseButtonInput(MouseButton.Right, hoverEvent.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
 
             // TODO: handle stylus events based on hoverEvent.Action
             // stylus should probably have it's own handler.


### PR DESCRIPTION
Fixes some inspections from the .NET 8 upgrade as seen in https://github.com/ppy/osu-framework/actions/runs/7754422132.

Fixes warnings such as the following:
> This call site is reachable on: 'Android' 21.0 and later. 'MotionEventButtonState.StylusPrimary' is only supported on: 'android' 23.0 and later. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)

Those warnings are new in .NET 8 because enum values are now also annotated.