### PR TITLE
Fix obsolete code in Android safe area handling by using AndroidX

### DIFF
--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -7,5 +7,6 @@
     <!-- NullabilityInfoContextSupport is disabled by default for Android -->
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <NoWarn>$(NoWarn);XA4218</NoWarn>
   </PropertyGroup>
 </Project>

--- a/osu.Framework.Android/AndroidExtensions.cs
+++ b/osu.Framework.Android/AndroidExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.Graphics;
+using osu.Framework.Graphics.Primitives;
+
+namespace osu.Framework.Android
+{
+    public static class AndroidExtensions
+    {
+        public static RectangleI ToRectangleI(this Rect rect) => new RectangleI(rect.Left, rect.Top, rect.Width(), rect.Height());
+    }
+}

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -187,24 +187,17 @@ namespace osu.Framework.Android
                 RenderGame();
         }
 
+        public override WindowInsets? OnApplyWindowInsets(WindowInsets? insets)
+        {
+            updateSafeArea();
+            return base.OnApplyWindowInsets(insets);
+        }
+
         [STAThread]
         public void RenderGame()
         {
             // request focus so that joystick input can immediately work.
             RequestFocus();
-
-            LayoutChange += (_, _) => updateSafeArea();
-
-            Activity.IsActive.BindValueChanged(active =>
-            {
-                // When rotating device 180 degrees in the background,
-                // LayoutChange doesn't trigger after returning to game.
-                // So update safe area once active again.
-                if (active.NewValue)
-                    updateSafeArea();
-            });
-
-            updateSafeArea();
 
             Host = new AndroidGameHost(this);
             Host.ExceptionThrown += handleException;

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.Versioning;
 using Android.Content;
-using Android.Graphics;
 using Android.OS;
 using Android.Runtime;
 using Android.Text;
@@ -16,9 +15,7 @@ using AndroidX.Window.Layout;
 using osu.Framework.Android.Input;
 using osu.Framework.Logging;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Platform;
 using osuTK.Graphics;
 
@@ -261,15 +258,12 @@ namespace osu.Framework.Android
                 usableWindowArea = usableWindowArea.Intersect(radiusInsetArea);
             }
 
-            if (OperatingSystem.IsAndroidVersionAtLeast(24) && Activity.IsInMultiWindowMode)
+            if (OperatingSystem.IsAndroidVersionAtLeast(24) && Activity.IsInMultiWindowMode && RootWindowInsets != null)
             {
                 // if we are in multi-window mode, the status bar is always visible (even if we request to hide it) and could be obstructing our view.
                 // if multi-window mode is not active, we can assume the status bar is hidden so we shouldn't consider it for safe area calculations.
-
-                // `SystemWindowInsetTop` should be the correct inset here, but it doesn't correctly work (gives `0` even if the view is obstructed).
-#pragma warning disable 618 // StableInsetTop is deprecated
-                int statusBarHeight = RootWindowInsets?.StableInsetTop ?? 0;
-#pragma warning restore 618 //
+                var insetsCompat = WindowInsetsCompat.ToWindowInsetsCompat(RootWindowInsets, this);
+                int statusBarHeight = insetsCompat.GetInsets(WindowInsetsCompat.Type.StatusBars()).Top;
                 usableWindowArea = usableWindowArea.Intersect(windowArea.Shrink(0, 0, statusBarHeight, 0));
             }
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -189,7 +189,7 @@ namespace osu.Framework.Android
 
         public override WindowInsets? OnApplyWindowInsets(WindowInsets? insets)
         {
-            updateSafeArea();
+            updateSafeArea(insets);
             return base.OnApplyWindowInsets(insets);
         }
 
@@ -218,7 +218,7 @@ namespace osu.Framework.Android
         /// <summary>
         /// Updates the <see cref="IWindow.SafeAreaPadding"/>, taking into account screen insets that may be obstructing this <see cref="AndroidGameView"/>.
         /// </summary>
-        private void updateSafeArea()
+        private void updateSafeArea(WindowInsets? windowInsets)
         {
             var metrics = WindowMetricsCalculator.Companion.OrCreate.ComputeCurrentWindowMetrics(Activity);
             var windowArea = metrics.Bounds.ToRectangleI();
@@ -226,18 +226,18 @@ namespace osu.Framework.Android
 
             if (OperatingSystem.IsAndroidVersionAtLeast(28))
             {
-                var cutout = RootWindowInsets?.DisplayCutout;
+                var cutout = windowInsets?.DisplayCutout;
 
                 if (cutout != null)
                     usableWindowArea = usableWindowArea.Shrink(cutout.SafeInsetLeft, cutout.SafeInsetRight, cutout.SafeInsetTop, cutout.SafeInsetBottom);
             }
 
-            if (OperatingSystem.IsAndroidVersionAtLeast(31) && RootWindowInsets != null)
+            if (OperatingSystem.IsAndroidVersionAtLeast(31) && windowInsets != null)
             {
-                var topLeftCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopLeft);
-                var topRightCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopRight);
-                var bottomLeftCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomLeft);
-                var bottomRightCorner = RootWindowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomRight);
+                var topLeftCorner = windowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopLeft);
+                var topRightCorner = windowInsets.GetRoundedCorner((int)RoundedCornerPosition.TopRight);
+                var bottomLeftCorner = windowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomLeft);
+                var bottomRightCorner = windowInsets.GetRoundedCorner((int)RoundedCornerPosition.BottomRight);
 
                 int cornerInsetLeft = Math.Max(topLeftCorner?.Radius ?? 0, bottomLeftCorner?.Radius ?? 0);
                 int cornerInsetRight = Math.Max(topRightCorner?.Radius ?? 0, bottomRightCorner?.Radius ?? 0);
@@ -251,11 +251,11 @@ namespace osu.Framework.Android
                 usableWindowArea = usableWindowArea.Intersect(radiusInsetArea);
             }
 
-            if (OperatingSystem.IsAndroidVersionAtLeast(24) && Activity.IsInMultiWindowMode && RootWindowInsets != null)
+            if (OperatingSystem.IsAndroidVersionAtLeast(24) && Activity.IsInMultiWindowMode && windowInsets != null)
             {
                 // if we are in multi-window mode, the status bar is always visible (even if we request to hide it) and could be obstructing our view.
                 // if multi-window mode is not active, we can assume the status bar is hidden so we shouldn't consider it for safe area calculations.
-                var insetsCompat = WindowInsetsCompat.ToWindowInsetsCompat(RootWindowInsets, this);
+                var insetsCompat = WindowInsetsCompat.ToWindowInsetsCompat(windowInsets, this);
                 int statusBarHeight = insetsCompat.GetInsets(WindowInsetsCompat.Type.StatusBars()).Top;
                 usableWindowArea = usableWindowArea.Intersect(windowArea.Shrink(0, 0, statusBarHeight, 0));
             }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -19,5 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osuTK.Android" Version="1.0.211" />
+    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.2.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This replaces obsolete calls with AndroidX compat classes that allow using new-style APIs on older android platforms.

Eg. [Display.getRealSize()](https://developer.android.com/reference/android/view/Display#getRealSize(android.graphics.Point)) is deprecated on API 31+ and the suggested alternative is [WindowManager.getCurrentWindowMetrics()](https://developer.android.com/reference/android/view/WindowManager#getCurrentWindowMetrics()) (API 30+), so instead of having to call the old API on old platforms and the new API on new platforms, we use AndroidX [WindowMetricsCalculator](https://developer.android.com/reference/androidx/window/layout/WindowMetricsCalculator) which does that for us.

`Microsoft.Maui.Essentials` is using `Xamarin.AndroidX` libraries ([see nuget](https://www.nuget.org/packages/Microsoft.Maui.Essentials#dependencies-body-tab)), so it's safe and supported to use them.