### PR TITLE
Ignore missing feedback api

### DIFF
--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -74,8 +74,16 @@ namespace osu.Framework.Platform.Windows.Native
 
         public static unsafe void SetWindowFeedbackSetting(IntPtr hwnd, FeedbackType feedback, bool configuration)
         {
-            int config = configuration ? 1 : 0; // mimics win32 BOOL type.
-            SetWindowFeedbackSetting(hwnd, feedback, 0, sizeof(int), &config);
+            try
+            {
+                int config = configuration ? 1 : 0; // mimics win32 BOOL type.
+                SetWindowFeedbackSetting(hwnd, feedback, 0, sizeof(int), &config);
+            }
+            catch
+            {
+                // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowfeedbacksetting#requirements
+                // this API only exists in Win8+.
+            }
         }
     }
 

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -83,7 +83,6 @@ namespace osu.Framework.Platform.Windows
             base.Create();
 
             // disable all pen and touch feedback as this causes issues when running "optimised" fullscreen under Direct3D11.
-
             foreach (var feedbackType in Enum.GetValues<FeedbackType>())
                 Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
 

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -83,16 +83,9 @@ namespace osu.Framework.Platform.Windows
             base.Create();
 
             // disable all pen and touch feedback as this causes issues when running "optimised" fullscreen under Direct3D11.
-            try
-            {
-                foreach (var feedbackType in Enum.GetValues<FeedbackType>())
-                    Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
-            }
-            catch
-            {
-                // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowfeedbacksetting#requirements
-                // this API only exists in Win8+.
-            }
+
+            foreach (var feedbackType in Enum.GetValues<FeedbackType>())
+                Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
 
             // enable window message events to use with `OnSDLEvent` below.
             SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -83,8 +83,16 @@ namespace osu.Framework.Platform.Windows
             base.Create();
 
             // disable all pen and touch feedback as this causes issues when running "optimised" fullscreen under Direct3D11.
-            foreach (var feedbackType in Enum.GetValues<FeedbackType>())
-                Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
+            try
+            {
+                foreach (var feedbackType in Enum.GetValues<FeedbackType>())
+                    Native.Input.SetWindowFeedbackSetting(WindowHandle, feedbackType, false);
+            }
+            catch
+            {
+                // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowfeedbacksetting#requirements
+                // this API only exists in Win8+.
+            }
 
             // enable window message events to use with `OnSDLEvent` below.
             SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);


### PR DESCRIPTION
This exists only on win8+: https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowfeedbacksetting#requirements

Before:
[1707225741.runtime.log](https://github.com/ppy/osu-framework/files/14180973/1707225741.runtime.log)

After:
![image_2024-02-06_16-40-43](https://github.com/ppy/osu-framework/assets/53872073/82b8aa2b-1fea-4d72-97d9-9dc41f8a936e)
