### PR TITLE
Use new MD5/SHA.HashData(Stream) overload

### DIFF
--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -265,10 +265,8 @@ namespace osu.Framework.Extensions
         /// <returns>A lower-case hex string representation of the hash (64 characters).</returns>
         public static string ComputeSHA2Hash(this Stream stream)
         {
-            string hash;
-
             stream.Seek(0, SeekOrigin.Begin);
-            hash = SHA256.HashData(stream).toLowercaseHex();
+            string hash = SHA256.HashData(stream).toLowercaseHex();
             stream.Seek(0, SeekOrigin.Begin);
 
             return hash;
@@ -283,10 +281,8 @@ namespace osu.Framework.Extensions
 
         public static string ComputeMD5Hash(this Stream stream)
         {
-            string hash;
-
             stream.Seek(0, SeekOrigin.Begin);
-            hash = MD5.HashData(stream).toLowercaseHex();
+            string hash = MD5.HashData(stream).toLowercaseHex();
             stream.Seek(0, SeekOrigin.Begin);
 
             return hash;

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -268,10 +268,7 @@ namespace osu.Framework.Extensions
             string hash;
 
             stream.Seek(0, SeekOrigin.Begin);
-
-            using (var alg = SHA256.Create())
-                hash = alg.ComputeHash(stream).toLowercaseHex();
-
+            hash = SHA256.HashData(stream).toLowercaseHex();
             stream.Seek(0, SeekOrigin.Begin);
 
             return hash;
@@ -289,8 +286,7 @@ namespace osu.Framework.Extensions
             string hash;
 
             stream.Seek(0, SeekOrigin.Begin);
-            using (var md5 = MD5.Create())
-                hash = md5.ComputeHash(stream).toLowercaseHex();
+            hash = MD5.HashData(stream).toLowercaseHex();
             stream.Seek(0, SeekOrigin.Begin);
 
             return hash;


### PR DESCRIPTION
Benchmark:

|        Method |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------- |---------:|----------:|----------:|-------:|----------:|
|     StreamMD5 | 2.645 μs | 0.0151 μs | 0.0134 μs | 0.0687 |     296 B |
| StreamMD5_New | 2.499 μs | 0.0105 μs | 0.0093 μs | 0.0381 |     160 B |
|     StreamSHA | 1.649 μs | 0.0132 μs | 0.0124 μs | 0.0935 |     392 B |
| StreamSHA_New | 1.568 μs | 0.0128 μs | 0.0114 μs | 0.0572 |     240 B |