### PR TITLE
Invalidate `GridContainer` only on DrawSize change

### DIFF
--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -139,7 +139,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private readonly Cached cellContent = new Cached();
-        private readonly LayoutValue cellLayout = new LayoutValue(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit);
+        private readonly LayoutValue cellLayout = new LayoutValue(Invalidation.DrawSize);
         private readonly LayoutValue cellChildLayout = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.Presence, InvalidationSource.Child);
 
         private CellContainer[,] cells = new CellContainer[0, 0];


### PR DESCRIPTION
Recomputing `GridContainer`'s layout is pretty allocation-heavy, which is happening during `DrawInfo` invalidation (common case - position change such as scrolling through overlays, comments, etc.).

Changing invalidation from `DrawSize` to `Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit` was a deliberate choice in https://github.com/ppy/osu-framework/pull/1139/commits/b0f4473ad0acaaabb718a385a6be47f4b1d304ed since looks like at the time of it's implementation nested grids weren't working properly.
![Снимок экрана 2024-02-16 235845](https://github.com/ppy/osu-framework/assets/22874522/32a4eba8-a251-431c-897b-e7429295a860)
However currently it seems like everything works fine somehow: tests are passing and as far as I can tell everything is good osu-side.
Also [FlowContainer](https://github.com/ppy/osu-framework/blob/d1a15e402157fcf8703cfd048b872c0bb0c37ce4/osu.Framework/Graphics/Containers/FlowContainer.cs#L66) has similar logic and it relies only on DrawSize invalidations which has been more than enough for years.
So I dunno. More eyes can find any problems if there are any, so I figured it's better to open a pr than just sitting on it guessing.

Example of scrolling in beatmap listing:
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/f572a0e4-395a-448f-9cc1-1cbe1d069115)|![pr](https://github.com/ppy/osu-framework/assets/22874522/acb63749-dcc3-4cce-b40c-927c0d53ea8c)|