### PR TITLE
Generalise markdown code block implementation to support indented style

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -86,9 +86,27 @@ Line below";
         }
 
         [Test]
-        public void TestFencedCode()
+        public void TestIndentedCodeBlock()
         {
-            AddStep("Markdown Fenced Code", () =>
+            AddStep("Markdown Indented Code Block", () =>
+            {
+                markdownContainer.Text = @"
+    [Escape me]
+    [[Escape me]]
+
+    {{
+      x = ""5""   # This assignment will not output anything
+      x         # This expression will print 5
+      x + 1     # This expression will print 6
+    }}
+";
+            });
+        }
+
+        [Test]
+        public void TestFencedCodeBlock()
+        {
+            AddStep("Markdown Fenced Code Block", () =>
             {
                 markdownContainer.Text = @"```scriban-html
 

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownCodeBlock.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownCodeBlock.cs
@@ -9,23 +9,32 @@ using osuTK.Graphics;
 namespace osu.Framework.Graphics.Containers.Markdown
 {
     /// <summary>
-    /// Visualises a fenced code block.
+    /// Visualises an indented/fenced code block.
     /// </summary>
     /// <code>
     /// ```
-    /// code
+    /// code1
+    /// code2
+    /// code3
     /// ```
     /// </code>
-    public partial class MarkdownFencedCodeBlock : CompositeDrawable, IMarkdownTextFlowComponent
+    /// <code>
+    ///
+    ///     code1
+    ///     code2
+    ///     code3
+    ///
+    /// </code>
+    public partial class MarkdownCodeBlock : CompositeDrawable, IMarkdownTextFlowComponent
     {
-        private readonly FencedCodeBlock fencedCodeBlock;
+        private readonly CodeBlock codeBlock;
 
         [Resolved]
         private IMarkdownTextFlowComponent parentFlowComponent { get; set; } = null!;
 
-        public MarkdownFencedCodeBlock(FencedCodeBlock fencedCodeBlock)
+        public MarkdownCodeBlock(CodeBlock codeBlock)
         {
-            this.fencedCodeBlock = fencedCodeBlock;
+            this.codeBlock = codeBlock;
 
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;
@@ -42,8 +51,8 @@ namespace osu.Framework.Graphics.Containers.Markdown
             };
 
             // Markdig sometimes appends empty lines to the processed block, only add original lines to the container
-            for (int i = 0; i < fencedCodeBlock.Lines.Count; i++)
-                textFlowContainer.AddParagraph(fencedCodeBlock.Lines.Lines[i].ToString());
+            for (int i = 0; i < codeBlock.Lines.Count; i++)
+                textFlowContainer.AddParagraph(codeBlock.Lines.Lines[i].ToString());
         }
 
         protected virtual Drawable CreateBackground() => new Box

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -241,8 +241,8 @@ namespace osu.Framework.Graphics.Containers.Markdown
                     container.Add(CreateQuoteBlock(quoteBlock));
                     break;
 
-                case FencedCodeBlock fencedCodeBlock:
-                    container.Add(CreateFencedCodeBlock(fencedCodeBlock));
+                case CodeBlock codeBlock:
+                    container.Add(CreateCodeBlock(codeBlock));
                     break;
 
                 case Table table:
@@ -311,11 +311,11 @@ namespace osu.Framework.Graphics.Containers.Markdown
         protected virtual MarkdownQuoteBlock CreateQuoteBlock(QuoteBlock quoteBlock) => new MarkdownQuoteBlock(quoteBlock);
 
         /// <summary>
-        /// Creates the visualiser for a <see cref="FencedCodeBlock"/>.
+        /// Creates the visualiser for a <see cref="CodeBlock"/>.
         /// </summary>
-        /// <param name="fencedCodeBlock">The <see cref="FencedCodeBlock"/> to visualise.</param>
+        /// <param name="codeBlock">The <see cref="CodeBlock"/> to visualise.</param>
         /// <returns>The visualiser.</returns>
-        protected virtual MarkdownFencedCodeBlock CreateFencedCodeBlock(FencedCodeBlock fencedCodeBlock) => new MarkdownFencedCodeBlock(fencedCodeBlock);
+        protected virtual MarkdownCodeBlock CreateCodeBlock(CodeBlock codeBlock) => new MarkdownCodeBlock(codeBlock);
 
         /// <summary>
         /// Creates the visualiser for a <see cref="Table"/>.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/27194

We commonly use the fenced style for code blocks (the ` ``` ` symbol), but there exists another style for code blocks in markdown, known as [indented code blocks](https://www.jetbrains.com/help/hub/markdown-syntax.html#indented-code-blocks). 

Markdig already handles everything for us and outputs the above as `CodeBlock` objects, but our current implementation was handling `FencedCodeBlock` specifically. Both styles render similarly, so I generalised the implementation to read from `CodeBlock`s instead of `FencedCodeBlock`s.

`CodeBlock` is a superclass of `FencedCodeBlock`, so this PR doesn't have to do extra logic for `FencedCodeBlock` objects.