### PR TITLE
Cleanup common Renderer methods

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Batches/GLLinearBatch.cs
+++ b/osu.Framework/Graphics/OpenGL/Batches/GLLinearBatch.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osuTK.Graphics.ES30;
 
@@ -11,14 +12,14 @@ namespace osu.Framework.Graphics.OpenGL.Batches
     internal class GLLinearBatch<T> : GLVertexBatch<T>
         where T : unmanaged, IEquatable<T>, IVertex
     {
-        private readonly PrimitiveType type;
+        private readonly PrimitiveTopology topology;
 
-        public GLLinearBatch(GLRenderer renderer, int size, int maxBuffers, PrimitiveType type)
+        public GLLinearBatch(GLRenderer renderer, int size, int maxBuffers, PrimitiveTopology topology)
             : base(renderer, size, maxBuffers)
         {
-            this.type = type;
+            this.topology = topology;
         }
 
-        protected override GLVertexBuffer<T> CreateVertexBuffer(GLRenderer renderer) => new GLLinearBuffer<T>(renderer, Size, type, BufferUsageHint.DynamicDraw);
+        protected override GLVertexBuffer<T> CreateVertexBuffer(GLRenderer renderer) => new GLLinearBuffer<T>(renderer, Size, topology, BufferUsageHint.DynamicDraw);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLLinearBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLLinearBuffer.cs
@@ -28,11 +28,11 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     {
         private readonly int amountVertices;
 
-        public GLLinearBuffer(GLRenderer renderer, int amountVertices, PrimitiveType type, BufferUsageHint usage)
+        public GLLinearBuffer(GLRenderer renderer, int amountVertices, PrimitiveTopology topology, BufferUsageHint usage)
             : base(renderer, amountVertices, usage)
         {
             this.amountVertices = amountVertices;
-            Type = type;
+            Topology = topology;
 
             Debug.Assert(amountVertices <= IRenderer.MAX_VERTICES);
         }
@@ -57,6 +57,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             }
         }
 
-        protected override PrimitiveType Type { get; }
+        protected override PrimitiveTopology Topology { get; }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLQuadBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLQuadBuffer.cs
@@ -63,6 +63,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         protected override int ToElementIndex(int vertexIndex) => 3 * vertexIndex / 2;
 
-        protected override PrimitiveType Type => PrimitiveType.Triangles;
+        protected override PrimitiveTopology Topology => PrimitiveTopology.Triangles;
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLVertexBuffer.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         protected virtual int ToElementIndex(int vertexIndex) => vertexIndex;
 
-        protected abstract PrimitiveType Type { get; }
+        protected abstract PrimitiveTopology Topology { get; }
 
         public void Draw()
         {
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         public void DrawRange(int startIndex, int endIndex)
         {
             Bind(true);
-            Renderer.DrawVertices(Type, ToElementIndex(startIndex), ToElements(endIndex - startIndex));
+            Renderer.DrawVertices(Topology, ToElementIndex(startIndex), ToElements(endIndex - startIndex));
         }
 
         public void Update()

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -233,17 +233,8 @@ namespace osu.Framework.Graphics.OpenGL
         protected override void SetFrameBufferImplementation(IFrameBuffer? frameBuffer) =>
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, ((GLFrameBuffer?)frameBuffer)?.FrameBuffer ?? backbufferFramebuffer);
 
-        /// <summary>
-        /// Deletes a frame buffer.
-        /// </summary>
-        /// <param name="frameBuffer">The frame buffer to delete.</param>
-        public void DeleteFrameBuffer(IFrameBuffer frameBuffer)
-        {
-            while (FrameBuffer == frameBuffer)
-                UnbindFrameBuffer(frameBuffer);
-
-            ScheduleDisposal(GL.DeleteFramebuffer, ((GLFrameBuffer)frameBuffer).FrameBuffer);
-        }
+        protected override void DeleteFrameBufferImplementation(IFrameBuffer frameBuffer)
+            => GL.DeleteFramebuffer(((GLFrameBuffer)frameBuffer).FrameBuffer);
 
         protected override void ClearImplementation(ClearInfo clearInfo)
         {

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -278,12 +278,9 @@ namespace osu.Framework.Graphics.OpenGL
             boundUniformBuffers[blockName] = glBuffer;
         }
 
-        public void DrawVertices(PrimitiveType type, int vertexStart, int verticesCount)
+        public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)
         {
             var glShader = (GLShader)Shader!;
-
-            glShader.BindUniformBlock("g_GlobalUniforms", GlobalUniformBuffer!);
-
             int currentUniformBinding = 0;
             int currentStorageBinding = 0;
 
@@ -308,7 +305,7 @@ namespace osu.Framework.Graphics.OpenGL
                 }
             }
 
-            GL.DrawElements(type, verticesCount, DrawElementsType.UnsignedShort, vertexStart * sizeof(ushort));
+            GL.DrawElements(GLUtils.ToPrimitiveType(topology), verticesCount, DrawElementsType.UnsignedShort, vertexStart * sizeof(ushort));
         }
 
         protected override void SetScissorStateImplementation(bool enabled)
@@ -500,7 +497,7 @@ namespace osu.Framework.Graphics.OpenGL
         protected override INativeTexture CreateNativeVideoTexture(int width, int height) => new GLVideoTexture(this, width, height);
 
         protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology topology)
-            => new GLLinearBatch<TVertex>(this, size, maxBuffers, GLUtils.ToPrimitiveType(topology));
+            => new GLLinearBatch<TVertex>(this, size, maxBuffers, topology);
 
         protected override IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) => new GLQuadBatch<TVertex>(this, size, maxBuffers);
     }

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -192,6 +192,9 @@ namespace osu.Framework.Graphics.OpenGL
             }
         }
 
+        protected override void SetUniformBufferImplementation(string blockName, IUniformBuffer buffer)
+            => boundUniformBuffers[blockName] = (IGLUniformBuffer)buffer;
+
         protected override bool SetTextureImplementation(INativeTexture? texture, int unit)
         {
             if (texture == null)
@@ -267,15 +270,6 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.ClearStencil(clearInfo.Stencil);
 
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
-        }
-
-        public void BindUniformBuffer(string blockName, IGLUniformBuffer glBuffer)
-        {
-            if (boundUniformBuffers.TryGetValue(blockName, out IGLUniformBuffer? current) && current == glBuffer)
-                return;
-
-            FlushCurrentBatch(FlushBatchSource.BindBuffer);
-            boundUniformBuffers[blockName] = glBuffer;
         }
 
         public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Threading;

--- a/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
+++ b/osu.Framework/Graphics/OpenGL/Shaders/GLShader.cs
@@ -142,15 +142,12 @@ namespace osu.Framework.Graphics.OpenGL.Shaders
 
         public virtual void BindUniformBlock(string blockName, IUniformBuffer buffer)
         {
-            if (buffer is not IGLUniformBuffer glBuffer)
-                throw new ArgumentException($"Buffer must be an {nameof(IGLUniformBuffer)}.");
-
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not retrieve uniforms from a disposed shader.");
 
             EnsureShaderCompiled();
 
-            renderer.BindUniformBuffer(blockName, glBuffer);
+            renderer.BindUniformBuffer(blockName, buffer);
         }
 
         private protected virtual bool CompileInternal()

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -966,6 +966,20 @@ namespace osu.Framework.Graphics.Rendering
         /// <param name="frameBuffer">The framebuffer to use, or null to use the backbuffer (i.e. main framebuffer).</param>
         protected abstract void SetFrameBufferImplementation(IFrameBuffer? frameBuffer);
 
+        /// <summary>
+        /// Deletes a frame buffer.
+        /// </summary>
+        /// <param name="frameBuffer">The frame buffer to delete.</param>
+        public void DeleteFrameBuffer(IFrameBuffer frameBuffer)
+        {
+            while (FrameBuffer == frameBuffer)
+                UnbindFrameBuffer(frameBuffer);
+
+            ScheduleDisposal(DeleteFrameBufferImplementation, frameBuffer);
+        }
+
+        protected abstract void DeleteFrameBufferImplementation(IFrameBuffer frameBuffer);
+
         #endregion
 
         public void DrawVertices(PrimitiveTopology topology, int vertexStart, int verticesCount)

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -110,6 +110,7 @@ namespace osu.Framework.Graphics.Rendering
 
         private readonly DepthValue backBufferDepth = new DepthValue();
 
+        private readonly Dictionary<string, IUniformBuffer> boundUniformBuffers = new Dictionary<string, IUniformBuffer>();
         private readonly Stack<IVertexBatch<TexturedVertex2D>> quadBatches = new Stack<IVertexBatch<TexturedVertex2D>>();
         private readonly List<IVertexBuffer> vertexBuffersInUse = new List<IVertexBuffer>();
         private readonly List<IVertexBatch> batchResetList = new List<IVertexBatch>();
@@ -228,6 +229,7 @@ namespace osu.Framework.Graphics.Rendering
             Shader?.Unbind();
             Shader = null;
 
+            boundUniformBuffers.Clear();
             viewportStack.Clear();
             projectionMatrixStack.Clear();
             maskingStack.Clear();
@@ -1039,6 +1041,19 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         /// <param name="uniform">The uniform to update.</param>
         protected abstract void SetUniformImplementation<T>(IUniformWithValue<T> uniform) where T : unmanaged, IEquatable<T>;
+
+        public void BindUniformBuffer(string blockName, IUniformBuffer buffer)
+        {
+            if (boundUniformBuffers.TryGetValue(blockName, out IUniformBuffer? current) && current == buffer)
+                return;
+
+            FlushCurrentBatch(FlushBatchSource.BindBuffer);
+            SetUniformBufferImplementation(blockName, buffer);
+
+            boundUniformBuffers[blockName] = buffer;
+        }
+
+        protected abstract void SetUniformBufferImplementation(string blockName, IUniformBuffer buffer);
 
         #endregion
 

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridLinearBatch.cs
@@ -2,9 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers;
-using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid.Batches
 {

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridQuadBatch.cs
@@ -5,7 +5,6 @@ using System;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers;
-using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid.Batches
 {
@@ -13,7 +12,7 @@ namespace osu.Framework.Graphics.Veldrid.Batches
         where T : unmanaged, IEquatable<T>, IVertex
     {
         public VeldridQuadBatch(VeldridRenderer renderer, int quads)
-            : base(renderer, quads * IRenderer.VERTICES_PER_QUAD, PrimitiveTopology.TriangleList, VeldridIndexLayout.Quad)
+            : base(renderer, quads * IRenderer.VERTICES_PER_QUAD, PrimitiveTopology.Triangles, VeldridIndexLayout.Quad)
         {
             if (quads > IRenderer.MAX_QUADS)
                 throw new OverflowException($"Attempted to initialise a {nameof(VeldridQuadBatch<T>)} with more than {nameof(IRenderer)}.{nameof(IRenderer.MAX_QUADS)} quads ({IRenderer.MAX_QUADS}).");

--- a/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
+++ b/osu.Framework/Graphics/Veldrid/Batches/VeldridVertexBatch.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
-using PrimitiveTopology = Veldrid.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid.Batches
 {

--- a/osu.Framework/Graphics/Veldrid/Buffers/IVeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/IVeldridVertexBuffer.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
-using osu.Framework.Graphics.Veldrid.Vertices;
 using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid.Buffers
@@ -12,10 +11,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
     internal interface IVeldridVertexBuffer<in T> : IVertexBuffer, IDisposable
         where T : unmanaged, IEquatable<T>, IVertex
     {
-        protected static readonly int STRIDE = VeldridVertexUtils<T>.STRIDE;
-
-        public static readonly VertexLayoutDescription LAYOUT = VeldridVertexUtils<T>.Layout;
-
         /// <summary>
         /// Gets the number of vertices in this <see cref="IVeldridVertexBuffer{T}"/>.
         /// </summary>

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private void recreateResources()
         {
             // The texture is created once and resized internally, so it should not be deleted.
-            deleteResources(false);
+            DeleteResources(false);
 
             if (depthFormat is PixelFormat depth)
             {
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// Deletes the resources of this frame buffer.
         /// </summary>
         /// <param name="deleteTexture">Whether the texture should also be deleted.</param>
-        private void deleteResources(bool deleteTexture)
+        public void DeleteResources(bool deleteTexture)
         {
             if (deleteTexture && !externalColourTarget)
                 colourTarget.Dispose();
@@ -140,11 +140,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             if (isDisposed)
                 return;
 
-            while (renderer.IsFrameBufferBound(this))
-                Unbind();
-
-            deleteResources(true);
-
+            renderer.DeleteFrameBuffer(this);
             isDisposed = true;
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -24,7 +24,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly PixelFormat? depthFormat;
 
         private readonly VeldridTexture colourTarget;
-        private readonly int mipLevel;
         private Texture? depthTarget;
 
         private Vector2 size = Vector2.One;
@@ -48,8 +47,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             }
         }
 
-        private readonly bool externalColourTarget;
-
         public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
         {
             // todo: we probably want the arguments separated to "PixelFormat[] colorFormats, PixelFormat depthFormat".
@@ -62,18 +59,6 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
             colourTarget = new FrameBufferTexture(renderer, filteringMode);
             Texture = renderer.CreateTexture(colourTarget);
-
-            recreateResources();
-        }
-
-        internal VeldridFrameBuffer(VeldridRenderer renderer, VeldridTexture colourTarget, int mipLevel)
-        {
-            this.renderer = renderer;
-            this.colourTarget = colourTarget;
-            this.mipLevel = mipLevel;
-
-            Texture = renderer.CreateTexture(colourTarget);
-            externalColourTarget = true;
 
             recreateResources();
         }
@@ -92,7 +77,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
             FramebufferDescription description = new FramebufferDescription
             {
-                ColorTargets = new[] { new FramebufferAttachmentDescription(colourTarget.GetResourceList().Single().Texture, 0, (uint)mipLevel) },
+                ColorTargets = new[] { new FramebufferAttachmentDescription(colourTarget.GetResourceList().Single().Texture, 0) },
                 DepthTarget = depthTarget == null ? null : new FramebufferAttachmentDescription(depthTarget, 0)
             };
 
@@ -112,7 +97,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// <param name="deleteTexture">Whether the texture should also be deleted.</param>
         public void DeleteResources(bool deleteTexture)
         {
-            if (deleteTexture && !externalColourTarget)
+            if (deleteTexture)
                 colourTarget.Dispose();
 
             if (Framebuffer.IsNotNull())

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private void recreateResources()
         {
             // The texture is created once and resized internally, so it should not be deleted.
-            DeleteResources(false);
+            deleteResources(false);
 
             if (depthFormat is PixelFormat depth)
             {
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         /// Deletes the resources of this frame buffer.
         /// </summary>
         /// <param name="deleteTexture">Whether the texture should also be deleted.</param>
-        public void DeleteResources(bool deleteTexture)
+        private void deleteResources(bool deleteTexture)
         {
             if (deleteTexture)
                 colourTarget.Dispose();
@@ -127,7 +127,11 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             if (isDisposed)
                 return;
 
-            renderer.DeleteFrameBuffer(this);
+            while (renderer.IsFrameBufferBound(this))
+                Unbind();
+
+            deleteResources(true);
+
             isDisposed = true;
         }
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridMetalVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridMetalVertexBuffer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
+using osu.Framework.Graphics.Veldrid.Vertices;
 using osu.Framework.Platform;
 using Veldrid;
 
@@ -47,7 +48,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         private unsafe void initialiseBuffer()
         {
-            sharedBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(IVeldridVertexBuffer<T>.STRIDE * Size), BufferUsage.VertexBuffer | BufferUsage.Dynamic));
+            sharedBuffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(VeldridVertexUtils<T>.STRIDE * Size), BufferUsage.VertexBuffer | BufferUsage.Dynamic));
             sharedBufferMemory = (T*)renderer.Device.Map(sharedBuffer, MapMode.Write).Data;
             memoryLease = NativeMemoryTracker.AddMemory(this, sharedBuffer.SizeInBytes);
 

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridVertexBuffer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Veldrid.Buffers.Staging;
+using osu.Framework.Graphics.Veldrid.Vertices;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using Veldrid;
@@ -78,7 +79,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             getMemory();
             Debug.Assert(stagingBuffer != null);
 
-            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * IVeldridVertexBuffer<T>.STRIDE), BufferUsage.VertexBuffer | stagingBuffer.CopyTargetUsageFlags));
+            buffer = renderer.Factory.CreateBuffer(new BufferDescription((uint)(Size * VeldridVertexUtils<T>.STRIDE), BufferUsage.VertexBuffer | stagingBuffer.CopyTargetUsageFlags));
             memoryLease = NativeMemoryTracker.AddMemory(this, buffer.SizeInBytes);
         }
 

--- a/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
+++ b/osu.Framework/Graphics/Veldrid/Shaders/VeldridShader.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
@@ -91,15 +90,12 @@ namespace osu.Framework.Graphics.Veldrid.Shaders
 
         public void BindUniformBlock(string blockName, IUniformBuffer buffer)
         {
-            if (buffer is not IVeldridUniformBuffer veldridBuffer)
-                throw new ArgumentException($"Buffer must be an {nameof(IVeldridUniformBuffer)}.");
-
             if (isDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not retrieve uniforms from a disposed shader.");
 
             EnsureShaderInitialised();
 
-            renderer.BindUniformBuffer(blockName, veldridBuffer);
+            renderer.BindUniformBuffer(blockName, buffer);
         }
 
         public VeldridUniformLayout? GetTextureLayout(int textureUnit) => textureUnit >= textureLayouts.Count ? null : textureLayouts[textureUnit];

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -590,15 +590,6 @@ namespace osu.Framework.Graphics.Veldrid
             boundIndexBuffer = indexBuffer;
         }
 
-        public void BindUniformBuffer(string blockName, IVeldridUniformBuffer veldridBuffer)
-        {
-            if (boundUniformBuffers.TryGetValue(blockName, out IVeldridUniformBuffer? current) && current == veldridBuffer)
-                return;
-
-            FlushCurrentBatch(FlushBatchSource.BindBuffer);
-            boundUniformBuffers[blockName] = veldridBuffer;
-        }
-
         private void ensureTextureUploadCommandsBegan()
         {
             if (beganTextureUpdateCommands)
@@ -804,10 +795,11 @@ namespace osu.Framework.Graphics.Veldrid
         {
         }
 
+        protected override void SetUniformBufferImplementation(string blockName, IUniformBuffer buffer)
+            => boundUniformBuffers[blockName] = (IVeldridUniformBuffer)buffer;
+
         public void RegisterUniformBufferForReset(IVeldridUniformBuffer buffer)
-        {
-            uniformBufferResetList.Add(buffer);
-        }
+            => uniformBufferResetList.Add(buffer);
 
         public void BindTextureResource(VeldridTextureResources resource, int unit) => boundTextureUnits[unit] = resource;
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -617,18 +617,6 @@ namespace osu.Framework.Graphics.Veldrid
         /// <param name="frameBuffer">The frame buffer to check.</param>
         public bool IsFrameBufferBound(IFrameBuffer frameBuffer) => FrameBuffer == frameBuffer;
 
-        /// <summary>
-        /// Deletes a frame buffer.
-        /// </summary>
-        /// <param name="frameBuffer">The frame buffer to delete.</param>
-        public void DeleteFrameBuffer(VeldridFrameBuffer frameBuffer)
-        {
-            while (FrameBuffer == frameBuffer)
-                UnbindFrameBuffer(frameBuffer);
-
-            frameBuffer.DeleteResources(true);
-        }
-
         private readonly Dictionary<GraphicsPipelineDescription, Pipeline> pipelineCache = new Dictionary<GraphicsPipelineDescription, Pipeline>();
 
         private Pipeline getPipelineInstance()

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -32,7 +32,7 @@ using Veldrid.OpenGL;
 using Veldrid.OpenGLBinding;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = Veldrid.PixelFormat;
-using PrimitiveTopology = Veldrid.PrimitiveTopology;
+using PrimitiveTopology = osu.Framework.Graphics.Rendering.PrimitiveTopology;
 
 namespace osu.Framework.Graphics.Veldrid
 {
@@ -490,52 +490,7 @@ namespace osu.Framework.Graphics.Veldrid
             SetFramebuffer(framebuffer);
         }
 
-        public void SetFramebuffer(Framebuffer framebuffer)
-        {
-            Commands.SetFramebuffer(framebuffer);
-            pipeline.Outputs = framebuffer.OutputDescription;
-        }
-
-        public void BindVertexBuffer<T>(IVeldridVertexBuffer<T> buffer)
-            where T : unmanaged, IEquatable<T>, IVertex
-        {
-            if (buffer == boundVertexBuffer)
-                return;
-
-            Commands.SetVertexBuffer(0, buffer.Buffer);
-            pipeline.ShaderSet.VertexLayouts[0] = IVeldridVertexBuffer<T>.LAYOUT;
-
-            FrameStatistics.Increment(StatisticsCounterType.VBufBinds);
-
-            boundVertexBuffer = buffer;
-        }
-
-        public void BindIndexBuffer(VeldridIndexLayout layout, int verticesCount)
-        {
-            ref var indexBuffer = ref layout == VeldridIndexLayout.Quad
-                ? ref quadIndexBuffer
-                : ref linearIndexBuffer;
-
-            if (indexBuffer == null || indexBuffer.VertexCapacity < verticesCount)
-            {
-                indexBuffer?.Dispose();
-                indexBuffer = new VeldridIndexBuffer(this, layout, verticesCount);
-            }
-
-            Commands.SetIndexBuffer(indexBuffer.Buffer, VeldridIndexBuffer.FORMAT);
-            boundIndexBuffer = indexBuffer;
-        }
-
-        public void BindUniformBuffer(string blockName, IVeldridUniformBuffer veldridBuffer)
-        {
-            if (boundUniformBuffers.TryGetValue(blockName, out IVeldridUniformBuffer? current) && current == veldridBuffer)
-                return;
-
-            FlushCurrentBatch(FlushBatchSource.BindBuffer);
-            boundUniformBuffers[blockName] = veldridBuffer;
-        }
-
-        public void DrawVertices(PrimitiveTopology type, int vertexStart, int verticesCount)
+        public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)
         {
             // normally we would flush/submit all texture upload commands at the end of the frame, since no actual rendering by the GPU will happen until then,
             // but turns out on macOS with non-apple GPU, this results in rendering corruption.
@@ -546,9 +501,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             var veldridShader = (VeldridShader)Shader!;
 
-            veldridShader.BindUniformBlock("g_GlobalUniforms", GlobalUniformBuffer!);
-
-            pipeline.PrimitiveTopology = type;
+            pipeline.PrimitiveTopology = topology.ToPrimitiveTopology();
             Array.Resize(ref pipeline.ResourceLayouts, veldridShader.LayoutCount);
 
             // Activate texture layouts.
@@ -599,6 +552,51 @@ namespace osu.Framework.Graphics.Veldrid
             int indexStart = boundIndexBuffer.TranslateToIndex(vertexStart);
             int indicesCount = boundIndexBuffer.TranslateToIndex(verticesCount);
             Commands.DrawIndexed((uint)indicesCount, 1, (uint)indexStart, 0, 0);
+        }
+
+        public void SetFramebuffer(Framebuffer framebuffer)
+        {
+            Commands.SetFramebuffer(framebuffer);
+            pipeline.Outputs = framebuffer.OutputDescription;
+        }
+
+        public void BindVertexBuffer<T>(IVeldridVertexBuffer<T> buffer)
+            where T : unmanaged, IEquatable<T>, IVertex
+        {
+            if (buffer == boundVertexBuffer)
+                return;
+
+            Commands.SetVertexBuffer(0, buffer.Buffer);
+            pipeline.ShaderSet.VertexLayouts[0] = IVeldridVertexBuffer<T>.LAYOUT;
+
+            FrameStatistics.Increment(StatisticsCounterType.VBufBinds);
+
+            boundVertexBuffer = buffer;
+        }
+
+        public void BindIndexBuffer(VeldridIndexLayout layout, int verticesCount)
+        {
+            ref var indexBuffer = ref layout == VeldridIndexLayout.Quad
+                ? ref quadIndexBuffer
+                : ref linearIndexBuffer;
+
+            if (indexBuffer == null || indexBuffer.VertexCapacity < verticesCount)
+            {
+                indexBuffer?.Dispose();
+                indexBuffer = new VeldridIndexBuffer(this, layout, verticesCount);
+            }
+
+            Commands.SetIndexBuffer(indexBuffer.Buffer, VeldridIndexBuffer.FORMAT);
+            boundIndexBuffer = indexBuffer;
+        }
+
+        public void BindUniformBuffer(string blockName, IVeldridUniformBuffer veldridBuffer)
+        {
+            if (boundUniformBuffers.TryGetValue(blockName, out IVeldridUniformBuffer? current) && current == veldridBuffer)
+                return;
+
+            FlushCurrentBatch(FlushBatchSource.BindBuffer);
+            boundUniformBuffers[blockName] = veldridBuffer;
         }
 
         private void ensureTextureUploadCommandsBegan()
@@ -745,10 +743,10 @@ namespace osu.Framework.Graphics.Veldrid
         public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
             => new VeldridFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
 
-        protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, Rendering.PrimitiveTopology primitiveType)
+        protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology primitiveType)
         {
             // maxBuffers is ignored because batches are not allowed to wrap around in Veldrid.
-            return new VeldridLinearBatch<TVertex>(this, size, primitiveType.ToPrimitiveTopology());
+            return new VeldridLinearBatch<TVertex>(this, size, primitiveType);
         }
 
         protected override IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers)

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -491,6 +491,9 @@ namespace osu.Framework.Graphics.Veldrid
             SetFramebuffer(framebuffer);
         }
 
+        protected override void DeleteFrameBufferImplementation(IFrameBuffer frameBuffer)
+            => ((VeldridFrameBuffer)frameBuffer).DeleteResources(true);
+
         public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)
         {
             // normally we would flush/submit all texture upload commands at the end of the frame, since no actual rendering by the GPU will happen until then,

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -20,6 +20,7 @@ using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Graphics.Veldrid.Buffers.Staging;
 using osu.Framework.Graphics.Veldrid.Shaders;
 using osu.Framework.Graphics.Veldrid.Textures;
+using osu.Framework.Graphics.Veldrid.Vertices;
 using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osuTK;
@@ -567,7 +568,7 @@ namespace osu.Framework.Graphics.Veldrid
                 return;
 
             Commands.SetVertexBuffer(0, buffer.Buffer);
-            pipeline.ShaderSet.VertexLayouts[0] = IVeldridVertexBuffer<T>.LAYOUT;
+            pipeline.ShaderSet.VertexLayouts[0] = VeldridVertexUtils<T>.Layout;
 
             FrameStatistics.Increment(StatisticsCounterType.VBufBinds);
 


### PR DESCRIPTION
- Adds `Renderer.DrawVertices()`, which is the method that binds the global UBO.
- Makes `globalUniformBuffer` private.
- Adds `Renderer.BindUniformBuffer()`, which does the state tracking/de-duping of flushes around UBO bindings.
- A few other misc cleanups.