### PR TITLE
Reduce frequency of global UBO changes

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLUniformBuffer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using osu.Framework.Graphics.Rendering;
+using osu.Framework.Statistics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL.Buffers
@@ -48,6 +49,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             GL.BindBuffer(BufferTarget.UniformBuffer, uboId);
             GL.BufferData(BufferTarget.UniformBuffer, size, ref data, BufferUsageHint.DynamicDraw);
             GL.BindBuffer(BufferTarget.UniformBuffer, 0);
+
+            FrameStatistics.Increment(StatisticsCounterType.UniformUpl);
         }
 
         #region Disposal

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Graphics.Rendering
         public WrapMode CurrentWrapModeS { get; private set; }
         public WrapMode CurrentWrapModeT { get; private set; }
         public bool IsMaskingActive { get; private set; }
-        public bool UsingBackbuffer => FrameBuffer == null;
+        public bool UsingBackbuffer { get; private set; }
         public Texture WhitePixel => whitePixel.Value;
         DepthValue IRenderer.BackbufferDepth => backBufferDepth;
 
@@ -652,6 +652,7 @@ namespace osu.Framework.Graphics.Rendering
 
             currentMaskingInfo = maskingInfo;
 
+            // Masking is enabled for as long as any masking info is active that's not the default.
             IsMaskingActive = maskingStack.Count > 1;
             globalUniformsChanged = true;
         }
@@ -909,6 +910,8 @@ namespace osu.Framework.Graphics.Rendering
             SetFrameBufferImplementation(frameBuffer);
 
             FrameBuffer = frameBuffer;
+
+            UsingBackbuffer = frameBuffer == null;
             globalUniformsChanged = true;
         }
 

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -26,6 +26,7 @@ using osuTK.Graphics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
+using Texture = osu.Framework.Graphics.Textures.Texture;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -68,8 +69,8 @@ namespace osu.Framework.Graphics.Rendering
         public StencilInfo CurrentStencilInfo { get; private set; }
         public WrapMode CurrentWrapModeS { get; private set; }
         public WrapMode CurrentWrapModeT { get; private set; }
-        public bool IsMaskingActive => maskingStack.Count > 1;
-        public bool UsingBackbuffer => frameBufferStack.Count == 0;
+        public bool IsMaskingActive { get; private set; }
+        public bool UsingBackbuffer => FrameBuffer == null;
         public Texture WhitePixel => whitePixel.Value;
         DepthValue IRenderer.BackbufferDepth => backBufferDepth;
 
@@ -137,6 +138,7 @@ namespace osu.Framework.Graphics.Rendering
         private IVertexBatch? currentActiveBatch;
         private MaskingInfo currentMaskingInfo;
         private int lastActiveTextureUnit;
+        private bool globalUniformsChanged;
 
         private static readonly GlobalStatistic<int>[] flush_source_statistics;
 
@@ -192,12 +194,6 @@ namespace osu.Framework.Graphics.Rendering
                 source.Value = 0;
 
             globalUniformBuffer ??= ((IRenderer)this).CreateUniformBuffer<GlobalUniformData>();
-            globalUniformBuffer.Data = globalUniformBuffer.Data with
-            {
-                IsDepthRangeZeroToOne = IsDepthRangeZeroToOne,
-                IsClipSpaceYInverted = IsClipSpaceYInverted,
-                IsUvOriginTopLeft = IsUvOriginTopLeft
-            };
 
             Debug.Assert(defaultQuadBatch != null);
 
@@ -218,6 +214,7 @@ namespace osu.Framework.Graphics.Rendering
                 }
             }
 
+            globalUniformsChanged = true;
             currentActiveBatch = null;
             CurrentBlendingParameters = new BlendingParameters();
             currentMaskingInfo = default;
@@ -604,7 +601,7 @@ namespace osu.Framework.Graphics.Rendering
 
             FlushCurrentBatch(FlushBatchSource.SetProjection);
 
-            globalUniformBuffer!.Data = globalUniformBuffer.Data with { ProjMatrix = matrix };
+            globalUniformsChanged = true;
             ProjectionMatrix = matrix;
         }
 
@@ -633,50 +630,6 @@ namespace osu.Framework.Graphics.Rendering
 
             FlushCurrentBatch(FlushBatchSource.SetMasking);
 
-            globalUniformBuffer!.Data = globalUniformBuffer.Data with
-            {
-                IsMasking = IsMaskingActive,
-                MaskingRect = new Vector4(
-                    maskingInfo.MaskingRect.Left,
-                    maskingInfo.MaskingRect.Top,
-                    maskingInfo.MaskingRect.Right,
-                    maskingInfo.MaskingRect.Bottom),
-                ToMaskingSpace = maskingInfo.ToMaskingSpace,
-                CornerRadius = maskingInfo.CornerRadius,
-                CornerExponent = maskingInfo.CornerExponent,
-                BorderThickness = maskingInfo.BorderThickness / maskingInfo.BlendRange,
-                BorderColour = maskingInfo.BorderThickness > 0
-                    ? new Matrix4(
-                        // TopLeft
-                        maskingInfo.BorderColour.TopLeft.SRGB.R,
-                        maskingInfo.BorderColour.TopLeft.SRGB.G,
-                        maskingInfo.BorderColour.TopLeft.SRGB.B,
-                        maskingInfo.BorderColour.TopLeft.SRGB.A,
-                        // BottomLeft
-                        maskingInfo.BorderColour.BottomLeft.SRGB.R,
-                        maskingInfo.BorderColour.BottomLeft.SRGB.G,
-                        maskingInfo.BorderColour.BottomLeft.SRGB.B,
-                        maskingInfo.BorderColour.BottomLeft.SRGB.A,
-                        // TopRight
-                        maskingInfo.BorderColour.TopRight.SRGB.R,
-                        maskingInfo.BorderColour.TopRight.SRGB.G,
-                        maskingInfo.BorderColour.TopRight.SRGB.B,
-                        maskingInfo.BorderColour.TopRight.SRGB.A,
-                        // BottomRight
-                        maskingInfo.BorderColour.BottomRight.SRGB.R,
-                        maskingInfo.BorderColour.BottomRight.SRGB.G,
-                        maskingInfo.BorderColour.BottomRight.SRGB.B,
-                        maskingInfo.BorderColour.BottomRight.SRGB.A)
-                    : globalUniformBuffer.Data.BorderColour,
-                MaskingBlendRange = maskingInfo.BlendRange,
-                AlphaExponent = maskingInfo.AlphaExponent,
-                EdgeOffset = maskingInfo.EdgeOffset,
-                DiscardInner = maskingInfo.Hollow,
-                InnerCornerRadius = maskingInfo.Hollow
-                    ? maskingInfo.HollowCornerRadius
-                    : globalUniformBuffer.Data.InnerCornerRadius
-            };
-
             if (isPushing)
             {
                 // When drawing to a viewport that doesn't match the projection size (e.g. via framebuffers), the resultant image will be scaled
@@ -698,6 +651,9 @@ namespace osu.Framework.Graphics.Rendering
                 PopScissor();
 
             currentMaskingInfo = maskingInfo;
+
+            IsMaskingActive = maskingStack.Count > 1;
+            globalUniformsChanged = true;
         }
 
         #endregion
@@ -869,16 +825,14 @@ namespace osu.Framework.Graphics.Rendering
 
             if (wrapModeS != CurrentWrapModeS)
             {
-                // Will flush the current batch internally.
-                globalUniformBuffer!.Data = globalUniformBuffer.Data with { WrapModeS = (int)wrapModeS };
                 CurrentWrapModeS = wrapModeS;
+                globalUniformsChanged = true;
             }
 
             if (wrapModeT != CurrentWrapModeT)
             {
-                // Will flush the current batch internally.
-                globalUniformBuffer!.Data = globalUniformBuffer.Data with { WrapModeT = (int)wrapModeT };
                 CurrentWrapModeT = wrapModeT;
+                globalUniformsChanged = true;
             }
 
             lastBoundTexture[unit] = texture;
@@ -952,12 +906,10 @@ namespace osu.Framework.Graphics.Rendering
                 return;
 
             FlushCurrentBatch(FlushBatchSource.SetFrameBuffer);
-
             SetFrameBufferImplementation(frameBuffer);
 
-            globalUniformBuffer!.Data = globalUniformBuffer.Data with { BackbufferDraw = UsingBackbuffer };
-
             FrameBuffer = frameBuffer;
+            globalUniformsChanged = true;
         }
 
         /// <summary>
@@ -972,6 +924,62 @@ namespace osu.Framework.Graphics.Rendering
         {
             if (Shader == null)
                 throw new InvalidOperationException("No shader bound.");
+
+            if (globalUniformsChanged)
+            {
+                globalUniformBuffer!.Data = new GlobalUniformData
+                {
+                    BackbufferDraw = UsingBackbuffer,
+                    IsDepthRangeZeroToOne = IsDepthRangeZeroToOne,
+                    IsClipSpaceYInverted = IsClipSpaceYInverted,
+                    IsUvOriginTopLeft = IsUvOriginTopLeft,
+                    ProjMatrix = ProjectionMatrix,
+                    ToMaskingSpace = currentMaskingInfo.ToMaskingSpace,
+                    IsMasking = IsMaskingActive,
+                    CornerRadius = currentMaskingInfo.CornerRadius,
+                    CornerExponent = currentMaskingInfo.CornerExponent,
+                    MaskingRect = new Vector4(
+                        currentMaskingInfo.MaskingRect.Left,
+                        currentMaskingInfo.MaskingRect.Top,
+                        currentMaskingInfo.MaskingRect.Right,
+                        currentMaskingInfo.MaskingRect.Bottom),
+                    BorderThickness = currentMaskingInfo.BorderThickness / currentMaskingInfo.BlendRange,
+                    BorderColour = currentMaskingInfo.BorderThickness > 0
+                        ? new Matrix4(
+                            // TopLeft
+                            currentMaskingInfo.BorderColour.TopLeft.SRGB.R,
+                            currentMaskingInfo.BorderColour.TopLeft.SRGB.G,
+                            currentMaskingInfo.BorderColour.TopLeft.SRGB.B,
+                            currentMaskingInfo.BorderColour.TopLeft.SRGB.A,
+                            // BottomLeft
+                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.R,
+                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.G,
+                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.B,
+                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.A,
+                            // TopRight
+                            currentMaskingInfo.BorderColour.TopRight.SRGB.R,
+                            currentMaskingInfo.BorderColour.TopRight.SRGB.G,
+                            currentMaskingInfo.BorderColour.TopRight.SRGB.B,
+                            currentMaskingInfo.BorderColour.TopRight.SRGB.A,
+                            // BottomRight
+                            currentMaskingInfo.BorderColour.BottomRight.SRGB.R,
+                            currentMaskingInfo.BorderColour.BottomRight.SRGB.G,
+                            currentMaskingInfo.BorderColour.BottomRight.SRGB.B,
+                            currentMaskingInfo.BorderColour.BottomRight.SRGB.A)
+                        : globalUniformBuffer.Data.BorderColour,
+                    MaskingBlendRange = currentMaskingInfo.BlendRange,
+                    AlphaExponent = currentMaskingInfo.AlphaExponent,
+                    EdgeOffset = currentMaskingInfo.EdgeOffset,
+                    DiscardInner = currentMaskingInfo.Hollow,
+                    InnerCornerRadius = currentMaskingInfo.Hollow
+                        ? currentMaskingInfo.HollowCornerRadius
+                        : globalUniformBuffer.Data.InnerCornerRadius,
+                    WrapModeS = (int)CurrentWrapModeS,
+                    WrapModeT = (int)CurrentWrapModeT
+                };
+
+                globalUniformsChanged = false;
+            }
 
             Shader.BindUniformBlock("g_GlobalUniforms", globalUniformBuffer!);
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/6186

Since the pre-req PR adds a common `DrawVertices()` method, we can now update the global UBO as late as possible - right before vertices need to be drawn.

The easiest way to see the difference is by using the GL renderer and noticing the reduction in the `Draw.UniformUpl` statistic. In `TestSceneTextFlow` it reduces uploads from 54 -> 28. This may lead to a minor performance increase.  
The Veldrid implementation does its own similar late-upload, which _could_ be removed but isn't done in this PR.

_In general_ though, this should slightly increase performance (not benchmarked) just from reducing struct copies.