### PR TITLE
Don't clear `Logger.NewEntry` handlers when flushing

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -469,15 +469,23 @@ namespace osu.Framework.Logging
 
         /// <summary>
         /// Pause execution until all logger writes have completed and file handles have been closed.
-        /// This will also unbind all handlers bound to <see cref="NewEntry"/>.
         /// </summary>
         public static void Flush()
         {
             lock (flush_sync_lock)
             {
                 writer_idle.WaitOne(2000);
-                NewEntry = null;
             }
+        }
+
+        /// <summary>
+        /// Pause execution until all logger writes have completed and file handles have been closed.
+        /// This will also unbind all handlers bound to <see cref="NewEntry"/>.
+        /// </summary>
+        public static void Dispose()
+        {
+            Flush();
+            NewEntry = null;
         }
     }
 

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -479,10 +479,9 @@ namespace osu.Framework.Logging
         }
 
         /// <summary>
-        /// Pause execution until all logger writes have completed and file handles have been closed.
-        /// This will also unbind all handlers bound to <see cref="NewEntry"/>.
+        /// Perform a <see cref="Flush"/> and unbind all events in preparation for game host shutdown.
         /// </summary>
-        public static void Dispose()
+        internal static void FlushForShutdown()
         {
             Flush();
             NewEntry = null;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -395,8 +395,8 @@ namespace osu.Framework.Platform
 
             // In the case of an unhandled exception, it's feasible that the disposal flow for `GameHost` doesn't run.
             // This can result in the exception not being logged (or being partially logged) due to the logger running asynchronously.
-            // We force flushing the logger here to ensure logging completes.
-            Logger.Flush();
+            // We force flushing the logger here to ensure logging completes (and also unbind in the process since we're aborting execution from here).
+            Logger.Dispose();
 
             var captured = ExceptionDispatchInfo.Capture(exception);
             var thrownEvent = new ManualResetEventSlim(false);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1391,7 +1391,7 @@ namespace osu.Framework.Platform
             Window?.Dispose();
 
             LoadingComponentsLogger.LogAndFlush();
-            Logger.Flush();
+            Logger.Dispose();
         }
 
         public void Dispose()

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -396,7 +396,7 @@ namespace osu.Framework.Platform
             // In the case of an unhandled exception, it's feasible that the disposal flow for `GameHost` doesn't run.
             // This can result in the exception not being logged (or being partially logged) due to the logger running asynchronously.
             // We force flushing the logger here to ensure logging completes (and also unbind in the process since we're aborting execution from here).
-            Logger.Dispose();
+            Logger.FlushForShutdown();
 
             var captured = ExceptionDispatchInfo.Capture(exception);
             var thrownEvent = new ManualResetEventSlim(false);
@@ -1391,7 +1391,7 @@ namespace osu.Framework.Platform
             Window?.Dispose();
 
             LoadingComponentsLogger.LogAndFlush();
-            Logger.Dispose();
+            Logger.FlushForShutdown();
         }
 
         public void Dispose()


### PR DESCRIPTION
Instead, `NewEntry` is cleared only when the `GameHost` is disposing.

This allows using `Logger.Flush()` when [exporting logs from osu!](https://github.com/ppy/osu/blob/d2990170d021f2caee2c6e66368f07792c7ac53c/osu.Game/Overlays/Settings/Sections/General/UpdateSettings.cs#L96), the specific use case is to log global statistics:
```cs
GlobalStatistics.OutputToLog();
Logger.Flush();

// create the compressed-logs.zip etc.
```

Clearing `NewEntry` when exporting logs is undesirable.