### PR TITLE
Remove Veldrid-OpenGL renderer, always use GLRenderer

### DIFF
--- a/osu.Framework/Configuration/RendererType.cs
+++ b/osu.Framework/Configuration/RendererType.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
+using osu.Framework.Graphics.OpenGL;
 
 namespace osu.Framework.Configuration
 {
@@ -19,9 +21,14 @@ namespace osu.Framework.Configuration
         [Description("Direct3D 11")]
         Direct3D11,
 
+        /// <summary>
+        /// Uses <see cref="GLRenderer"/>.
+        /// </summary>
         [Description("OpenGL")]
         OpenGL,
 
+        // Can be removed 20240820
+        [Obsolete]
         [Description("OpenGL (Legacy)")]
         OpenGLLegacy,
     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -857,15 +857,8 @@ namespace osu.Framework.Platform
             // See https://github.com/ppy/osu/issues/23003
             if (RuntimeInfo.OS != RuntimeInfo.Platform.iOS)
             {
-                // Non-veldrid "known-to-work".
-                yield return RendererType.OpenGLLegacy;
+                yield return RendererType.OpenGL;
             }
-
-            // Other available renderers should also be returned (to make this method usable as "all available renderers for current platform"),
-            // but will never be preferred as OpenGLLegacy will always work.
-            yield return RendererType.OpenGL;
-
-            if (!RuntimeInfo.IsApple) yield return RendererType.Vulkan;
         }
 
         protected virtual void ChooseAndSetupRenderer()
@@ -901,9 +894,12 @@ namespace osu.Framework.Platform
             {
                 try
                 {
-                    if (type == RendererType.OpenGLLegacy)
-                        // the legacy renderer. this is basically guaranteed to support all platforms.
+                    if (type == RendererType.OpenGL)
+                    {
+                        // Use the legacy GL renderer. This is basically guaranteed to support all platforms
+                        // and performs better than the Veldrid-GL renderer due to reduction in allocs.
                         SetupRendererAndWindow("gl", GraphicsSurfaceType.OpenGL);
+                    }
                     else
                         SetupRendererAndWindow("veldrid", rendererToGraphicsSurfaceType(type));
 
@@ -1262,6 +1258,11 @@ namespace osu.Framework.Platform
             }, true);
 
             inputConfig = new InputConfigManager(Storage, AvailableInputHandlers);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            if (Config.Get<RendererType>(FrameworkSetting.Renderer) == RendererType.OpenGLLegacy)
+                Config.SetValue(FrameworkSetting.Renderer, RendererType.OpenGL);
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         /// <summary>


### PR DESCRIPTION
Spurred by people using this renderer, likely because "legacy" has a bad connotation associated with it (e.g. https://discord.com/channels/188630481301012481/1097318920991559880/1209220240383418438).

This forces `GLRenderer` ("legacy") to be used even when the `OpenGL` renderer type is selected. We will never be using Veldrid-GL because it allocates a ton, and we can't really make it efficient due to the way o!f works (except until https://github.com/ppy/osu-framework/pull/6190, but even then I wouldn't use it).

There will be a second change osu! side to disable the renderer from being shown as an option.

This also disables Vulkan as a fallback option - it's unstable at least in the way implemented via `VeldridRenderer`. It'll perhaps return with https://github.com/ppy/osu-framework/pull/6190.