### PR TITLE
Prefer using `UserProfile` over `Personal` to account for breaking changes in .NET 8

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -45,6 +45,7 @@ namespace osu.Framework.Platform.Linux
                     yield return xdg;
 
                 yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+                yield return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
                 foreach (string path in base.UserStoragePaths)
                     yield return path;

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -35,6 +35,7 @@ namespace osu.Framework.Platform.MacOS
                     yield return xdg;
 
                 yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share");
+                yield return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
                 foreach (string path in base.UserStoragePaths)
                     yield return path;


### PR DESCRIPTION
This PR aims to address the issues regarding recent breaking changes to `Environment.GetFolderPath` for Unix systems. The changes in question are noted by Microsoft [here](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix), although the changes to Android do not affect o!f; only Linux and MacOS.

I hit the effects of this breaking change in osu!lazer due to admittedly strange circumstances which I'll explain with a timeline.

- I install osu!stable, causing `~/osu` to be created.
- I later install osu!lazer, which then uses this directory.
- I clone osu!lazer to `~/Documents/osu` at some point.
- **Years later, o!f migrates to .NET 8.**
- Lazer tries to check for `SpecialFolder.Personal`, which in .NET 6 would be `$HOME`, but in .NET 8 is now `$HOME/Documents`.
- Lazer sees that this folder exists and uses this directory as the user storage folder.
- The original lazer installation directory at `~/osu` is then ignored.

We can solve this by simply introducing the user's home folder to the list of available storage paths. It was discussed to be a final fallback, however I'm not sure this is a good idea as the problem would still trigger in my scenario.