### PR TITLE
Reduce allocations in `PerformanceOverlay` while in expanded state

### DIFF
--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -77,22 +77,27 @@ namespace osu.Framework.Graphics.Performance
 
         // for some reason PerformanceOverlay has 0 width despite using AutoSizeAxes, and it doesn't look simple to fix.
         // let's just work around it and consider frame statistics display dimensions for receiving input events.
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Children.OfType<FrameStatisticsDisplay>().Any(d => d.ReceivePositionalInputAt(screenSpacePos));
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            foreach (var child in this)
+            {
+                if (child is FrameStatisticsDisplay display && display.ReceivePositionalInputAt(screenSpacePos))
+                    return true;
+            }
+
+            return false;
+        }
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             switch (e.Key)
             {
                 case Key.ControlLeft:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Expanded = true;
-
+                    applyToDisplays(static d => d.Expanded = true);
                     break;
 
                 case Key.ShiftLeft:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Running = false;
-
+                    applyToDisplays(static d => d.Running = false);
                     break;
             }
 
@@ -104,15 +109,11 @@ namespace osu.Framework.Graphics.Performance
             switch (e.Key)
             {
                 case Key.ControlLeft:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Expanded = false;
-
+                    applyToDisplays(static d => d.Expanded = false);
                     break;
 
                 case Key.ShiftLeft:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Running = true;
-
+                    applyToDisplays(static d => d.Running = true);
                     break;
             }
 
@@ -124,15 +125,11 @@ namespace osu.Framework.Graphics.Performance
             switch (e.Touch.Source)
             {
                 case TouchSource.Touch1:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Expanded = true;
-
+                    applyToDisplays(static d => d.Expanded = true);
                     break;
 
                 case TouchSource.Touch2:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Running = false;
-
+                    applyToDisplays(static d => d.Running = false);
                     break;
             }
 
@@ -144,15 +141,11 @@ namespace osu.Framework.Graphics.Performance
             switch (e.Touch.Source)
             {
                 case TouchSource.Touch1:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Expanded = false;
-
+                    applyToDisplays(static d => d.Expanded = false);
                     break;
 
                 case TouchSource.Touch2:
-                    foreach (var display in Children.OfType<FrameStatisticsDisplay>())
-                        display.Running = true;
-
+                    applyToDisplays(static d => d.Running = true);
                     break;
             }
 
@@ -201,10 +194,22 @@ namespace osu.Framework.Graphics.Performance
                     break;
             }
 
-            foreach (FrameStatisticsDisplay d in Children.OfType<FrameStatisticsDisplay>())
-                d.State = state;
+            foreach (var child in this)
+            {
+                if (child is FrameStatisticsDisplay display)
+                    display.State = state;
+            }
 
             StateChanged?.Invoke(State);
+        }
+
+        private void applyToDisplays(Predicate<FrameStatisticsDisplay> predicate)
+        {
+            foreach (var child in this)
+            {
+                if (child is FrameStatisticsDisplay display)
+                    predicate.Invoke(display);
+            }
         }
 
         private void updateInfoText()

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Performance
 
         private bool initialised;
 
-        private readonly List<FrameStatisticsDisplay> framedDisplays = new List<FrameStatisticsDisplay>();
+        private readonly List<FrameStatisticsDisplay> frameDisplays = new List<FrameStatisticsDisplay>();
 
         public FrameStatisticsMode State
         {
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics.Performance
         // let's just work around it and consider frame statistics display dimensions for receiving input events.
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
         {
-            foreach (var display in framedDisplays)
+            foreach (var display in frameDisplays)
             {
                 if (display.ReceivePositionalInputAt(screenSpacePos))
                     return true;
@@ -192,7 +192,7 @@ namespace osu.Framework.Graphics.Performance
                             };
 
                             Add(display);
-                            framedDisplays.Add(display);
+                            frameDisplays.Add(display);
                         }
                     }
 
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics.Performance
                     break;
             }
 
-            foreach (var display in framedDisplays)
+            foreach (var display in frameDisplays)
                 display.State = state;
 
             StateChanged?.Invoke(State);
@@ -208,7 +208,7 @@ namespace osu.Framework.Graphics.Performance
 
         private void applyToDisplays(Predicate<FrameStatisticsDisplay> predicate)
         {
-            foreach (var display in framedDisplays)
+            foreach (var display in frameDisplays)
                 predicate.Invoke(display);
         }
 


### PR DESCRIPTION
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/251bbf86-1207-4ddc-be9a-116408af75b5)|![pr](https://github.com/ppy/osu-framework/assets/22874522/c6fff6d4-c335-4607-bcee-f6817a02cbe5)|