### PR TITLE
Reduce allocs in `AggregateBindable`

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkAggregateBindable.cs
+++ b/osu.Framework.Benchmarks/BenchmarkAggregateBindable.cs
@@ -11,15 +11,27 @@ namespace osu.Framework.Benchmarks
     {
         private readonly BindableInt source1 = new BindableInt();
         private readonly BindableInt source2 = new BindableInt();
+        private readonly AggregateBindable<int> boundAggregate = new AggregateBindable<int>(((i, j) => i + j));
+        private readonly AggregateBindable<int> aggregate = new AggregateBindable<int>(((i, j) => i + j));
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            boundAggregate.AddSource(source1);
+            boundAggregate.AddSource(source2);
+        }
 
         [Benchmark]
-        public void AggregateRecalculation()
+        public void AddRemoveSource()
         {
-            var aggregate = new AggregateBindable<int>(((i, j) => i + j));
-
             aggregate.AddSource(source1);
             aggregate.AddSource(source2);
+            aggregate.RemoveAllSources();
+        }
 
+        [Benchmark]
+        public void SetValue()
+        {
             for (int i = 0; i < 100; i++)
             {
                 source1.Value = i;

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Bindables
                     return;
 
                 var boundCopy = bindable.GetBoundCopy();
-                sourceMapping.Add(new WeakRefPair(new WeakReference<IBindable<T>>(bindable), boundCopy));
+                sourceMapping.Add(new WeakRefPair(bindable.GetWeakReference(), boundCopy));
                 boundCopy.BindValueChanged(recalculateAggregate, true);
             }
         }
@@ -114,10 +114,10 @@ namespace osu.Framework.Bindables
 
         private class WeakRefPair
         {
-            public readonly WeakReference<IBindable<T>> WeakReference;
+            public readonly WeakReference<Bindable<T>> WeakReference;
             public readonly IBindable<T> BoundCopy;
 
-            public WeakRefPair(WeakReference<IBindable<T>> weakReference, IBindable<T> boundCopy)
+            public WeakRefPair(WeakReference<Bindable<T>> weakReference, IBindable<T> boundCopy)
             {
                 WeakReference = weakReference;
                 BoundCopy = boundCopy;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -440,7 +440,7 @@ namespace osu.Framework.Bindables
 
         IBindable IBindable.GetBoundCopy() => GetBoundCopy();
 
-        public WeakReference<Bindable<T>> GetWeakReference() => weakReference;
+        WeakReference<Bindable<T>> IBindable<T>.GetWeakReference() => weakReference;
 
         IBindable<T> IBindable<T>.GetBoundCopy() => GetBoundCopy();
 

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -440,6 +440,8 @@ namespace osu.Framework.Bindables
 
         IBindable IBindable.GetBoundCopy() => GetBoundCopy();
 
+        public WeakReference<Bindable<T>> GetWeakReference() => weakReference;
+
         IBindable<T> IBindable<T>.GetBoundCopy() => GetBoundCopy();
 
         /// <inheritdoc cref="IBindable{T}.GetBoundCopy"/>

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -111,5 +111,10 @@ namespace osu.Framework.Bindables
 
         /// <inheritdoc cref="IBindable.GetBoundCopy"/>
         IBindable<T> GetBoundCopy();
+
+        /// <summary>
+        /// Retrieves a weak reference to this bindable.
+        /// </summary>
+        internal WeakReference<Bindable<T>> GetWeakReference();
     }
 }


### PR DESCRIPTION
The benchmarks are below, but only the 2nd result is the significant one to me because it removes a `WeakReference` alloc. It's still not zero, though, and the other alloc is very hard/impossible to remove with the current structure of things.

Master:
|          Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|---------------- |----------:|----------:|----------:|-------:|----------:|
| AddRemoveSource |  2.111 us | 0.0413 us | 0.0776 us | 0.2098 |   1.72 KB |
|        SetValue | 20.122 us | 0.2580 us | 0.2413 us | 0.5493 |   4.69 KB |

Without allocating weak references:
|          Method |      Mean |     Error |    StdDev |   Gen0 | Allocated |
|---------------- |----------:|----------:|----------:|-------:|----------:|
| AddRemoveSource |  1.760 us | 0.0352 us | 0.0481 us | 0.2041 |   1.67 KB |
|        SetValue | 18.815 us | 0.3394 us | 0.2834 us | 0.5493 |   4.69 KB |

Struct:
| Method          | Mean      | Error     | StdDev    | Gen0   | Allocated |
|---------------- |----------:|----------:|----------:|-------:|----------:|
| AddRemoveSource |  1.580 us | 0.0169 us | 0.0141 us | 0.1411 |   1.16 KB |
| SetValue        | 18.746 us | 0.0980 us | 0.0917 us | 0.5493 |   4.69 KB |
