### PR TITLE
Remove bindable from `CircularProgress`

### DIFF
--- a/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                         Size = new Vector2(circle_radius),
                         RelativePositionAxes = Axes.Both,
                         Position = new Vector2(xPos, yPos),
-                        Current = { Value = 1 }
+                        Progress = 1
                     });
 
                     circlesContainerBuffered.Add(new CircularProgress
@@ -91,7 +91,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                         Size = new Vector2(circle_radius),
                         RelativePositionAxes = Axes.Both,
                         Position = new Vector2(xPos, yPos),
-                        Current = { Value = 1 }
+                        Progress = 1
                     });
                 }
             }

--- a/osu.Framework.Tests/Visual/Performance/TestSceneVertexUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneVertexUploadPerformance.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Tests.Visual.Performance
             base.Update();
 
             foreach (var p in Flow.OfType<CircularProgress>())
-                p.Current.Value = (p.Current.Value + (Time.Elapsed * RNG.NextSingle()) / 1000) % 1;
+                p.Progress = (p.Progress + (Time.Elapsed * RNG.NextSingle()) / 1000) % 1;
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -145,23 +145,23 @@ namespace osu.Framework.Tests.Visual.UserInterface
             switch (rotateMode)
             {
                 case 0:
-                    clock.Current.Value = Time.Current % (period * 2) / period - 1;
+                    clock.Progress = Time.Current % (period * 2) / period - 1;
                     break;
 
                 case 1:
-                    clock.Current.Value = Time.Current % period / period;
+                    clock.Progress = Time.Current % period / period;
                     break;
 
                 case 2:
-                    clock.Current.Value = Time.Current % period / period - 1;
+                    clock.Progress = Time.Current % period / period - 1;
                     break;
 
                 case 3:
-                    clock.Current.Value = Time.Current % transition_period / transition_period / 5 - 0.1f;
+                    clock.Progress = Time.Current % transition_period / transition_period / 5 - 0.1f;
                     break;
 
                 case 4:
-                    clock.Current.Value = (Time.Current % transition_period / transition_period / 5 - 0.1f + 2) % 2 - 1;
+                    clock.Progress = (Time.Current % transition_period / transition_period / 5 - 0.1f + 2) % 2 - 1;
                     break;
             }
         }
@@ -245,19 +245,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
             switch (tf)
             {
                 case 0:
-                    clock.FillTo(0).Then().FillTo(1, 1000).Loop();
+                    clock.ProgressTo(0).Then().ProgressTo(1, 1000).Loop();
                     break;
 
                 case 1:
-                    clock.FillTo(1).Then().FillTo(0, 1000).Loop();
+                    clock.ProgressTo(1).Then().ProgressTo(0, 1000).Loop();
                     break;
 
                 case 2:
-                    clock.FillTo(0, 1000).Then().FillTo(1, 1000).Loop();
+                    clock.ProgressTo(0, 1000).Then().ProgressTo(1, 1000).Loop();
                     break;
 
                 case 3:
-                    clock.FillTo(0).Then().FillTo(1, 1000, Easing.InOutQuart).Loop();
+                    clock.ProgressTo(0).Then().ProgressTo(1, 1000, Easing.InOutQuart).Loop();
                     break;
             }
         }

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -148,8 +148,8 @@ namespace osu.Framework.Graphics.Cursor
                     progress.FadeColour(Color4.SkyBlue)
                             .TransformTo(nameof(progress.InnerRadius), 0.2f)
                             .TransformTo(nameof(progress.InnerRadius), 0.3f, 150, Easing.OutQuint)
-                            .TransformBindableTo(progress.Current, 0)
-                            .TransformBindableTo(progress.Current, 1, duration / 3 * 2);
+                            .ProgressTo(0)
+                            .ProgressTo(1, duration / 3 * 2);
 
                     using (BeginDelayedSequence(duration / 3 * 2))
                     {
@@ -165,7 +165,7 @@ namespace osu.Framework.Graphics.Cursor
             {
                 this.FadeOut(400, Easing.OutQuint);
 
-                progress.TransformBindableTo(progress.Current, 0, 400, Easing.OutQuint)
+                progress.ProgressTo(0, 400, Easing.OutQuint)
                         .TransformTo(nameof(progress.InnerRadius), 0.2f, 50, Easing.OutQuint);
             }
         }


### PR DESCRIPTION
There's zero to no reason to have it `Bindable` imo.
Performance impact is tiny, though in cases such as `TestSceneVertexUploadPerformance` it's quite noticeable (which is unrealistic, but still).
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/c269595e-6c4e-4019-883f-cdd6c943ab9c)|![pr](https://github.com/ppy/osu-framework/assets/22874522/96ddfa2b-981e-4ba6-bafb-1e75f3812a42)|