### PR TITLE
Fix first call to `cycleLogs` failing due to directory not existing

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -429,6 +429,9 @@ namespace osu.Framework.Logging
         {
             try
             {
+                if (!storage.ExistsDirectory(string.Empty))
+                    return;
+
                 DateTime logCycleCutoff = DateTime.UtcNow.AddDays(-7);
                 var logFiles = new DirectoryInfo(storage.GetFullPath(string.Empty)).GetFiles("*.log");
 


### PR DESCRIPTION
In an edge case scenario, this could throw.

```
----------------------------------------------------------
runtime Log for dean (LogLevel: Debug)
Running osu-server-spectator unknown on .NET 8.0.2
Environment: macOS (Unix 14.3.0), 8 cores 
----------------------------------------------------------
2024-02-28 08:49:26 [verbose]: Cycling logs failed (System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/dean/Projects/osu-server-spectator/osu.Server.Spectator/Logs'.
2024-02-28 08:49:26 [verbose]: at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
2024-02-28 08:49:26 [verbose]: at System.IO.Enumeration.FileSystemEnumerator`1.Init()
2024-02-28 08:49:26 [verbose]: at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
2024-02-28 08:49:26 [verbose]: at System.IO.Enumeration.FileSystemEnumerableFactory.FileInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
2024-02-28 08:49:26 [verbose]: at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
2024-02-28 08:49:26 [verbose]: at System.IO.DirectoryInfo.GetFiles(String searchPattern, EnumerationOptions enumerationOptions)
2024-02-28 08:49:26 [verbose]: at osu.Framework.Logging.Logger.cycleLogs())
```