### PR TITLE
Track Veldrid staging resources per-frame

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -38,13 +38,8 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private DeviceBuffer? currentVertexBuffer;
         private VertexLayoutDescription currentVertexLayout;
 
-        /// <summary>
-        /// Creates a new <see cref="GraphicsPipeline"/>.
-        /// </summary>
-        /// <param name="device">The veldrid device.</param>
-        /// <param name="trackExecutions">Whether to notify of execution status via <see cref="BasicPipeline.ExecutionStarted"/> and <see cref="BasicPipeline.ExecutionFinished"/>.</param>
-        public GraphicsPipeline(VeldridDevice device, bool trackExecutions = true)
-            : base(device, trackExecutions)
+        public GraphicsPipeline(VeldridDevice device)
+            : base(device)
         {
             pipelineDesc.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -38,8 +38,13 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private DeviceBuffer? currentVertexBuffer;
         private VertexLayoutDescription currentVertexLayout;
 
-        public GraphicsPipeline(VeldridDevice device)
-            : base(device)
+        /// <summary>
+        /// Creates a new <see cref="GraphicsPipeline"/>.
+        /// </summary>
+        /// <param name="device">The veldrid device.</param>
+        /// <param name="trackExecutions">Whether to notify of execution status via <see cref="BasicPipeline.ExecutionStarted"/> and <see cref="BasicPipeline.ExecutionFinished"/>.</param>
+        public GraphicsPipeline(VeldridDevice device, bool trackExecutions = true)
+            : base(device, trackExecutions)
         {
             pipelineDesc.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -65,34 +65,15 @@ namespace osu.Framework.Graphics.Veldrid
             updateStats();
         }
 
+        /// <summary>
+        /// Updates the current execution index and frees any resources that have not been used for
+        /// <see cref="Rendering.Renderer.RESOURCE_FREE_NO_USAGE_LENGTH"/> executions.
+        /// </summary>
+        /// <param name="executionIndex">The current execution index.</param>
         private void executionStarted(ulong executionIndex)
         {
             currentExecutionIndex = executionIndex;
-        }
 
-        /// <summary>
-        /// Updates the state of the resources in this pool in two steps:
-        /// <list type="bullet">
-        /// <item>Returns all textures that the GPU has finished using back to the pool.</item>
-        /// <item>Frees any textures that have not been used for <see cref="Rendering.Renderer.RESOURCE_FREE_NO_USAGE_LENGTH"/> frames.</item>
-        /// </list>
-        /// </summary>
-        private void executionFinished(ulong executionIndex)
-        {
-            // return any resource that the GPU has finished using in the last frame.
-            for (int i = 0; i < used.Count; i++)
-            {
-                var item = used[i];
-
-                // Usages are sequential so we can stop checking after the first non-completed usage.
-                if (item.FrameUsageIndex > executionIndex)
-                    break;
-
-                available.Add(item);
-                used.RemoveAt(i--);
-            }
-
-            // free any resource that hasn't been used for a while.
             for (int i = 0; i < available.Count; i++)
             {
                 var item = available[i];
@@ -105,6 +86,30 @@ namespace osu.Framework.Graphics.Veldrid
                     available.Remove(item);
                     break;
                 }
+            }
+
+            updateStats();
+        }
+
+        /// <summary>
+        /// Returns all resources that the GPU has finished using back to the pool.
+        /// </summary>
+        /// <param name="executionIndex">The finished execution index.</param>
+        private void executionFinished(ulong executionIndex)
+        {
+            for (int i = 0; i < used.Count; i++)
+            {
+                var item = used[i];
+
+                // Usages are sequential so we can stop checking after the usage exceeding the index.
+                if (item.FrameUsageIndex > executionIndex)
+                    break;
+
+                if (item.FrameUsageIndex != executionIndex)
+                    continue;
+
+                available.Add(item);
+                used.RemoveAt(i--);
             }
 
             updateStats();

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -23,6 +23,9 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected VeldridStagingResourcePool(GraphicsPipeline pipeline, string name)
         {
+            if (!pipeline.TrackingExecutions)
+                throw new ArgumentException($"An execution-tracking {nameof(GraphicsPipeline)} is required.", nameof(pipeline));
+
             Pipeline = pipeline;
 
             usageStat = GlobalStatistics.Get<ResourcePoolUsageStatistic>(nameof(VeldridRenderer), $"{name} usage");

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -74,17 +74,15 @@ namespace osu.Framework.Graphics.Veldrid
         {
             currentExecutionIndex = executionIndex;
 
-            for (int i = 0; i < available.Count; i++)
+            if (available.Count > 0)
             {
-                var item = available[i];
-
+                var item = available[0];
                 ulong framesSinceUsage = executionIndex - item.FrameUsageIndex;
 
                 if (framesSinceUsage >= Rendering.Renderer.RESOURCE_FREE_NO_USAGE_LENGTH)
                 {
                     item.Resource.Dispose();
                     available.Remove(item);
-                    break;
                 }
             }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -23,9 +23,6 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected VeldridStagingResourcePool(GraphicsPipeline pipeline, string name)
         {
-            if (!pipeline.TrackingExecutions)
-                throw new ArgumentException($"An execution-tracking {nameof(GraphicsPipeline)} is required.", nameof(pipeline));
-
             Pipeline = pipeline;
 
             usageStat = GlobalStatistics.Get<ResourcePoolUsageStatistic>(nameof(VeldridRenderer), $"{name} usage");

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Wasapi" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.5-gc8dfc5ca19" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.9-ga61b647961" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gca6cec7843" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/veldrid/pull/39
- [x] Nuget package update with above.

The current logic makes this assumption:

```csharp
// Iterate backwards to find the last signalled fence, which can be considered the last completed execution.
```

This is not actually correct because command buffers/command lists aren't guaranteed to finish sequentially. In other words, suppose two command buffers `A` and `B` are submitted in turn, it is generally guaranteed for all graphics APIs that the execution of `A` **starts** before `B`, but it is _not_ guaranteed that `A` **finishes** before `B`.

So the most important parts of this change are:
- Calling `BasicPipeline.ExecutionFinished` with _only_ the specific execution that finished.
- Changing `VeldridStagingResourcePool` to only free resources with the specific execution index from above.

The rest is fluff - optimisation and code-restructuring.