### PR TITLE
Fix over time degradation of deferred renderer performance

### DIFF
--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -80,6 +80,11 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             dead_chunks.Clear();
         }
 
+        ~DeferredUniformBuffer()
+        {
+            Dispose(false);
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -77,6 +77,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
 
             data = default;
             currentChunk = default;
+            dead_chunks.Clear();
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -80,8 +80,31 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             dead_chunks.Clear();
         }
 
+        ~DeferredUniformBuffer()
+        {
+            Dispose(false);
+        }
+
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool isDisposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
+            renderer.ScheduleDisposal(static b =>
+            {
+                foreach ((_, ResourceSet set) in b.bufferChunks)
+                    set.Dispose();
+            }, this);
         }
 
         private readonly record struct ChunkReference

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -80,11 +80,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             dead_chunks.Clear();
         }
 
-        ~DeferredUniformBuffer()
-        {
-            Dispose(false);
-        }
-
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
I happened upon this by total accident. I don't have a reliable way to reproduce this, so I hope the changes make sense on their own.

Because the list isn't cleared, it would keep increasing in size over time and eventually take down the game. For me, this happened abruptly. Also disposal wasn't implemented...

As a side note, I wish to implement this entire flow better in the future but I haven't found a way yet.