### PR TITLE
Fix incorrect disposal pattern

### DIFF
--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -108,17 +108,17 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         public void Dispose()
         {
-            if (isDisposed)
-                return;
-
-            isDisposed = true;
-
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)
         {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
             Renderer.ScheduleDisposal(texture =>
             {
                 while (texture.tryGetNextUpload(out var upload))


### PR DESCRIPTION
This could cause problems if the object is resurrected. It's not the proper disposal pattern.
