### PR TITLE
Provides generic version of `LifetimeEntryManager`

### DIFF
--- a/osu.Framework/Graphics/Performance/LifetimeEntry.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntry.cs
@@ -7,13 +7,17 @@ using System;
 
 namespace osu.Framework.Graphics.Performance
 {
+    public class LifetimeEntry : LifetimeEntry<LifetimeEntry>
+    {
+    }
+
     /// <summary>
     /// An object for a <see cref="LifetimeEntryManager"/> to consume, which provides a <see cref="LifetimeStart"/> and <see cref="LifetimeEnd"/>.
     /// </summary>
     /// <remarks>
     /// Management of the object which the <see cref="LifetimeEntry"/> refers to is left up to the consumer.
     /// </remarks>
-    public class LifetimeEntry
+    public abstract class LifetimeEntry<T> where T : LifetimeEntry<T>
     {
         private double lifetimeStart = double.MinValue;
 
@@ -42,12 +46,12 @@ namespace osu.Framework.Graphics.Performance
         /// Invoked before <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> changes.
         /// It is used because <see cref="LifetimeChanged"/> cannot be used to ensure comparator stability.
         /// </summary>
-        internal event Action<LifetimeEntry> RequestLifetimeUpdate;
+        internal event Action<T> RequestLifetimeUpdate;
 
         /// <summary>
         /// Invoked after <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> changes.
         /// </summary>
-        public event Action<LifetimeEntry> LifetimeChanged;
+        public event Action<T> LifetimeChanged;
 
         /// <summary>
         /// Update <see cref="LifetimeStart"/> of this <see cref="LifetimeEntry"/>.
@@ -74,12 +78,12 @@ namespace osu.Framework.Graphics.Performance
         /// <param name="end">The new <see cref="LifetimeEnd"/> value.</param>
         protected void SetLifetime(double start, double end)
         {
-            RequestLifetimeUpdate?.Invoke(this);
+            RequestLifetimeUpdate?.Invoke((T)this);
 
             lifetimeStart = start;
             lifetimeEnd = Math.Max(start, end); // Negative intervals are undesired.
 
-            LifetimeChanged?.Invoke(this);
+            LifetimeChanged?.Invoke((T)this);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Performance/LifetimeEntry.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntry.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 
 namespace osu.Framework.Graphics.Performance
@@ -46,12 +44,12 @@ namespace osu.Framework.Graphics.Performance
         /// Invoked before <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> changes.
         /// It is used because <see cref="LifetimeChanged"/> cannot be used to ensure comparator stability.
         /// </summary>
-        internal event Action<T> RequestLifetimeUpdate;
+        internal event Action<T>? RequestLifetimeUpdate;
 
         /// <summary>
         /// Invoked after <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> changes.
         /// </summary>
-        public event Action<T> LifetimeChanged;
+        public event Action<T>? LifetimeChanged;
 
         /// <summary>
         /// Update <see cref="LifetimeStart"/> of this <see cref="LifetimeEntry"/>.


### PR DESCRIPTION
I noticed that the `LifetimeEntryManager` class is not generic. This will cause me to have to cast repeatedly if I overload the `LifetimeEntry` class:

```cs
public class MyEntry : LiftTimeEntry {}
// ...
private readonly LifetimeEntryManager manager = new();
// ...
this.manager.AddEntry(new MyEntry());
this.manager.EntryBecameAlive += (LifetimeEntry e) => {
  var my = (MyEntry)e;
}
this.manager.EntryBecameDead += (LifetimeEntry e) => {
  var my = (MyEntry)e;
}
```

I thought maybe we should provide a generic version (LifetimeEntryManager<MyEntry>) to avoid such excessive casts. In addition, I noticed that osu! also casts classes like [this](https://ptb.discord.com/channels/188630481301012481/589331078574112768/1216754528079319070).

Ultimately, I settled on using CRTP as a trick to accomplish this. However, due to limitations of C# features, some functions may not be implemented perfectly. And for the sake of compatibility, I still provide a non-generic version to avoid some break-changes.

Todo:

- [ ] Rewrite XML comments of these classes.