### PR TITLE
Remove effect prioritisation to fix segfaults

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using ManagedBass;
 using ManagedBass.Mix;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Statistics;
@@ -421,13 +420,7 @@ namespace osu.Framework.Audio.Mixing.Bass
                     // Effects with greatest priority are stored at the front of the list.
                     effect.Priority = -i;
 
-                    if (effect.Handle != 0)
-                    {
-                        // Todo: Temporary bypass to attempt to fix failing test runs.
-                        if (!DebugUtils.IsNUnitRunning)
-                            ManagedBass.Bass.FXSetPriority(effect.Handle, effect.Priority);
-                    }
-                    else
+                    if (effect.Handle == 0)
                         effect.Handle = ManagedBass.Bass.ChannelSetFX(Handle, effect.Effect.FXType, effect.Priority);
 
                     ManagedBass.Bass.FXSetParameters(effect.Handle, effect.Effect);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/6202

I intend for this to be a somewhat temporary change because this entire thing needs to be rewritten... As far as I can tell we're not relying on effect priorities in osu! (cc @nekodex ).

We've had issues with `FXSetPriority` segfaulting the test runner in the past, but it has not been reported to be doing the same in-game: https://github.com/ppy/osu/discussions/27338

I haven't been able to repro this in osu!framework, but, under pipewire the game should segfault when entering `PlayerLoader` with the following diff applied:
```diff
diff --git a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
index 2605a84008..1ff9a69fbc 100644
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -14,6 +14,7 @@
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Statistics;
+using osu.Framework.Utils;

 namespace osu.Framework.Audio.Mixing.Bass
 {
@@ -272,6 +273,14 @@ protected override void UpdateState()
                 removeChannelFromBassMix(channel);
             }

+            foreach (var effect in ActiveEffects)
+            {
+                if (effect.Handle == 0)
+                    continue;
+
+                ManagedBass.Bass.FXSetPriority(effect.Handle, RNG.Next(0, 10));
+            }
+
             FrameStatistics.Add(StatisticsCounterType.MixChannels, activeChannels.Count);
             base.UpdateState();
         }
```

I considered the alternative of instead removing and re-adding the effects. This causes a short but noticeable glitch when player load finishes.

What's the cause of all of this? I don't know. Likely some sort of x86-register dependent behaviour in BASS (wouldn't be the first time). It's a bit too deep for the time being.