### PR TITLE
Add event handler for user change of `TabControl` tab selection

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Testing;
@@ -117,7 +119,24 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             public readonly Queue<TabItem<TestEnum>> UserTabSelectionChangedQueue = new Queue<TabItem<TestEnum>>();
 
-            protected override void OnUserTabSelectionChanged(TabItem<TestEnum> item) => UserTabSelectionChangedQueue.Enqueue(item);
+            private Box background = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AddInternal(background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = FrameworkColour.YellowGreen,
+                    Alpha = 0,
+                });
+            }
+
+            protected override void OnUserTabSelectionChanged(TabItem<TestEnum> item)
+            {
+                UserTabSelectionChangedQueue.Enqueue(item);
+                background.FadeOutFromOne(500);
+            }
         }
 
         private enum TestEnum

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
@@ -67,12 +67,27 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestSwitchTabMethodSendsEvent()
+        {
+            AddStep("set switchable", () => tabControl.IsSwitchable = true);
+            AddStep("call switch tab", () => tabControl.SwitchTab(1));
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.Second);
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.Second);
+            AddStep("call switch tab", () => tabControl.SwitchTab(-1));
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.First);
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.First);
+        }
+
+        [Test]
         public void TestSwitchUsingKeyBindingSendsEvent()
         {
             AddStep("set switchable", () => tabControl.IsSwitchable = true);
             AddStep("switch forward", () => InputManager.Keys(PlatformAction.DocumentNext));
             AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.Second);
             AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.Second);
+            AddStep("switch backward", () => InputManager.Keys(PlatformAction.DocumentPrevious));
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.First);
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.First);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
@@ -35,14 +35,28 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestClickSendsEvent()
         {
+            AddStep("click second tab", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<TabItem<TestEnum>>().ElementAt(1));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.Second);
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.Second);
+        }
+
+        [Test]
+        public void TestClickSameTabDoesNotSendEvent()
+        {
+            AddAssert("first tab selected", () => tabControl.Current.Value == TestEnum.First);
             AddStep("click first tab", () =>
             {
                 InputManager.MoveMouseTo(this.ChildrenOfType<TabItem<TestEnum>>().First());
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("selected tab = first", () => tabControl.Current.Value == TestEnum.First);
-            AddAssert("selected tab queue has \"first\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.First);
+            AddAssert("first tab still selected", () => tabControl.Current.Value == TestEnum.First);
+            AddAssert("selected tab queue empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
         }
 
         [Test]
@@ -76,6 +90,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("set selected tab = second", () => tabControl.Current.Value = TestEnum.Second);
             AddAssert("selected tab queue still empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
+        }
+
+        [TearDownSteps]
+        public void TearDownSteps()
+        {
+            AddAssert("selected tab queue empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
         }
 
         private partial class EventQueuesTabControl : BasicTabControl<TestEnum>

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControlEvents.cs
@@ -1,0 +1,94 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public partial class TestSceneTabControlEvents : ManualInputManagerTestScene
+    {
+        private EventQueuesTabControl tabControl = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("add tab control", () => Child = tabControl = new EventQueuesTabControl
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(150, 40),
+                Items = Enum.GetValues<TestEnum>(),
+            });
+
+            AddAssert("selected tab queue empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
+        }
+
+        [Test]
+        public void TestClickSendsEvent()
+        {
+            AddStep("click first tab", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<TabItem<TestEnum>>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("selected tab = first", () => tabControl.Current.Value == TestEnum.First);
+            AddAssert("selected tab queue has \"first\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.First);
+        }
+
+        [Test]
+        public void TestSelectItemMethodSendsEvent()
+        {
+            AddStep("call select item", () => tabControl.SelectItem(TestEnum.Second));
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.Second);
+        }
+
+        [Test]
+        public void TestSwitchUsingKeyBindingSendsEvent()
+        {
+            AddStep("set switchable", () => tabControl.IsSwitchable = true);
+            AddStep("switch forward", () => InputManager.Keys(PlatformAction.DocumentNext));
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.Second);
+            AddAssert("selected tab queue has \"second\"", () => tabControl.UserTabSelectionChangedQueue.Dequeue().Value == TestEnum.Second);
+        }
+
+        [Test]
+        public void TestSwitchOnRemovalDoesNotSendEvent()
+        {
+            AddStep("set switchable", () => tabControl.IsSwitchable = true);
+            AddStep("remove first tab", () => tabControl.RemoveItem(TestEnum.First));
+
+            AddAssert("selected tab = second", () => tabControl.Current.Value == TestEnum.Second);
+            AddAssert("selected tab queue still empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
+        }
+
+        [Test]
+        public void TestBindableChangeDoesNotSendEvent()
+        {
+            AddStep("set selected tab = second", () => tabControl.Current.Value = TestEnum.Second);
+            AddAssert("selected tab queue still empty", () => tabControl.UserTabSelectionChangedQueue.Count == 0);
+        }
+
+        private partial class EventQueuesTabControl : BasicTabControl<TestEnum>
+        {
+            public readonly Queue<TabItem<TestEnum>> UserTabSelectionChangedQueue = new Queue<TabItem<TestEnum>>();
+
+            protected override void OnUserTabSelectionChanged(TabItem<TestEnum> item) => UserTabSelectionChangedQueue.Enqueue(item);
+        }
+
+        private enum TestEnum
+        {
+            First,
+            Second,
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -376,11 +376,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         private bool selectTab(TabItem<T> tab)
         {
-            var lastTab = SelectedTab;
+            if (tab == SelectedTab)
+                return false;
 
-            updateSelectedTab(tab);
-            Current.Value = SelectedTab != null ? SelectedTab.Value : default;
-            return SelectedTab != lastTab;
+            Current.Value = tab != null ? tab.Value : default;
+            return true;
         }
 
         private void updateSelectedTab(TabItem<T> tab)

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -384,15 +384,6 @@ namespace osu.Framework.Graphics.UserInterface
                 OnUserTabSelectionChanged(tab);
         }
 
-        private bool selectTab(TabItem<T> tab)
-        {
-            if (tab == SelectedTab)
-                return false;
-
-            Current.Value = tab != null ? tab.Value : default;
-            return true;
-        }
-
         /// <summary>
         /// Switches the currently selected tab forward or backward one index, optionally wrapping.
         /// </summary>
@@ -421,6 +412,15 @@ namespace osu.Framework.Graphics.UserInterface
                 found = allTabs.FirstOrDefault(t => t != SelectedTab);
 
             return found != null && selectTab(found);
+        }
+
+        private bool selectTab(TabItem<T> tab)
+        {
+            if (tab == SelectedTab)
+                return false;
+
+            Current.Value = tab != null ? tab.Value : default;
+            return true;
         }
 
         private void activationRequested(TabItem<T> tab)

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -366,18 +366,21 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="tab">The tab to select.</param>
         protected void SelectTab(TabItem<T> tab)
         {
-            UpdateTabSelection(tab);
-            OnUserTabSelectionChanged(tab);
+            if (UpdateTabSelection(tab))
+                OnUserTabSelectionChanged(tab);
         }
 
         /// <summary>
         /// Selects a <see cref="TabItem{T}"/>.
         /// </summary>
         /// <param name="tab">The tab to select.</param>
-        protected virtual void UpdateTabSelection(TabItem<T> tab)
+        protected virtual bool UpdateTabSelection(TabItem<T> tab)
         {
+            var lastTab = SelectedTab;
+
             updateSelectedTab(tab);
             Current.Value = SelectedTab != null ? SelectedTab.Value : default;
+            return SelectedTab != lastTab;
         }
 
         private void updateSelectedTab(TabItem<T> tab)

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -369,15 +369,11 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="tab">The tab to select.</param>
         protected void SelectTab(TabItem<T> tab)
         {
-            if (UpdateTabSelection(tab))
+            if (selectTab(tab))
                 OnUserTabSelectionChanged(tab);
         }
 
-        /// <summary>
-        /// Updates <see cref="SelectedTab"/> and <see cref="Current"/> bindable to the given tab.
-        /// </summary>
-        /// <param name="tab">The tab to select.</param>
-        protected virtual bool UpdateTabSelection(TabItem<T> tab)
+        private bool selectTab(TabItem<T> tab)
         {
             var lastTab = SelectedTab;
 
@@ -433,7 +429,7 @@ namespace osu.Framework.Graphics.UserInterface
                 found = allTabs.FirstOrDefault(t => t != SelectedTab);
 
             if (found != null)
-                UpdateTabSelection(found);
+                selectTab(found);
 
             return SelectedTab != lastTab;
         }

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -403,11 +403,9 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         /// <param name="direction">Pass 1 to move to the next tab, or -1 to move to the previous tab.</param>
         /// <param name="wrap">If <c>true</c>, moving past the start or the end of the tab list will wrap to the opposite end.</param>
-        public virtual void SwitchTab(int direction, bool wrap = true)
+        public void SwitchTab(int direction, bool wrap = true)
         {
-            bool changed = switchTab(direction, wrap);
-
-            if (changed)
+            if (switchTab(direction, wrap))
                 OnUserTabSelectionChanged(SelectedTab);
         }
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -352,9 +352,10 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Selects a <see cref="TabItem{T}"/> and signals an event that the user selected the given tab value via <see cref="OnUserTabSelectionChanged"/>.
+        /// Selects the tab representing the provided item.
         /// </summary>
         /// <param name="item">The item to select.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the provided item doesn't exist in the tab control.</exception>
         public void SelectItem(T item)
         {
             if (!tabMap.TryGetValue(item, out var tab))

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -374,7 +374,7 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Selects a <see cref="TabItem{T}"/>.
+        /// Updates <see cref="SelectedTab"/> and <see cref="Current"/> bindable to the given tab.
         /// </summary>
         /// <param name="tab">The tab to select.</param>
         protected virtual bool UpdateTabSelection(TabItem<T> tab)


### PR DESCRIPTION
- See https://github.com/ppy/osu/pull/27448 for previous discussion

The abstraction may look a little bit too much, but I've been trying to find a middle-ground between code readability and simplicity of structure. 

The previously existing `SelectTab` method is supposed to do all that's necessary for the tab selection to be changed, without necessarily being related to user action, so I've renamed it to `UpdateTabSelection`.

I've also introduced two methods, `SelectTab` and `SelectItem`, the former is for internal use by `TabItem` click event to update tab selection and trigger user event, meanwhile the latter is for external use by calling it with the target item to update tab selection and trigger user event as well (e.g. osu! calling the method when changing editor screen mode, so that an auxiliary sample is played).

I didn't want `SelectTab` to exist in the first place, but it's necessary so that the `TabItem` click event doesn't have to call `SelectItem` and perform an unnecessary lookup for an already known tab item, so that's why it's there.