### PR TITLE
Reduce scope of experimental renderer options

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -847,7 +847,6 @@ namespace osu.Framework.Platform
                     yield return RendererType.Direct3D11;
                     yield return RendererType.Deferred_Direct3D11;
                     yield return RendererType.OpenGL;
-                    yield return RendererType.Deferred_OpenGL;
                     yield return RendererType.Deferred_Vulkan;
 
                     break;
@@ -863,7 +862,6 @@ namespace osu.Framework.Platform
                     yield return RendererType.Metal;
                     yield return RendererType.Deferred_Metal;
                     yield return RendererType.OpenGL;
-                    yield return RendererType.Deferred_OpenGL;
 
                     break;
 


### PR DESCRIPTION
On a second look, I think I want to reduce the scope of this.

Windows: I want to push people towards D3D11 or Vulkan, even if OpenGL Experimental behaves better than OpenGL.
macOS: OpenGL should practically never be used.