### PR TITLE
Simplify `CompositeDrawable.CheckChildrenLife`

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -718,14 +718,10 @@ namespace osu.Framework.Graphics.Containers
         {
             bool anyAliveChanged = false;
 
-            for (int i = 0; i < internalChildren.Count; i++)
+            for (int i = internalChildren.Count - 1; i >= 0; i--)
             {
                 var state = checkChildLife(internalChildren[i]);
-
                 anyAliveChanged |= state.HasFlagFast(ChildLifeStateChange.MadeAlive) || state.HasFlagFast(ChildLifeStateChange.MadeDead);
-
-                if (state.HasFlagFast(ChildLifeStateChange.Removed))
-                    i--;
             }
 
             FrameStatistics.Add(StatisticsCounterType.CCL, internalChildren.Count);


### PR DESCRIPTION
Was trying to investigate why ccl is so expensive in complex scenes, but failed (my guess is that it's just the loop itself).
Now looks way simpler (imo) without `ChildLifeStateChange` enum.
No performance difference.
Kinda useless but eh