### PR TITLE
Add support for custom clipboard formats

### DIFF
--- a/osu.Framework.Android/AndroidClipboard.cs
+++ b/osu.Framework.Android/AndroidClipboard.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using Android.Content;
 using osu.Framework.Platform;
 using SixLabors.ImageSharp;
@@ -10,6 +11,7 @@ namespace osu.Framework.Android
     public class AndroidClipboard : Clipboard
     {
         private readonly ClipboardManager? clipboardManager;
+        private readonly Dictionary<string, string> customFormatValues = new Dictionary<string, string>();
 
         public AndroidClipboard(AndroidGameView view)
         {
@@ -18,14 +20,45 @@ namespace osu.Framework.Android
 
         public override string? GetText() => clipboardManager?.PrimaryClip?.GetItemAt(0)?.Text;
 
-        public override void SetText(string text)
-        {
-            if (clipboardManager != null)
-                clipboardManager.PrimaryClip = ClipData.NewPlainText(null, text);
-        }
-
         public override Image<TPixel>? GetImage<TPixel>() => null;
 
-        public override bool SetImage(Image image) => false;
+        public override bool SetData(params ClipboardEntry[] entries)
+        {
+            if (clipboardManager == null)
+                return false;
+
+            customFormatValues.Clear();
+            clipboardManager.PrimaryClip = null;
+
+            if (entries.Length == 0)
+                return false;
+
+            bool success = true;
+
+            foreach (var entry in entries)
+            {
+                switch (entry)
+                {
+                    case ClipboardTextEntry textEntry:
+                        clipboardManager.PrimaryClip = ClipData.NewPlainText(null, textEntry.Value);
+                        break;
+
+                    case ClipboardCustomEntry customEntry:
+                        customFormatValues[customEntry.Format] = customFormatValues[customEntry.Value];
+                        break;
+
+                    default:
+                        success = false;
+                        break;
+                }
+            }
+
+            return success;
+        }
+
+        public override string? GetCustom(string format)
+        {
+            return customFormatValues[format];
+        }
     }
 }

--- a/osu.Framework/Platform/Clipboard.cs
+++ b/osu.Framework/Platform/Clipboard.cs
@@ -48,13 +48,14 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Get clipboard content with custom format
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Name of the custom format</returns>
         public abstract string? GetCustom(string format);
 
         /// <summary>
         /// Get clipboard content with custom format
         /// </summary>
-        /// <returns></returns>
+        /// <param name="format">Name of the custom format</param>
+        /// <param name="text">Text to copy to the clipboard</param>
         public void SetCustom(string format, string text)
         {
             SetData(
@@ -65,7 +66,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Copy multiple values to the clipboard
         /// </summary>
-        /// <param name="entries"></param>
+        /// <param name="entries">Entries to copy the clipboard</param>
         public abstract bool SetData(params ClipboardEntry[] entries);
     }
 }

--- a/osu.Framework/Platform/Clipboard.cs
+++ b/osu.Framework/Platform/Clipboard.cs
@@ -20,7 +20,12 @@ namespace osu.Framework.Platform
         /// Copy text to the clipboard.
         /// </summary>
         /// <param name="text">Text to copy to the clipboard</param>
-        public abstract void SetText(string text);
+        public void SetText(string text)
+        {
+            SetData(
+                new ClipboardTextEntry(text)
+            );
+        }
 
         /// <summary>
         /// Retrieve an image from the clipboard.
@@ -33,6 +38,34 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <param name="image">The image to copy to the clipboard</param>
         /// <returns>Whether the image was successfully copied or not</returns>
-        public abstract bool SetImage(Image image);
+        public bool SetImage(Image image)
+        {
+            return SetData(
+                new ClipboardImageEntry(image)
+            );
+        }
+
+        /// <summary>
+        /// Get clipboard content with custom format
+        /// </summary>
+        /// <returns></returns>
+        public abstract string? GetCustom(string format);
+
+        /// <summary>
+        /// Get clipboard content with custom format
+        /// </summary>
+        /// <returns></returns>
+        public void SetCustom(string format, string text)
+        {
+            SetData(
+                new ClipboardCustomEntry(format, text)
+            );
+        }
+
+        /// <summary>
+        /// Copy multiple values to the clipboard
+        /// </summary>
+        /// <param name="entries"></param>
+        public abstract bool SetData(params ClipboardEntry[] entries);
     }
 }

--- a/osu.Framework/Platform/ClipboardCustomEntry.cs
+++ b/osu.Framework/Platform/ClipboardCustomEntry.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    public class ClipboardCustomEntry : ClipboardEntry
+    {
+        public readonly string Format;
+        public readonly string Value;
+
+        public ClipboardCustomEntry(string format, string text)
+        {
+            Format = format;
+            Value = text;
+        }
+    }
+}

--- a/osu.Framework/Platform/ClipboardCustomEntry.cs
+++ b/osu.Framework/Platform/ClipboardCustomEntry.cs
@@ -3,6 +3,9 @@
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// Represents a value with a custom format in the clipboard
+    /// </summary>
     public class ClipboardCustomEntry : ClipboardEntry
     {
         public readonly string Format;

--- a/osu.Framework/Platform/ClipboardEntry.cs
+++ b/osu.Framework/Platform/ClipboardEntry.cs
@@ -1,0 +1,9 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    public abstract class ClipboardEntry
+    {
+    }
+}

--- a/osu.Framework/Platform/ClipboardEntry.cs
+++ b/osu.Framework/Platform/ClipboardEntry.cs
@@ -3,6 +3,9 @@
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// Represents a single item in the clipboard
+    /// </summary>
     public abstract class ClipboardEntry
     {
     }

--- a/osu.Framework/Platform/ClipboardImageEntry.cs
+++ b/osu.Framework/Platform/ClipboardImageEntry.cs
@@ -5,6 +5,9 @@ using SixLabors.ImageSharp;
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// Represents an image value in the clipboard
+    /// </summary>
     public class ClipboardImageEntry : ClipboardEntry
     {
         public readonly Image Value;

--- a/osu.Framework/Platform/ClipboardImageEntry.cs
+++ b/osu.Framework/Platform/ClipboardImageEntry.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using SixLabors.ImageSharp;
+
+namespace osu.Framework.Platform
+{
+    public class ClipboardImageEntry : ClipboardEntry
+    {
+        public readonly Image Value;
+
+        public ClipboardImageEntry(Image text)
+        {
+            Value = text;
+        }
+    }
+}

--- a/osu.Framework/Platform/ClipboardTextEntry.cs
+++ b/osu.Framework/Platform/ClipboardTextEntry.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    public class ClipboardTextEntry : ClipboardEntry
+    {
+        public readonly string Value;
+
+        public ClipboardTextEntry(string text)
+        {
+            Value = text;
+        }
+    }
+}

--- a/osu.Framework/Platform/ClipboardTextEntry.cs
+++ b/osu.Framework/Platform/ClipboardTextEntry.cs
@@ -3,6 +3,9 @@
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// Represents a plain-text value in the clipboard
+    /// </summary>
     public class ClipboardTextEntry : ClipboardEntry
     {
         public readonly string Value;

--- a/osu.Framework/Platform/HeadlessClipboard.cs
+++ b/osu.Framework/Platform/HeadlessClipboard.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using SixLabors.ImageSharp;
 
 namespace osu.Framework.Platform
@@ -15,21 +16,41 @@ namespace osu.Framework.Platform
     {
         private string? clipboardText;
         private Image? clipboardImage;
+        private readonly Dictionary<string, string> customValues = new Dictionary<string, string>();
 
         public override string? GetText() => clipboardText;
 
-        public override void SetText(string text)
-        {
-            clipboardImage = null;
-            clipboardText = text;
-        }
-
         public override Image<TPixel>? GetImage<TPixel>() => clipboardImage?.CloneAs<TPixel>();
 
-        public override bool SetImage(Image image)
+        public override string? GetCustom(string format)
+        {
+            return customValues[format];
+        }
+
+        public override bool SetData(params ClipboardEntry[] entries)
         {
             clipboardText = null;
-            clipboardImage = image;
+            clipboardImage = null;
+            customValues.Clear();
+
+            foreach (var entry in entries)
+            {
+                switch (entry)
+                {
+                    case ClipboardTextEntry textEntry:
+                        clipboardText = textEntry.Value;
+                        break;
+
+                    case ClipboardImageEntry imageEntry:
+                        clipboardImage = imageEntry.Value;
+                        break;
+
+                    case ClipboardCustomEntry customEntry:
+                        customValues[customEntry.Format] = customEntry.Value;
+                        break;
+                }
+            }
+
             return true;
         }
     }

--- a/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Clipboard.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using SDL2;
 using SixLabors.ImageSharp;
 
@@ -8,21 +10,47 @@ namespace osu.Framework.Platform.SDL2
 {
     public class SDL2Clipboard : Clipboard
     {
+        private readonly Dictionary<string, string> customFormatValues = new Dictionary<string, string>();
+
         // SDL cannot differentiate between string.Empty and no text (eg. empty clipboard or an image)
         // doesn't matter as text editors don't really allow copying empty strings.
         // assume that empty text means no text.
         public override string? GetText() => SDL.SDL_HasClipboardText() == SDL.SDL_bool.SDL_TRUE ? SDL.SDL_GetClipboardText() : null;
-
-        public override void SetText(string text) => SDL.SDL_SetClipboardText(text);
 
         public override Image<TPixel>? GetImage<TPixel>()
         {
             return null;
         }
 
-        public override bool SetImage(Image image)
+        public override string? GetCustom(string format)
         {
-            return false;
+            return customFormatValues[format];
+        }
+
+        public override bool SetData(params ClipboardEntry[] entries)
+        {
+            customFormatValues.Clear();
+
+            if (entries.Any(e => e is ClipboardImageEntry))
+            {
+                return false;
+            }
+
+            foreach (var entry in entries)
+            {
+                switch (entry)
+                {
+                    case ClipboardTextEntry textEntry:
+                        SDL.SDL_SetClipboardText(textEntry.Value);
+                        break;
+
+                    case ClipboardCustomEntry customEntry:
+                        customFormatValues[customEntry.Format] = customEntry.Value;
+                        break;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/osu.Framework/Platform/Windows/WindowsClipboard.cs
+++ b/osu.Framework/Platform/Windows/WindowsClipboard.cs
@@ -240,8 +240,6 @@ namespace osu.Framework.Platform.Windows
 
             bool success = true;
 
-            List<IntPtr> toFree = new List<IntPtr>();
-
             try
             {
                 if (!OpenClipboard(IntPtr.Zero))
@@ -288,17 +286,12 @@ namespace osu.Framework.Platform.Windows
                     finally
                     {
                         if (hGlobal != IntPtr.Zero)
-                            toFree.Add(hGlobal);
+                            GlobalFree(hGlobal);
                     }
                 }
             }
             finally
             {
-                foreach (IntPtr free in toFree)
-                {
-                    GlobalFree(free);
-                }
-
                 CloseClipboard();
             }
 

--- a/osu.Framework/Platform/Windows/WindowsClipboard.cs
+++ b/osu.Framework/Platform/Windows/WindowsClipboard.cs
@@ -138,6 +138,7 @@ namespace osu.Framework.Platform.Windows
 
             var rawEntries = new List<RawClipboardEntry>();
 
+            // Required for compatibility with browser clipboard https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md#on-windows
             var webCustomFormats = new Dictionary<string, string>();
 
             foreach (var entry in entries)


### PR DESCRIPTION
Allows copying values with custom formats to the clipboard. For now only writes custom formats to the system clipboard on windows, other platforms will store the value in-memory for now. I only did windows for now to not blur up the PR in size.
For simplicity, I limited the custom formats to be text-only.

Adds support for [web custom formats](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md) on windows, for interoperability with the browser clipboard API.

Web custom formats expects a clipboard entry containing a map of all custom formats in json. The name of the clipboard entries depends on the platform. For windows these entries are expected to be in the `Web Custom Format Map` entry:
```json
{
  "text/custom" : "Web Custom Format0",
  "image/custom" : "Web Custom Format1"
}
```

## Changes made:
- `osu.Framework/Platform/Clipboard.cs`
  - Allow writing custom formats
  - Allow writing multiple formats at the same time
- `osu.Framework/Platform/HeadlessClipboard.cs`
  - Added in-memory storage for custom formats
- `osu.Framework/Platform/Windows/WindowsClipboard.cs`
  - Write custom formats to win32 clipboard api
  - When copying, will generate clipboard entries for custom formats to support web custom formats
  - When pasting, clipboard will fallback to web custom formats clipboard entries and will try to retrieve the data from those instead (to allow copy paste from browser -> osu framework)
- `osu.Framework/Platform/MacOS/MacOSClipboard.cs`
  - Added in-memory fallback for custom formats
- `osu.Framework/Platform/SDL2/SDL2Clipboard.cs`
  - Added in-memory fallback for custom formats
- `osu.Framework.Android/AndroidClipboard.cs`
  - Added in-memory fallback for custom formats
- `osu.Framework/Platform/ClipboardEntry.cs`, `osu.Framework/Platform/ClipboardTextEntry.cs`, `osu.Framework/Platform/ClipboardImageEntry.cs`, `osu.Framework/Platform/ClipboardCustomEntry.cs`
  - Added classes to represent different types of clipboard entries