### PR TITLE
Update SDL2 package + use `SDL_GetWindowSizeInPixels`

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsSurface.cs
@@ -58,29 +58,7 @@ namespace osu.Framework.Platform.SDL2
 
         public Size GetDrawableSize()
         {
-            int width, height;
-
-            switch (Type)
-            {
-                case GraphicsSurfaceType.OpenGL:
-                default:
-                    SDL.SDL_GL_GetDrawableSize(window.SDLWindowHandle, out width, out height);
-                    break;
-
-                case GraphicsSurfaceType.Vulkan:
-                    SDL.SDL_Vulkan_GetDrawableSize(window.SDLWindowHandle, out width, out height);
-                    break;
-
-                case GraphicsSurfaceType.Metal:
-                    SDL.SDL_Metal_GetDrawableSize(window.SDLWindowHandle, out width, out height);
-                    break;
-
-                case GraphicsSurfaceType.Direct3D11:
-                    // todo: SDL has no "drawable size" method for D3D11, return window size for now.
-                    SDL.SDL_GetWindowSize(window.SDLWindowHandle, out width, out height);
-                    break;
-            }
-
+            SDL.SDL_GetWindowSizeInPixels(window.SDLWindowHandle, out int width, out int height);
             return new Size(width, height);
         }
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
-    <PackageReference Include="ppy.SDL2-CS" Version="1.0.693-alpha" />
+    <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2023.720.0" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
- Includes fix for https://github.com/libsdl-org/SDL/issues/9283
- Adds + uses `SDL_GetWindowSizeInPixels` (https://github.com/ppy/SDL2-CS/issues/181).
    - In SDL3, this function replaces the `GetDrawableSize()` methods (see: https://github.com/libsdl-org/SDL/blob/main/docs/README-migration.md#sdl_metalh).
    - Although the `GetDrawableSize()` methods use this as a fallback pathway, this should also be a stable API in SDL2.
        - [x] Tested on OpenGL/macOS
        - [x] Tested on Metal/macOS
        - [x] Tested on D3D/Windows (can't notice a difference)
        - [x] Tested on OpenGL/Windows
        - [x] Tested on Vulkan/Windows
        - [x] Tested on Linux (Wayland)
        - [x] Tested on Linux (X11)