### PR TITLE
Tweak behavior of cursor movement while text is selected to better match expectations

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -854,15 +854,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
             AddAssert("first word selected", () => textBox.SelectedText == "cwm");
 
-            // forward word move should jump from right end of selection
+            // forward word move should put cursor at right end of selection
             AddStep("move cursor forward (word)", () => InputManager.Keys(PlatformAction.MoveForwardWord));
-            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
-            AddAssert("second word selected", () => textBox.SelectedText == "fjord");
+            AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
+            AddAssert("second word selected", () => textBox.SelectedText == " fjord");
 
             // same thing but for "back-facing" selection
             AddStep("move cursor forward (word)", () => InputManager.Keys(PlatformAction.MoveForwardWord));
-            AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
-            AddAssert("fourth word selected", () => textBox.SelectedText == " vext");
+            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
+            AddAssert("second word selected", () => textBox.SelectedText == "fjord");
 
             // right char move should put cursor at right end of selection
             AddStep("select all", () => textBox.SelectAll());
@@ -870,15 +870,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
             AddAssert("last word selected", () => textBox.SelectedText == "quiz");
 
-            // backward word move should jump from left end of selection
+            // backward word move should put cursor at left end of selection
             AddStep("move cursor backward (word)", () => InputManager.Keys(PlatformAction.MoveBackwardWord));
-            AddStep("select forward (word)", () => InputManager.Keys(PlatformAction.SelectForwardWord));
-            AddAssert("second-from-last word selected", () => textBox.SelectedText == "bank");
+            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
+            AddAssert("second-from-last word selected", () => textBox.SelectedText == "bank ");
 
             // same thing but for "front-facing" selection
             AddStep("move cursor backward (word)", () => InputManager.Keys(PlatformAction.MoveBackwardWord));
-            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
-            AddAssert("fourth-from-last word selected", () => textBox.SelectedText == "glyphs ");
+            AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
+            AddAssert("second-from-last word selected", () => textBox.SelectedText == "bank");
         }
 
         private void prependString(InsertableTextBox textBox, string text)

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -827,6 +827,60 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("all text selected", () => textBox.SelectedText, () => Is.EqualTo(textBox.Text));
         }
 
+        [Test]
+        public void TestCursorMovementWithSelection()
+        {
+            TextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new BasicTextBox
+                {
+                    Size = new Vector2(300, 40),
+                    Text = "cwm fjord glyphs vext bank quiz",
+                    ReadOnly = false
+                });
+            });
+
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            // left char move should put cursor at left end of selection
+            AddStep("select all", () => textBox.SelectAll());
+            AddStep("move cursor backward (char)", () => InputManager.Keys(PlatformAction.MoveBackwardChar));
+            AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
+            AddAssert("first word selected", () => textBox.SelectedText == "cwm");
+
+            // forward word move should jump from right end of selection
+            AddStep("move cursor forward (word)", () => InputManager.Keys(PlatformAction.MoveForwardWord));
+            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
+            AddAssert("second word selected", () => textBox.SelectedText == "fjord");
+
+            // same thing but for "back-facing" selection
+            AddStep("move cursor forward (word)", () => InputManager.Keys(PlatformAction.MoveForwardWord));
+            AddStep("select next word", () => InputManager.Keys(PlatformAction.SelectForwardWord));
+            AddAssert("fourth word selected", () => textBox.SelectedText == " vext");
+
+            // right char move should put cursor at right end of selection
+            AddStep("select all", () => textBox.SelectAll());
+            AddStep("move cursor forward (char)", () => InputManager.Keys(PlatformAction.MoveForwardChar));
+            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
+            AddAssert("last word selected", () => textBox.SelectedText == "quiz");
+
+            // backward word move should jump from left end of selection
+            AddStep("move cursor backward (word)", () => InputManager.Keys(PlatformAction.MoveBackwardWord));
+            AddStep("select forward (word)", () => InputManager.Keys(PlatformAction.SelectForwardWord));
+            AddAssert("second-from-last word selected", () => textBox.SelectedText == "bank");
+
+            // same thing but for "front-facing" selection
+            AddStep("move cursor backward (word)", () => InputManager.Keys(PlatformAction.MoveBackwardWord));
+            AddStep("select previous word", () => InputManager.Keys(PlatformAction.SelectBackwardWord));
+            AddAssert("fourth-from-last word selected", () => textBox.SelectedText == "glyphs ");
+        }
+
         private void prependString(InsertableTextBox textBox, string text)
         {
             InputManager.Keys(PlatformAction.MoveBackwardLine);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -302,23 +302,27 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
 
                 case PlatformAction.MoveBackwardWord:
-                    if (hasSelection && selectionEnd != selectionLeft)
+                    if (hasSelection)
                     {
-                        selectionEnd = selectionLeft;
-                        selectionStart = lastSelectionBounds.end;
+                        MoveCursorBy(selectionLeft - selectionEnd);
+                    }
+                    else
+                    {
+                        MoveCursorBy(GetBackwardWordAmount());
                     }
 
-                    MoveCursorBy(GetBackwardWordAmount());
                     return true;
 
                 case PlatformAction.MoveForwardWord:
-                    if (hasSelection && selectionEnd != selectionRight)
+                    if (hasSelection)
                     {
-                        selectionEnd = selectionRight;
-                        selectionStart = lastSelectionBounds.end;
+                        MoveCursorBy(selectionRight - selectionEnd);
+                    }
+                    else
+                    {
+                        MoveCursorBy(GetForwardWordAmount());
                     }
 
-                    MoveCursorBy(GetForwardWordAmount());
                     return true;
 
                 case PlatformAction.MoveBackwardLine:

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -280,9 +280,7 @@ namespace osu.Framework.Graphics.UserInterface
                 case PlatformAction.MoveBackwardChar:
                     if (hasSelection)
                     {
-                        selectionStart = selectionEnd = selectionLeft;
-                        cursorAndLayout.Invalidate();
-                        onTextDeselected(lastSelectionBounds);
+                        MoveCursorBy(selectionLeft - selectionEnd);
                     }
                     else
                     {
@@ -294,9 +292,7 @@ namespace osu.Framework.Graphics.UserInterface
                 case PlatformAction.MoveForwardChar:
                     if (hasSelection)
                     {
-                        selectionStart = selectionEnd = selectionRight;
-                        cursorAndLayout.Invalidate();
-                        onTextDeselected(lastSelectionBounds);
+                        MoveCursorBy(selectionRight - selectionEnd);
                     }
                     else
                     {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -278,18 +278,50 @@ namespace osu.Framework.Graphics.UserInterface
 
                 // Cursor Manipulation
                 case PlatformAction.MoveBackwardChar:
-                    MoveCursorBy(-1);
+                    if (selectionLength > 0)
+                    {
+                        selectionStart = selectionEnd = selectionLeft;
+                        cursorAndLayout.Invalidate();
+                        onTextDeselected(lastSelectionBounds);
+                    }
+                    else
+                    {
+                        MoveCursorBy(-1);
+                    }
+
                     return true;
 
                 case PlatformAction.MoveForwardChar:
-                    MoveCursorBy(1);
+                    if (selectionLength > 0)
+                    {
+                        selectionStart = selectionEnd = selectionRight;
+                        cursorAndLayout.Invalidate();
+                        onTextDeselected(lastSelectionBounds);
+                    }
+                    else
+                    {
+                        MoveCursorBy(1);
+                    }
+
                     return true;
 
                 case PlatformAction.MoveBackwardWord:
+                    if (selectionLength > 0 && selectionEnd != selectionLeft)
+                    {
+                        selectionEnd = selectionLeft;
+                        selectionStart = lastSelectionBounds.end;
+                    }
+
                     MoveCursorBy(GetBackwardWordAmount());
                     return true;
 
                 case PlatformAction.MoveForwardWord:
+                    if (selectionLength > 0 && selectionEnd != selectionRight)
+                    {
+                        selectionEnd = selectionRight;
+                        selectionStart = lastSelectionBounds.end;
+                    }
+
                     MoveCursorBy(GetForwardWordAmount());
                     return true;
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -278,7 +278,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 // Cursor Manipulation
                 case PlatformAction.MoveBackwardChar:
-                    if (selectionLength > 0)
+                    if (hasSelection)
                     {
                         selectionStart = selectionEnd = selectionLeft;
                         cursorAndLayout.Invalidate();
@@ -292,7 +292,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
 
                 case PlatformAction.MoveForwardChar:
-                    if (selectionLength > 0)
+                    if (hasSelection)
                     {
                         selectionStart = selectionEnd = selectionRight;
                         cursorAndLayout.Invalidate();
@@ -306,7 +306,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
 
                 case PlatformAction.MoveBackwardWord:
-                    if (selectionLength > 0 && selectionEnd != selectionLeft)
+                    if (hasSelection && selectionEnd != selectionLeft)
                     {
                         selectionEnd = selectionLeft;
                         selectionStart = lastSelectionBounds.end;
@@ -316,7 +316,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
 
                 case PlatformAction.MoveForwardWord:
-                    if (selectionLength > 0 && selectionEnd != selectionRight)
+                    if (hasSelection && selectionEnd != selectionRight)
                     {
                         selectionEnd = selectionRight;
                         selectionStart = lastSelectionBounds.end;
@@ -479,7 +479,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (selectionLength == 0)
                 selectionEnd = Math.Clamp(selectionStart + amount, 0, text.Length);
 
-            if (selectionLength > 0)
+            if (hasSelection)
             {
                 string removedText = removeSelection();
                 OnUserTextRemoved(removedText);
@@ -556,7 +556,7 @@ namespace osu.Framework.Graphics.UserInterface
             float cursorPosEnd = getPositionAt(selectionEnd);
 
             float? selectionWidth = null;
-            if (selectionLength > 0)
+            if (hasSelection)
                 selectionWidth = getPositionAt(selectionRight) - cursorPos;
 
             float cursorRelativePositionAxesInBox = (cursorPosEnd - textContainerPosX) / (DrawWidth - 2 * LeftRightPadding);
@@ -648,6 +648,7 @@ namespace osu.Framework.Graphics.UserInterface
         private int selectionEnd;
 
         private int selectionLength => Math.Abs(selectionEnd - selectionStart);
+        private bool hasSelection => selectionLength > 0;
 
         private int selectionLeft => Math.Min(selectionStart, selectionEnd);
         private int selectionRight => Math.Max(selectionStart, selectionEnd);
@@ -665,7 +666,7 @@ namespace osu.Framework.Graphics.UserInterface
                 selectionEnd = Math.Clamp(selectionEnd + offset, 0, text.Length);
             else
             {
-                if (selectionLength > 0 && Math.Abs(offset) <= 1)
+                if (hasSelection && Math.Abs(offset) <= 1)
                 {
                     //we don't want to move the location when "removing" an existing selection, just set the new location.
                     if (offset > 0)
@@ -850,7 +851,7 @@ namespace osu.Framework.Graphics.UserInterface
                     continue;
                 }
 
-                if (selectionLength > 0)
+                if (hasSelection)
                     removeSelection();
 
                 if (text.Length + 1 > LengthLimit)
@@ -930,7 +931,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (lastSelectionBounds.start == selectionStart && lastSelectionBounds.end == selectionEnd)
                 return;
 
-            if (selectionLength > 0)
+            if (hasSelection)
                 OnTextSelectionChanged(selectionType);
             else
                 onTextDeselected(lastSelectionBounds);
@@ -1064,7 +1065,7 @@ namespace osu.Framework.Graphics.UserInterface
             cursorAndLayout.Invalidate();
         }
 
-        public string SelectedText => selectionLength > 0 ? Text.Substring(selectionLeft, selectionLength) : string.Empty;
+        public string SelectedText => hasSelection ? Text.Substring(selectionLeft, selectionLength) : string.Empty;
 
         /// <summary>
         /// Whether <see cref="KeyDownEvent"/>s should be blocked because of recent text input from a <see cref="TextInputSource"/>.
@@ -1222,7 +1223,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (text.Length == 0) return;
 
                 selectionEnd = getCharacterClosestTo(e.MousePosition);
-                if (selectionLength > 0)
+                if (hasSelection)
                     GetContainingInputManager().ChangeFocus(this);
             }
 
@@ -1586,7 +1587,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return;
                 }
 
-                if (selectionLength > 0)
+                if (hasSelection)
                     removeSelection();
             }
 


### PR DESCRIPTION
In most common text input fields that I've tested (Chrome, Firefox, Word, etc.), a left/right cursor movement while text is selected will place the cursor on the left/right border of the selection.

https://github.com/ppy/osu-framework/assets/47010459/9f6ee6fd-e0b5-44e8-9449-a089ee73d585

Currently, o!f's `TextBox` treats these cursor movements as... just regular movements. This can lead to some weird/unexpected cursor placements when coming out of selections.

https://github.com/ppy/osu-framework/assets/47010459/65ab1d54-c72d-49ce-a2a4-044a764664b2

These changes bring the behavior closer to what is usually seen in other programs.

https://github.com/ppy/osu-framework/assets/47010459/5a0f22a7-9011-45cc-bf59-149182c1d01a

Behavior when moving along word borders is also changed. Different programs I checked against had different behaviors, so I elected to copy what Chrome does (jump to the next/previous word from the selection borders).