### PR TITLE
Split words on more characters in text flow container

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -121,6 +121,14 @@ namespace osu.Framework.Tests.Visual.Containers
             assertSpriteTextCount(0);
         }
 
+        [Test]
+        public void TestWordSplittingEdgeCases()
+        {
+            AddStep("set latin text", () => textContainer.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer mattis eu turpis vitae posuere. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam mauris nibh, faucibus maximus ornare eu, ultrices ut ipsum. Proin rhoncus, nunc et faucibus pretium, nisl nunc dapibus massa, et scelerisque nibh ligula id odio. Praesent dapibus ex sed nunc egestas, in placerat risus mattis. Nulla sed ligula velit. Vestibulum auctor porta eros et condimentum. Etiam laoreet nunc nec lacinia pulvinar. Mauris hendrerit, mi at aliquet condimentum, ex ex cursus dolor, non porta erat eros id justo. Cras malesuada tincidunt nunc, at tincidunt risus eleifend id. Maecenas hendrerit venenatis mi et lobortis. Etiam sem tortor, elementum eget lacus non, porta tristique quam. Morbi sed lacinia odio. Phasellus ut pretium nunc. Fusce vitae mollis magna, vel scelerisque dui. ");
+            AddStep("set url", () => textContainer.Text = "https://osu.ppy.sh/home/news/2024-03-27-osutaiko-world-cup-2024-round-of-32-recap");
+            AddStep("set cjk text", () => textContainer.Text = "語自うし志景ル産倍びょ頭携エタシ声児スせざ最3連居ほあ曽望をよ津葉ゅ首新る知偏啓ぞにへ。稿ネ奈座最クつ肉表ス幸更へ書整鈴話ア済検ヌナヲオ観体ヨワノホ導6凶ケツヌ食折テヤ国地ね右米東ろとふ方悩岳犠眠担よみ。5高おゆ括待チオ見1野ハワホシ作政すぞちも素著タ本球ヤサユ勝覚っおはう憂夫ふに離論資キ補彦リ浮68並茨りご。");
+        }
+
         private void assertSpriteTextCount(int count)
             => AddAssert($"text flow has {count} sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == count);
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -126,7 +126,7 @@ namespace osu.Framework.Tests.Visual.Containers
         {
             AddStep("set latin text", () => textContainer.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer mattis eu turpis vitae posuere. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam mauris nibh, faucibus maximus ornare eu, ultrices ut ipsum. Proin rhoncus, nunc et faucibus pretium, nisl nunc dapibus massa, et scelerisque nibh ligula id odio. Praesent dapibus ex sed nunc egestas, in placerat risus mattis. Nulla sed ligula velit. Vestibulum auctor porta eros et condimentum. Etiam laoreet nunc nec lacinia pulvinar. Mauris hendrerit, mi at aliquet condimentum, ex ex cursus dolor, non porta erat eros id justo. Cras malesuada tincidunt nunc, at tincidunt risus eleifend id. Maecenas hendrerit venenatis mi et lobortis. Etiam sem tortor, elementum eget lacus non, porta tristique quam. Morbi sed lacinia odio. Phasellus ut pretium nunc. Fusce vitae mollis magna, vel scelerisque dui. ");
             AddStep("set url", () => textContainer.Text = "https://osu.ppy.sh/home/news/2024-03-27-osutaiko-world-cup-2024-round-of-32-recap");
-            AddStep("set cjk text", () => textContainer.Text = "語自うし志景ル産倍びょ頭携エタシ声児スせざ最3連居ほあ曽望をよ津葉ゅ首新る知偏啓ぞにへ。稿ネ奈座最クつ肉表ス幸更へ書整鈴話ア済検ヌナヲオ観体ヨワノホ導6凶ケツヌ食折テヤ国地ね右米東ろとふ方悩岳犠眠担よみ。5高おゆ括待チオ見1野ハワホシ作政すぞちも素著タ本球ヤサユ勝覚っおはう憂夫ふに離論資キ補彦リ浮68並茨りご。");
+            AddStep("set cjk text", () => textContainer.Text = "日本の桜は世界中から観光客を引きつけています。寿司は美味しい伝統的な日本食です。東京タワーは景色が美しいです。速い新幹線は、便利な交通手段です。富士山は、その美しさと完全な形状で知られています。日本文化は、優雅さと繊細さを象徴しています。抹茶は特別な日本の茶です。着物は、伝統的な日本の衣装で、特別な場面でよく着用されます。");
         }
 
         private void assertSpriteTextCount(int count)

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using osu.Framework.Graphics.Sprites;
@@ -88,7 +89,13 @@ namespace osu.Framework.Graphics.Containers
 
             for (int i = 0; i < text.Length; i++)
             {
-                if (i == 0 || char.IsSeparator(text[i - 1]) || char.IsControl(text[i - 1]))
+                if (i == 0
+                    || char.IsSeparator(text[i - 1])
+                    || char.IsControl(text[i - 1])
+                    || char.GetUnicodeCategory(text[i - 1]) == UnicodeCategory.DashPunctuation
+                    || text[i - 1] == '/'
+                    || text[i - 1] == '\\'
+                    || (isCjkCharacter(text[i - 1]) && !char.IsPunctuation(text[i])))
                 {
                     words.Add(builder.ToString());
                     builder.Clear();
@@ -101,6 +108,8 @@ namespace osu.Framework.Graphics.Containers
                 words.Add(builder.ToString());
 
             return words.ToArray();
+
+            bool isCjkCharacter(char c) => c >= '\x2E80' && c <= '\x9FFF';
         }
 
         protected virtual TSpriteText CreateSpriteText(TextFlowContainer textFlowContainer)


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/10085
- Closes https://github.com/ppy/osu/issues/14837

I'm not really considering the performance implications of this, just looking to get a baseline more-correct behaviour in place.

The change is basically a best-effort heuristic, although I did use a slightly smarter split method for CJK to attempt to ensure no hanging punctuation.