### PR TITLE
Prepare `SDL2ControllerBindings` class for SDL3

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
@@ -54,22 +54,22 @@ namespace osu.Framework.Platform.SDL2
                                      .Select(i => SDL.SDL_GameControllerGetBindForAxis(ControllerHandle, (SDL.SDL_GameControllerAxis)i)).ToArray();
         }
 
-        public bool IsJoystickButtonBound(byte index)
+        public bool IsJoystickButtonBound(byte buttonIndex)
         {
             for (int i = 0; i < ButtonBindings.Length; i++)
             {
-                if (ButtonBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && ButtonBindings[i].value.button == index)
+                if (ButtonBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && ButtonBindings[i].value.button == buttonIndex)
                     return true;
             }
 
             return false;
         }
 
-        public bool IsJoystickAxisBound(byte index)
+        public bool IsJoystickAxisBound(byte axisIndex)
         {
             for (int i = 0; i < AxisBindings.Length; i++)
             {
-                if (AxisBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && AxisBindings[i].value.axis == index)
+                if (AxisBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && AxisBindings[i].value.axis == axisIndex)
                     return true;
             }
 

--- a/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Platform.SDL2
         {
             for (int i = 0; i < AxisBindings.Length; i++)
             {
-                if (AxisBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && AxisBindings[i].value.button == index)
+                if (AxisBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && AxisBindings[i].value.axis == index)
                     return true;
             }
 

--- a/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Platform.SDL2
     /// Maintain a copy of the SDL-provided bindings for the given controller.
     /// Used to determine whether a given event's joystick button or axis is unmapped.
     /// </summary>
-    public class SDL2ControllerBindings
+    internal class SDL2ControllerBindings
     {
         public readonly IntPtr JoystickHandle;
         public readonly IntPtr ControllerHandle;

--- a/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
+++ b/osu.Framework/Platform/SDL2/SDL2ControllerBindings.cs
@@ -54,26 +54,26 @@ namespace osu.Framework.Platform.SDL2
                                      .Select(i => SDL.SDL_GameControllerGetBindForAxis(ControllerHandle, (SDL.SDL_GameControllerAxis)i)).ToArray();
         }
 
-        public SDL.SDL_GameControllerButton GetButtonForIndex(byte index)
+        public bool IsJoystickButtonBound(byte index)
         {
             for (int i = 0; i < ButtonBindings.Length; i++)
             {
                 if (ButtonBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && ButtonBindings[i].value.button == index)
-                    return (SDL.SDL_GameControllerButton)i;
+                    return true;
             }
 
-            return SDL.SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_INVALID;
+            return false;
         }
 
-        public SDL.SDL_GameControllerAxis GetAxisForIndex(byte index)
+        public bool IsJoystickAxisBound(byte index)
         {
             for (int i = 0; i < AxisBindings.Length; i++)
             {
                 if (AxisBindings[i].bindType != SDL.SDL_GameControllerBindType.SDL_CONTROLLER_BINDTYPE_NONE && AxisBindings[i].value.button == index)
-                    return (SDL.SDL_GameControllerAxis)i;
+                    return true;
             }
 
-            return SDL.SDL_GameControllerAxis.SDL_CONTROLLER_AXIS_INVALID;
+            return false;
         }
     }
 }

--- a/osu.Framework/Platform/SDL2Window_Input.cs
+++ b/osu.Framework/Platform/SDL2Window_Input.cs
@@ -357,7 +357,7 @@ namespace osu.Framework.Platform
         private void handleJoyButtonEvent(SDL.SDL_JoyButtonEvent evtJbutton)
         {
             // if this button exists in the controller bindings, skip it
-            if (controllers.TryGetValue(evtJbutton.which, out var state) && state.GetButtonForIndex(evtJbutton.button) != SDL.SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_INVALID)
+            if (controllers.TryGetValue(evtJbutton.which, out var state) && state.IsJoystickButtonBound(evtJbutton.button))
                 return;
 
             var button = JoystickButton.FirstButton + evtJbutton.button;
@@ -387,7 +387,7 @@ namespace osu.Framework.Platform
         private void handleJoyAxisEvent(SDL.SDL_JoyAxisEvent evtJaxis)
         {
             // if this axis exists in the controller bindings, skip it
-            if (controllers.TryGetValue(evtJaxis.which, out var state) && state.GetAxisForIndex(evtJaxis.axis) != SDL.SDL_GameControllerAxis.SDL_CONTROLLER_AXIS_INVALID)
+            if (controllers.TryGetValue(evtJaxis.which, out var state) && state.IsJoystickAxisBound(evtJaxis.axis))
                 return;
 
             enqueueJoystickAxisInput(JoystickAxisSource.Axis1 + evtJaxis.axis, evtJaxis.axisValue);


### PR DESCRIPTION
In SDL3, controller bindings are handled differently so the existing `Get{Axis,Button}ForIndex()` can't be implemented (eg. a joystick button can map to a gamepad axis, but that method expects each axis to be bound to an axis; ditto for button).

Instead, the methods have been changed to `IsJoystick{Axis,Button}Bound()` which can work in SDL3, and doesn't change semantics for consumers, which were only checking if the axis/button was bound or not.

This PR also includes minor cleanup that just renames things.