### PR TITLE
Fix tablet driver log output subscription not unsubscribing after disposing/disabling

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletDriver.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTabletDriver;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Components;
+using OpenTabletDriver.Plugin.Logging;
 using OpenTabletDriver.Plugin.Tablet;
 using LogLevel = osu.Framework.Logging.LogLevel;
 
@@ -33,11 +34,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             knownVendors = vendors.Distinct().ToArray();
 
-            Log.Output += (_, logMessage) =>
-            {
-                LogLevel level = (int)logMessage.Level > (int)LogLevel.Error ? LogLevel.Error : LogLevel.Verbose;
-                PostLog?.Invoke($"{logMessage.Group}: {logMessage.Message}", level, null);
-            };
+            Log.Output += postLog;
 
             deviceHub.DevicesChanged += (_, args) =>
             {
@@ -47,6 +44,12 @@ namespace osu.Framework.Input.Handlers.Tablet
             };
 
             detectAsync();
+        }
+
+        private void postLog(object? _, LogMessage logMessage)
+        {
+            LogLevel level = (int)logMessage.Level > (int)LogLevel.Error ? LogLevel.Error : LogLevel.Verbose;
+            PostLog?.Invoke($"{logMessage.Group}: {logMessage.Message}", level, null);
         }
 
         private void detectAsync()
@@ -93,6 +96,13 @@ namespace osu.Framework.Input.Handlers.Tablet
             var provider = serviceCollection.BuildServiceProvider();
 
             return provider.GetRequiredService<TabletDriver>();
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+
+            Log.Output -= postLog;
         }
     }
 }


### PR DESCRIPTION
Noticed when working on something tablet-related.

`Dispose` has a new keyword since the base class doesn't have it virtual and is from an external package (i.e. `OpenTabletDriver`).

Before:
![osu Framework Tests_SY5Lr9YSZQ](https://github.com/ppy/osu-framework/assets/35318437/921ba1bc-6cb0-4059-b8ba-d04f4627b23f)

After:
![osu Framework Tests_WPVqiWfCsD](https://github.com/ppy/osu-framework/assets/35318437/9b916808-4c07-4311-a80f-f4ea56cb4369)
