### PR TITLE
Fix tablet info not clearing when unplugged

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// <summary>
         /// Information on the currently connected tablet device. May be null if no tablet is detected.
         /// </summary>
-        IBindable<TabletInfo> Tablet { get; }
+        IBindable<TabletInfo?> Tablet { get; }
 
         /// <summary>
         /// The rotation of the tablet area in degrees.

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -54,9 +54,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             host.Window.Resized += () => updateOutputArea(host.Window);
 
-            AreaOffset.BindValueChanged(_ => updateInputArea(device));
-            AreaSize.BindValueChanged(_ => updateInputArea(device), true);
-            Rotation.BindValueChanged(_ => updateInputArea(device), true);
+            AreaOffset.BindValueChanged(_ => updateTabletAndInputArea(device));
+            AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device), true);
+            Rotation.BindValueChanged(_ => updateTabletAndInputArea(device), true);
 
             Enabled.BindValueChanged(enabled =>
             {
@@ -103,7 +103,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                 device.OutputMode = outputMode;
                 outputMode.Tablet = device.CreateReference();
 
-                updateInputArea(device);
+                updateTabletAndInputArea(device);
                 updateOutputArea(host.Window);
             }
         }
@@ -140,7 +140,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             }
         }
 
-        private void updateInputArea(InputDeviceTree? inputDevice)
+        private void updateTabletAndInputArea(InputDeviceTree? inputDevice)
         {
             if (inputDevice == null)
                 return;

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             host.Window.Resized += () => updateOutputArea(host.Window);
 
             AreaOffset.BindValueChanged(_ => updateTabletAndInputArea(device));
-            AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device), true);
+            AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device));
             Rotation.BindValueChanged(_ => updateTabletAndInputArea(device), true);
 
             Enabled.BindValueChanged(enabled =>

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -40,9 +40,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<float> Rotation { get; } = new Bindable<float>();
 
-        public IBindable<TabletInfo> Tablet => tablet;
+        public IBindable<TabletInfo?> Tablet => tablet;
 
-        private readonly Bindable<TabletInfo> tablet = new Bindable<TabletInfo>();
+        private readonly Bindable<TabletInfo?> tablet = new Bindable<TabletInfo?>();
 
         private Task? lastInitTask;
 
@@ -106,6 +106,8 @@ namespace osu.Framework.Input.Handlers.Tablet
                 updateTabletAndInputArea(device);
                 updateOutputArea(host.Window);
             }
+            else
+                tablet.Value = null;
         }
 
         private void handleDeviceReported(object? sender, IDeviceReport report)


### PR DESCRIPTION
After a tablet is plugged in for the first time, "No tablet detected!" and the faq link would never show again when no tablet is connected.

`tablet.Value` is potentially null as said in the xmldoc so made it that way, probably regressed somewhere. `TabletInfo` and `ITabletHandler`'s xmldoc says:
https://github.com/ppy/osu-framework/blob/2ec0642943c077e8ebfb1aa58e4bb9971faee640/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs#L11
but have no idea what the removal refactor would look like. Just to note because the changes are relevant to those classes/interfaces.

The gifs below show me plugging and unplugging two different tablets:

| Before | After |
| --- | --- |
| ![C2GBCp91tT](https://github.com/ppy/osu-framework/assets/35318437/3fbda546-f86d-4e09-8bc1-e8f4a36fccbd) | ![Dp2Z7jZhby](https://github.com/ppy/osu-framework/assets/35318437/393e9515-e7b9-4439-ad77-7b50c2e72d02) |
| ![SYhHVwcKdE](https://github.com/ppy/osu-framework/assets/35318437/1ab2e62d-de6e-45bf-891b-7948de578669) | ![S5HzhN4zeE](https://github.com/ppy/osu-framework/assets/35318437/ad99b352-936f-40cd-b604-f5e45ee379f6) |