### PR TITLE
Avoid masking calculations on valid drawables

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -66,6 +66,7 @@ namespace osu.Framework.Graphics
             AddLayout(screenSpaceDrawQuadBacking);
             AddLayout(drawColourInfoBacking);
             AddLayout(requiredParentSizeToFitBacking);
+            AddLayout(maskingBacking);
         }
 
         private static readonly GlobalStatistic<int> total_count = GlobalStatistics.Get<int>(nameof(Drawable), "Total constructed");
@@ -509,7 +510,9 @@ namespace osu.Framework.Graphics
             if (HasProxy && source != proxy)
                 return false;
 
-            IsMaskedAway = ComputeIsMaskedAway(maskingBounds);
+            if (!maskingBacking.IsValid)
+                IsMaskedAway = maskingBacking.Value = ComputeIsMaskedAway(maskingBounds);
+
             return true;
         }
 
@@ -1555,6 +1558,8 @@ namespace osu.Framework.Graphics
         /// actually masked away, but it may be false, even if the Drawable was masked away.
         /// </summary>
         internal bool IsMaskedAway { get; private set; }
+
+        private readonly LayoutValue<bool> maskingBacking = new LayoutValue<bool>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.DrawSize);
 
         private readonly LayoutValue<Quad> screenSpaceDrawQuadBacking = new LayoutValue<Quad>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence);
 


### PR DESCRIPTION
Not sure whether this selection of invalidation flags is sufficient or more than needed.

|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/675b98c8-a4a9-470f-beeb-120935f29669)|![pr](https://github.com/ppy/osu-framework/assets/22874522/c4dcfb5b-efe8-4994-80c4-cec22d9b59fb)|

osu performance difference is similar to shown in https://github.com/ppy/osu-framework/issues/6224