### PR TITLE
Use generic math for bindable numbers

### DIFF
--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -96,28 +96,12 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                // TODO: wait for syntax like T is IFloatingPoint<T>
-
-                if (typeof(T) == typeof(sbyte))
-                    return (T)(object)(sbyte)1;
-                if (typeof(T) == typeof(byte))
-                    return (T)(object)(byte)1;
-                if (typeof(T) == typeof(short))
-                    return (T)(object)(short)1;
-                if (typeof(T) == typeof(ushort))
-                    return (T)(object)(ushort)1;
-                if (typeof(T) == typeof(int))
-                    return (T)(object)1;
-                if (typeof(T) == typeof(uint))
-                    return (T)(object)1U;
-                if (typeof(T) == typeof(long))
-                    return (T)(object)1L;
-                if (typeof(T) == typeof(ulong))
-                    return (T)(object)1UL;
                 if (typeof(T) == typeof(float))
                     return (T)(object)float.Epsilon;
+                if (typeof(T) == typeof(double))
+                    return (T)(object)double.Epsilon;
 
-                return (T)(object)double.Epsilon;
+                return T.One;
             }
         }
 

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -4,15 +4,14 @@
 #nullable disable
 
 using System;
-using System.Diagnostics;
-using System.Globalization;
+using System.Numerics;
 using JetBrains.Annotations;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
 {
     public class BindableNumber<T> : RangeConstrainedBindable<T>, IBindableNumber<T>
-        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
+        where T : struct, INumber<T>, IMinMaxValue<T>
     {
         [CanBeNull]
         public event Action<T> PrecisionChanged;
@@ -39,10 +38,10 @@ namespace osu.Framework.Bindables
             get => precision;
             set
             {
-                if (precision.Equals(value))
+                if (precision == value)
                     return;
 
-                if (value.CompareTo(default) <= 0)
+                if (value <= T.Zero)
                     throw new ArgumentOutOfRangeException(nameof(Precision), value, "Must be greater than 0.");
 
                 SetPrecision(value, true, this);
@@ -75,98 +74,20 @@ namespace osu.Framework.Bindables
 
         private void setValue(T value)
         {
-            if (Precision.CompareTo(DefaultPrecision) > 0)
+            if (Precision > DefaultPrecision)
             {
-                double doubleValue = ClampValue(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
-                doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
+                double doubleValue = double.CreateTruncating(T.Clamp(value, MinValue, MaxValue));
+                doubleValue = Math.Round(doubleValue / double.CreateTruncating(Precision)) * double.CreateTruncating(Precision);
 
-                base.Value = convertFromDouble(doubleValue);
+                base.Value = T.CreateTruncating(doubleValue);
             }
             else
                 base.Value = value;
         }
 
-        private T convertFromDouble(double value)
-        {
-            if (typeof(T) == typeof(sbyte))
-                return (T)(object)Convert.ToSByte(value);
-            if (typeof(T) == typeof(byte))
-                return (T)(object)Convert.ToByte(value);
-            if (typeof(T) == typeof(short))
-                return (T)(object)Convert.ToInt16(value);
-            if (typeof(T) == typeof(ushort))
-                return (T)(object)Convert.ToUInt16(value);
-            if (typeof(T) == typeof(int))
-                return (T)(object)Convert.ToInt32(value);
-            if (typeof(T) == typeof(uint))
-                return (T)(object)Convert.ToUInt32(value);
-            if (typeof(T) == typeof(long))
-                return (T)(object)Convert.ToInt64(value);
-            if (typeof(T) == typeof(ulong))
-                return (T)(object)Convert.ToUInt64(value);
-            if (typeof(T) == typeof(float))
-                return (T)(object)Convert.ToSingle(value);
+        protected override T DefaultMinValue => T.MinValue;
 
-            return (T)(object)value;
-        }
-
-        protected override T DefaultMinValue
-        {
-            get
-            {
-                Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
-
-                if (typeof(T) == typeof(sbyte))
-                    return (T)(object)sbyte.MinValue;
-                if (typeof(T) == typeof(byte))
-                    return (T)(object)byte.MinValue;
-                if (typeof(T) == typeof(short))
-                    return (T)(object)short.MinValue;
-                if (typeof(T) == typeof(ushort))
-                    return (T)(object)ushort.MinValue;
-                if (typeof(T) == typeof(int))
-                    return (T)(object)int.MinValue;
-                if (typeof(T) == typeof(uint))
-                    return (T)(object)uint.MinValue;
-                if (typeof(T) == typeof(long))
-                    return (T)(object)long.MinValue;
-                if (typeof(T) == typeof(ulong))
-                    return (T)(object)ulong.MinValue;
-                if (typeof(T) == typeof(float))
-                    return (T)(object)float.MinValue;
-
-                return (T)(object)double.MinValue;
-            }
-        }
-
-        protected override T DefaultMaxValue
-        {
-            get
-            {
-                Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
-
-                if (typeof(T) == typeof(sbyte))
-                    return (T)(object)sbyte.MaxValue;
-                if (typeof(T) == typeof(byte))
-                    return (T)(object)byte.MaxValue;
-                if (typeof(T) == typeof(short))
-                    return (T)(object)short.MaxValue;
-                if (typeof(T) == typeof(ushort))
-                    return (T)(object)ushort.MaxValue;
-                if (typeof(T) == typeof(int))
-                    return (T)(object)int.MaxValue;
-                if (typeof(T) == typeof(uint))
-                    return (T)(object)uint.MaxValue;
-                if (typeof(T) == typeof(long))
-                    return (T)(object)long.MaxValue;
-                if (typeof(T) == typeof(ulong))
-                    return (T)(object)ulong.MaxValue;
-                if (typeof(T) == typeof(float))
-                    return (T)(object)float.MaxValue;
-
-                return (T)(object)double.MaxValue;
-            }
-        }
+        protected override T DefaultMaxValue => T.MaxValue;
 
         /// <summary>
         /// The default <see cref="Precision"/>.
@@ -175,6 +96,8 @@ namespace osu.Framework.Bindables
         {
             get
             {
+                // TODO: wait for syntax like T is IFloatingPoint<T>
+
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)(sbyte)1;
                 if (typeof(T) == typeof(byte))
@@ -244,63 +167,11 @@ namespace osu.Framework.Bindables
             typeof(T) != typeof(float) &&
             typeof(T) != typeof(double); // Will be **constant** after JIT.
 
-        public void Set<TNewValue>(TNewValue val) where TNewValue : struct,
-            IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
-        {
-            Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
+        public void Set<TNewValue>(TNewValue val) where TNewValue : struct, INumber<TNewValue>
+            => Value = T.CreateTruncating(val);
 
-            // Comparison between typeof(T) and type literals are treated as **constant** on value types.
-            // Code paths for other types will be eliminated.
-            if (typeof(T) == typeof(byte))
-                ((BindableNumber<byte>)(object)this).Value = val.ToByte(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(sbyte))
-                ((BindableNumber<sbyte>)(object)this).Value = val.ToSByte(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(ushort))
-                ((BindableNumber<ushort>)(object)this).Value = val.ToUInt16(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(short))
-                ((BindableNumber<short>)(object)this).Value = val.ToInt16(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(uint))
-                ((BindableNumber<uint>)(object)this).Value = val.ToUInt32(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(int))
-                ((BindableNumber<int>)(object)this).Value = val.ToInt32(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(ulong))
-                ((BindableNumber<ulong>)(object)this).Value = val.ToUInt64(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(long))
-                ((BindableNumber<long>)(object)this).Value = val.ToInt64(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(float))
-                ((BindableNumber<float>)(object)this).Value = val.ToSingle(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(double))
-                ((BindableNumber<double>)(object)this).Value = val.ToDouble(NumberFormatInfo.InvariantInfo);
-        }
-
-        public void Add<TNewValue>(TNewValue val) where TNewValue : struct,
-            IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
-        {
-            Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
-
-            // Comparison between typeof(T) and type literals are treated as **constant** on value types.
-            // Code pathes for other types will be eliminated.
-            if (typeof(T) == typeof(byte))
-                ((BindableNumber<byte>)(object)this).Value += val.ToByte(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(sbyte))
-                ((BindableNumber<sbyte>)(object)this).Value += val.ToSByte(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(ushort))
-                ((BindableNumber<ushort>)(object)this).Value += val.ToUInt16(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(short))
-                ((BindableNumber<short>)(object)this).Value += val.ToInt16(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(uint))
-                ((BindableNumber<uint>)(object)this).Value += val.ToUInt32(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(int))
-                ((BindableNumber<int>)(object)this).Value += val.ToInt32(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(ulong))
-                ((BindableNumber<ulong>)(object)this).Value += val.ToUInt64(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(long))
-                ((BindableNumber<long>)(object)this).Value += val.ToInt64(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(float))
-                ((BindableNumber<float>)(object)this).Value += val.ToSingle(NumberFormatInfo.InvariantInfo);
-            else if (typeof(T) == typeof(double))
-                ((BindableNumber<double>)(object)this).Value += val.ToDouble(NumberFormatInfo.InvariantInfo);
-        }
+        public void Add<TNewValue>(TNewValue val) where TNewValue : struct, INumber<TNewValue>
+            => Value += T.CreateTruncating(val);
 
         /// <summary>
         /// Sets the value of the bindable to Min + (Max - Min) * amt
@@ -309,8 +180,10 @@ namespace osu.Framework.Bindables
         /// </summary>
         public void SetProportional(float amt, float snap = 0)
         {
-            double min = MinValue.ToDouble(NumberFormatInfo.InvariantInfo);
-            double max = MaxValue.ToDouble(NumberFormatInfo.InvariantInfo);
+            // TODO: Use IFloatingPointIeee754<T>.Lerp when applicable
+
+            double min = double.CreateTruncating(MinValue);
+            double max = double.CreateTruncating(MaxValue);
             double value = min + (max - min) * amt;
             if (snap > 0)
                 value = Math.Round(value / snap) * snap;
@@ -345,20 +218,8 @@ namespace osu.Framework.Bindables
 
         protected override Bindable<T> CreateInstance() => new BindableNumber<T>();
 
-        protected sealed override T ClampValue(T value, T minValue, T maxValue) => max(minValue, min(maxValue, value));
+        protected sealed override T ClampValue(T value, T minValue, T maxValue) => T.Clamp(value, minValue, maxValue);
 
         protected sealed override bool IsValidRange(T min, T max) => min.CompareTo(max) <= 0;
-
-        private static T max(T value1, T value2)
-        {
-            int comparison = value1.CompareTo(value2);
-            return comparison > 0 ? value1 : value2;
-        }
-
-        private static T min(T value1, T value2)
-        {
-            int comparison = value1.CompareTo(value2);
-            return comparison > 0 ? value2 : value1;
-        }
     }
 }

--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Numerics;
 
 namespace osu.Framework.Bindables
 {
@@ -12,7 +13,7 @@ namespace osu.Framework.Bindables
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/>.</typeparam>
     public class BindableNumberWithCurrent<T> : BindableNumber<T>, IBindableWithCurrent<T>
-        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
+        where T : struct, INumber<T>, IMinMaxValue<T>
     {
         private BindableNumber<T> currentBound;
 

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -2,14 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Numerics;
 using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using Vector2 = osuTK.Vector2;
 
 namespace osu.Framework.Graphics.UserInterface
 {
     public partial class BasicSliderBar<T> : SliderBar<T>
-        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
+        where T : struct, INumber<T>, IMinMaxValue<T>
     {
         public Color4 BackgroundColour
         {

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -2,17 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Globalization;
+using System.Numerics;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osuTK.Input;
-using osuTK;
 using osu.Framework.Input.Events;
+using osuTK.Input;
+using Vector2 = osuTK.Vector2;
 
 namespace osu.Framework.Graphics.UserInterface
 {
     public abstract partial class SliderBar<T> : Container, IHasCurrentValue<T>
-        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
+        where T : struct, INumber<T>, IMinMaxValue<T>
     {
         /// <summary>
         /// Range padding reduces the range of movement a slider bar is allowed to have
@@ -121,9 +121,9 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (ShouldHandleAsRelativeDrag(e))
             {
-                float min = currentNumberInstantaneous.MinValue.ToSingle(NumberFormatInfo.InvariantInfo);
-                float max = currentNumberInstantaneous.MaxValue.ToSingle(NumberFormatInfo.InvariantInfo);
-                float val = currentNumberInstantaneous.Value.ToSingle(NumberFormatInfo.InvariantInfo);
+                float min = float.CreateTruncating(currentNumberInstantaneous.MinValue);
+                float max = float.CreateTruncating(currentNumberInstantaneous.MaxValue);
+                float val = float.CreateTruncating(currentNumberInstantaneous.Value);
 
                 relativeValueAtMouseDown = (val - min) / (max - min);
 

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -13,11 +13,12 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Input.Events;
 using osuTK.Input;
+using System.Numerics;
 
 namespace osu.Framework.Testing.Drawables.Steps
 {
     public partial class StepSlider<T> : SliderBar<T>
-        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
+        where T : struct, INumber<T>, IMinMaxValue<T>
     {
         private readonly Box selection;
         private readonly Box background;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -25,9 +26,9 @@ using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing.Drawables.Steps;
 using osu.Framework.Threading;
-using osuTK;
 using osuTK.Graphics;
 using Logger = osu.Framework.Logging.Logger;
+using Vector2 = osuTK.Vector2;
 
 namespace osu.Framework.Testing
 {
@@ -364,7 +365,7 @@ namespace osu.Framework.Testing
             });
         });
 
-        protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, IComparable<T>, IConvertible, IEquatable<T> => schedule(() =>
+        protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, INumber<T>, IMinMaxValue<T> => schedule(() =>
         {
             StepsContainer.Add(new StepSlider<T>(description, min, max, start)
             {


### PR DESCRIPTION
The generic math interfaces were experimental in .NET 6, then received breaking change of namespace in .NET 7. It's considered mature now.

Please DO test for Mono-based runtimes (especially iOS AOT) for such type-system related feature.