### PR TITLE
Perform rounding to `Precision` in `BindableNumber` on `decimal` to avoid rounding error accumulation

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableNumberTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableNumberTest.cs
@@ -57,6 +57,33 @@ namespace osu.Framework.Tests.Bindables
         }
 
         /// <summary>
+        /// This test exercises that when sitting a decimal <see cref="BindableNumber{T}.Precision"/> like 0.1 on a <c>BindableNumber&lt;float&gt;</c>,
+        /// the resulting <see cref="BindableNumber{T}.Value"/> is the closest to the actual closest <c>float</c> number
+        /// to the real-world decimal.
+        /// This matters because certain methods of rounding to the precision specified on the <see cref="BindableNumber{T}"/>
+        /// cause rounding errors that show up elsewhere in undesirable ways.
+        /// </summary>
+        [Test]
+        public void TestDecimalPrecision()
+        {
+            var bindable = new BindableNumber<float>
+            {
+                Precision = 0.1f,
+                Value = 5.2f
+            };
+            Assert.That(bindable.Value, Is.EqualTo(5.2f));
+
+            bindable.Value = 4.3f;
+            Assert.That(bindable.Value, Is.EqualTo(4.3f));
+
+            bindable.Precision = 0.01f;
+            Assert.That(bindable.Value, Is.EqualTo(4.3f));
+
+            bindable.Value = 9.87f;
+            Assert.That(bindable.Value, Is.EqualTo(9.87f));
+        }
+
+        /// <summary>
         /// Tests that value can be added to on all supported <see cref="BindableNumber{T}"/> types.
         /// </summary>
         [TestCaseSource(nameof(typeSource))]

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using JetBrains.Annotations;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
@@ -77,16 +78,18 @@ namespace osu.Framework.Bindables
         {
             if (Precision.CompareTo(DefaultPrecision) > 0)
             {
-                double doubleValue = ClampValue(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
-                doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
+                // this rounding is purposefully performed on `decimal` to ensure that the resulting value is the closest possible floating-point
+                // number to actual real-world base-10 decimals, as that is the most common usage of precision.
+                decimal accurateResult = ClampValue(value, MinValue, MaxValue).ToDecimal(NumberFormatInfo.InvariantInfo);
+                accurateResult = Math.Round(accurateResult / Precision.ToDecimal(NumberFormatInfo.InvariantInfo)) * Precision.ToDecimal(NumberFormatInfo.InvariantInfo);
 
-                base.Value = convertFromDouble(doubleValue);
+                base.Value = convertFromDecimal(accurateResult);
             }
             else
                 base.Value = value;
         }
 
-        private T convertFromDouble(double value)
+        private T convertFromDecimal(decimal value)
         {
             if (typeof(T) == typeof(sbyte))
                 return (T)(object)Convert.ToSByte(value);
@@ -106,8 +109,10 @@ namespace osu.Framework.Bindables
                 return (T)(object)Convert.ToUInt64(value);
             if (typeof(T) == typeof(float))
                 return (T)(object)Convert.ToSingle(value);
+            if (typeof(T) == typeof(double))
+                return (T)(object)Convert.ToDouble(value);
 
-            return (T)(object)value;
+            throw new InvalidCastException($"Cannot convert from decimal to {typeof(T).ReadableName()}");
         }
 
         protected override T DefaultMinValue


### PR DESCRIPTION
RFC. Closes https://github.com/ppy/osu/issues/27847.

Didn't really benchmark this as I consider it a basic correctness issue, but will do on request. Game-side units tests pass.