### PR TITLE
Fix unnecessary array copying in `WindowsClipboard.SetImage()`

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsClipboard.cs
+++ b/osu.Framework/Platform/Windows/WindowsClipboard.cs
@@ -94,16 +94,11 @@ namespace osu.Framework.Platform.Windows
             {
                 var encoder = image.Configuration.ImageFormatsManager.GetEncoder(BmpFormat.Instance);
                 image.Save(stream, encoder);
-                var span = new ReadOnlySpan<byte>(stream.GetBuffer(), bitmap_file_header_length, (int)stream.Length - bitmap_file_header_length);
-                IntPtr unmanagedPointer = Marshal.AllocHGlobal(span.Length);
 
-                unsafe
-                {
-                    fixed (void* source = span)
-                        Buffer.MemoryCopy(source, unmanagedPointer.ToPointer(), span.Length, span.Length);
-                }
-
-                return setClipboard(unmanagedPointer, span.Length, cf_dib);
+                int bitmapDataLength = (int)stream.Length - bitmap_file_header_length;
+                IntPtr unmanagedPointer = Marshal.AllocHGlobal(bitmapDataLength);
+                Marshal.Copy(stream.GetBuffer(), bitmap_file_header_length, unmanagedPointer, bitmapDataLength);
+                return setClipboard(unmanagedPointer, bitmapDataLength, cf_dib);
             }
         }
 

--- a/osu.Framework/Platform/Windows/WindowsClipboard.cs
+++ b/osu.Framework/Platform/Windows/WindowsClipboard.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using SixLabors.ImageSharp;
@@ -91,19 +90,21 @@ namespace osu.Framework.Platform.Windows
 
         public override bool SetImage(Image image)
         {
-            byte[] array;
-
             using (var stream = new MemoryStream())
             {
                 var encoder = image.Configuration.ImageFormatsManager.GetEncoder(BmpFormat.Instance);
                 image.Save(stream, encoder);
-                array = stream.ToArray().Skip(bitmap_file_header_length).ToArray();
+                var span = new ReadOnlySpan<byte>(stream.GetBuffer(), bitmap_file_header_length, (int)stream.Length - bitmap_file_header_length);
+                IntPtr unmanagedPointer = Marshal.AllocHGlobal(span.Length);
+
+                unsafe
+                {
+                    fixed (void* source = span)
+                        Buffer.MemoryCopy(source, unmanagedPointer.ToPointer(), span.Length, span.Length);
+                }
+
+                return setClipboard(unmanagedPointer, span.Length, cf_dib);
             }
-
-            IntPtr unmanagedPointer = Marshal.AllocHGlobal(array.Length);
-            Marshal.Copy(array, 0, unmanagedPointer, array.Length);
-
-            return setClipboard(unmanagedPointer, array.Length, cf_dib);
         }
 
         private static bool setClipboard(IntPtr pointer, int bytes, uint format)


### PR DESCRIPTION
The old code of `SetImage()` would:

1. Allocate the necessary memory with `MemoryStream`
2. Copy that to a temporary array
3. Skip some bytes with LINQ and copy that to a new array
4. Copy that array into unmanaged memory with `Marshal.AllocHGlobal()`
5. memcopy that memory in a new `GlobalAlloc()` array

The new code skips steps 2 and 3.