### PR TITLE
FFmpeg: Update FFmpeg.AutoGen to 7.0.0

### DIFF
--- a/osu.Framework/Graphics/Video/FFmpegExtensions.cs
+++ b/osu.Framework/Graphics/Video/FFmpegExtensions.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Graphics.Video
                 case AVPixelFormat.AV_PIX_FMT_VDPAU:
                 case AVPixelFormat.AV_PIX_FMT_CUDA:
                 case AVPixelFormat.AV_PIX_FMT_VAAPI:
-                case AVPixelFormat.AV_PIX_FMT_VAAPI_IDCT:
-                case AVPixelFormat.AV_PIX_FMT_VAAPI_MOCO:
                 case AVPixelFormat.AV_PIX_FMT_DXVA2_VLD:
                 case AVPixelFormat.AV_PIX_FMT_QSV:
                 case AVPixelFormat.AV_PIX_FMT_VIDEOTOOLBOX:
@@ -28,7 +26,6 @@ namespace osu.Framework.Graphics.Video
                 case AVPixelFormat.AV_PIX_FMT_MEDIACODEC:
                 case AVPixelFormat.AV_PIX_FMT_VULKAN:
                 case AVPixelFormat.AV_PIX_FMT_MMAL:
-                case AVPixelFormat.AV_PIX_FMT_XVMC:
                     return true;
 
                 default:

--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -14,6 +14,11 @@ namespace osu.Framework.Graphics.Video
 {
     public unsafe class FFmpegFuncs
     {
+        static FFmpegFuncs()
+        {
+            DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
+        }
+
         #region Delegates
 
         public delegate int AvDictSetDelegate(AVDictionary** pm, [MarshalAs(UnmanagedType.LPUTF8Str)] string key, [MarshalAs(UnmanagedType.LPUTF8Str)] string value, int flags);

--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -16,7 +16,8 @@ namespace osu.Framework.Graphics.Video
     {
         static FFmpegFuncs()
         {
-            DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
+            if (RuntimeInfo.IsDesktop)
+                DynamicallyLoadedBindings.FunctionResolver = new FFmpegFunctionResolver();
         }
 
         #region Delegates

--- a/osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFunctionResolver.cs
@@ -1,0 +1,72 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using FFmpeg.AutoGen;
+
+namespace osu.Framework.Graphics.Video
+{
+    /// <summary>
+    /// Resolves the FFmpeg native functions required for video playback.
+    ///
+    /// If you want to support a different set of libraries, consider implementing the <see cref="IFunctionResolver"/> interface yourself.
+    /// </summary>
+    public sealed class FFmpegFunctionResolver : IFunctionResolver
+    {
+        // The order here matters because of inter-library dependencies.
+        // avcodec and swscale depend on avutil, avformat depends on avcodec.
+        private static readonly string[] libraries = ["avutil", "avcodec", "swscale", "avformat"];
+
+        private readonly Dictionary<string, IntPtr> loadedLibraries = new Dictionary<string, IntPtr>(libraries.Length);
+
+        /// <summary>
+        /// Load the default set of FFmpeg libraries.
+        /// </summary>
+        /// <exception cref="DllNotFoundException">If one of the libraries cannot be found in the DLL directory.</exception>
+        /// <exception cref="BadImageFormatException">If one of the library files is invalid.</exception>
+        public FFmpegFunctionResolver()
+        {
+            foreach (string library in libraries)
+                loadLibrary(library);
+        }
+
+        private void loadLibrary(string libraryName)
+        {
+            string libraryFileName = getLibraryFileName(libraryName);
+            IntPtr handle = NativeLibrary.Load(libraryFileName, RuntimeInfo.EntryAssembly, DllImportSearchPath.UseDllDirectoryForDependencies);
+
+            loadedLibraries.Add(libraryName, handle);
+        }
+
+        public T GetFunctionDelegate<T>(string libraryName, string functionName, bool throwOnError = true)
+        {
+            if (!loadedLibraries.TryGetValue(libraryName, out IntPtr libraryHandle))
+                throw new InvalidOperationException($"Required library {getLibraryFileName(libraryName)} was not loaded on initialization.");
+
+            IntPtr funcPtr = NativeLibrary.GetExport(libraryHandle, functionName);
+            return Marshal.GetDelegateForFunctionPointer<T>(funcPtr);
+        }
+
+        private string getLibraryFileName(string libraryName)
+        {
+            int version = ffmpeg.LibraryVersionMap[libraryName];
+
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    return $"{libraryName}-{version}.dll";
+
+                case RuntimeInfo.Platform.Linux:
+                    return $"lib{libraryName}.so.{version}";
+
+                case RuntimeInfo.Platform.macOS:
+                    return $"lib{libraryName}.{version}.dylib";
+
+                default:
+                    throw new PlatformNotSupportedException();
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -806,8 +806,6 @@ namespace osu.Framework.Graphics.Video
 
         protected virtual FFmpegFuncs CreateFuncs()
         {
-            DynamicallyLoadedBindings.FunctionResolver ??= new FFmpegFunctionResolver();
-
             return new FFmpegFuncs
             {
                 av_dict_set = FFmpeg.AutoGen.ffmpeg.av_dict_set,

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -783,6 +783,15 @@ namespace osu.Framework.Graphics.Video
                     if (!hwVideoDecoder.HasValue || !targetHwDecoders.HasFlagFast(hwVideoDecoder.Value))
                         continue;
 
+                    // VP9 Hardware decoding hangs on macOS on x64 platforms: https://trac.ffmpeg.org/ticket/9599
+                    if (codec.Id == AVCodecID.AV_CODEC_ID_VP9
+                        && hwVideoDecoder == HardwareVideoDecoder.VideoToolbox
+                        && RuntimeInfo.OS == RuntimeInfo.Platform.macOS
+                        && RuntimeInformation.OSArchitecture == Architecture.X64)
+                    {
+                        continue;
+                    }
+
                     codecs.Add((codec, hwDeviceType));
                 }
             }

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -22,7 +22,6 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Framework.Platform.Linux.Native;
 
 namespace osu.Framework.Graphics.Video
 {
@@ -108,25 +107,6 @@ namespace osu.Framework.Graphics.Video
         private readonly FFmpegFuncs ffmpeg;
 
         internal bool Looping;
-
-        static VideoDecoder()
-        {
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
-            {
-                void loadVersionedLibraryGlobally(string name)
-                {
-                    int version = FFmpeg.AutoGen.ffmpeg.LibraryVersionMap[name];
-                    Library.Load($"lib{name}.so.{version}", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
-                }
-
-                // FFmpeg.AutoGen doesn't load libraries as RTLD_GLOBAL, so we must load them ourselves to fix inter-library dependencies
-                // otherwise they would fallback to the system-installed libraries that can differ in version installed.
-                loadVersionedLibraryGlobally("avutil");
-                loadVersionedLibraryGlobally("avcodec");
-                loadVersionedLibraryGlobally("avformat");
-                loadVersionedLibraryGlobally("swscale");
-            }
-        }
 
         /// <summary>
         /// Creates a new video decoder that decodes the given video file.
@@ -817,37 +797,7 @@ namespace osu.Framework.Graphics.Video
 
         protected virtual FFmpegFuncs CreateFuncs()
         {
-            // other frameworks should handle native libraries themselves
-            FFmpeg.AutoGen.ffmpeg.GetOrLoadLibrary = name =>
-            {
-                int version = FFmpeg.AutoGen.ffmpeg.LibraryVersionMap[name];
-
-                // "lib" prefix and extensions are resolved by .net core
-                string libraryName;
-
-                switch (RuntimeInfo.OS)
-                {
-                    case RuntimeInfo.Platform.macOS:
-                        libraryName = $"{name}.{version}";
-                        break;
-
-                    case RuntimeInfo.Platform.Windows:
-                        libraryName = $"{name}-{version}";
-                        break;
-
-                    // To handle versioning in Linux, we have to specify the entire file name
-                    // because Linux uses a version suffix after the file extension (e.g. libavutil.so.56)
-                    // More info: https://learn.microsoft.com/en-us/dotnet/standard/native-interop/native-library-loading?view=net-6.0
-                    case RuntimeInfo.Platform.Linux:
-                        libraryName = $"lib{name}.so.{version}";
-                        break;
-
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(RuntimeInfo.OS), RuntimeInfo.OS, null);
-                }
-
-                return NativeLibrary.Load(libraryName, RuntimeInfo.EntryAssembly, DllImportSearchPath.UseDllDirectoryForDependencies | DllImportSearchPath.SafeDirectories);
-            };
+            DynamicallyLoadedBindings.FunctionResolver ??= new FFmpegFunctionResolver();
 
             return new FFmpegFuncs
             {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="managed-midi" Version="1.10.1" />
-    <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />


### PR DESCRIPTION
Closes #5051. There is still a VP9 bug (discussed in that issue), but there hasn't been any movement [upstream](https://trac.ffmpeg.org/ticket/9599) so I assume this is not going to be fixed. I have added a rudimentary (untested) workaround for that issue in this PR.

Prerequisite:
- [x] #6255 

FFmpeg.AutoGen had a [large API change](https://github.com/Ruslan-B/FFmpeg.AutoGen/pull/227) somewhere around 5.0 or 5.1.

The gist is that `ffmpeg.GetOrLoadLibrary` was removed in favour of the `IFunctionResolver` API. The default resolvers are not usable in o!f[^1], so I added a simple `FFmpegFunctionResolver` class.

Note:
- Mobile platforms should work fine now that #6255 also updates the native libraries on mobile
- The `OSArchitecture` check is a bit awkward, but seems to [work as expected](https://github.com/ppy/osu-framework/pull/6256#issuecomment-2068864274)

Feel free to start testing / giving feedback, but this still needs a bit of work, and a lot of testing.

Testing:
- [x] macOS (x64)
- [x] macOS (arm64)
- [x] macOS (Rosetta)
- [x] Windows (x64)
- [x] Linux (x64)
- [x] iOS (arm64)
- [x] iOS simulator (x86_64)

[^1]: The built-in `LibraryDependenciesMap` is wrong for the custom libraries used in o!f. It also requires fiddling with the `RootPath` property and calls system APis (dlopen etc.) directly. Using `NativeLibrary` instead should be more ergonomic.  