### PR TITLE
Set IME rectangle before starting text input

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1362,9 +1362,9 @@ namespace osu.Framework.Graphics.UserInterface
             // We don't deactivate and activate, but instead keep text input active during the focus handoff, so that virtual keyboards on phones don't flicker.
 
             if (previousFocusWasTextBox)
-                textInput.EnsureActivated(AllowIme);
+                textInput.EnsureActivated(AllowIme, ScreenSpaceDrawQuad.AABBFloat);
             else
-                textInput.Activate(AllowIme);
+                textInput.Activate(AllowIme, ScreenSpaceDrawQuad.AABBFloat);
 
             textInput.OnTextInput += handleTextInput;
             textInput.OnImeComposition += handleImeComposition;

--- a/osu.Framework/Input/TextInputSource.cs
+++ b/osu.Framework/Input/TextInputSource.cs
@@ -30,16 +30,23 @@ namespace osu.Framework.Input
         /// User text input can be acquired through <see cref="OnTextInput"/>, <see cref="OnImeComposition"/> and <see cref="OnImeResult"/>.
         /// </summary>
         /// <param name="allowIme">Whether input using IME should be allowed.</param>
+        /// <param name="imeRectangle">
+        /// Rough location of where the text will be input, so the native implementation
+        /// can adjust virtual keyboards and IME popups.
+        /// </param>
         /// <remarks>
         /// Each <see cref="Activate"/> must be followed by a <see cref="Deactivate"/>.
         /// </remarks>
-        public void Activate(bool allowIme)
+        public void Activate(bool allowIme, RectangleF imeRectangle)
         {
             if (Interlocked.Increment(ref activationCounter) == 1)
+            {
+                SetImeRectangle(imeRectangle);
                 ActivateTextInput(allowIme);
+            }
             else
                 // the latest consumer that activated should always take precedence in (dis)allowing IME.
-                EnsureActivated(allowIme);
+                EnsureActivated(allowIme, imeRectangle);
         }
 
         /// <summary>
@@ -47,10 +54,20 @@ namespace osu.Framework.Input
         /// and that the user can start entering text.
         /// </summary>
         /// <param name="allowIme">Whether input using IME should be allowed.</param>
-        public void EnsureActivated(bool allowIme)
+        /// <param name="imeRectangle">
+        /// Rough location of where the text will be input, so the native implementation
+        /// can adjust virtual keyboards and IME popups. Can be <c>null</c> to avoid changing
+        /// the IME rectangle.
+        /// </param>
+        public void EnsureActivated(bool allowIme, RectangleF? imeRectangle = null)
         {
             if (activationCounter >= 1)
+            {
+                if (imeRectangle.HasValue)
+                    SetImeRectangle(imeRectangle.Value);
+
                 EnsureTextInputActivated(allowIme);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Intended to fix on-screen keyboard overlapping text boxes on SDL3 Android (https://github.com/ppy/osu-framework/pull/6105#issuecomment-2066993789).

From [`SDL_SetTextInputRect`](https://wiki.libsdl.org/SDL3/SDL_SetTextInputRect) documentation:

> To start text input in a given location, this function is intended to be called before [SDL_StartTextInput](https://wiki.libsdl.org/SDL3/SDL_StartTextInput), although some platforms support moving the rectangle even while text input (and a composition) is active.

Both `TextInputSource.Activate()` and `EnsureActivated()` have the new IME rectangle parameter, but it's optional in `EnsureActivated()` as it's only intended to be set when changing focus to a new text box.

If a text box already has input focus, it's assumed that the last `SetImeRectangle()` call provided a more accurate rectangle, so `EnsureActivated()` is called without a rectangle. (SDL remembers the last used IME rectangle and re-uses it).

How it looks with SDL3 Android:

https://github.com/ppy/osu-framework/assets/16479013/d894c2dd-39b0-45a2-8043-ffb7d0aba8ac
