### PR TITLE
Work around broken `SDL_EVENT_FINGER_DOWN` events that lead to stuck touches

### DIFF
--- a/osu.Framework/Platform/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3Window_Input.cs
@@ -251,6 +251,11 @@ namespace osu.Framework.Platform
 
             if (evtTfinger.type == SDL_EventType.SDL_EVENT_FINGER_DOWN)
             {
+                // TODO: remove when upstream fixes https://github.com/libsdl-org/SDL/issues/9591
+                // ignore SDL_EVENT_FINGER_DOWN for fingers that are already pressed
+                if (existingSource != null)
+                    return;
+
                 Debug.Assert(existingSource == null);
                 existingSource = assignNextAvailableTouchSource(evtTfinger.fingerID);
             }


### PR DESCRIPTION
- First noticed in https://github.com/ppy/osu-framework/pull/6105#pullrequestreview-2011866789

Works around https://github.com/libsdl-org/SDL/issues/9591 by ignoring the broken touch down events.

Buggy finger up events shouldn't cause any issues as releasing an already pressed finger will be ignored at the [`TouchInput`](https://github.com/ppy/osu-framework/blob/75ed421f60228920abd819cebc5982cb7799bbbb/osu.Framework/Input/StateChanges/TouchInput.cs#L56) level.

Current behaviour on `Relase` (`Debug` fails an assert): The bug leads to phantom touches that stick around. In the second part of the video, I show that pressing 3+ fingers only shows two touch points as the other 8 are stuck.

https://github.com/ppy/osu-framework/assets/16479013/f78eb849-9c2f-4784-becd-3332c16161ca
