### PR TITLE
Set event filter early in the startup process to work around SDL issue

### DIFF
--- a/osu.Framework/Platform/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3Window.cs
@@ -156,6 +156,7 @@ namespace osu.Framework.Platform
 
             SDL3.SDL_LogSetPriority(SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL3.SDL_SetLogOutputFunction(&logOutput, IntPtr.Zero);
+            SDL3.SDL_SetEventFilter(&eventFilter, ObjectHandle.Handle);
 
             graphicsSurface = new SDL3GraphicsSurface(this, surfaceType);
 
@@ -217,7 +218,6 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual void Run()
         {
-            SDL3.SDL_SetEventFilter(&eventFilter, ObjectHandle.Handle);
             SDL3.SDL_AddEventWatch(&eventWatch, ObjectHandle.Handle);
 
             RunMainLoop();


### PR DESCRIPTION
- Causes issues in https://github.com/ppy/osu-framework/pull/6105#discussion_r1572622366
- Upstream bug: https://github.com/libsdl-org/SDL/issues/9592

Turns out that setting the event filter drops all events, so this PR moves the `SDL_SetEventFilter` call as close as possible to `SDL_Init`.

The filter isn't doing too much so this shouldn't cause any issues (it'll be doing more in #6235, but that could only cause some dropped events on startup).

I've tested this with #6105 and can confirm it fixes the issue so [this workaround](https://github.com/ppy/osu-framework/pull/6105/files#diff-1f9486dea90c3d24267f78ddcaaf9155ede2cfc612414bf25cfe5877d75fa9d4R25-R27) is no longer needed.