### PR TITLE
Set SDL_HINT_APP_NAME in SDL3GameHost constructor

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.iOS
         {
         }
 
-        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new IOSWindow(preferredSurface);
+        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new IOSWindow(preferredSurface, Options.FriendlyGameName);
 
         protected override void SetupForRun()
         {

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -31,8 +31,8 @@ namespace osu.Framework.iOS
             }
         }
 
-        public IOSWindow(GraphicsSurfaceType surfaceType)
-            : base(surfaceType)
+        public IOSWindow(GraphicsSurfaceType surfaceType, string appName)
+            : base(surfaceType, appName)
         {
         }
 

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -33,5 +33,14 @@ namespace osu.Framework
         /// If the SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR environment variable is set, this property will have no effect.
         /// </remarks>
         public bool BypassCompositor { get; set; } = true;
+
+        /// <summary>
+        /// The friendly name of the game to be hosted. This is used to display the name to the user,
+        /// for example in the window title bar or in OS windows and prompts.
+        /// </summary>
+        /// <remarks>
+        /// If empty, GameHost will choose a default name based on the gameName.
+        /// </remarks>
+        public string FriendlyGameName { get; set; } = string.Empty;
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -336,6 +336,11 @@ namespace osu.Framework.Platform
         {
             Options = options ?? new HostOptions();
 
+            if (string.IsNullOrEmpty(Options.FriendlyGameName))
+            {
+                Options.FriendlyGameName = $@"osu!framework (running ""{gameName}"")";
+            }
+
             Name = gameName;
 
             JsonConvert.DefaultSettings = () => new JsonSerializerSettings

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1031,7 +1031,7 @@ namespace osu.Framework.Platform
 
                 Window.SetupWindow(Config);
                 Window.Create();
-                Window.Title = $@"osu!framework (running ""{Name}"")";
+                Window.Title = Options.FriendlyGameName;
 
                 Renderer.Initialise(Window.GraphicsSurface);
 

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Platform.Linux
             base.SetupForRun();
         }
 
-        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new SDL3DesktopWindow(preferredSurface);
+        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new SDL3DesktopWindow(preferredSurface, Options.FriendlyGameName);
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new LinuxReadableKeyCombinationProvider();
 

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Platform.MacOS
         {
         }
 
-        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new MacOSWindow(preferredSurface);
+        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new MacOSWindow(preferredSurface, Options.FriendlyGameName);
 
         public override IEnumerable<string> UserStoragePaths
         {

--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -24,8 +24,8 @@ namespace osu.Framework.Platform.MacOS
         private IntPtr originalScrollWheel;
         private ScrollWheelDelegate scrollWheelHandler;
 
-        public MacOSWindow(GraphicsSurfaceType surfaceType)
-            : base(surfaceType)
+        public MacOSWindow(GraphicsSurfaceType surfaceType, string appName)
+            : base(surfaceType, appName)
         {
         }
 

--- a/osu.Framework/Platform/SDL3DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL3DesktopWindow.cs
@@ -7,8 +7,8 @@ namespace osu.Framework.Platform
 {
     internal class SDL3DesktopWindow : SDL3Window
     {
-        public SDL3DesktopWindow(GraphicsSurfaceType surfaceType)
-            : base(surfaceType)
+        public SDL3DesktopWindow(GraphicsSurfaceType surfaceType, string appName)
+            : base(surfaceType, appName)
         {
         }
 

--- a/osu.Framework/Platform/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3Window.cs
@@ -145,9 +145,11 @@ namespace osu.Framework.Platform
         /// </summary>
         protected ObjectHandle<SDL3Window> ObjectHandle { get; private set; }
 
-        protected SDL3Window(GraphicsSurfaceType surfaceType)
+        protected SDL3Window(GraphicsSurfaceType surfaceType, string appName)
         {
             ObjectHandle = new ObjectHandle<SDL3Window>(this, GCHandleType.Normal);
+
+            SDL3.SDL_SetHint(SDL3.SDL_HINT_APP_NAME, appName);
 
             if (SDL3.SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO | SDL_InitFlags.SDL_INIT_GAMEPAD) < 0)
             {

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Platform.Windows
             timePeriod = new TimePeriod(1);
         }
 
-        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new WindowsWindow(preferredSurface);
+        protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new WindowsWindow(preferredSurface, Options.FriendlyGameName);
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => base.PlatformKeyBindings.Concat(new[]
         {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -36,8 +36,8 @@ namespace osu.Framework.Platform.Windows
         /// </summary>
         private readonly bool applyBorderlessWindowHack;
 
-        public WindowsWindow(GraphicsSurfaceType surfaceType)
-            : base(surfaceType)
+        public WindowsWindow(GraphicsSurfaceType surfaceType, string appName)
+            : base(surfaceType, appName)
         {
             switch (surfaceType)
             {


### PR DESCRIPTION
Supersedes #5650. Closes ppy/osu#25783.

The [docs](https://wiki.libsdl.org/SDL3/SDL_HINT_APP_NAME) say that
> This hint should be set before SDL is initialized.

Since `SDL_Init` is called in the `SDL3Window` constructor, this means that the application name must be known at that point in time. So it's not possible to rely on the window title.

This appName value is then used to tell SDL the application name to show in OS windows, prompts, etc.:

![image](https://github.com/ppy/osu-framework/assets/13467374/66d73491-3416-4717-ad87-82ee237669d2)

The `appName` could arguably be used as the initial window title.