### PR TITLE
Update masking calculations without creating masking sub-tree

### DIFF
--- a/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
+++ b/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
@@ -7,6 +7,7 @@ using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Layout;
 using osu.Framework.Testing;
@@ -496,6 +497,29 @@ namespace osu.Framework.Tests.Layout
             });
 
             AddAssert("still valid", () => isValid);
+        }
+
+        /// <summary>
+        /// Tests that changing Masking property will invalidate child masking bounds.
+        /// </summary>
+        [Test]
+        public void TestChildMaskingInvalidationOnMaskingChange()
+        {
+            Container container = null;
+            RectangleF childMaskingBounds = new RectangleF();
+
+            AddStep("createTest", () =>
+            {
+                Child = container = new Container
+                {
+                    Size = new Vector2(100)
+                };
+            });
+
+            AddAssert("Masking is off", () => container.Masking == false);
+            AddStep("Save child bounds", () => childMaskingBounds = container.ChildMaskingBounds);
+            AddStep("Disable masking", () => container.Masking = true);
+            AddAssert("Child masking bounds has changed", () => childMaskingBounds != container.ChildMaskingBounds);
         }
 
         private partial class TestBox1 : Box

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
@@ -229,8 +229,8 @@ namespace osu.Framework.Tests.Visual.Containers
 
             protected override DrawNode CreateDrawNode() => new TestBoxDrawNode(this);
 
-            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
-                => currentDrawNode = base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
+                => currentDrawNode = base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
 
             private class TestBoxDrawNode : SpriteDrawNode
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
@@ -103,10 +103,10 @@ namespace osu.Framework.Tests.Visual.Drawables
                 Alpha = 0;
             }
 
-            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
             {
                 hasDrawn = true;
-                return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+                return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -271,16 +271,13 @@ namespace osu.Framework.Graphics.Containers
 
         protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData);
 
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
         {
-            bool result = base.UpdateSubTreeMasking(source, maskingBounds);
-
             childrenUpdateVersion = updateVersion;
-
-            return result;
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
         }
 
-        protected override RectangleF ComputeChildMaskingBounds(RectangleF maskingBounds) => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
+        protected override RectangleF ComputeChildMaskingBounds() => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
 
         private Vector2 lastScreenSpaceSize;
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -271,10 +271,10 @@ namespace osu.Framework.Graphics.Containers
 
         protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData);
 
-        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             childrenUpdateVersion = updateVersion;
-            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
         }
 
         protected override RectangleF ComputeChildMaskingBounds() => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away

--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -10,13 +10,13 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public partial class CircularContainer : Container
     {
-        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             // this shouldn't have to be done here, but it's the only place it works correctly.
             // see https://github.com/ppy/osu-framework/pull/1666
             CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
 
-            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -970,7 +970,7 @@ namespace osu.Framework.Graphics.Containers
         {
             // The masking check is overly expensive (requires creation of ScreenSpaceDrawQuad) when only few children exist.
             // However, masking must be computed regardless whenever UpdateChildrenMasking is set to false, since children will rely on masking of this composite.
-            if (UpdateChildrenMasking && aliveInternalChildren.Count >= amount_children_required_for_masking_check && CanBeFlattened)
+            if (UpdateChildrenMasking && aliveInternalChildren.Count < amount_children_required_for_masking_check && CanBeFlattened)
                 return false;
 
             return base.ComputeIsMaskedAway(maskingBounds);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -909,8 +909,9 @@ namespace osu.Framework.Graphics.Containers
         /// If the return value is false, then descendants don't perform their masking calculations.
         /// </summary>
         /// <remarks>
-        /// Useful in cases when we are certain that all the descendants within this <see cref="CompositeDrawable"/> will not be masked away as long as
+        /// Useful in cases when we are certain that all the descendants of this <see cref="CompositeDrawable"/> will not be masked away as long as
         /// it's not masked away.
+        /// Alternative to setting <see cref="ComputeIsMaskedAway"/> to false for every descendant of this <see cref="CompositeDrawable"/>.
         /// </remarks>
         protected virtual bool UpdateChildrenMasking => true;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -976,7 +976,7 @@ namespace osu.Framework.Graphics.Containers
             return base.ComputeIsMaskedAway(maskingBounds);
         }
 
-        private readonly LayoutValue<RectangleF> childMaskingBoundsBacking = new LayoutValue<RectangleF>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence | Invalidation.DrawNode | Invalidation.Parent);
+        private readonly LayoutValue<RectangleF> childMaskingBoundsBacking = new LayoutValue<RectangleF>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence | Invalidation.Parent);
 
         public RectangleF ChildMaskingBounds => childMaskingBoundsBacking.IsValid ? childMaskingBoundsBacking : childMaskingBoundsBacking.Value = ComputeChildMaskingBounds();
 
@@ -1472,6 +1472,7 @@ namespace osu.Framework.Graphics.Containers
                     return;
 
                 masking = value;
+                childMaskingBoundsBacking.Invalidate();
                 Invalidate(Invalidation.DrawNode);
             }
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -976,7 +976,7 @@ namespace osu.Framework.Graphics.Containers
             return base.ComputeIsMaskedAway(maskingBounds);
         }
 
-        private readonly LayoutValue<RectangleF> childMaskingBoundsBacking = new LayoutValue<RectangleF>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence | Invalidation.Parent);
+        private readonly LayoutValue<RectangleF> childMaskingBoundsBacking = new LayoutValue<RectangleF>(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence);
 
         public RectangleF ChildMaskingBounds => childMaskingBoundsBacking.IsValid ? childMaskingBoundsBacking : childMaskingBoundsBacking.Value = ComputeChildMaskingBounds();
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -210,7 +210,7 @@ namespace osu.Framework.Graphics.Containers
             return result;
         }
 
-        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             // We can accurately compute intersections - the scheduled reset is no longer required.
             isIntersectingResetDelegate?.Cancel();
@@ -233,7 +233,7 @@ namespace osu.Framework.Graphics.Containers
                 isIntersectingCache.Validate();
             }
 
-            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.PolygonExtensions;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Layout;
 using osu.Framework.Threading;
 
@@ -211,10 +210,8 @@ namespace osu.Framework.Graphics.Containers
             return result;
         }
 
-        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
         {
-            bool result = base.UpdateSubTreeMasking(source, maskingBounds);
-
             // We can accurately compute intersections - the scheduled reset is no longer required.
             isIntersectingResetDelegate?.Cancel();
             isIntersectingResetDelegate = null;
@@ -230,13 +227,13 @@ namespace osu.Framework.Graphics.Containers
                 // The first condition is an intersection against the hierarchy, including any parents that may be masking this wrapper.
                 // It is the same calculation as Drawable.IsMaskedAway, however IsMaskedAway is optimised out for some CompositeDrawables (which this wrapper is).
                 // The second condition is an exact intersection against the optimising container, which further optimises rotated AABBs where the wrapper content is not visible.
-                IsIntersecting = maskingBounds.IntersectsWith(ScreenSpaceDrawQuad.AABBFloat)
+                IsIntersecting = ComputeMaskingBounds().IntersectsWith(ScreenSpaceDrawQuad.AABBFloat)
                                  && OptimisingContainer?.ScreenSpaceDrawQuad.Intersects(ScreenSpaceDrawQuad) != false;
 
                 isIntersectingCache.Validate();
             }
 
-            return result;
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1881,8 +1881,9 @@ namespace osu.Framework.Graphics
         /// <param name="frame">The frame which the <see cref="DrawNode"/> sub-tree should be generated for.</param>
         /// <param name="treeIndex">The index of the <see cref="DrawNode"/> to use.</param>
         /// <param name="forceNewDrawNode">Whether the creation of a new <see cref="DrawNode"/> should be forced, rather than re-using an existing <see cref="DrawNode"/>.</param>
+        /// <param name="propagateMasking">Whether masking calculations will be propagated within this sub-tree.</param>
         /// <returns>A complete and updated <see cref="DrawNode"/>, or null if the <see cref="DrawNode"/> would be invisible.</returns>
-        internal virtual DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal virtual DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             DrawNode node = drawNodes[treeIndex];
 

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -60,13 +60,7 @@ namespace osu.Framework.Graphics
             // We do not want to receive updates. That is the business of the original drawable.
             public override bool IsPresent => false;
 
-            public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
-            {
-                if (Original.IsDisposed)
-                    return false;
-
-                return Original.UpdateSubTreeMasking(this, maskingBounds);
-            }
+            protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => false;
 
             private class ProxyDrawNode : DrawNode
             {

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -37,9 +37,9 @@ namespace osu.Framework.Graphics
 
             protected override DrawNode CreateDrawNode() => new ProxyDrawNode(this);
 
-            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
             {
-                var node = (ProxyDrawNode)base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+                var node = (ProxyDrawNode)base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
 
                 node.DrawNodeIndex = treeIndex;
                 node.FrameCount = frame;

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -95,10 +95,10 @@ namespace osu.Framework.Graphics.Lines
             textureCache.Validate();
         }
 
-        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             validateTexture();
-            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+            return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -517,7 +517,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             protected internal IEnumerable<DrawableDropdownMenuItem> VisibleMenuItems => Children.OfType<DrawableDropdownMenuItem>().Where(i => i.MatchingFilter);
-            protected internal IEnumerable<DrawableDropdownMenuItem> MenuItemsInView => VisibleMenuItems.Where(item => !item.IsMaskedAway);
+            protected internal IEnumerable<DrawableDropdownMenuItem> MenuItemsInView => VisibleMenuItems.Where(item => !item.WasMaskedAway);
 
             public DrawableDropdownMenuItem PreselectedItem => VisibleMenuItems.FirstOrDefault(c => c.IsPreSelected)
                                                                ?? VisibleMenuItems.FirstOrDefault(c => c.IsSelected);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -472,7 +472,6 @@ namespace osu.Framework.Platform
             TypePerformanceMonitor.NewFrame();
 
             Root.UpdateSubTree();
-            Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 
             using (var buffer = DrawRoots.GetForWrite())
                 buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -474,7 +474,7 @@ namespace osu.Framework.Platform
             Root.UpdateSubTree();
 
             using (var buffer = DrawRoots.GetForWrite())
-                buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false);
+                buffer.Object = Root.GenerateDrawNodeSubtree(frameCount, buffer.Index, false, true);
         }
 
         private bool didRenderFrame;

--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Testing
 
         protected override bool CanBeFlattened => false;
 
-        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode, bool propagateMasking)
         {
             switch (recordState.Value)
             {
@@ -54,10 +54,10 @@ namespace osu.Framework.Testing
 
                     currentFrame.Value = currentFrame.MaxValue = 0;
 
-                    return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+                    return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode, propagateMasking);
 
                 case RecordState.Recording:
-                    var node = base.GenerateDrawNodeSubtree(frame, treeIndex, true);
+                    var node = base.GenerateDrawNodeSubtree(frame, treeIndex, true, propagateMasking);
 
                     referenceRecursively(node);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/1432 (we can't override `UpdateSubTreeMasking` to bypass masking checks since it no longer exists, so this became a requirement)
Improves upon proposal in https://github.com/ppy/osu-framework/issues/6224

Depends on:
- [ ] https://github.com/ppy/osu-framework/pull/6266

(Note that screenshot from `master` already contains https://github.com/ppy/osu-framework/pull/6243)
|master|pr|
|---|---|
|![fr-master](https://github.com/ppy/osu-framework/assets/22874522/20f9b81b-5254-41f3-bbbe-dfdba8454036)|![fr-pr](https://github.com/ppy/osu-framework/assets/22874522/a1947b54-bb03-4776-8cd9-ae4d4c40d120)|