### PR TITLE
Guard against unsupported window mode on startup

### DIFF
--- a/osu.Framework/Platform/SDL3Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL3Window_Windowing.cs
@@ -90,6 +90,9 @@ namespace osu.Framework.Platform
 
             config.BindWith(FrameworkSetting.WindowMode, WindowMode);
 
+            if (!SupportedWindowModes.Contains(WindowMode.Value))
+                WindowMode.Value = DefaultWindowMode;
+
             WindowMode.BindValueChanged(evt =>
             {
                 switch (evt.NewValue)


### PR DESCRIPTION
- Closes #6262 

I'd have hoped this GameHost code would guard against unsupported window modes, but this runs before the window is created so it has no effect.

https://github.com/ppy/osu-framework/blob/79d8e449cfb88a32b125ae3530ae53aee96b3f80/osu.Framework/Platform/GameHost.cs#L1229-L1236