### PR TITLE
Allow customising the `Main()` function on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Android
 
         internal static AndroidGameSurface Surface => (AndroidGameSurface)MSurface!;
 
-        protected abstract Game CreateGame();
+        protected virtual Game CreateGame() => throw new NotImplementedException();
 
         protected override string[] GetLibraries() => new string[] { "SDL3" };
 
@@ -41,12 +41,21 @@ namespace osu.Framework.Android
 
         protected override IRunnable CreateSDLMainRunnable() => new Runnable(() =>
         {
-            var host = new AndroidGameHost(this);
-            host.Run(CreateGame());
+            Main();
 
             if (!IsFinishing)
                 Finish();
         });
+
+        /// <summary>
+        /// The main function. Set up the <see cref="AndroidGameHost"/> and run your game.
+        /// Return to exit this activity.
+        /// </summary>
+        protected virtual void Main()
+        {
+            var host = new AndroidGameHost(this);
+            host.Run(CreateGame());
+        }
 
         protected override void OnCreate(Bundle? savedInstanceState)
         {

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -72,8 +72,10 @@ namespace osu.Framework.Android
         public override void OnTrimMemory(TrimMemory level)
         {
             base.OnTrimMemory(level);
-            host?.Collect();
+            TrimMemory?.Invoke();
         }
+
+        internal event Action? TrimMemory;
 
         protected override void OnStop()
         {

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -33,6 +33,10 @@ namespace osu.Framework.Android
 
         internal static AndroidGameSurface Surface => (AndroidGameSurface)MSurface!;
 
+        /// <summary>
+        /// Create the game to be run.
+        /// </summary>
+        /// <remarks>Either override this or <see cref="Main"/>.</remarks>
         protected virtual Game CreateGame() => throw new NotImplementedException();
 
         protected override string[] GetLibraries() => new string[] { "SDL3" };
@@ -51,6 +55,7 @@ namespace osu.Framework.Android
         /// The main function. Set up the <see cref="AndroidGameHost"/> and run your game.
         /// Return to exit this activity.
         /// </summary>
+        /// <remarks>Either override this or <see cref="CreateGame"/>.</remarks>
         protected virtual void Main()
         {
             var host = new AndroidGameHost(this, string.Empty);

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -11,7 +11,6 @@ using Java.Lang;
 using ManagedBass;
 using Org.Libsdl.App;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Platform;
 using Debug = System.Diagnostics.Debug;
 
 namespace osu.Framework.Android
@@ -34,8 +33,6 @@ namespace osu.Framework.Android
 
         internal static AndroidGameSurface Surface => (AndroidGameSurface)MSurface!;
 
-        private GameHost? host;
-
         protected abstract Game CreateGame();
 
         protected override string[] GetLibraries() => new string[] { "SDL3" };
@@ -44,7 +41,7 @@ namespace osu.Framework.Android
 
         protected override IRunnable CreateSDLMainRunnable() => new Runnable(() =>
         {
-            host = new AndroidGameHost(this);
+            var host = new AndroidGameHost(this);
             host.Run(CreateGame());
 
             if (!IsFinishing)

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -45,17 +45,6 @@ namespace osu.Framework.Android
         protected override IRunnable CreateSDLMainRunnable() => new Runnable(() =>
         {
             host = new AndroidGameHost(this);
-            host.AllowScreenSuspension.Result.BindValueChanged(allow =>
-            {
-                RunOnUiThread(() =>
-                {
-                    if (!allow.NewValue)
-                        Window?.AddFlags(WindowManagerFlags.KeepScreenOn);
-                    else
-                        Window?.ClearFlags(WindowManagerFlags.KeepScreenOn);
-                });
-            }, true);
-
             host.Run(CreateGame());
 
             if (!IsFinishing)

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Android
         /// </summary>
         protected virtual void Main()
         {
-            var host = new AndroidGameHost(this);
+            var host = new AndroidGameHost(this, string.Empty);
             host.Run(CreateGame());
         }
 

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -36,6 +36,7 @@ namespace osu.Framework.Android
         {
             base.SetupForRun();
 
+            activity.TrimMemory += Collect;
             AllowScreenSuspension.Result.BindValueChanged(allow =>
             {
                 activity.RunOnUiThread(() =>
@@ -111,6 +112,14 @@ namespace osu.Framework.Android
         public override bool SuspendToBackground()
         {
             return activity.MoveTaskToBack(true);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (activity.IsNotNull())
+                activity.TrimMemory -= Collect;
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Android.App;
 using Android.Content;
+using Android.Views;
 using osu.Framework.Android.Graphics.Textures;
 using osu.Framework.Android.Graphics.Video;
 using osu.Framework.Configuration;
@@ -29,6 +30,22 @@ namespace osu.Framework.Android
             : base(string.Empty)
         {
             this.activity = activity;
+        }
+
+        protected override void SetupForRun()
+        {
+            base.SetupForRun();
+
+            AllowScreenSuspension.Result.BindValueChanged(allow =>
+            {
+                activity.RunOnUiThread(() =>
+                {
+                    if (!allow.NewValue)
+                        activity.Window?.AddFlags(WindowManagerFlags.KeepScreenOn);
+                    else
+                        activity.Window?.ClearFlags(WindowManagerFlags.KeepScreenOn);
+                });
+            }, true);
         }
 
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -26,8 +26,8 @@ namespace osu.Framework.Android
     {
         private readonly AndroidGameActivity activity;
 
-        public AndroidGameHost(AndroidGameActivity activity)
-            : base(string.Empty)
+        public AndroidGameHost(AndroidGameActivity activity, string gameName, HostOptions? options = null)
+            : base(gameName, options)
         {
             this.activity = activity;
         }


### PR DESCRIPTION
Since iOS and desktop have `Main()` functions by default, why not allow it on android. SDL expects us to provide a main function anyways.

If we ever add `HostOptions` that make sense on android, those can be set in the custom `Main()`.

Consumers should override either `Main()` or `CreateGame()`. This is a non-breaking change.