### PR TITLE
Add `Update` event to `IWindow`

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -783,13 +783,7 @@ namespace osu.Framework.Platform
                 {
                     if (Window != null)
                     {
-                        switch (Window)
-                        {
-                            case SDL3Window window:
-                                window.Update += windowUpdate;
-                                break;
-                        }
-
+                        Window.Update += windowUpdate;
                         Window.Suspended += Suspend;
                         Window.Resumed += Resume;
                         Window.LowOnMemory += Collect;

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -39,6 +39,11 @@ namespace osu.Framework.Platform
         void Create();
 
         /// <summary>
+        /// Invoked once every window event loop.
+        /// </summary>
+        event Action? Update;
+
+        /// <summary>
         /// Invoked when the window close (X) button or another platform-native exit action has been pressed.
         /// </summary>
         event Action? ExitRequested;


### PR DESCRIPTION
The switch in `GameHost` has irked me for some time. It was mostly there since osuTK provided the event with a different signature.