### PR TITLE
Use SDL3 screen saver functions to implement `AllowScreenSuspension`

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -45,17 +45,6 @@ namespace osu.Framework.Android
         protected override IRunnable CreateSDLMainRunnable() => new Runnable(() =>
         {
             host = new AndroidGameHost(this);
-            host.AllowScreenSuspension.Result.BindValueChanged(allow =>
-            {
-                RunOnUiThread(() =>
-                {
-                    if (!allow.NewValue)
-                        Window?.AddFlags(WindowManagerFlags.KeepScreenOn);
-                    else
-                        Window?.ClearFlags(WindowManagerFlags.KeepScreenOn);
-                });
-            }, true);
-
             host.Run(CreateGame());
 
             if (!IsFinishing)

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -30,15 +30,6 @@ namespace osu.Framework.iOS
 
         protected override IWindow CreateWindow(GraphicsSurfaceType preferredSurface) => new IOSWindow(preferredSurface, Options.FriendlyGameName);
 
-        protected override void SetupForRun()
-        {
-            base.SetupForRun();
-
-            AllowScreenSuspension.Result.BindValueChanged(allow =>
-                    InputThread.Scheduler.Add(() => UIApplication.SharedApplication.IdleTimerDisabled = !allow.NewValue),
-                true);
-        }
-
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1060,6 +1060,14 @@ namespace osu.Framework.Platform
             }, true);
 
             IsActive.BindTo(Window.IsActive);
+
+            AllowScreenSuspension.Result.BindValueChanged(e =>
+            {
+                if (e.NewValue)
+                    Window.EnableScreenSuspension();
+                else
+                    Window.DisableScreenSuspension();
+            }, true);
         }
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -197,6 +197,16 @@ namespace osu.Framework.Platform
         void CancelFlash();
 
         /// <summary>
+        /// Enable any system level timers that might dim or turn off the screen.
+        /// </summary>
+        void EnableScreenSuspension();
+
+        /// <summary>
+        /// Disable any system level timers that might dim or turn off the screen.
+        /// </summary>
+        void DisableScreenSuspension();
+
+        /// <summary>
         /// Start the window's run loop.
         /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
         /// </summary>

--- a/osu.Framework/Platform/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3Window.cs
@@ -407,6 +407,10 @@ namespace osu.Framework.Platform
             SDL3.SDL_FlashWindow(SDLWindowHandle, SDL_FlashOperation.SDL_FLASH_CANCEL);
         });
 
+        public void EnableScreenSuspension() => ScheduleCommand(() => SDL3.SDL_EnableScreenSaver());
+
+        public void DisableScreenSuspension() => ScheduleCommand(() => SDL3.SDL_DisableScreenSaver());
+
         /// <summary>
         /// Attempts to set the window's icon to the specified image.
         /// </summary>


### PR DESCRIPTION
This removes the custom Android and iOS implementations, and also adds support for desktop platforms.

[Android](https://github.com/Susko3/SDL/blob/dc61b4b2f81c72028d7114e8b914b044d46f94f0/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java#L903-L907) and [iOS](https://github.com/Susko3/SDL/blob/dc61b4b2f81c72028d7114e8b914b044d46f94f0/src/video/uikit/SDL_uikitvideo.m#L173-L176) implementation in SDL3 match our old custom code.