### PR TITLE
Fix `GameHost.Collect()` being called twice on android

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -11,7 +11,6 @@ using Java.Lang;
 using ManagedBass;
 using Org.Libsdl.App;
 using osu.Framework.Extensions.ObjectExtensions;
-using osu.Framework.Platform;
 using Debug = System.Diagnostics.Debug;
 
 namespace osu.Framework.Android
@@ -34,8 +33,6 @@ namespace osu.Framework.Android
 
         internal static AndroidGameSurface Surface => (AndroidGameSurface)MSurface!;
 
-        private GameHost? host;
-
         protected abstract Game CreateGame();
 
         protected override string[] GetLibraries() => new string[] { "SDL3" };
@@ -44,7 +41,7 @@ namespace osu.Framework.Android
 
         protected override IRunnable CreateSDLMainRunnable() => new Runnable(() =>
         {
-            host = new AndroidGameHost(this);
+            var host = new AndroidGameHost(this);
             host.AllowScreenSuspension.Result.BindValueChanged(allow =>
             {
                 RunOnUiThread(() =>

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -80,12 +80,6 @@ namespace osu.Framework.Android
             }
         }
 
-        public override void OnTrimMemory(TrimMemory level)
-        {
-            base.OnTrimMemory(level);
-            host?.Collect();
-        }
-
         protected override void OnStop()
         {
             base.OnStop();

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.SDL3-CS.Android" Version="2024.418.1" />
+    <PackageReference Include="ppy.SDL3-CS.Android" Version="2024.522.0" />
     <PackageReference Include="Xamarin.AndroidX.Window" Version="1.2.0.1" PrivateAssets="compile" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Depends on (to have identical behaviour):
- [x] https://github.com/libsdl-org/SDL/pull/9654
- [x] New SDL3-CS build.

SDL sends us a `SDL_EVENT_LOW_MEMORY` when Android's `onLowMemory()` handler fires. o!f handles this event and calls `GameHost.Collect()`. We also have our own handling in `onTrimMemory()`. Depending on how android handles those two functions, we may collect memory twice.

I think it makes more sense to just have `SDL_EVENT_LOW_MEMORY` handling, and not have custom logic just for android.

This PR was originally meant to pick out the useful parts from https://github.com/ppy/osu-framework/pull/6269/files#r1584189904, but I've since realised SDL already sends us a low memory event that we handle.