### PR TITLE
Fix broken macOS CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Setup Go
         uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.9
 
       - name: Install httpbin
         run: go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@latest


### PR DESCRIPTION
Looks like some update to the runner broke our CI workflow for a few days now, example: https://github.com/ppy/osu-framework/actions/runs/8930403598/job/24530431772?pr=6276

I'm hoping specifying the version directly fixes this. I've pinned it to the version of the last successful run (https://github.com/ppy/osu-framework/actions/runs/8838769431/job/24270660297).