### PR TITLE
Fix `Xamarin.Jetbrains.Annotations` conflicting with `Jetbrains.Annotations`

### DIFF
--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -19,6 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.SDL3-CS.Android" Version="2024.418.1" />
-    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.2.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Window" Version="1.2.0.1" PrivateAssets="compile" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This conflict was most noticeable when using `[NotNull]` in osu! https://github.com/ppy/osu/commit/9c22fa3a9fbae0fb568e5a7b36d4c688268add3a.

This doesn't fix the conflict in `osu.Framework.Android`, but it does fix it for downstream projects. If a fix is needed for o!f, [`PackageReference` `Aliases`](https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#packagereference-aliases) can be used.

I've tested osu! with a local framework checkout and with a local package, and it works fine without the [workaround](https://github.com/ppy/osu/commit/9c22fa3a9fbae0fb568e5a7b36d4c688268add3a).

---

- Upstream issue (wontfix): https://github.com/xamarin/AndroidX/issues/885

The namespace conflict can be tested with this diff (compile error on `master`, works fine with this PR):

```diff
diff --git a/osu.Framework.Tests.Android/TestGameActivity.cs b/osu.Framework.Tests.Android/TestGameActivity.cs
index 19851817f..8dfae3995 100644
--- a/osu.Framework.Tests.Android/TestGameActivity.cs
+++ b/osu.Framework.Tests.Android/TestGameActivity.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Android.App;
+using JetBrains.Annotations;
 using osu.Framework.Android;
 
 namespace osu.Framework.Tests.Android
@@ -9,6 +10,7 @@ namespace osu.Framework.Tests.Android
     [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, Exported = true, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
     public class TestGameActivity : AndroidGameActivity
     {
+        [NotNull]
         protected override Game CreateGame()
             => new VisualTestGame();
     }
```