### PR TITLE
Add parent container per row in `GridContainer`

### DIFF
--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -206,7 +206,6 @@ namespace osu.Framework.Graphics.Containers
                     rows[r].Add(cells[r, c]);
                 }
 
-                rows[r].Depth = r;
                 AddInternal(rows[r]);
             }
 

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Graphics.Containers
         private readonly LayoutValue cellChildLayout = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.Presence, InvalidationSource.Child);
 
         private CellContainer[,] cells = new CellContainer[0, 0];
-        private CellsRow[] rows = new CellsRow[0];
+        private CellsRow[] rows = Array.Empty<CellsRow>();
 
         private int cellRows => rows.Length;
         private int cellColumns => cells.GetLength(1);

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -234,8 +234,7 @@ namespace osu.Framework.Graphics.Containers
 
             for (int row = 0; row < cellRows; row++)
             {
-                if (row > 0)
-                    rows[row].Y = cumulativeHeight;
+                rows[row].Y = cumulativeHeight;
 
                 for (int col = 0; col < cellColumns; col++)
                 {


### PR DESCRIPTION
Improves performance in cases when `GridContainer` is too big with Masking and DrawNode sub-trees having to traverse less elements when most of the rows are masked away.

This change is non-breaking, all the `GridContainer` usages can be left untouched (except https://github.com/ppy/osu/blob/6cfe1356cd9ac77f70d762fab573e58bfd61b2c2/osu.Game/Screens/Edit/EditorScreenWithTimeline.cs#L96, the only case I could found with broken depth, which is a downside of this pr).

# Example
Imagine a `GridContainer` with a size of 5 * 1000 cells with 20 rows visible. In master we are traversing each cell no matter what (5000 cells), now we are traversing all the rows + cells of non-masked rows (1000 + 20 * 5 = 1100 cells). And the longer the `GridContainer` the bigger the relative benefit.
Of course in case of a small grid there are more total containers, however I didn't notice any considerable performance regressions anywhere.

# Downside
Less control over Depth of the children.


# Test
Map with a big table for testing: https://osu.ppy.sh/beatmapsets/1238185#mania/2574372
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/1e1048e2-8700-43c9-8cca-d92ec2b78d2b)|![pr](https://github.com/ppy/osu-framework/assets/22874522/9d93e539-ae03-4a3c-874c-161ae9966d75)|