### PR TITLE
Improve input handling performance of `TableContainer`

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1453,13 +1453,18 @@ namespace osu.Framework.Graphics.Containers
             if (!ReceivePositionalInputAtSubTree(screenSpacePos))
                 return false;
 
+            PropagatePositionalInputQueue(screenSpacePos, queue);
+
+            return true;
+        }
+
+        internal virtual void PropagatePositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        {
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
             {
                 if (ShouldBeConsideredForInput(aliveInternalChildren[i]))
                     aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
             }
-
-            return true;
         }
 
         #endregion


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26886 (Or at very least should improve things considerably).

By default `CompositeDrawable` (in our case `GridContainer`) is trying to build positional input sub-tree with all it's internal children and then throwing away unused ones. By assuming all the content within cells isn't overlapping other cells and contained within it's boundaries (which is a case for the `TableContainer`) we can propagate positional input only to a set cell and ignore the others.

With that https://github.com/ppy/osu/pull/27958 could've been undone (performance on mouse move is way better now), however idle performance is still not that great since non-positional input sub-tree is [being created on each frame](https://github.com/ppy/osu-framework/blob/9c6dee5e854d396f9c223ab9f722995d3fa7a193/osu.Framework/Input/InputManager.cs#L497) if nothing is being focused.

This version of `GridContainer` can probably be made public with a better name.

Master:
https://streamable.com/t9tkah
Pr:
https://streamable.com/yy6jrq