### PR TITLE
Allow insecure requests on debug builds via `OSU_INSECURE_REQUESTS` environment variable

### DIFF
--- a/osu.Framework.Tests/FlakyTestAttribute.cs
+++ b/osu.Framework.Tests/FlakyTestAttribute.cs
@@ -1,7 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+using NUnit.Framework.Internal.Commands;
 
 namespace osu.Framework.Tests
 {
@@ -9,16 +13,63 @@ namespace osu.Framework.Tests
     /// An attribute to mark any flaky tests.
     /// Will add a retry count unless environment variable `FAIL_FLAKY_TESTS` is set to `1`.
     /// </summary>
-    public class FlakyTestAttribute : RetryAttribute
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class FlakyTestAttribute : NUnitAttribute, IRepeatTest
     {
+        private readonly int tryCount;
+
         public FlakyTestAttribute()
             : this(10)
         {
         }
 
         public FlakyTestAttribute(int tryCount)
-            : base(FrameworkEnvironment.FailFlakyTests ? 1 : tryCount)
         {
+            this.tryCount = tryCount;
+        }
+
+        public TestCommand Wrap(TestCommand command) => new FlakyTestCommand(command, tryCount);
+
+        // Adapted from https://github.com/nunit/nunit/blob/4eaab2eef3713907ca37bfb2f7f47e3fc2785214/src/NUnitFramework/framework/Attributes/RetryAttribute.cs
+        // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+        public class FlakyTestCommand : DelegatingTestCommand
+        {
+            private readonly int tryCount;
+
+            public FlakyTestCommand(TestCommand innerCommand, int tryCount)
+                : base(innerCommand)
+            {
+                this.tryCount = tryCount;
+            }
+
+            public override TestResult Execute(TestExecutionContext context)
+            {
+                int count = FrameworkEnvironment.FailFlakyTests ? 1 : tryCount;
+
+                while (count-- > 0)
+                {
+                    try
+                    {
+                        context.CurrentResult = innerCommand.Execute(context);
+                    }
+                    catch (Exception ex)
+                    {
+                        context.CurrentResult ??= context.CurrentTest.MakeTestResult();
+                        context.CurrentResult.RecordException(ex);
+                    }
+
+                    if (context.CurrentResult.ResultState != ResultState.Failure)
+                        break;
+
+                    if (count > 0)
+                    {
+                        context.CurrentResult = context.CurrentTest.MakeTestResult();
+                        context.CurrentRepeatCount++;
+                    }
+                }
+
+                return context.CurrentResult;
+            }
         }
     }
 }

--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -94,5 +94,18 @@ namespace osu.Framework.Tests.IO
             byte[]? result = store.Get(null);
             Assert.That(result, Is.Null);
         }
+
+        [Test]
+        public void TestFileUrlFails([Values(true, false)] bool async)
+        {
+            // Known, guaranteed file path.
+            string path = new Uri(RuntimeInfo.EntryAssembly.Location).AbsoluteUri;
+
+            byte[]? result = async
+                ? store.GetAsync(path).GetResultSafely()
+                : store.Get(path);
+
+            Assert.That(result, Is.Null);
+        }
     }
 }

--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        public void TestValidGet([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        public void TestValidUrlReturnsData([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
         {
             byte[]? result = async
                 ? store.GetAsync($"{protocol}://{host}/image/png").GetResultSafely()
@@ -71,7 +71,7 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test]
-        public void TestInvalidGet([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        public void TestMissingSchemeReturnsNull([Values(true, false)] bool async)
         {
             byte[]? result = async
                 ? store.GetAsync($"{host}/image/png").GetResultSafely()
@@ -81,14 +81,14 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test]
-        public void TestInvalidUrl()
+        public void TestInvalidUrlReturnsNull()
         {
             byte[]? result = store.Get("this is not a valid url");
             Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void TestNullUrl()
+        public void TestNullUrlReturnsNull()
         {
             // Not sure if this store should accept a null URL, but let's test it anyway.
             byte[]? result = store.Get(null);

--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Tests.IO
         private static readonly IEnumerable<string> protocols;
 
         private bool oldAllowInsecureRequests;
-        private OnlineStore store;
+        private OnlineStore store = null!;
 
         static TestOnlineStore()
         {

--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -107,5 +107,15 @@ namespace osu.Framework.Tests.IO
 
             Assert.That(result, Is.Null);
         }
+
+        [Test]
+        public void TestBadWebRequest([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        {
+            byte[]? result = async
+                ? store.GetAsync($"{protocol}://{host}/status/500").GetResultSafely()
+                : store.Get($"{protocol}://{host}/status/500");
+
+            Assert.That(result, Is.Null);
+        }
     }
 }

--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.IO.Stores;
+
+namespace osu.Framework.Tests.IO
+{
+    [TestFixture]
+    [Category("httpbin")]
+    public class TestOnlineStore
+    {
+        private const string default_protocol = "http";
+
+        private static readonly string host;
+        private static readonly IEnumerable<string> protocols;
+
+        private bool oldAllowInsecureRequests;
+        private OnlineStore store;
+
+        static TestOnlineStore()
+        {
+            bool localHttpBin = Environment.GetEnvironmentVariable("OSU_TESTS_LOCAL_HTTPBIN") == "1";
+
+            if (localHttpBin)
+            {
+                // httpbin very frequently falls over and causes random tests to fail
+                // Thus github actions builds rely on a local httpbin instance to run the tests
+
+                host = "127.0.0.1:8080";
+                protocols = new[] { default_protocol };
+            }
+            else
+            {
+                host = "httpbin.org";
+                protocols = new[] { default_protocol, "https" };
+            }
+        }
+
+        [OneTimeSetUp]
+        public void GlobalSetup()
+        {
+            oldAllowInsecureRequests = FrameworkEnvironment.AllowInsecureRequests;
+            FrameworkEnvironment.AllowInsecureRequests = true;
+        }
+
+        [OneTimeTearDown]
+        public void GlobalTeardown()
+        {
+            FrameworkEnvironment.AllowInsecureRequests = oldAllowInsecureRequests;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            store = new OnlineStore();
+        }
+
+        [Test, Retry(5)]
+        public void TestValidGet([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        {
+            byte[]? result = async
+                ? store.GetAsync($"{protocol}://{host}/image/png").GetResultSafely()
+                : store.Get($"{protocol}://{host}/image/png");
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Has.Length.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestInvalidGet([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        {
+            byte[]? result = async
+                ? store.GetAsync($"{host}/image/png").GetResultSafely()
+                : store.Get($"{host}/image/png");
+
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void TestInvalidUrl()
+        {
+            byte[]? result = store.Get("this is not a valid url");
+            Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void TestNullUrl()
+        {
+            // Not sure if this store should accept a null URL, but let's test it anyway.
+            byte[]? result = store.Get(null);
+            Assert.That(result, Is.Null);
+        }
+    }
+}

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -32,6 +32,8 @@ namespace osu.Framework.Tests.IO
         private static readonly string host;
         private static readonly IEnumerable<string> protocols;
 
+        private bool oldAllowInsecureRequests;
+
         static TestWebRequest()
         {
             bool localHttpBin = Environment.GetEnvironmentVariable("OSU_TESTS_LOCAL_HTTPBIN") == "1";
@@ -51,14 +53,26 @@ namespace osu.Framework.Tests.IO
             }
         }
 
+        [SetUp]
+        public void Setup()
+        {
+            oldAllowInsecureRequests = FrameworkEnvironment.AllowInsecureRequests;
+            FrameworkEnvironment.AllowInsecureRequests = true;
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            FrameworkEnvironment.AllowInsecureRequests = oldAllowInsecureRequests;
+        }
+
         [Test, Retry(5)]
         public void TestValidGet([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
         {
             string url = $"{protocol}://{host}/get";
             var request = new JsonWebRequest<HttpBinGetResponse>(url)
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true
+                Method = HttpMethod.Get
             };
 
             testValidGetInternal(async, request, "osu-framework");
@@ -74,8 +88,7 @@ namespace osu.Framework.Tests.IO
             string url = $"{protocol}://{host}/get";
             var request = new JsonWebRequest<HttpBinGetResponse>(url)
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true
+                Method = HttpMethod.Get
             };
 
             Task.Run(() => testValidGetInternal(false, request, "osu-framework")).WaitSafely();
@@ -87,8 +100,7 @@ namespace osu.Framework.Tests.IO
             string url = $"{protocol}://{host}/get";
             var request = new CustomUserAgentWebRequest(url)
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true
+                Method = HttpMethod.Get
             };
 
             testValidGetInternal(async, request, "custom-ua");
@@ -143,7 +155,6 @@ namespace osu.Framework.Tests.IO
                 var request = new DelayedWebRequest
                 {
                     Method = HttpMethod.Get,
-                    AllowInsecureRequests = true,
                     Delay = induced_delay
                 };
 
@@ -186,8 +197,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new WebRequest($"{protocol}://{invalid_get_url}")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true
+                Method = HttpMethod.Get
             };
 
             Exception finishedException = null;
@@ -208,10 +218,7 @@ namespace osu.Framework.Tests.IO
         [Test, Retry(5)]
         public void TestBadStatusCode([Values(true, false)] bool async)
         {
-            var request = new WebRequest($"{default_protocol}://{host}/hidden-basic-auth/user/passwd")
-            {
-                AllowInsecureRequests = true,
-            };
+            var request = new WebRequest($"{default_protocol}://{host}/hidden-basic-auth/user/passwd");
 
             bool hasThrown = false;
             request.Failed += exception => hasThrown = exception != null;
@@ -230,10 +237,7 @@ namespace osu.Framework.Tests.IO
         [Test, Retry(5)]
         public void TestJsonWebRequestThrowsCorrectlyOnMultipleErrors([Values(true, false)] bool async)
         {
-            var request = new JsonWebRequest<Drawable>("badrequest://www.google.com")
-            {
-                AllowInsecureRequests = true,
-            };
+            var request = new JsonWebRequest<Drawable>("badrequest://www.google.com");
 
             bool hasThrown = false;
             request.Failed += exception => hasThrown = exception != null;
@@ -261,8 +265,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -290,8 +293,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -317,8 +319,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -348,8 +349,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/delay/10")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -383,8 +383,7 @@ namespace osu.Framework.Tests.IO
             var cancellationSource = new CancellationTokenSource();
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -409,8 +408,7 @@ namespace osu.Framework.Tests.IO
             var cancellationSource = new CancellationTokenSource();
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -436,8 +434,7 @@ namespace osu.Framework.Tests.IO
             var cancellationSource = new CancellationTokenSource();
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             bool hasThrown = false;
@@ -466,7 +463,6 @@ namespace osu.Framework.Tests.IO
             var request = new DelayedWebRequest
             {
                 Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
                 Timeout = 1000,
                 Delay = 2
             };
@@ -493,7 +489,6 @@ namespace osu.Framework.Tests.IO
             var request = new WebRequest($"{default_protocol}://{host}/delay/4")
             {
                 Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
                 Timeout = 1000
             };
 
@@ -518,8 +513,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             request.Started += () => { };
@@ -546,8 +540,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             using (request)
@@ -580,8 +573,7 @@ namespace osu.Framework.Tests.IO
 
             var request = new JsonWebRequest<HttpBinGetResponse>($@"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true
+                Method = HttpMethod.Get
             };
 
             request.AddParameter(test_key_1, test_val_1);
@@ -608,8 +600,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinPostResponse>($"{default_protocol}://{host}/post")
             {
-                Method = HttpMethod.Post,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Post
             };
 
             request.AddParameter("testkey1", "testval1");
@@ -645,7 +636,6 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinPostResponse>($"{default_protocol}://{host}/post")
             {
                 Method = HttpMethod.Post,
-                AllowInsecureRequests = true,
                 ContentType = "application/json"
             };
 
@@ -672,8 +662,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new WebRequest($"{default_protocol}://{host}/post")
             {
-                Method = HttpMethod.Post,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Post
             };
 
             if (async)
@@ -702,8 +691,7 @@ namespace osu.Framework.Tests.IO
 
             var request = new JsonWebRequest<HttpBinPutResponse>($"{default_protocol}://{host}/put")
             {
-                Method = HttpMethod.Put,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Put
             };
 
             request.AddParameter(test_key_1, test_val_1, RequestParameterType.Query);
@@ -735,8 +723,7 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinPutResponse>($"{default_protocol}://{host}/get")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
 
             Assert.Throws<ArgumentException>(() => request.AddParameter("cannot", "work", RequestParameterType.Form));
@@ -777,7 +764,6 @@ namespace osu.Framework.Tests.IO
                 var request = new DelayedWebRequest
                 {
                     Method = HttpMethod.Get,
-                    AllowInsecureRequests = true,
                     Timeout = 1000,
                     Delay = 2
                 };
@@ -804,8 +790,7 @@ namespace osu.Framework.Tests.IO
 
             WebRequest request = new WebRequest($"{default_protocol}://{host}/{endpoint}/{bytes_count}")
             {
-                Method = HttpMethod.Get,
-                AllowInsecureRequests = true,
+                Method = HttpMethod.Get
             };
             if (chunked)
                 request.AddParameter("chunk_size", chunk_size.ToString());
@@ -819,6 +804,21 @@ namespace osu.Framework.Tests.IO
             Assert.IsFalse(request.Aborted);
 
             Assert.AreEqual(bytes_count, request.ResponseStream.Length);
+        }
+
+        [Test, Retry(5)]
+        public void TestAllowInsecureRequestsOverride([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        {
+            FrameworkEnvironment.AllowInsecureRequests = false;
+
+            string url = $"{protocol}://{host}/get";
+            var request = new JsonWebRequest<HttpBinGetResponse>(url)
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true
+            };
+
+            testValidGetInternal(async, request, "osu-framework");
         }
 
         private static Dictionary<string, string> convertDictionary(Dictionary<string, object> dict)

--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Development;
 using osu.Framework.Platform;
 
 namespace osu.Framework
@@ -19,6 +20,12 @@ namespace osu.Framework
         public static int? VertexBufferCount { get; }
         public static bool NoStructuredBuffers { get; }
         public static string? DeferredRendererEventsOutputPath { get; }
+
+        /// <summary>
+        /// Whether non-SSL requests should be allowed. Debug only. Defaults to disabled.
+        /// When disabled, http:// requests will be automatically converted to https://.
+        /// </summary>
+        public static bool AllowInsecureRequests { get; internal set; }
 
         static FrameworkEnvironment()
         {
@@ -41,6 +48,9 @@ namespace osu.Framework
             NoStructuredBuffers = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_NO_SSBO")) ?? false;
 
             DeferredRendererEventsOutputPath = Environment.GetEnvironmentVariable("DEFERRED_RENDERER_EVENTS_OUTPUT");
+
+            if (DebugUtils.IsDebugBuild)
+                AllowInsecureRequests = parseBool(Environment.GetEnvironmentVariable("OSU_INSECURE_REQUESTS")) ?? false;
         }
 
         private static bool? parseBool(string? value)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -26,12 +26,6 @@ namespace osu.Framework.IO.Network
         internal const int MAX_RETRIES = 1;
 
         /// <summary>
-        /// Whether non-SSL requests should be allowed. Defaults to disabled.
-        /// In the default state, http:// requests will be automatically converted to https://.
-        /// </summary>
-        public bool AllowInsecureRequests;
-
-        /// <summary>
         /// Invoked when a response has been received, but not data has been received.
         /// </summary>
         public event Action Started;
@@ -243,6 +237,21 @@ namespace osu.Framework.IO.Network
         }
 
         public HttpResponseHeaders ResponseHeaders => response.Headers;
+
+        private bool? allowInsecureRequests;
+
+        /// <summary>
+        /// Whether non-SSL requests should be allowed. Defaults to disabled.
+        /// In the default state, http:// requests will be automatically converted to https://.
+        /// </summary>
+        /// <remarks>
+        /// Setting this overrides the <c>OSU_INSECURE_REQUESTS</c> environment variable.
+        /// </remarks>
+        public bool AllowInsecureRequests
+        {
+            get => allowInsecureRequests ?? FrameworkEnvironment.AllowInsecureRequests;
+            set => allowInsecureRequests = value;
+        }
 
         /// <summary>
         /// Performs the request asynchronously.

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -23,7 +23,15 @@ namespace osu.Framework.IO.Network
 {
     public class WebRequest : IDisposable
     {
+        public const int DEFAULT_TIMEOUT = 10000;
+
         internal const int MAX_RETRIES = 1;
+
+        private const int buffer_size = 32768;
+        private const string form_boundary = "-----------------------------28947758029299";
+        private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
+
+        private static readonly Logger logger = Logger.GetLogger(LoggingTarget.Network);
 
         /// <summary>
         /// Invoked when a response has been received, but not data has been received.
@@ -55,33 +63,48 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public bool Aborted { get; private set; }
 
-        private bool completed;
-
         /// <summary>
-        /// Whether the <see cref="WebRequest"/> has been run.
+        /// The response stream.
         /// </summary>
-        public bool Completed
-        {
-            get => completed;
-            private set
-            {
-                completed = value;
-                if (!completed) return;
+        public Stream ResponseStream { get; private set; }
 
-                // WebRequests can only be used once - no need to keep events bound
-                // This helps with disposal in PerformAsync usages
-                Started = null;
-                Finished = null;
-                Failed = null;
-                DownloadProgress = null;
-                UploadProgress = null;
-            }
-        }
+        public HttpResponseHeaders ResponseHeaders => response.Headers;
 
         /// <summary>
         /// The URL of this request.
         /// </summary>
         public string Url;
+
+        public HttpMethod Method = HttpMethod.Get;
+
+        /// <summary>
+        /// The amount of time from last sent or received data to trigger a timeout and abort the request.
+        /// </summary>
+        public int Timeout = DEFAULT_TIMEOUT;
+
+        /// <summary>
+        /// Whether this request should internally retry (up to <see cref="MAX_RETRIES"/> times) on a timeout before throwing an exception.
+        /// </summary>
+        public bool AllowRetryOnTimeout = true;
+
+        /// <summary>
+        /// The content type when POST content is provided.
+        /// </summary>
+        public string ContentType;
+
+        /// <summary>
+        /// The type of content expected by this web request.
+        /// </summary>
+        protected virtual string Accept => string.Empty;
+
+        /// <summary>
+        /// The value of the User-agent HTTP header.
+        /// </summary>
+        protected virtual string UserAgent => "osu-framework";
+
+        internal int RetryCount { get; private set; }
+
+        private long contentLength => requestStream?.Length ?? 0;
 
         /// <summary>
         /// Query string parameters.
@@ -103,32 +126,6 @@ namespace osu.Framework.IO.Network
         /// </summary>
         private readonly IDictionary<string, string> headers = new Dictionary<string, string>();
 
-        public const int DEFAULT_TIMEOUT = 10000;
-
-        public HttpMethod Method = HttpMethod.Get;
-
-        /// <summary>
-        /// The amount of time from last sent or received data to trigger a timeout and abort the request.
-        /// </summary>
-        public int Timeout = DEFAULT_TIMEOUT;
-
-        /// <summary>
-        /// The type of content expected by this web request.
-        /// </summary>
-        protected virtual string Accept => string.Empty;
-
-        /// <summary>
-        /// The value of the User-agent HTTP header.
-        /// </summary>
-        protected virtual string UserAgent => "osu-framework";
-
-        internal int RetryCount { get; private set; }
-
-        /// <summary>
-        /// Whether this request should internally retry (up to <see cref="MAX_RETRIES"/> times) on a timeout before throwing an exception.
-        /// </summary>
-        public bool AllowRetryOnTimeout { get; set; } = true;
-
         private CancellationToken? userToken;
         private CancellationTokenSource abortToken;
         private CancellationTokenSource timeoutToken;
@@ -136,11 +133,11 @@ namespace osu.Framework.IO.Network
         private LengthTrackingStream requestStream;
         private HttpResponseMessage response;
 
-        private long contentLength => requestStream?.Length ?? 0;
-
-        private const string form_boundary = "-----------------------------28947758029299";
-
-        private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
+        private MemoryStream rawContent;
+        private int responseBytesRead;
+        private byte[] buffer;
+        private bool? allowInsecureRequests;
+        private bool completed;
 
         private static readonly HttpClient client = new HttpClient(
             // SocketsHttpHandler causes crash in Android Debug, and seems to have compatibility issue on SSL
@@ -165,26 +162,45 @@ namespace osu.Framework.IO.Network
             Timeout = System.Threading.Timeout.InfiniteTimeSpan
         };
 
-        private static readonly Logger logger = Logger.GetLogger(LoggingTarget.Network);
-
         public WebRequest(string url = null, params object[] args)
         {
             if (!string.IsNullOrEmpty(url))
                 Url = args.Length == 0 ? url : string.Format(url, args);
         }
 
-        private int responseBytesRead;
+        /// <summary>
+        /// Whether non-SSL requests should be allowed. Defaults to disabled.
+        /// In the default state, http:// requests will be automatically converted to https://.
+        /// </summary>
+        /// <remarks>
+        /// Setting this overrides the <c>OSU_INSECURE_REQUESTS</c> environment variable.
+        /// </remarks>
+        public bool AllowInsecureRequests
+        {
+            get => allowInsecureRequests ?? FrameworkEnvironment.AllowInsecureRequests;
+            set => allowInsecureRequests = value;
+        }
 
-        private const int buffer_size = 32768;
-        private byte[] buffer;
+        /// <summary>
+        /// Whether the <see cref="WebRequest"/> has been run.
+        /// </summary>
+        public bool Completed
+        {
+            get => completed;
+            private set
+            {
+                completed = value;
+                if (!completed) return;
 
-        private MemoryStream rawContent;
-
-        public string ContentType;
-
-        protected virtual Stream CreateOutputStream() => new MemoryStream();
-
-        public Stream ResponseStream;
+                // WebRequests can only be used once - no need to keep events bound
+                // This helps with disposal in PerformAsync usages
+                Started = null;
+                Finished = null;
+                Failed = null;
+                DownloadProgress = null;
+                UploadProgress = null;
+            }
+        }
 
         /// <summary>
         /// Retrieve the full response body as a UTF8 encoded string.
@@ -236,22 +252,7 @@ namespace osu.Framework.IO.Network
             }
         }
 
-        public HttpResponseHeaders ResponseHeaders => response.Headers;
-
-        private bool? allowInsecureRequests;
-
-        /// <summary>
-        /// Whether non-SSL requests should be allowed. Defaults to disabled.
-        /// In the default state, http:// requests will be automatically converted to https://.
-        /// </summary>
-        /// <remarks>
-        /// Setting this overrides the <c>OSU_INSECURE_REQUESTS</c> environment variable.
-        /// </remarks>
-        public bool AllowInsecureRequests
-        {
-            get => allowInsecureRequests ?? FrameworkEnvironment.AllowInsecureRequests;
-            set => allowInsecureRequests = value;
-        }
+        protected virtual Stream CreateOutputStream() => new MemoryStream();
 
         /// <summary>
         /// Performs the request asynchronously.
@@ -284,7 +285,7 @@ namespace osu.Framework.IO.Network
             if (!AllowInsecureRequests && !url.StartsWith(@"https://", StringComparison.Ordinal))
             {
                 logger.Add($"Insecure request was automatically converted to https ({Url})");
-                url = @"https://" + url.Replace(@"http://", @"");
+                url = "https://" + url.Replace("http://", string.Empty);
             }
 
             // If a user token already exists, keep it. Otherwise, take on the previous user token, as this could be a retry of the request.

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -17,6 +17,9 @@ namespace osu.Framework.IO.Stores
     {
         public async Task<byte[]> GetAsync(string url, CancellationToken cancellationToken = default)
         {
+            if (!validateScheme(url))
+                return null;
+
             this.LogIfNonBackgroundThread(url);
 
             try
@@ -35,7 +38,7 @@ namespace osu.Framework.IO.Stores
 
         public virtual byte[] Get(string url)
         {
-            if (!url.StartsWith(@"https://", StringComparison.Ordinal))
+            if (!validateScheme(url))
                 return null;
 
             this.LogIfNonBackgroundThread(url);
@@ -64,6 +67,14 @@ namespace osu.Framework.IO.Stores
         }
 
         public IEnumerable<string> GetAvailableResources() => Enumerable.Empty<string>();
+
+        private bool validateScheme(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+                return false;
+
+            return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+        }
 
         #region IDisposable Support
 


### PR DESCRIPTION
- Adds the environment variable (`OSU_INSECURE_REQUESTS`).
- `WebRequest.AllowInsecureRequests` updated to act as an override of the environment variable.
- Added validation to `OnlineStore.GetAsync()`. This existed originally but was removed and incorrectly reverted at some point. Can't seem to pinpoint the exact commit where this happened.
- Adjusted `OnlineStore` to check for either `http` or `http` schemes. Added tests.

WIki entry: https://github.com/ppy/osu-framework/wiki/Environment-variables#osu_insecure_requests