### PR TITLE
Improve draw performance of `Waveform`

### DIFF
--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -39,6 +39,36 @@ namespace osu.Framework.Graphics.Colour
 
         public static SRGBColour operator *(SRGBColour first, SRGBColour second)
         {
+            if (isWhite(first))
+            {
+                if (first.Alpha == 1)
+                    return second;
+
+                return new SRGBColour
+                {
+                    SRGB = new Color4(
+                        second.SRGB.R,
+                        second.SRGB.G,
+                        second.SRGB.B,
+                        first.SRGB.A * second.SRGB.A)
+                };
+            }
+
+            if (isWhite(second))
+            {
+                if (second.Alpha == 1)
+                    return first;
+
+                return new SRGBColour
+                {
+                    SRGB = new Color4(
+                        first.SRGB.R,
+                        first.SRGB.G,
+                        first.SRGB.B,
+                        first.SRGB.A * second.SRGB.A)
+                };
+            }
+
             var firstLinear = first.Linear;
             var secondLinear = second.Linear;
 
@@ -54,6 +84,9 @@ namespace osu.Framework.Graphics.Colour
 
         public static SRGBColour operator *(SRGBColour first, float second)
         {
+            if (second == 1)
+                return first;
+
             var firstLinear = first.Linear;
 
             return new SRGBColour
@@ -91,6 +124,8 @@ namespace osu.Framework.Graphics.Colour
         /// </summary>
         /// <param name="alpha">The alpha factor to multiply with.</param>
         public void MultiplyAlpha(float alpha) => SRGB.A *= alpha;
+
+        private static bool isWhite(SRGBColour colour) => colour.SRGB.R == 1 && colour.SRGB.G == 1 && colour.SRGB.B == 1;
 
         public readonly bool Equals(SRGBColour other) => SRGB.Equals(other.SRGB);
         public override string ToString() => $"srgb: {SRGB}, linear: {Linear}";


### PR DESCRIPTION
Colours in waveform aren't being stored anywhere and recomputed every frame for each quad. While `Interpolation.ValueAt` uses a *correct* way of interpolating between colours by first converting them to linear and operation result to srgb, there's an underlying power function, which in combination with amount of quads and total interpolations results in draw performance loss.
![Снимок экрана 2024-05-14 192528](https://github.com/ppy/osu-framework/assets/22874522/0056acc5-d59f-471b-b9da-6a7f3f218315)
I chose just to avoid space conversion as a whole, and while resulting colour looks a bit darker, I think performance gain worth it.

|master|cc3cb43d8f1c975d15848695b076d4fd51f3d2f5|f8043ea8eb18d279efc82fc7de8b874537da0d69|
|---|---|---|
|![osu-waveform-master](https://github.com/ppy/osu-framework/assets/22874522/7969bd61-0e83-4864-8d71-7119960e7e5f)|![osu-waveform-pr](https://github.com/ppy/osu-framework/assets/22874522/d872446f-1a32-499c-8f25-cafd75d95220)|![osu-waveform-no-interpolation](https://github.com/ppy/osu-framework/assets/22874522/f6fdbbe3-628e-4b39-b043-9f0d41b1d26a)|
|![waveform-master](https://github.com/ppy/osu-framework/assets/22874522/6b4a684a-c07e-483a-92d2-cf4af7983fbf)|![waveform-pr](https://github.com/ppy/osu-framework/assets/22874522/035c6d0a-c8e8-44d2-8c79-65deee18d835)|![waveform-no-interpolation](https://github.com/ppy/osu-framework/assets/22874522/c3a4912f-f3ba-494c-8776-cff646c6913b)|

cc3cb43d8f1c975d15848695b076d4fd51f3d2f5 may also help a little in other scenarios. For exapmple computing child colour (which is white by default in most cases) while applying colour to the parent (or changing parent's alpha) wont trigger colour conversion:
|master|pr|
|---|---|
|![master](https://github.com/ppy/osu-framework/assets/22874522/fc847f01-acf7-4622-9189-d78bc05602e9)|![pr](https://github.com/ppy/osu-framework/assets/22874522/37fa15f4-5c14-4c66-809e-7e7a9ebf8e00)|