### PR TITLE
Implement focus traps

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -135,7 +135,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         /// <summary>
-        /// Ensures that performing <see cref="InputManager.ChangeFocus(Drawable)"/> to a drawable with disabled <see cref="Drawable.AcceptsFocus"/> returns <see langword="false"/>.
+        /// Ensures that performing <see cref="IFocusManager.ChangeFocus(Drawable)"/> to a drawable with disabled <see cref="Drawable.AcceptsFocus"/> returns <see langword="false"/>.
         /// </summary>
         [Test]
         public void DisabledFocusDrawableCannotReceiveFocusViaChangeFocus()
@@ -143,13 +143,13 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkFocused(() => requestingFocus);
 
             AddStep("disable focus from top left", () => focusTopLeft.AllowAcceptingFocus = false);
-            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+            AddAssert("cannot switch focus to top left", () => !((IFocusManager)InputManager).ChangeFocus(focusTopLeft));
 
             checkFocused(() => requestingFocus);
         }
 
         /// <summary>
-        /// Ensures that performing <see cref="InputManager.ChangeFocus(Drawable)"/> to a non-present drawable returns <see langword="false"/>.
+        /// Ensures that performing <see cref="IFocusManager.ChangeFocus(Drawable)"/> to a non-present drawable returns <see langword="false"/>.
         /// </summary>
         [Test]
         public void NotPresentDrawableCannotReceiveFocusViaChangeFocus()
@@ -157,13 +157,13 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkFocused(() => requestingFocus);
 
             AddStep("hide top left", () => focusTopLeft.Alpha = 0);
-            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+            AddAssert("cannot switch focus to top left", () => !((IFocusManager)InputManager).ChangeFocus(focusTopLeft));
 
             checkFocused(() => requestingFocus);
         }
 
         /// <summary>
-        /// Ensures that performing <see cref="InputManager.ChangeFocus(Drawable)"/> to a drawable of a non-present parent returns <see langword="false"/>.
+        /// Ensures that performing <see cref="IFocusManager.ChangeFocus(Drawable)"/> to a drawable of a non-present parent returns <see langword="false"/>.
         /// </summary>
         [Test]
         public void DrawableOfNotPresentParentCannotReceiveFocusViaChangeFocus()
@@ -183,7 +183,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 Remove(focusTopLeft, false);
                 container.Add(focusTopLeft);
             });
-            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+            AddAssert("cannot switch focus to top left", () => !((IFocusManager)InputManager).ChangeFocus(focusTopLeft));
 
             checkFocused(() => requestingFocus);
         }

--- a/osu.Framework.Tests/Visual/Input/TestSceneHandleInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneHandleInput.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
@@ -37,7 +38,7 @@ namespace osu.Framework.Tests.Visual.Input
             {
                 handleNonPositionalInput.Enabled = true;
                 InputManager.MoveMouseTo(handleNonPositionalInput);
-                InputManager.TriggerFocusContention(null);
+                ((IFocusManager)InputManager).TriggerFocusContention(null);
             });
             AddAssert($"check {nameof(handleNonPositionalInput)}", () => !handleNonPositionalInput.IsHovered && handleNonPositionalInput.HasFocus);
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -13,6 +14,8 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Testing;
 using osu.Framework.Testing.Input;
@@ -543,6 +546,90 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("search bar hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
         }
 
+        [Test]
+        public void TestKeyBindingIsolation()
+        {
+            ManualTextDropdown dropdown = null!;
+            TestKeyBindingHandler keyBindingHandler = null!;
+
+            AddStep("setup dropdown", () =>
+            {
+                dropdown = createDropdowns<ManualTextDropdown>(1)[0];
+                dropdown.AlwaysShowSearchBar = true;
+            });
+
+            AddStep("setup key binding handler", () =>
+            {
+                Add(new TestKeyBindingContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = keyBindingHandler = new TestKeyBindingHandler
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                });
+            });
+
+            AddAssert("search bar hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+            toggleDropdownViaClick(() => dropdown);
+
+            AddStep("press space", () =>
+            {
+                InputManager.Key(Key.Space);
+                // we must send something via the text input path for TextBox to block the space key press above,
+                // we're not supposed to do this here, but we don't have a good way of simulating text input from ManualInputManager so let's just do this for now.
+                // todo: add support for simulating text typing at a ManualInputManager level for more realistic results.
+                dropdown.TextInput.Text(" ");
+            });
+            AddAssert("handler did not receive press", () => !keyBindingHandler.ReceivedPress);
+
+            toggleDropdownViaClick(() => dropdown);
+
+            AddStep("press space", () =>
+            {
+                InputManager.Key(Key.Space);
+                // we must send something via the text input path for TextBox to block the space key press above,
+                // we're not supposed to do this here, but we don't have a good way of simulating text input from ManualInputManager so let's just do this for now.
+                dropdown.TextInput.Text(" ");
+            });
+            AddAssert("handler did not receive press", () => !keyBindingHandler.ReceivedPress);
+        }
+
+        [Test]
+        public void TestMouseFromTouch()
+        {
+            ManualTextDropdown dropdown = null!;
+            TestClickHandler clickHandler = null!;
+
+            AddStep("setup dropdown", () =>
+            {
+                dropdown = createDropdowns<ManualTextDropdown>(1)[0];
+                dropdown.AlwaysShowSearchBar = true;
+            });
+
+            AddStep("setup click handler", () => Add(clickHandler = new TestClickHandler
+            {
+                RelativeSizeAxes = Axes.Both
+            }));
+
+            AddAssert("search bar hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddStep("begin touch", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, dropdown.Header.ScreenSpaceDrawQuad.Centre)));
+            AddStep("end touch", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, dropdown.Header.ScreenSpaceDrawQuad.Centre)));
+
+            AddAssert("search bar still hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("handler received click", () => clickHandler.ReceivedClick);
+
+            AddStep("type something", () => dropdown.TextInput.Text("something"));
+            AddAssert("search bar still hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("search bar empty", () => dropdown.Header.SearchTerm.Value, () => Is.Null.Or.Empty);
+
+            AddStep("hide click handler", () => clickHandler.Hide());
+            AddStep("begin touch", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, dropdown.Header.ScreenSpaceDrawQuad.Centre)));
+            AddStep("end touch", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, dropdown.Header.ScreenSpaceDrawQuad.Centre)));
+
+            AddAssert("search bar visible", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
         #endregion
 
         private TestDropdown createDropdown() => createDropdowns(1).Single();
@@ -646,6 +733,45 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 Assert.That(text, Is.Not.Null);
                 return $"{text}: {base.GenerateItemText(item)}";
             }
+        }
+
+        private partial class TestKeyBindingContainer : KeyBindingContainer<TestAction>
+        {
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
+            {
+                new KeyBinding(InputKey.Space, TestAction.SpaceAction)
+            };
+        }
+
+        private partial class TestKeyBindingHandler : Drawable, IKeyBindingHandler<TestAction>
+        {
+            public bool ReceivedPress;
+
+            public bool OnPressed(KeyBindingPressEvent<TestAction> e)
+            {
+                ReceivedPress = true;
+                return true;
+            }
+
+            public void OnReleased(KeyBindingReleaseEvent<TestAction> e)
+            {
+            }
+        }
+
+        private partial class TestClickHandler : Drawable
+        {
+            public bool ReceivedClick;
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                ReceivedClick = true;
+                return true;
+            }
+        }
+
+        private enum TestAction
+        {
+            SpaceAction,
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -488,6 +488,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestAfterSelectingSearchedItem()
+        {
+            ManualTextDropdown dropdown = null!;
+
+            AddStep("setup dropdown", () => dropdown = createDropdowns<ManualTextDropdown>(1)[0]);
+            toggleDropdownViaClick(() => dropdown);
+
+            AddStep("trigger text", () => dropdown.TextInput.Text("test 4"));
+            AddAssert("search bar visible", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+
+            AddStep("press enter", () => InputManager.Key(Key.Enter));
+            AddAssert("search bar hidden", () => dropdown.ChildrenOfType<DropdownSearchBar>().Single().State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("dropdown closed", () => dropdown.Menu.State == MenuState.Closed);
+        }
+
+        [Test]
         public void TestAlwaysShowSearchBar()
         {
             ManualTextDropdown dropdown = null!;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -491,7 +491,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestAfterSelectingSearchedItem()
+        public void TestSelectSearchedItem()
         {
             ManualTextDropdown dropdown = null!;
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
@@ -395,7 +396,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
             AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any());
 
-            AddStep("take away text box focus", () => InputManager.ChangeFocus(null));
+            AddStep("take away text box focus", () => ((IFocusManager)InputManager).ChangeFocus(null));
             AddAssert("popover hidden", () => !this.ChildrenOfType<Popover>().Any());
         }
 

--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -22,11 +22,11 @@ namespace osu.Framework.Graphics.Containers
             {
                 case Visibility.Hidden:
                     if (HasFocus)
-                        GetContainingInputManager().ChangeFocus(null);
+                        GetContainingFocusManager().ChangeFocus(null);
                     break;
 
                 case Visibility.Visible:
-                    Schedule(() => GetContainingInputManager().TriggerFocusContention(this));
+                    Schedule(() => GetContainingFocusManager().TriggerFocusContention(this));
                     break;
             }
         }

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
                 return false;
 
             var nextTab = nextTabStop(TabbableContentContainer, e.ShiftPressed);
-            if (nextTab != null) GetContainingInputManager().ChangeFocus(nextTab);
+            if (nextTab != null) GetContainingFocusManager().ChangeFocus(nextTab);
             return true;
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1492,6 +1492,8 @@ namespace osu.Framework.Graphics
         /// <returns>The first parent <see cref="InputManager"/>.</returns>
         protected InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
 
+        protected IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
+
         private CompositeDrawable parent;
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1492,6 +1492,11 @@ namespace osu.Framework.Graphics
         /// <returns>The first parent <see cref="InputManager"/>.</returns>
         protected InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
 
+        /// <summary>
+        /// Retrieve the first parent in the tree which implements <see cref="IFocusManager"/>.
+        /// As this is performing an upward tree traversal, avoid calling every frame.
+        /// </summary>
+        /// <returns>The first parent <see cref="IFocusManager"/>.</returns>
         protected IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
 
         private CompositeDrawable parent;

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -25,57 +25,6 @@ using osuTK.Input;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    internal interface IDropdown
-    {
-        event Action<MenuState> MenuStateChanged;
-
-        /// <summary>
-        /// Whether the dropdown is currently enabled.
-        /// </summary>
-        IBindable<bool> Enabled { get; }
-
-        /// <summary>
-        /// The current menu state.
-        /// </summary>
-        MenuState MenuState { get; }
-
-        /// <summary>
-        /// Toggles the menu.
-        /// </summary>
-        void ToggleMenu();
-
-        /// <summary>
-        /// Shows the menu.
-        /// </summary>
-        void ShowMenu();
-
-        /// <summary>
-        /// Hides the menu.
-        /// </summary>
-        void HideMenu();
-
-        /// <summary>
-        /// Commits the current pre-selected value.
-        /// </summary>
-        void CommitPreselection();
-
-        /// <summary>
-        /// Triggers focus contention on the parenting <see cref="IFocusManager"/>.
-        /// </summary>
-        /// <remarks>
-        /// Focus management is isolated by the <see cref="Dropdown{T}"/>. This invokes the method on the parenting <see cref="IFocusManager"/> un-interrupted.
-        /// </remarks>
-        void TriggerFocusContention(Drawable triggerSource);
-
-        /// <summary>
-        /// Triggers a change of focus on the parenting <see cref="IFocusManager"/>.
-        /// </summary>
-        /// <remarks>
-        /// Focus management is isolated by the <see cref="Dropdown{T}"/>. This invokes the method on the parenting <see cref="IFocusManager"/> un-interrupted.
-        /// </remarks>
-        bool ChangeFocus(Drawable potentialFocusTarget);
-    }
-
     /// <summary>
     /// A drop-down menu to select from a group of values.
     /// </summary>
@@ -833,6 +782,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         #endregion
 
+        #region IFocusManager
+
         Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
 
         // Isolate input so that the Menu doesn't disturb focus. Focus is managed via the IDropdown interface.
@@ -840,6 +791,10 @@ namespace osu.Framework.Graphics.UserInterface
 
         // Isolate input so that the Menu doesn't disturb focus. Focus is managed via the IDropdown interface.
         bool IFocusManager.ChangeFocus(Drawable potentialFocusTarget) => false;
+
+        #endregion
+
+        #region IDropdown
 
         event Action<MenuState> IDropdown.MenuStateChanged
         {
@@ -857,13 +812,13 @@ namespace osu.Framework.Graphics.UserInterface
                 Menu.Toggle();
         }
 
-        void IDropdown.ShowMenu()
+        void IDropdown.OpenMenu()
         {
             if (!Current.Disabled)
                 Menu.State = MenuState.Open;
         }
 
-        void IDropdown.HideMenu()
+        void IDropdown.CloseMenu()
         {
             if (!Current.Disabled)
                 Menu.State = MenuState.Closed;
@@ -888,5 +843,7 @@ namespace osu.Framework.Graphics.UserInterface
         void IDropdown.TriggerFocusContention(Drawable triggerSource) => GetContainingFocusManager().TriggerFocusContention(triggerSource);
 
         bool IDropdown.ChangeFocus(Drawable potentialFocusTarget) => GetContainingFocusManager().ChangeFocus(potentialFocusTarget);
+
+        #endregion
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -268,6 +268,7 @@ namespace osu.Framework.Graphics.UserInterface
             Current.ValueChanged += val => Scheduler.AddOnce(updateItemSelection, val.NewValue);
             Current.DisabledChanged += disabled =>
             {
+                enabled.Value = !disabled;
                 if (disabled && Menu.State == MenuState.Open)
                     Menu.State = MenuState.Closed;
             };

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -785,8 +785,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         #region IFocusManager
 
-        Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
-
         // Isolate input so that the Menu doesn't disturb focus. Focus is managed via the IDropdown interface.
         void IFocusManager.TriggerFocusContention(Drawable triggerSource) { }
 

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -252,7 +252,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Children = new Drawable[]
                 {
                     Header = CreateHeader(),
-                    Menu = CreateMenu().With(d => d.Depth = -1)
+                    Menu = CreateMenu()
                 },
                 Direction = FillDirection.Vertical,
                 RelativeSizeAxes = Axes.X,

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -65,8 +65,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         public BindableBool Enabled { get; } = new BindableBool(true);
 
-        public Action ToggleMenu;
-
         protected DropdownHeader()
         {
             Masking = true;
@@ -108,15 +106,6 @@ namespace osu.Framework.Graphics.UserInterface
             Enabled.BindValueChanged(_ => updateState(), true);
         }
 
-        protected override bool OnClick(ClickEvent e)
-        {
-            if (!Enabled.Value)
-                return false;
-
-            ToggleMenu?.Invoke();
-            return false;
-        }
-
         protected override bool OnHover(HoverEvent e)
         {
             updateState();
@@ -127,14 +116,6 @@ namespace osu.Framework.Graphics.UserInterface
         {
             updateState();
             base.OnHoverLost(e);
-        }
-
-        public void UpdateSearchBarFocus(MenuState state)
-        {
-            if (state == MenuState.Open)
-                SearchBar.ObtainFocus();
-            else
-                SearchBar.ReleaseFocus();
         }
 
         private void updateState()

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -5,6 +5,7 @@
 
 using osuTK.Graphics;
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -63,7 +64,10 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected internal abstract LocalisableString Label { get; set; }
 
-        public BindableBool Enabled { get; } = new BindableBool(true);
+        private readonly IBindable<bool> enabled = new Bindable<bool>(true);
+
+        [Resolved]
+        private IDropdown dropdown { get; set; } = null!;
 
         protected DropdownHeader()
         {
@@ -103,7 +107,8 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            Enabled.BindValueChanged(_ => updateState(), true);
+            enabled.BindTo(dropdown.Enabled);
+            enabled.BindValueChanged(_ => updateState(), true);
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -120,15 +125,15 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void updateState()
         {
-            Colour = Enabled.Value ? Color4.White : DisabledColour;
-            Background.Colour = IsHovered && Enabled.Value ? BackgroundColourHover : BackgroundColour;
+            Colour = enabled.Value ? Color4.White : DisabledColour;
+            Background.Colour = IsHovered && enabled.Value ? BackgroundColourHover : BackgroundColour;
         }
 
         public override bool HandleNonPositionalInput => IsHovered;
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (!Enabled.Value)
+            if (!enabled.Value)
                 return true;
 
             switch (e.Key)
@@ -148,7 +153,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
         {
-            if (!Enabled.Value)
+            if (!enabled.Value)
                 return true;
 
             switch (e.Action)

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected internal abstract LocalisableString Label { get; set; }
 
-        private readonly IBindable<bool> enabled = new Bindable<bool>(true);
+        public readonly IBindable<bool> Enabled = new Bindable<bool>(true);
 
         [Resolved]
         private IDropdown dropdown { get; set; } = null!;
@@ -107,8 +107,8 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            enabled.BindTo(dropdown.Enabled);
-            enabled.BindValueChanged(_ => updateState(), true);
+            Enabled.BindTo(dropdown.Enabled);
+            Enabled.BindValueChanged(_ => updateState(), true);
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -125,15 +125,15 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void updateState()
         {
-            Colour = enabled.Value ? Color4.White : DisabledColour;
-            Background.Colour = IsHovered && enabled.Value ? BackgroundColourHover : BackgroundColour;
+            Colour = Enabled.Value ? Color4.White : DisabledColour;
+            Background.Colour = IsHovered && Enabled.Value ? BackgroundColourHover : BackgroundColour;
         }
 
         public override bool HandleNonPositionalInput => IsHovered;
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (!enabled.Value)
+            if (!Enabled.Value)
                 return true;
 
             switch (e.Key)
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
         {
-            if (!enabled.Value)
+            if (!Enabled.Value)
                 return true;
 
             switch (e.Action)

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -157,8 +157,6 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected abstract TextBox CreateTextBox();
 
-        Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
-
         void IFocusManager.TriggerFocusContention(Drawable? triggerSource)
         {
             // Clear search text first without releasing focus.

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -176,8 +176,24 @@ namespace osu.Framework.Graphics.UserInterface
 
         // Focus management is isolated to the IDropdown interface by Dropdown.
         Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
-        void IFocusManager.TriggerFocusContention(Drawable? triggerSource) => dropdown.TriggerFocusContention(triggerSource);
-        bool IFocusManager.ChangeFocus(Drawable? potentialFocusTarget) => dropdown.ChangeFocus(potentialFocusTarget);
+
+        void IFocusManager.TriggerFocusContention(Drawable? triggerSource)
+        {
+            // Clear search text first without releasing focus.
+            if (Back())
+                return;
+
+            dropdown.TriggerFocusContention(triggerSource);
+        }
+
+        bool IFocusManager.ChangeFocus(Drawable? potentialFocusTarget)
+        {
+            // Clear search text first without releasing focus.
+            if (Back())
+                return false;
+
+            return dropdown.ChangeFocus(potentialFocusTarget);
+        }
 
         private partial class ClickHandler : Drawable
         {

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -59,7 +59,6 @@ namespace osu.Framework.Graphics.UserInterface
             };
 
             dropdown.MenuStateChanged += onMenuStateChanged;
-            dropdown.Enabled.BindValueChanged(onDropdownEnabledChanged);
         }
 
         protected override void LoadComplete()
@@ -124,19 +123,16 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private void onMenuStateChanged(MenuState state)
         {
-            // Reset states when the menu is closed via external means.
+            // Reset states when the menu is closed by any means.
             if (state == MenuState.Closed)
-                resetState();
-        }
+            {
+                SearchTerm.Value = string.Empty;
 
-        /// <summary>
-        /// Handles changes to dropdown enablement.
-        /// </summary>
-        private void onDropdownEnabledChanged(ValueChangedEvent<bool> enabled)
-        {
-            // Reset states when the dropdown is disabled.
-            if (!enabled.NewValue)
-                resetState();
+                if (textBox.HasFocus)
+                    dropdown.ChangeFocus(null);
+
+                dropdown.CloseMenu();
+            }
         }
 
         /// <summary>
@@ -157,24 +153,10 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Un-focuses the textbox, clears the search term, and closes the menu.
-        /// </summary>
-        private void resetState()
-        {
-            SearchTerm.Value = string.Empty;
-
-            if (textBox.HasFocus)
-                dropdown.ChangeFocus(null);
-
-            dropdown.CloseMenu();
-        }
-
-        /// <summary>
         /// Creates the <see cref="TextBox"/>.
         /// </summary>
         protected abstract TextBox CreateTextBox();
 
-        // Focus management is isolated to the IDropdown interface by Dropdown.
         Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
 
         void IFocusManager.TriggerFocusContention(Drawable? triggerSource)

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -1,10 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
+using osu.Framework.Input.Events;
 using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
@@ -39,17 +41,36 @@ namespace osu.Framework.Graphics.UserInterface
             RelativeSizeAxes = Axes.Both;
             AlwaysPresent = true;
 
-            InternalChild = textBox = CreateTextBox().With(t =>
+            InternalChildren = new Drawable[]
             {
-                t.ReleaseFocusOnCommit = false;
-                t.RelativeSizeAxes = Axes.Both;
-                t.Size = new Vector2(1f);
-                t.Current = SearchTerm;
+                textBox = CreateTextBox().With(t =>
+                {
+                    t.RelativeSizeAxes = Axes.Both;
+                    t.Size = new Vector2(1f);
+                    t.Current = SearchTerm;
+                    t.ReleaseFocusOnCommit = true;
+                    t.CommitOnFocusLost = false;
+                    t.OnCommit += (_, _) => dropdown.CommitPreselection();
+                }),
+                new ClickHandler
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Click = onClick
+                }
+            };
+
+            dropdown.MenuStateChanged += state =>
+            {
+                if (state == MenuState.Closed && textBox.HasFocus)
+                    dropdown.ChangeFocus(null);
+            };
+
+            dropdown.Enabled.BindValueChanged(enabled =>
+            {
+                if (!enabled.NewValue && textBox.HasFocus)
+                    dropdown.ChangeFocus(null);
             });
         }
-
-        // Override to remove the visibility check. This element is always present even though it may not be physically visible on the screen.
-        public override bool PropagatePositionalInputSubTree => IsPresent && RequestsPositionalInputSubTree && !IsMaskedAway;
 
         protected override void LoadComplete()
         {
@@ -58,6 +79,11 @@ namespace osu.Framework.Graphics.UserInterface
             SearchTerm.BindValueChanged(v => updateVisibility());
             updateVisibility();
         }
+
+        public override bool PropagateNonPositionalInputSubTree => dropdown.Enabled.Value && base.PropagateNonPositionalInputSubTree;
+
+        // Importantly, this also removes the visibility condition of the base implementation - this element is always present even though it may not be physically visible on the screen.
+        public override bool PropagatePositionalInputSubTree => dropdown.Enabled.Value && RequestsPositionalInputSubTree && !IsMaskedAway;
 
         protected override void Update()
         {
@@ -72,11 +98,15 @@ namespace osu.Framework.Graphics.UserInterface
 
             hasFocus = textBox.HasFocus;
 
+            if (hasFocus)
+                dropdown.ShowMenu();
+            else
+                dropdown.HideMenu();
+
             if (!hasFocus)
                 SearchTerm.Value = string.Empty;
 
             updateVisibility();
-            dropdown.ToggleMenu();
         }
 
         public bool Back()
@@ -99,12 +129,32 @@ namespace osu.Framework.Graphics.UserInterface
                 : Visibility.Hidden;
         }
 
+        private bool onClick(ClickEvent e)
+        {
+            // Always allow input to fall through if the textbox is visible.
+            if (State.Value == Visibility.Visible)
+                return false;
+
+            // Otherwise, the search box acts as a hook to show/hide the menu.
+            dropdown.ToggleMenu();
+
+            // Importantly, when the menu is closed as a result of the above toggle,
+            // block the textbox from receiving input so that it doesn't get re-focused.
+            return dropdown.MenuState == MenuState.Closed;
+        }
+
         protected abstract TextBox CreateTextBox();
 
+        // Focus management is isolated to the IDropdown interface by Dropdown.
         Drawable IFocusManager.FocusedDrawable => GetContainingFocusManager().FocusedDrawable;
-
         void IFocusManager.TriggerFocusContention(Drawable? triggerSource) => dropdown.TriggerFocusContention(triggerSource);
+        bool IFocusManager.ChangeFocus(Drawable? potentialFocusTarget) => dropdown.ChangeFocus(potentialFocusTarget);
 
-        public bool ChangeFocus(Drawable? potentialFocusTarget) => dropdown.ChangeFocus(potentialFocusTarget);
+        private partial class ClickHandler : Drawable
+        {
+            public required Func<ClickEvent, bool> Click { get; init; }
+
+            protected override bool OnClick(ClickEvent e) => Click(e);
+        }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -116,7 +116,11 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Handles textbox commits to select the current item.
         /// </summary>
-        private void onTextBoxCommit(TextBox sender, bool newText) => dropdown.CommitPreselection();
+        private void onTextBoxCommit(TextBox sender, bool newText)
+        {
+            dropdown.CommitPreselection();
+            dropdown.CloseMenu();
+        }
 
         /// <summary>
         /// Handles changes to the menu visibility.

--- a/osu.Framework/Graphics/UserInterface/IDropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/IDropdown.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Input;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    internal interface IDropdown
+    {
+        /// <summary>
+        /// An event that occurs when the menu state changes.
+        /// </summary>
+        event Action<MenuState> MenuStateChanged;
+
+        /// <summary>
+        /// Whether the dropdown is currently enabled.
+        /// </summary>
+        IBindable<bool> Enabled { get; }
+
+        /// <summary>
+        /// The current menu state.
+        /// </summary>
+        MenuState MenuState { get; }
+
+        /// <summary>
+        /// Toggles the menu.
+        /// </summary>
+        void ToggleMenu();
+
+        /// <summary>
+        /// Opens the menu.
+        /// </summary>
+        void OpenMenu();
+
+        /// <summary>
+        /// Closes the menu.
+        /// </summary>
+        void CloseMenu();
+
+        /// <summary>
+        /// Commits the current pre-selected value.
+        /// </summary>
+        void CommitPreselection();
+
+        /// <summary>
+        /// Triggers focus contention on the parenting <see cref="IFocusManager"/>.
+        /// </summary>
+        /// <remarks>
+        /// Focus management is isolated by the <see cref="Dropdown{T}"/>. This invokes the method on the parenting <see cref="IFocusManager"/> un-interrupted.
+        /// </remarks>
+        void TriggerFocusContention(Drawable? triggerSource);
+
+        /// <summary>
+        /// Triggers a change of focus on the parenting <see cref="IFocusManager"/>.
+        /// </summary>
+        /// <remarks>
+        /// Focus management is isolated by the <see cref="Dropdown{T}"/>. This invokes the method on the parenting <see cref="IFocusManager"/> un-interrupted.
+        /// </remarks>
+        bool ChangeFocus(Drawable? potentialFocusTarget);
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -249,7 +249,7 @@ namespace osu.Framework.Graphics.UserInterface
                     AnimateClose();
 
                     if (HasFocus)
-                        GetContainingInputManager()?.ChangeFocus(parentMenu);
+                        GetContainingFocusManager()?.ChangeFocus(parentMenu);
                     break;
 
                 case MenuState.Open:
@@ -262,7 +262,7 @@ namespace osu.Framework.Graphics.UserInterface
                     {
                         Schedule(delegate
                         {
-                            if (State == MenuState.Open) GetContainingInputManager().ChangeFocus(this);
+                            if (State == MenuState.Open) GetContainingFocusManager().ChangeFocus(this);
                         });
                     }
 
@@ -570,7 +570,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (item.Item.Items.Count > 0)
             {
                 if (submenu.State == MenuState.Open)
-                    Schedule(delegate { GetContainingInputManager().ChangeFocus(submenu); });
+                    Schedule(delegate { GetContainingFocusManager().ChangeFocus(submenu); });
                 else
                     submenu.Open();
             }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1154,9 +1154,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void killFocus()
         {
-            var manager = GetContainingFocusManager();
-            if (manager?.FocusedDrawable == this)
-                manager.ChangeFocus(null);
+            if (GetContainingInputManager()?.FocusedDrawable == this)
+                GetContainingFocusManager()?.ChangeFocus(null);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1154,7 +1154,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void killFocus()
         {
-            var manager = GetContainingInputManager();
+            var manager = GetContainingFocusManager();
             if (manager?.FocusedDrawable == this)
                 manager.ChangeFocus(null);
         }
@@ -1224,7 +1224,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 selectionEnd = getCharacterClosestTo(e.MousePosition);
                 if (hasSelection)
-                    GetContainingInputManager().ChangeFocus(this);
+                    GetContainingFocusManager().ChangeFocus(this);
             }
 
             cursorAndLayout.Invalidate();

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
@@ -535,7 +536,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             OnCommit = null;
 
-            unbindInput(false);
+            unbindInput(null);
 
             base.Dispose(isDisposing);
         }
@@ -1315,7 +1316,7 @@ namespace osu.Framework.Graphics.UserInterface
             // let's say that a focus loss is not a user event as focus is commonly indirectly lost.
             FinalizeImeComposition(false);
 
-            unbindInput(e.NextFocused is TextBox);
+            unbindInput(e.NextFocused as TextBox);
 
             updateCaretVisibility();
 
@@ -1335,7 +1336,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override void OnFocus(FocusEvent e)
         {
-            bindInput(e.PreviouslyFocused is TextBox);
+            bindInput(e.PreviouslyFocused as TextBox);
 
             updateCaretVisibility();
         }
@@ -1349,8 +1350,10 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private bool textInputBound;
 
-        private void bindInput(bool previousFocusWasTextBox)
+        private void bindInput([CanBeNull] TextBox previous)
         {
+            Debug.Assert(textInput != null);
+
             if (textInputBound)
             {
                 textInput.EnsureActivated(AllowIme);
@@ -1360,7 +1363,7 @@ namespace osu.Framework.Graphics.UserInterface
             // TextBox has special handling of text input activation when focus is changed directly from one TextBox to another.
             // We don't deactivate and activate, but instead keep text input active during the focus handoff, so that virtual keyboards on phones don't flicker.
 
-            if (previousFocusWasTextBox)
+            if (previous?.textInput == textInput)
                 textInput.EnsureActivated(AllowIme, ScreenSpaceDrawQuad.AABBFloat);
             else
                 textInput.Activate(AllowIme, ScreenSpaceDrawQuad.AABBFloat);
@@ -1372,15 +1375,17 @@ namespace osu.Framework.Graphics.UserInterface
             textInputBound = true;
         }
 
-        private void unbindInput(bool nextFocusIsTextBox)
+        private void unbindInput([CanBeNull] TextBox next)
         {
+            Debug.Assert(textInput != null);
+
             if (!textInputBound)
                 return;
 
             textInputBound = false;
 
             // see the comment above, in `bindInput(bool)`.
-            if (!nextFocusIsTextBox)
+            if (next?.textInput != textInput)
                 textInput.Deactivate();
 
             textInput.OnTextInput -= handleTextInput;

--- a/osu.Framework/Input/IFocusManager.cs
+++ b/osu.Framework/Input/IFocusManager.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Input
+{
+    public interface IFocusManager : IDrawable
+    {
+        /// <summary>
+        /// The currently focused <see cref="Drawable"/>. Null if there is no current focus.
+        /// </summary>
+        Drawable FocusedDrawable { get; }
+
+        /// <summary>
+        /// Reset current focused drawable to the top-most drawable which is <see cref="Drawable.RequestsFocus"/>.
+        /// </summary>
+        /// <param name="triggerSource">The source which triggered this event.</param>
+        void TriggerFocusContention(Drawable? triggerSource);
+
+        /// <summary>
+        /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
+        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <paramref name="potentialFocusTarget"/>.
+        /// <paramref name="potentialFocusTarget"/> can be null to reset focus.
+        /// If the given drawable is already focused, nothing happens and no events are fired.
+        /// </summary>
+        /// <param name="potentialFocusTarget">The drawable to become focused.</param>
+        /// <returns>True if the given drawable is now focused (or focus is dropped in the case of a null target).</returns>
+        bool ChangeFocus(Drawable? potentialFocusTarget);
+    }
+}

--- a/osu.Framework/Input/IFocusManager.cs
+++ b/osu.Framework/Input/IFocusManager.cs
@@ -8,11 +8,6 @@ namespace osu.Framework.Input
     public interface IFocusManager : IDrawable
     {
         /// <summary>
-        /// The currently focused <see cref="Drawable"/>. Null if there is no current focus.
-        /// </summary>
-        Drawable FocusedDrawable { get; }
-
-        /// <summary>
         /// Reset current focused drawable to the top-most drawable which is <see cref="Drawable.RequestsFocus"/>.
         /// </summary>
         /// <param name="triggerSource">The source which triggered this event.</param>
@@ -20,7 +15,7 @@ namespace osu.Framework.Input
 
         /// <summary>
         /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
-        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <paramref name="potentialFocusTarget"/>.
+        /// then unfocuses the current <see cref="InputManager.FocusedDrawable"/> and focuses <paramref name="potentialFocusTarget"/>.
         /// <paramref name="potentialFocusTarget"/> can be null to reset focus.
         /// If the given drawable is already focused, nothing happens and no events are fired.
         /// </summary>

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -31,7 +31,7 @@ using MouseState = osu.Framework.Input.States.MouseState;
 
 namespace osu.Framework.Input
 {
-    public abstract partial class InputManager : Container, IInputStateChangeHandler
+    public abstract partial class InputManager : Container, IInputStateChangeHandler, IFocusManager
     {
         /// <summary>
         /// The initial delay before key repeat begins.

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -366,17 +366,17 @@ namespace osu.Framework.Input
             return joystickAxisEventManagers[source] = manager;
         }
 
-        /// <summary>
-        /// Reset current focused drawable to the top-most drawable which is <see cref="Drawable.RequestsFocus"/>.
-        /// </summary>
-        /// <param name="triggerSource">The source which triggered this event.</param>
+        [Obsolete("This method does not allow trapping focus. Use GetContainingFocusManager().TriggerFocusContention instead.")] // Can be removed 20241118
         public void TriggerFocusContention(Drawable triggerSource)
         {
             if (FocusedDrawable == null) return;
 
             Logger.Log($"Focus contention triggered by {triggerSource}.");
-            ChangeFocus(null);
+            changeFocus(null);
         }
+
+        [Obsolete("This method does not allow trapping focus. Use GetContainingFocusManager().ChangeFocus() instead.")] // Can be removed 20241118
+        public bool ChangeFocus(Drawable potentialFocusTarget) => changeFocus(potentialFocusTarget);
 
         /// <summary>
         /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
@@ -386,7 +386,7 @@ namespace osu.Framework.Input
         /// </summary>
         /// <param name="potentialFocusTarget">The drawable to become focused.</param>
         /// <returns>True if the given drawable is now focused (or focus is dropped in the case of a null target).</returns>
-        public bool ChangeFocus(Drawable potentialFocusTarget) => ChangeFocus(potentialFocusTarget, CurrentState);
+        private bool changeFocus(Drawable potentialFocusTarget) => ChangeFocus(potentialFocusTarget, CurrentState);
 
         /// <summary>
         /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
@@ -1031,7 +1031,7 @@ namespace osu.Framework.Input
                 return false;
 
             Logger.Log($"Focus on \"{FocusedDrawable}\" no longer valid as a result of {nameof(unfocusIfNoLongerValid)}.", LoggingTarget.Runtime, LogLevel.Debug);
-            ChangeFocus(null);
+            changeFocus(null);
             return true;
         }
 
@@ -1090,7 +1090,7 @@ namespace osu.Framework.Input
                 }
             }
 
-            ChangeFocus(focusTarget);
+            changeFocus(focusTarget);
         }
 
         private void focusTopMostRequestingDrawable()
@@ -1100,12 +1100,12 @@ namespace osu.Framework.Input
             {
                 if (d.RequestsFocus)
                 {
-                    ChangeFocus(d);
+                    changeFocus(d);
                     return;
                 }
             }
 
-            ChangeFocus(null);
+            changeFocus(null);
         }
 
         private class MouseLeftButtonEventManager : MouseButtonEventManager

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -324,7 +324,7 @@ namespace osu.Framework.Testing
             {
                 case TestBrowserAction.Search:
                     if (leftContainer.Width == 0) toggleTestList();
-                    GetContainingInputManager().ChangeFocus(searchTextBox);
+                    GetContainingFocusManager().ChangeFocus(searchTextBox);
                     return true;
 
                 case TestBrowserAction.Reload:


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/25769
Fixes https://github.com/ppy/osu/issues/26079 (likely)
Supersedes / closes https://github.com/ppy/osu-framework/pull/6095
Closes https://github.com/ppy/osu-framework/pull/6097 (note that https://github.com/ppy/osu/issues/25850 is likely not fixed by this and will need reimplementation)

By extracting focus-management logic out of `InputManager`, we can implement something akin to a focus trap. Components can trap the focus management (`ChangeFocus()`/`TriggerFocusContention()`) of their subcomponents to add supplementary logic.

This PR features a partial redesign of `Dropdown` making use of this. There are two components wanting to manage focus here - the `Menu` and the `TextBox`.
- The `Menu`'s focus is trapped by `Dropdown` and reduced to a no-op.
- The `TextBox`'s focus is trapped within `DropdownSearchBox` to perform additional functionality such as opening the dropdown on focus, selecting items on commit, clearing text on escape, etc.

This is not a breaking change, but I've obsoleted `InputManager.TriggerFocusContention()` and `InputManager.ChangeFocus()` partially to make this easy to test.