### PR TITLE
Avoid colour space conversion when multiplying `SRGBColour` by white

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkSRGBColourMultiplication.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSRGBColourMultiplication.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics.Colour;
+using osuTK.Graphics;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkSRGBColourMultiplication : BenchmarkTest
+    {
+        private static readonly SRGBColour white = new SRGBColour
+        {
+            SRGB = new Color4(1f, 1f, 1f, 1f)
+        };
+
+        private static readonly SRGBColour white_with_opacity = new SRGBColour
+        {
+            SRGB = new Color4(1f, 1f, 1f, 0.5f)
+        };
+
+        private static readonly SRGBColour gray = new SRGBColour
+        {
+            SRGB = Color4.Gray
+        };
+
+        private static readonly SRGBColour gray_light = new SRGBColour
+        {
+            SRGB = Color4.LightGray
+        };
+
+        [Benchmark]
+        public SRGBColour MultiplyNonWhite()
+        {
+            return gray * gray_light;
+        }
+
+        [Benchmark]
+        public SRGBColour MultiplyWhite()
+        {
+            return gray * white;
+        }
+
+        [Benchmark]
+        public SRGBColour MultiplyWhiteWithOpacity()
+        {
+            return gray * white_with_opacity;
+        }
+
+        [Benchmark]
+        public SRGBColour MultiplyConstOne()
+        {
+            return gray * 1;
+        }
+
+        [Benchmark]
+        public SRGBColour MultiplyConstNonOne()
+        {
+            return gray * 0.5f;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -39,6 +39,36 @@ namespace osu.Framework.Graphics.Colour
 
         public static SRGBColour operator *(SRGBColour first, SRGBColour second)
         {
+            if (isWhite(first))
+            {
+                if (first.Alpha == 1)
+                    return second;
+
+                return new SRGBColour
+                {
+                    SRGB = new Color4(
+                        second.SRGB.R,
+                        second.SRGB.G,
+                        second.SRGB.B,
+                        first.Alpha * second.Alpha)
+                };
+            }
+
+            if (isWhite(second))
+            {
+                if (second.Alpha == 1)
+                    return first;
+
+                return new SRGBColour
+                {
+                    SRGB = new Color4(
+                        first.SRGB.R,
+                        first.SRGB.G,
+                        first.SRGB.B,
+                        first.Alpha * second.Alpha)
+                };
+            }
+
             var firstLinear = first.Linear;
             var secondLinear = second.Linear;
 
@@ -54,6 +84,9 @@ namespace osu.Framework.Graphics.Colour
 
         public static SRGBColour operator *(SRGBColour first, float second)
         {
+            if (second == 1)
+                return first;
+
             var firstLinear = first.Linear;
 
             return new SRGBColour
@@ -91,6 +124,8 @@ namespace osu.Framework.Graphics.Colour
         /// </summary>
         /// <param name="alpha">The alpha factor to multiply with.</param>
         public void MultiplyAlpha(float alpha) => SRGB.A *= alpha;
+
+        private static bool isWhite(SRGBColour colour) => colour.SRGB.R == 1 && colour.SRGB.G == 1 && colour.SRGB.B == 1;
 
         public readonly bool Equals(SRGBColour other) => SRGB.Equals(other.SRGB);
         public override string ToString() => $"srgb: {SRGB}, linear: {Linear}";


### PR DESCRIPTION
Part of https://github.com/ppy/osu-framework/pull/6284.
Useful when computing `ColourInfo` of drawables which have white colour while applying colour to the parent (or changing parent's alpha).
Example would be applying colour/alpha to the tree of nested containers. In master some time will be spent computing colour on each level, but since by default they have white colour, we will basically passing it down to the children without conversions.
# Benchmark
master:
```
|                   Method |      Mean |    Error |   StdDev | Allocated |
|------------------------- |----------:|---------:|---------:|----------:|
|         MultiplyNonWhite | 140.09 ns | 0.385 ns | 0.341 ns |         - |
|            MultiplyWhite | 102.45 ns | 0.242 ns | 0.189 ns |         - |
| MultiplyWhiteWithOpacity | 102.51 ns | 0.221 ns | 0.173 ns |         - |
|         MultiplyConstOne |  96.63 ns | 0.176 ns | 0.165 ns |         - |
|      MultiplyConstNonOne |  97.18 ns | 0.269 ns | 0.225 ns |         - |
```
pr:
```
|                   Method |       Mean |     Error |    StdDev | Allocated |
|------------------------- |-----------:|----------:|----------:|----------:|
|         MultiplyNonWhite | 122.098 ns | 0.2430 ns | 0.1897 ns |         - |
|            MultiplyWhite |   6.129 ns | 0.0118 ns | 0.0110 ns |         - |
| MultiplyWhiteWithOpacity |   8.953 ns | 0.0491 ns | 0.0410 ns |         - |
|         MultiplyConstOne |   1.227 ns | 0.0057 ns | 0.0053 ns |         - |
|      MultiplyConstNonOne |  93.844 ns | 0.1871 ns | 0.1750 ns |         - |
```