### PR TITLE
Fix incorrect assertion and possible nullref

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1377,20 +1377,21 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void unbindInput([CanBeNull] TextBox next)
         {
-            Debug.Assert(textInput != null);
-
             if (!textInputBound)
                 return;
 
             textInputBound = false;
 
-            // see the comment above, in `bindInput(bool)`.
-            if (next?.textInput != textInput)
-                textInput.Deactivate();
+            if (textInput != null)
+            {
+                // see the comment above, in `bindInput(bool)`.
+                if (next?.textInput != textInput)
+                    textInput.Deactivate();
 
-            textInput.OnTextInput -= handleTextInput;
-            textInput.OnImeComposition -= handleImeComposition;
-            textInput.OnImeResult -= handleImeResult;
+                textInput.OnTextInput -= handleTextInput;
+                textInput.OnImeComposition -= handleImeComposition;
+                textInput.OnImeResult -= handleImeResult;
+            }
 
             // in case keys are held and we lose focus, we should no longer block key events
             textInputBlocking = false;


### PR DESCRIPTION
I've had the following osu! side tests fail when using a local framework checkout:
```
TestConfineAlwaysInFullscreen
TestConfineAlwaysUserSetting
```
```
 at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2) in /Users/smgi/Repos/osu-framework/osu.Framework/Logging/ThrowingTraceListener.cs:line 27
   at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
   at System.Diagnostics.Debug.Fail(String message, String detailMessage)
   at osu.Framework.Graphics.UserInterface.TextBox.unbindInput(TextBox next) in /Users/smgi/Repos/osu-framework/osu.Framework/Graphics/UserInterface/TextBox.cs:line 1380
   at osu.Framework.Graphics.UserInterface.TextBox.Dispose(Boolean isDisposing) in /Users/smgi/Repos/osu-framework/osu.Framework/Graphics/UserInterface/TextBox.cs:line 539
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/smgi/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 80
```
Basically, this can happen if the `TextBox` is disposed before getting loaded.