### PR TITLE
Rollback Veldrid to fix broken buffered containers

### DIFF
--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredFrameBuffer.cs
@@ -139,7 +139,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
                             (uint)resourceSize.Y,
                             1,
                             1,
-                            PixelFormat.R8G8B8A8UNorm,
+                            PixelFormat.R8_G8_B8_A8_UNorm,
                             TextureUsage.Sampled | TextureUsage.RenderTarget)),
                     deferredFrameBuffer.renderer.Factory.CreateSampler(
                         new SamplerDescription(

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             }
         }
 
-        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
+        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
         {
             // todo: we probably want the arguments separated to "PixelFormat[] colorFormats, PixelFormat depthFormat".
             if (formats?.Length > 1)
@@ -147,7 +147,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             protected override TextureUsage Usages => base.Usages | TextureUsage.RenderTarget;
 
-            public FrameBufferTexture(VeldridRenderer renderer, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
+            public FrameBufferTexture(VeldridRenderer renderer, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear)
                 : base(renderer, 1, 1, true, filteringMode)
             {
                 BypassTextureUploadQueueing = true;

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -27,8 +27,8 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
 
         private GraphicsPipelineDescription pipelineDesc = new GraphicsPipelineDescription
         {
-            RasterizerState = RasterizerStateDescription.CULL_NONE,
-            BlendState = BlendStateDescription.SINGLE_OVERRIDE_BLEND,
+            RasterizerState = RasterizerStateDescription.CullNone,
+            BlendState = BlendStateDescription.SingleOverrideBlend,
             ShaderSet = { VertexLayouts = new VertexLayoutDescription[1] }
         };
 

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
         /// <param name="filteringMode">The filtering mode.</param>
         /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads). If null, no initialisation is provided out-of-the-box.</param>
-        public VeldridTexture(IVeldridRenderer renderer, int width, int height, bool manualMipmaps = false, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear,
+        public VeldridTexture(IVeldridRenderer renderer, int width, int height, bool manualMipmaps = false, SamplerFilter filteringMode = SamplerFilter.MinLinear_MagLinear_MipLinear,
                               Color4? initialisationColour = null)
         {
             this.manualMipmaps = manualMipmaps;
@@ -458,7 +458,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             {
                 texture?.Dispose();
 
-                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, PixelFormat.R8G8B8A8UNorm, Usages);
+                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, PixelFormat.R8_G8_B8_A8_UNorm, Usages);
                 texture = Renderer.Factory.CreateTexture(ref textureDescription);
 
                 // todo: we may want to look into not having to allocate chunks of zero byte region for initialising textures

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
@@ -48,13 +48,13 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
                     resourceList[i] = new VeldridTextureResources
                     (
-                        Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, PixelFormat.R8UNorm, Usages)),
+                        Renderer.Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, PixelFormat.R8_UNorm, Usages)),
                         Renderer.Factory.CreateSampler(new SamplerDescription
                         {
                             AddressModeU = SamplerAddressMode.Clamp,
                             AddressModeV = SamplerAddressMode.Clamp,
                             AddressModeW = SamplerAddressMode.Clamp,
-                            Filter = SamplerFilter.MinLinearMagLinearMipLinear,
+                            Filter = SamplerFilter.MinLinear_MagLinear_MipLinear,
                             MinimumLod = 0,
                             MaximumLod = IRenderer.MAX_MIPMAP_LEVELS,
                             MaximumAnisotropy = 0,

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -14,7 +14,7 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Veldrid;
 using Veldrid.OpenGL;
-using Veldrid.OpenGLBindings;
+using Veldrid.OpenGLBinding;
 
 namespace osu.Framework.Graphics.Veldrid
 {
@@ -106,7 +106,7 @@ namespace osu.Framework.Graphics.Veldrid
             var options = new GraphicsDeviceOptions
             {
                 HasMainSwapchain = true,
-                SwapchainDepthFormat = PixelFormat.R16UNorm,
+                SwapchainDepthFormat = PixelFormat.R16_UNorm,
                 SyncToVerticalBlank = true,
                 ResourceBindingModel = ResourceBindingModel.Improved,
             };

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -14,13 +14,15 @@ using osuTK.Graphics;
 using SharpGen.Runtime;
 using Veldrid;
 using Veldrid.MetalBindings;
-using Veldrid.OpenGLBindings;
+using Veldrid.OpenGLBinding;
 using Vortice.Direct3D11;
 using Vortice.DXGI;
 using Vulkan;
+using GetPName = Veldrid.OpenGLBinding.GetPName;
 using GraphicsBackend = Veldrid.GraphicsBackend;
 using PrimitiveTopology = Veldrid.PrimitiveTopology;
 using StencilOperation = Veldrid.StencilOperation;
+using StringName = Veldrid.OpenGLBinding.StringName;
 using VertexAttribPointerType = osuTK.Graphics.ES30.VertexAttribPointerType;
 
 namespace osu.Framework.Graphics.Veldrid
@@ -123,19 +125,19 @@ namespace osu.Framework.Graphics.Veldrid
                 switch (renderBufferFormats[i])
                 {
                     case RenderBufferFormat.D16:
-                        pixelFormats[i] = PixelFormat.R16UNorm;
+                        pixelFormats[i] = PixelFormat.R16_UNorm;
                         break;
 
                     case RenderBufferFormat.D32:
-                        pixelFormats[i] = PixelFormat.R32Float;
+                        pixelFormats[i] = PixelFormat.R32_Float;
                         break;
 
                     case RenderBufferFormat.D24S8:
-                        pixelFormats[i] = PixelFormat.D24UNormS8UInt;
+                        pixelFormats[i] = PixelFormat.D24_UNorm_S8_UInt;
                         break;
 
                     case RenderBufferFormat.D32S8:
-                        pixelFormats[i] = PixelFormat.D32FloatS8UInt;
+                        pixelFormats[i] = PixelFormat.D32_Float_S8_UInt;
                         break;
 
                     default:
@@ -151,10 +153,10 @@ namespace osu.Framework.Graphics.Veldrid
             switch (mode)
             {
                 case TextureFilteringMode.Linear:
-                    return SamplerFilter.MinLinearMagLinearMipLinear;
+                    return SamplerFilter.MinLinear_MagLinear_MipLinear;
 
                 case TextureFilteringMode.Nearest:
-                    return SamplerFilter.MinPointMagPointMipPoint;
+                    return SamplerFilter.MinPoint_MagPoint_MipPoint;
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode));

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Wasapi" Version="2022.1216.0" />
-    <PackageReference Include="ppy.Veldrid" Version="4.9.56-g0c0f3564ac" />
+    <PackageReference Include="ppy.Veldrid" Version="4.9.11-ged7d28974e" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-gca6cec7843" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->


### PR DESCRIPTION
This reverts commit 812e5290b88142271040fb4114c7e0d5c4ac2975, reversing changes made to 9c6dee5e854d396f9c223ab9f722995d3fa7a193.

MacOS buffered containers broke in the latest Veldrid release, pushed in https://github.com/ppy/osu-framework/pull/6275