### PR TITLE
Add a way to make Drawable clicks not change focus

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2404,6 +2404,11 @@ namespace osu.Framework.Graphics
         public virtual bool AcceptsFocus => false;
 
         /// <summary>
+        /// If true, returning true in <see cref="OnClick"/> causes the current focus target to be unfocused.
+        /// </summary>
+        public virtual bool ChangeFocusOnClick => true;
+
+        /// <summary>
         /// Whether this Drawable is currently hovered over.
         /// </summary>
         /// <remarks>This is updated only if <see cref="HandlePositionalInput"/> is true.</remarks>

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Input
 
             ClickedDrawable.SetTarget(clicked!);
 
-            if (ChangeFocusOnClick)
+            if (ChangeFocusOnClick && clicked?.ChangeFocusOnClick != false)
                 InputManager.ChangeFocusFromClick(clicked);
 
             if (clicked != null)


### PR DESCRIPTION
RFC. This is useful in situations like the osu!-side collection dropdown, which expects to remain open when the add/remove button is pressed.

Master:

https://github.com/ppy/osu-framework/assets/1329837/a0fed169-b0d6-4876-afcb-f866b802239f

With this PR (+ diff below):

https://github.com/ppy/osu-framework/assets/1329837/87430d1f-755d-44b5-9287-205291470e1a

```diff
diff --git a/osu.Game/Collections/CollectionDropdown.cs b/osu.Game/Collections/CollectionDropdown.cs
index 15dd644073..c04689b097 100644
--- a/osu.Game/Collections/CollectionDropdown.cs
+++ b/osu.Game/Collections/CollectionDropdown.cs
@@ -202,7 +202,7 @@ public CollectionDropdownDrawableMenuItem(MenuItem item)
             [BackgroundDependencyLoader]
             private void load()
             {
-                AddInternal(addOrRemoveButton = new IconButton
+                AddInternal(addOrRemoveButton = new NoFocusChangeIconButton
                 {
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight,
@@ -271,6 +271,11 @@ private void addOrRemove()
             }

             protected override Drawable CreateContent() => (Content)base.CreateContent();
+
+            private partial class NoFocusChangeIconButton : IconButton
+            {
+                public override bool ChangeFocusOnClick => false;
+            }
         }
     }
 }
```