### PR TITLE
Fix IL3000 warning on Android

### DIFF
--- a/osu.Framework.Tests/IO/TestOnlineStore.cs
+++ b/osu.Framework.Tests/IO/TestOnlineStore.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Tests.IO
         public void TestFileUrlFails([Values(true, false)] bool async)
         {
             // Known, guaranteed file path.
-            string path = new Uri(RuntimeInfo.EntryAssembly.Location).AbsoluteUri;
+            string path = new Uri(AppContext.BaseDirectory).AbsoluteUri;
 
             byte[]? result = async
                 ? store.GetAsync(path).GetResultSafely()


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000

> osu-framework\osu.Framework.Tests\IO\TestOnlineStore.cs(102,35): warning IL3000: 'System.Reflection.Assembly.Location' always returns an empty string for assemblies embedded in a single-file app. If the path to the app directory is needed, consider calling 'System.AppContext.BaseDirectory'.

Likely to show on embedded mobile platforms like iOS and Android.