### PR TITLE
Colour API proposal

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
+++ b/osu.Framework.Benchmarks/BenchmarkColourInfo.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
-using osuTK.Graphics;
 
 namespace osu.Framework.Benchmarks
 {
@@ -18,9 +18,9 @@ namespace osu.Framework.Benchmarks
         {
             get
             {
-                yield return ColourInfo.SingleColour(Color4.Transparent);
-                yield return ColourInfo.SingleColour(Color4.Cyan);
-                yield return ColourInfo.SingleColour(Color4.DarkGray);
+                yield return ColourInfo.SingleColour(SRGBColour.Transparent);
+                yield return ColourInfo.SingleColour(SRGBColour.Cyan);
+                yield return ColourInfo.SingleColour(SRGBColour.DarkGray);
             }
         }
 
@@ -28,13 +28,13 @@ namespace osu.Framework.Benchmarks
         public SRGBColour ConvertToSRGBColour() => Colour;
 
         [Benchmark]
-        public Color4 ConvertToColor4() => ((SRGBColour)Colour).Linear;
+        public Colour4 ConvertToColour4() => ((SRGBColour)Colour).ToLinear().Linear;
 
         [Benchmark]
-        public Color4 ExtractAndConvertToColor4()
+        public Colour4 ExtractAndConvertToColour4()
         {
             Colour.TryExtractSingleColour(out SRGBColour colour);
-            return colour.Linear;
+            return colour.ToLinear().Linear;
         }
     }
 }

--- a/osu.Framework.Benchmarks/BenchmarkSRGBColourMultiplication.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSRGBColourMultiplication.cs
@@ -3,31 +3,18 @@
 
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Graphics.Colour;
-using osuTK.Graphics;
 
 namespace osu.Framework.Benchmarks
 {
     public class BenchmarkSRGBColourMultiplication : BenchmarkTest
     {
-        private static readonly SRGBColour white = new SRGBColour
-        {
-            SRGB = new Color4(1f, 1f, 1f, 1f)
-        };
+        private static readonly SRGBColour white = SRGBColour.White;
 
-        private static readonly SRGBColour white_with_opacity = new SRGBColour
-        {
-            SRGB = new Color4(1f, 1f, 1f, 0.5f)
-        };
+        private static readonly SRGBColour white_with_opacity = SRGBColour.White.Opacity(0.5f);
 
-        private static readonly SRGBColour gray = new SRGBColour
-        {
-            SRGB = Color4.Gray
-        };
+        private static readonly SRGBColour gray = SRGBColour.Gray;
 
-        private static readonly SRGBColour gray_light = new SRGBColour
-        {
-            SRGB = Color4.LightGray
-        };
+        private static readonly SRGBColour gray_light = SRGBColour.LightGray;
 
         [Benchmark]
         public SRGBColour MultiplyNonWhite()

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneGammaCorrection.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneGammaCorrection.cs
@@ -185,7 +185,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddAssert("interpolation in linear space", () =>
             {
                 var middle = interpolatingLines.Children[interpolatingLines.Children.Count / 2];
-                return middle.Colour.AverageColour.Linear == new Color4(0.5f, 0f, 0.5f, 1f);
+                return middle.Colour.AverageColour.ToLinear().Linear == new Colour4(0.5f, 0f, 0.5f, 1f);
             });
         }
 

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -175,18 +175,15 @@ namespace osu.Framework.Graphics.Colour
                 return this;
 
             if (TryExtractSingleColour(out SRGBColour single))
+                return single.MultiplyAlpha(alpha);
+
+            return new ColourInfo
             {
-                single.MultiplyAlpha(alpha);
-                return single;
-            }
-
-            ColourInfo result = this;
-            result.TopLeft.MultiplyAlpha(alpha);
-            result.BottomLeft.MultiplyAlpha(alpha);
-            result.TopRight.MultiplyAlpha(alpha);
-            result.BottomRight.MultiplyAlpha(alpha);
-
-            return result;
+                TopLeft = TopLeft.MultiplyAlpha(alpha),
+                BottomLeft = BottomLeft.MultiplyAlpha(alpha),
+                TopRight = TopRight.MultiplyAlpha(alpha),
+                BottomRight = BottomRight.MultiplyAlpha(alpha),
+            };
         }
 
         public readonly bool Equals(ColourInfo other)

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Colour
 {
     /// <summary>
     /// ColourInfo contains information about the colours of all 4 vertices of a quad.
-    /// These colours are always stored in linear space.
+    /// These colours are stored as gamma-corrected sRGB.
     /// </summary>
     public struct ColourInfo : IEquatable<ColourInfo>, IEquatable<SRGBColour>
     {
@@ -23,9 +23,9 @@ namespace osu.Framework.Graphics.Colour
         public bool HasSingleColour;
 
         /// <summary>
-        /// Creates a ColourInfo with a single linear colour assigned to all vertices.
+        /// Creates a ColourInfo with a single colour assigned to all vertices.
         /// </summary>
-        /// <param name="colour">The single linear colour to be assigned to all vertices.</param>
+        /// <param name="colour">The single colour to be assigned to all vertices.</param>
         /// <returns>The created ColourInfo.</returns>
         public static ColourInfo SingleColour(SRGBColour colour)
         {

--- a/osu.Framework/Graphics/Colour/LinearColour.cs
+++ b/osu.Framework/Graphics/Colour/LinearColour.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics.Contracts;
+
+namespace osu.Framework.Graphics.Colour
+{
+    /// <summary>
+    /// A colour in linear-light (or gamma-expanded) sRGB colour space. This should only be used to do calculations on colours.
+    /// Otherwise, <see cref="SRGBColour"/> should be preferred.
+    /// To convert from the linear-light to a gamma-corrected sRGB representation, use the <see cref="ToSRGB"/> method.
+    /// </summary>
+    public readonly record struct LinearColour
+    {
+        /// <summary>
+        /// The colour values stored in this <see cref="LinearColour"/> struct.
+        /// </summary>
+        public readonly Colour4 Linear;
+
+        /// <summary>
+        /// Create a <see cref="LinearColour"/> from a <see cref="Colour4"/>, treating
+        /// the contained colour components as being in linear-light sRGB colour space.
+        /// </summary>
+        /// <param name="colour">The raw colour values to store.</param>
+        public LinearColour(Colour4 colour) => Linear = colour;
+
+        /// <summary>
+        /// Convert this <see cref="LinearColour"/> into an <see cref="SRGBColour"/> by applying
+        /// a gamma correction to the chromatic (RGB) components. The alpha component is untouched.
+        /// </summary>
+        /// <returns>An <see cref="SRGBColour"/> struct containing the converted values.</returns>
+        [Pure]
+        public SRGBColour ToSRGB() => new SRGBColour(Linear.ToSRGB());
+
+        public static LinearColour operator +(LinearColour first, LinearColour second) => new LinearColour(first.Linear + second.Linear);
+
+        public static LinearColour operator *(LinearColour first, LinearColour second) => new LinearColour(first.Linear * second.Linear);
+        public static LinearColour operator *(LinearColour first, float scalar) => new LinearColour(first.Linear * scalar);
+
+        public static LinearColour operator /(LinearColour first, float scalar) => new LinearColour(first.Linear / scalar);
+    }
+}

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -5,6 +5,7 @@ using osuTK;
 using osuTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using System;
+using System.Diagnostics.Contracts;
 
 namespace osu.Framework.Graphics.Colour
 {
@@ -24,6 +25,21 @@ namespace osu.Framework.Graphics.Colour
         /// A <see cref="Color4"/> representation of this colour in the linear space.
         /// </summary>
         public Color4 Linear => SRGB.ToLinear();
+
+        /// <summary>
+        /// Create a <see cref="SRGBColour"/> from a <see cref="Colour4"/>, treating
+        /// the contained colour components as being in gamma-corrected sRGB colour space.
+        /// </summary>
+        /// <param name="colour">The raw colour values to store.</param>
+        public SRGBColour(Colour4 colour) => SRGB = colour;
+
+        /// <summary>
+        /// Convert this <see cref="SRGBColour"/> into a <see cref="LinearColour"/> by removing
+        /// the gamma correction of the chromatic (RGB) components. The alpha component is untouched.
+        /// </summary>
+        /// <returns>A <see cref="LinearColour"/> struct containing the converted values.</returns>
+        [Pure]
+        public readonly LinearColour ToLinear() => new LinearColour(SRGB.ToLinear());
 
         /// <summary>
         /// The alpha component of this colour.

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -3,31 +3,44 @@
 
 using osuTK;
 using osuTK.Graphics;
-using osu.Framework.Extensions.Color4Extensions;
 using System;
 using System.Diagnostics.Contracts;
+using Veldrid;
 
 namespace osu.Framework.Graphics.Colour
 {
     /// <summary>
-    /// A wrapper struct around Color4 that takes care of converting between sRGB and linear colour spaces.
+    /// A wrapper struct around <see cref="Colour4"/> that takes care of converting between sRGB and linear colour spaces.
     /// Internally this struct stores the colour in sRGB space, which is exposed by the <see cref="SRGB"/> member.
-    /// This struct converts to linear space by using the <see cref="Linear"/> member.
+    /// This struct converts to linear space by using the <see cref="ToLinear"/> method.
     /// </summary>
-    public struct SRGBColour : IEquatable<SRGBColour>
+    public readonly record struct SRGBColour
     {
         /// <summary>
-        /// A <see cref="Color4"/> representation of this colour in the sRGB space.
+        /// A <see cref="Colour4"/> representation of this colour in the sRGB space.
         /// </summary>
-        public Color4 SRGB;
+        public readonly Colour4 SRGB;
 
         /// <summary>
-        /// A <see cref="Color4"/> representation of this colour in the linear space.
+        /// A <see cref="Colour4"/> representation of this colour in the linear space.
         /// </summary>
-        public Color4 Linear => SRGB.ToLinear();
+        [Obsolete("Use ToLinear() instead.")]
+        public Colour4 Linear => SRGB.ToLinear();
 
         /// <summary>
-        /// Create a <see cref="SRGBColour"/> from a <see cref="Colour4"/>, treating
+        /// Create an <see cref="SRGBColour"/> from four 8-bit RGBA component values, in the range 0-255.
+        /// </summary>
+        /// <param name="r">The red component.</param>
+        /// <param name="g">The green component.</param>
+        /// <param name="b">The blue component.</param>
+        /// <param name="a">The alpha component.</param>
+        public SRGBColour(byte r, byte g, byte b, byte a)
+            : this(new Colour4(r, g, b, a))
+        {
+        }
+
+        /// <summary>
+        /// Create an <see cref="SRGBColour"/> from a <see cref="Colour4"/>, treating
         /// the contained colour components as being in gamma-corrected sRGB colour space.
         /// </summary>
         /// <param name="colour">The raw colour values to store.</param>
@@ -39,7 +52,7 @@ namespace osu.Framework.Graphics.Colour
         /// </summary>
         /// <returns>A <see cref="LinearColour"/> struct containing the converted values.</returns>
         [Pure]
-        public readonly LinearColour ToLinear() => new LinearColour(SRGB.ToLinear());
+        public LinearColour ToLinear() => new LinearColour(SRGB.ToLinear());
 
         /// <summary>
         /// The alpha component of this colour.
@@ -47,10 +60,10 @@ namespace osu.Framework.Graphics.Colour
         public float Alpha => SRGB.A;
 
         // todo: these implicit operators should be replaced with explicit static methods (https://github.com/ppy/osu-framework/issues/5714).
-        public static implicit operator SRGBColour(Color4 value) => new SRGBColour { SRGB = value };
-        public static implicit operator Color4(SRGBColour value) => value.SRGB;
+        public static implicit operator SRGBColour(Color4 value) => new SRGBColour(value);
+        public static implicit operator Color4(SRGBColour value) => value.ToColor4();
 
-        public static implicit operator SRGBColour(Colour4 value) => new SRGBColour { SRGB = value };
+        public static implicit operator SRGBColour(Colour4 value) => new SRGBColour(value);
         public static implicit operator Colour4(SRGBColour value) => value.SRGB;
 
         public static SRGBColour operator *(SRGBColour first, SRGBColour second)
@@ -60,14 +73,7 @@ namespace osu.Framework.Graphics.Colour
                 if (first.Alpha == 1)
                     return second;
 
-                return new SRGBColour
-                {
-                    SRGB = new Color4(
-                        second.SRGB.R,
-                        second.SRGB.G,
-                        second.SRGB.B,
-                        first.Alpha * second.Alpha)
-                };
+                return second.MultiplyAlpha(first.Alpha);
             }
 
             if (isWhite(second))
@@ -75,27 +81,10 @@ namespace osu.Framework.Graphics.Colour
                 if (second.Alpha == 1)
                     return first;
 
-                return new SRGBColour
-                {
-                    SRGB = new Color4(
-                        first.SRGB.R,
-                        first.SRGB.G,
-                        first.SRGB.B,
-                        first.Alpha * second.Alpha)
-                };
+                return first.MultiplyAlpha(second.Alpha);
             }
 
-            var firstLinear = first.Linear;
-            var secondLinear = second.Linear;
-
-            return new SRGBColour
-            {
-                SRGB = new Color4(
-                    firstLinear.R * secondLinear.R,
-                    firstLinear.G * secondLinear.G,
-                    firstLinear.B * secondLinear.B,
-                    firstLinear.A * secondLinear.A).ToSRGB(),
-            };
+            return (first.ToLinear() * second.ToLinear()).ToSRGB();
         }
 
         public static SRGBColour operator *(SRGBColour first, float second)
@@ -103,37 +92,15 @@ namespace osu.Framework.Graphics.Colour
             if (second == 1)
                 return first;
 
-            var firstLinear = first.Linear;
-
-            return new SRGBColour
-            {
-                SRGB = new Color4(
-                    firstLinear.R * second,
-                    firstLinear.G * second,
-                    firstLinear.B * second,
-                    firstLinear.A * second).ToSRGB(),
-            };
+            return (first.ToLinear() * second).ToSRGB();
         }
 
         public static SRGBColour operator /(SRGBColour first, float second) => first * (1 / second);
 
-        public static SRGBColour operator +(SRGBColour first, SRGBColour second)
-        {
-            var firstLinear = first.Linear;
-            var secondLinear = second.Linear;
+        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => (first.ToLinear() + second.ToLinear()).ToSRGB();
 
-            return new SRGBColour
-            {
-                SRGB = new Color4(
-                    firstLinear.R + secondLinear.R,
-                    firstLinear.G + secondLinear.G,
-                    firstLinear.B + secondLinear.B,
-                    firstLinear.A + secondLinear.A).ToSRGB(),
-            };
-        }
-
-        public readonly Vector4 ToVector() => new Vector4(SRGB.R, SRGB.G, SRGB.B, SRGB.A);
-        public static SRGBColour FromVector(Vector4 v) => new SRGBColour { SRGB = new Color4(v.X, v.Y, v.Z, v.W) };
+        public Vector4 ToVector() => new Vector4(SRGB.R, SRGB.G, SRGB.B, SRGB.A);
+        public static SRGBColour FromVector(Vector4 v) => new SRGBColour(new Colour4(v.X, v.Y, v.Z, v.W));
 
         /// <summary>
         /// Returns a new <see cref="SRGBColour"/> with the same RGB components, but multiplying the current
@@ -145,7 +112,42 @@ namespace osu.Framework.Graphics.Colour
 
         private static bool isWhite(SRGBColour colour) => colour.SRGB.R == 1 && colour.SRGB.G == 1 && colour.SRGB.B == 1;
 
-        public readonly bool Equals(SRGBColour other) => SRGB.Equals(other.SRGB);
-        public override string ToString() => $"srgb: {SRGB}, linear: {Linear}";
+        /// <summary>
+        /// Returns a new <see cref="SRGBColour"/> with the same RGB components and a specified alpha value.
+        /// The final alpha is clamped to the 0-1 range.
+        /// </summary>
+        /// <param name="alpha">The new alpha value for the returned colour, in the 0-1 range.</param>
+        [Pure]
+        public SRGBColour Opacity(float alpha) => new SRGBColour(SRGB.Opacity(alpha));
+
+        /// <summary>
+        /// Returns a lightened version of the colour.
+        /// </summary>
+        /// <param name="amount">Percentage light addition</param>
+        [Pure]
+        public SRGBColour Lighten(float amount) => new SRGBColour(SRGB.Lighten(amount));
+
+        /// <summary>
+        /// Returns a darkened version of the colour.
+        /// </summary>
+        /// <param name="amount">Percentage light reduction</param>
+        [Pure]
+        public SRGBColour Darken(float amount) => new SRGBColour(SRGB.Darken(amount));
+
+        /// <summary>
+        /// Return an <see cref="RgbaFloat"/> for interactions with Veldrid.
+        /// </summary>
+        /// <returns>An <see cref="RgbaFloat"/> containing the same colour values as this <see cref="SRGBColour"/>.</returns>
+        [Pure]
+        public RgbaFloat ToRgbaFloat() => new RgbaFloat(SRGB.Vector);
+
+        /// <summary>
+        /// Return a <see cref="Color4"/> for interactions with osuTK.
+        /// </summary>
+        /// <returns>A <see cref="Color4"/> containing the same colour values as this <see cref="SRGBColour"/>.</returns>
+        [Pure]
+        public Color4 ToColor4() => new Color4(SRGB.R, SRGB.G, SRGB.B, SRGB.A);
+
+        public override string ToString() => $"srgb: {SRGB}, linear: {ToLinear()}";
     }
 }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osuTK;
@@ -149,5 +149,714 @@ namespace osu.Framework.Graphics.Colour
         public Color4 ToColor4() => new Color4(SRGB.R, SRGB.G, SRGB.B, SRGB.A);
 
         public override string ToString() => $"srgb: {SRGB}, linear: {ToLinear()}";
+
+        #region Constants
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 255, 255, 0).
+        /// </summary>
+        public static SRGBColour Transparent => new SRGBColour(255, 255, 255, 0);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (240, 248, 255, 255).
+        /// </summary>
+        public static SRGBColour AliceBlue => new SRGBColour(240, 248, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (250, 235, 215, 255).
+        /// </summary>
+        public static SRGBColour AntiqueWhite => new SRGBColour(250, 235, 215, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 255, 255, 255).
+        /// </summary>
+        public static SRGBColour Aqua => new SRGBColour(0, 255, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (127, 255, 212, 255).
+        /// </summary>
+        public static SRGBColour Aquamarine => new SRGBColour(127, 255, 212, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (240, 255, 255, 255).
+        /// </summary>
+        public static SRGBColour Azure => new SRGBColour(240, 255, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (245, 245, 220, 255).
+        /// </summary>
+        public static SRGBColour Beige => new SRGBColour(245, 245, 220, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 228, 196, 255).
+        /// </summary>
+        public static SRGBColour Bisque => new SRGBColour(255, 228, 196, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 0, 0, 255).
+        /// </summary>
+        public static SRGBColour Black => new SRGBColour(0, 0, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 235, 205, 255).
+        /// </summary>
+        public static SRGBColour BlanchedAlmond => new SRGBColour(255, 235, 205, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 0, 255, 255).
+        /// </summary>
+        public static SRGBColour Blue => new SRGBColour(0, 0, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (138, 43, 226, 255).
+        /// </summary>
+        public static SRGBColour BlueViolet => new SRGBColour(138, 43, 226, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (165, 42, 42, 255).
+        /// </summary>
+        public static SRGBColour Brown => new SRGBColour(165, 42, 42, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (222, 184, 135, 255).
+        /// </summary>
+        public static SRGBColour BurlyWood => new SRGBColour(222, 184, 135, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (95, 158, 160, 255).
+        /// </summary>
+        public static SRGBColour CadetBlue => new SRGBColour(95, 158, 160, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (127, 255, 0, 255).
+        /// </summary>
+        public static SRGBColour Chartreuse => new SRGBColour(127, 255, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (210, 105, 30, 255).
+        /// </summary>
+        public static SRGBColour Chocolate => new SRGBColour(210, 105, 30, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 127, 80, 255).
+        /// </summary>
+        public static SRGBColour Coral => new SRGBColour(255, 127, 80, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (100, 149, 237, 255).
+        /// </summary>
+        public static SRGBColour CornflowerBlue => new SRGBColour(100, 149, 237, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 248, 220, 255).
+        /// </summary>
+        public static SRGBColour Cornsilk => new SRGBColour(255, 248, 220, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (220, 20, 60, 255).
+        /// </summary>
+        public static SRGBColour Crimson => new SRGBColour(220, 20, 60, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 255, 255, 255).
+        /// </summary>
+        public static SRGBColour Cyan => new SRGBColour(0, 255, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 0, 139, 255).
+        /// </summary>
+        public static SRGBColour DarkBlue => new SRGBColour(0, 0, 139, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 139, 139, 255).
+        /// </summary>
+        public static SRGBColour DarkCyan => new SRGBColour(0, 139, 139, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (184, 134, 11, 255).
+        /// </summary>
+        public static SRGBColour DarkGoldenrod => new SRGBColour(184, 134, 11, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (169, 169, 169, 255).
+        /// </summary>
+        public static SRGBColour DarkGray => new SRGBColour(169, 169, 169, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 100, 0, 255).
+        /// </summary>
+        public static SRGBColour DarkGreen => new SRGBColour(0, 100, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (189, 183, 107, 255).
+        /// </summary>
+        public static SRGBColour DarkKhaki => new SRGBColour(189, 183, 107, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (139, 0, 139, 255).
+        /// </summary>
+        public static SRGBColour DarkMagenta => new SRGBColour(139, 0, 139, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (85, 107, 47, 255).
+        /// </summary>
+        public static SRGBColour DarkOliveGreen => new SRGBColour(85, 107, 47, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 140, 0, 255).
+        /// </summary>
+        public static SRGBColour DarkOrange => new SRGBColour(255, 140, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (153, 50, 204, 255).
+        /// </summary>
+        public static SRGBColour DarkOrchid => new SRGBColour(153, 50, 204, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (139, 0, 0, 255).
+        /// </summary>
+        public static SRGBColour DarkRed => new SRGBColour(139, 0, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (233, 150, 122, 255).
+        /// </summary>
+        public static SRGBColour DarkSalmon => new SRGBColour(233, 150, 122, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (143, 188, 139, 255).
+        /// </summary>
+        public static SRGBColour DarkSeaGreen => new SRGBColour(143, 188, 139, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (72, 61, 139, 255).
+        /// </summary>
+        public static SRGBColour DarkSlateBlue => new SRGBColour(72, 61, 139, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (47, 79, 79, 255).
+        /// </summary>
+        public static SRGBColour DarkSlateGray => new SRGBColour(47, 79, 79, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 206, 209, 255).
+        /// </summary>
+        public static SRGBColour DarkTurquoise => new SRGBColour(0, 206, 209, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (148, 0, 211, 255).
+        /// </summary>
+        public static SRGBColour DarkViolet => new SRGBColour(148, 0, 211, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 20, 147, 255).
+        /// </summary>
+        public static SRGBColour DeepPink => new SRGBColour(255, 20, 147, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 191, 255, 255).
+        /// </summary>
+        public static SRGBColour DeepSkyBlue => new SRGBColour(0, 191, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (105, 105, 105, 255).
+        /// </summary>
+        public static SRGBColour DimGray => new SRGBColour(105, 105, 105, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (30, 144, 255, 255).
+        /// </summary>
+        public static SRGBColour DodgerBlue => new SRGBColour(30, 144, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (178, 34, 34, 255).
+        /// </summary>
+        public static SRGBColour Firebrick => new SRGBColour(178, 34, 34, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 250, 240, 255).
+        /// </summary>
+        public static SRGBColour FloralWhite => new SRGBColour(255, 250, 240, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (34, 139, 34, 255).
+        /// </summary>
+        public static SRGBColour ForestGreen => new SRGBColour(34, 139, 34, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 0, 255, 255).
+        /// </summary>
+        public static SRGBColour Fuchsia => new SRGBColour(255, 0, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (220, 220, 220, 255).
+        /// </summary>
+        public static SRGBColour Gainsboro => new SRGBColour(220, 220, 220, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (248, 248, 255, 255).
+        /// </summary>
+        public static SRGBColour GhostWhite => new SRGBColour(248, 248, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 215, 0, 255).
+        /// </summary>
+        public static SRGBColour Gold => new SRGBColour(255, 215, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (218, 165, 32, 255).
+        /// </summary>
+        public static SRGBColour Goldenrod => new SRGBColour(218, 165, 32, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (128, 128, 128, 255).
+        /// </summary>
+        public static SRGBColour Gray => new SRGBColour(128, 128, 128, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 128, 0, 255).
+        /// </summary>
+        public static SRGBColour Green => new SRGBColour(0, 128, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (173, 255, 47, 255).
+        /// </summary>
+        public static SRGBColour GreenYellow => new SRGBColour(173, 255, 47, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (240, 255, 240, 255).
+        /// </summary>
+        public static SRGBColour Honeydew => new SRGBColour(240, 255, 240, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 105, 180, 255).
+        /// </summary>
+        public static SRGBColour HotPink => new SRGBColour(255, 105, 180, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (205, 92, 92, 255).
+        /// </summary>
+        public static SRGBColour IndianRed => new SRGBColour(205, 92, 92, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (75, 0, 130, 255).
+        /// </summary>
+        public static SRGBColour Indigo => new SRGBColour(75, 0, 130, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 255, 240, 255).
+        /// </summary>
+        public static SRGBColour Ivory => new SRGBColour(255, 255, 240, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (240, 230, 140, 255).
+        /// </summary>
+        public static SRGBColour Khaki => new SRGBColour(240, 230, 140, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (230, 230, 250, 255).
+        /// </summary>
+        public static SRGBColour Lavender => new SRGBColour(230, 230, 250, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 240, 245, 255).
+        /// </summary>
+        public static SRGBColour LavenderBlush => new SRGBColour(255, 240, 245, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (124, 252, 0, 255).
+        /// </summary>
+        public static SRGBColour LawnGreen => new SRGBColour(124, 252, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 250, 205, 255).
+        /// </summary>
+        public static SRGBColour LemonChiffon => new SRGBColour(255, 250, 205, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (173, 216, 230, 255).
+        /// </summary>
+        public static SRGBColour LightBlue => new SRGBColour(173, 216, 230, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (240, 128, 128, 255).
+        /// </summary>
+        public static SRGBColour LightCoral => new SRGBColour(240, 128, 128, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (224, 255, 255, 255).
+        /// </summary>
+        public static SRGBColour LightCyan => new SRGBColour(224, 255, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (250, 250, 210, 255).
+        /// </summary>
+        public static SRGBColour LightGoldenrodYellow => new SRGBColour(250, 250, 210, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (144, 238, 144, 255).
+        /// </summary>
+        public static SRGBColour LightGreen => new SRGBColour(144, 238, 144, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (211, 211, 211, 255).
+        /// </summary>
+        public static SRGBColour LightGray => new SRGBColour(211, 211, 211, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 182, 193, 255).
+        /// </summary>
+        public static SRGBColour LightPink => new SRGBColour(255, 182, 193, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 160, 122, 255).
+        /// </summary>
+        public static SRGBColour LightSalmon => new SRGBColour(255, 160, 122, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (32, 178, 170, 255).
+        /// </summary>
+        public static SRGBColour LightSeaGreen => new SRGBColour(32, 178, 170, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (135, 206, 250, 255).
+        /// </summary>
+        public static SRGBColour LightSkyBlue => new SRGBColour(135, 206, 250, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (119, 136, 153, 255).
+        /// </summary>
+        public static SRGBColour LightSlateGray => new SRGBColour(119, 136, 153, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (176, 196, 222, 255).
+        /// </summary>
+        public static SRGBColour LightSteelBlue => new SRGBColour(176, 196, 222, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 255, 224, 255).
+        /// </summary>
+        public static SRGBColour LightYellow => new SRGBColour(255, 255, 224, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 255, 0, 255).
+        /// </summary>
+        public static SRGBColour Lime => new SRGBColour(0, 255, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (50, 205, 50, 255).
+        /// </summary>
+        public static SRGBColour LimeGreen => new SRGBColour(50, 205, 50, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (250, 240, 230, 255).
+        /// </summary>
+        public static SRGBColour Linen => new SRGBColour(250, 240, 230, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 0, 255, 255).
+        /// </summary>
+        public static SRGBColour Magenta => new SRGBColour(255, 0, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (128, 0, 0, 255).
+        /// </summary>
+        public static SRGBColour Maroon => new SRGBColour(128, 0, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (102, 205, 170, 255).
+        /// </summary>
+        public static SRGBColour MediumAquamarine => new SRGBColour(102, 205, 170, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 0, 205, 255).
+        /// </summary>
+        public static SRGBColour MediumBlue => new SRGBColour(0, 0, 205, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (186, 85, 211, 255).
+        /// </summary>
+        public static SRGBColour MediumOrchid => new SRGBColour(186, 85, 211, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (147, 112, 219, 255).
+        /// </summary>
+        public static SRGBColour MediumPurple => new SRGBColour(147, 112, 219, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (60, 179, 113, 255).
+        /// </summary>
+        public static SRGBColour MediumSeaGreen => new SRGBColour(60, 179, 113, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (123, 104, 238, 255).
+        /// </summary>
+        public static SRGBColour MediumSlateBlue => new SRGBColour(123, 104, 238, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 250, 154, 255).
+        /// </summary>
+        public static SRGBColour MediumSpringGreen => new SRGBColour(0, 250, 154, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (72, 209, 204, 255).
+        /// </summary>
+        public static SRGBColour MediumTurquoise => new SRGBColour(72, 209, 204, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (199, 21, 133, 255).
+        /// </summary>
+        public static SRGBColour MediumVioletRed => new SRGBColour(199, 21, 133, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (25, 25, 112, 255).
+        /// </summary>
+        public static SRGBColour MidnightBlue => new SRGBColour(25, 25, 112, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (245, 255, 250, 255).
+        /// </summary>
+        public static SRGBColour MintCream => new SRGBColour(245, 255, 250, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 228, 225, 255).
+        /// </summary>
+        public static SRGBColour MistyRose => new SRGBColour(255, 228, 225, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 228, 181, 255).
+        /// </summary>
+        public static SRGBColour Moccasin => new SRGBColour(255, 228, 181, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 222, 173, 255).
+        /// </summary>
+        public static SRGBColour NavajoWhite => new SRGBColour(255, 222, 173, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 0, 128, 255).
+        /// </summary>
+        public static SRGBColour Navy => new SRGBColour(0, 0, 128, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (253, 245, 230, 255).
+        /// </summary>
+        public static SRGBColour OldLace => new SRGBColour(253, 245, 230, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (128, 128, 0, 255).
+        /// </summary>
+        public static SRGBColour Olive => new SRGBColour(128, 128, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (107, 142, 35, 255).
+        /// </summary>
+        public static SRGBColour OliveDrab => new SRGBColour(107, 142, 35, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 165, 0, 255).
+        /// </summary>
+        public static SRGBColour Orange => new SRGBColour(255, 165, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 69, 0, 255).
+        /// </summary>
+        public static SRGBColour OrangeRed => new SRGBColour(255, 69, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (218, 112, 214, 255).
+        /// </summary>
+        public static SRGBColour Orchid => new SRGBColour(218, 112, 214, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (238, 232, 170, 255).
+        /// </summary>
+        public static SRGBColour PaleGoldenrod => new SRGBColour(238, 232, 170, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (152, 251, 152, 255).
+        /// </summary>
+        public static SRGBColour PaleGreen => new SRGBColour(152, 251, 152, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (175, 238, 238, 255).
+        /// </summary>
+        public static SRGBColour PaleTurquoise => new SRGBColour(175, 238, 238, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (219, 112, 147, 255).
+        /// </summary>
+        public static SRGBColour PaleVioletRed => new SRGBColour(219, 112, 147, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 239, 213, 255).
+        /// </summary>
+        public static SRGBColour PapayaWhip => new SRGBColour(255, 239, 213, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 218, 185, 255).
+        /// </summary>
+        public static SRGBColour PeachPuff => new SRGBColour(255, 218, 185, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (205, 133, 63, 255).
+        /// </summary>
+        public static SRGBColour Peru => new SRGBColour(205, 133, 63, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 192, 203, 255).
+        /// </summary>
+        public static SRGBColour Pink => new SRGBColour(255, 192, 203, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (221, 160, 221, 255).
+        /// </summary>
+        public static SRGBColour Plum => new SRGBColour(221, 160, 221, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (176, 224, 230, 255).
+        /// </summary>
+        public static SRGBColour PowderBlue => new SRGBColour(176, 224, 230, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (128, 0, 128, 255).
+        /// </summary>
+        public static SRGBColour Purple => new SRGBColour(128, 0, 128, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 0, 0, 255).
+        /// </summary>
+        public static SRGBColour Red => new SRGBColour(255, 0, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (188, 143, 143, 255).
+        /// </summary>
+        public static SRGBColour RosyBrown => new SRGBColour(188, 143, 143, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (65, 105, 225, 255).
+        /// </summary>
+        public static SRGBColour RoyalBlue => new SRGBColour(65, 105, 225, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (139, 69, 19, 255).
+        /// </summary>
+        public static SRGBColour SaddleBrown => new SRGBColour(139, 69, 19, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (250, 128, 114, 255).
+        /// </summary>
+        public static SRGBColour Salmon => new SRGBColour(250, 128, 114, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (244, 164, 96, 255).
+        /// </summary>
+        public static SRGBColour SandyBrown => new SRGBColour(244, 164, 96, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (46, 139, 87, 255).
+        /// </summary>
+        public static SRGBColour SeaGreen => new SRGBColour(46, 139, 87, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 245, 238, 255).
+        /// </summary>
+        public static SRGBColour SeaShell => new SRGBColour(255, 245, 238, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (160, 82, 45, 255).
+        /// </summary>
+        public static SRGBColour Sienna => new SRGBColour(160, 82, 45, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (192, 192, 192, 255).
+        /// </summary>
+        public static SRGBColour Silver => new SRGBColour(192, 192, 192, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (135, 206, 235, 255).
+        /// </summary>
+        public static SRGBColour SkyBlue => new SRGBColour(135, 206, 235, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (106, 90, 205, 255).
+        /// </summary>
+        public static SRGBColour SlateBlue => new SRGBColour(106, 90, 205, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (112, 128, 144, 255).
+        /// </summary>
+        public static SRGBColour SlateGray => new SRGBColour(112, 128, 144, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 250, 250, 255).
+        /// </summary>
+        public static SRGBColour Snow => new SRGBColour(255, 250, 250, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 255, 127, 255).
+        /// </summary>
+        public static SRGBColour SpringGreen => new SRGBColour(0, 255, 127, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (70, 130, 180, 255).
+        /// </summary>
+        public static SRGBColour SteelBlue => new SRGBColour(70, 130, 180, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (210, 180, 140, 255).
+        /// </summary>
+        public static SRGBColour Tan => new SRGBColour(210, 180, 140, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (0, 128, 128, 255).
+        /// </summary>
+        public static SRGBColour Teal => new SRGBColour(0, 128, 128, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (216, 191, 216, 255).
+        /// </summary>
+        public static SRGBColour Thistle => new SRGBColour(216, 191, 216, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 99, 71, 255).
+        /// </summary>
+        public static SRGBColour Tomato => new SRGBColour(255, 99, 71, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (64, 224, 208, 255).
+        /// </summary>
+        public static SRGBColour Turquoise => new SRGBColour(64, 224, 208, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (238, 130, 238, 255).
+        /// </summary>
+        public static SRGBColour Violet => new SRGBColour(238, 130, 238, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (245, 222, 179, 255).
+        /// </summary>
+        public static SRGBColour Wheat => new SRGBColour(245, 222, 179, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 255, 255, 255).
+        /// </summary>
+        public static SRGBColour White => new SRGBColour(255, 255, 255, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (245, 245, 245, 255).
+        /// </summary>
+        public static SRGBColour WhiteSmoke => new SRGBColour(245, 245, 245, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (255, 255, 0, 255).
+        /// </summary>
+        public static SRGBColour Yellow => new SRGBColour(255, 255, 0, 255);
+
+        /// <summary>
+        /// Gets the system color with (R, G, B, A) = (154, 205, 50, 255).
+        /// </summary>
+        public static SRGBColour YellowGreen => new SRGBColour(154, 205, 50, 255);
+
+        #endregion
     }
 }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -136,10 +136,12 @@ namespace osu.Framework.Graphics.Colour
         public static SRGBColour FromVector(Vector4 v) => new SRGBColour { SRGB = new Color4(v.X, v.Y, v.Z, v.W) };
 
         /// <summary>
-        /// Multiplies the alpha value of this colour by the given alpha factor.
+        /// Returns a new <see cref="SRGBColour"/> with the same RGB components, but multiplying the current
+        /// alpha component by a scalar value. The final alpha is clamped to the 0-1 range.
         /// </summary>
-        /// <param name="alpha">The alpha factor to multiply with.</param>
-        public void MultiplyAlpha(float alpha) => SRGB.A *= alpha;
+        /// <param name="scalar">The value that the existing alpha will be multiplied by.</param>
+        [Pure]
+        public SRGBColour MultiplyAlpha(float scalar) => new SRGBColour(SRGB.MultiplyAlpha(scalar));
 
         private static bool isWhite(SRGBColour colour) => colour.SRGB.R == 1 && colour.SRGB.G == 1 && colour.SRGB.B == 1;
 

--- a/osu.Framework/Graphics/Colour4.cs
+++ b/osu.Framework/Graphics/Colour4.cs
@@ -11,10 +11,11 @@ using osuTK.Graphics;
 namespace osu.Framework.Graphics
 {
     /// <summary>
-    /// Represents an RGBA colour in the linear colour space, having colour components in the range 0-1.
+    /// Represents an RGBA colour with colour components in the range 0-1.
+    /// Only stores raw colour values and does not imply any colour space.
     /// Stored internally as a <see cref="Vector4"/> for performance.
     /// </summary>
-    public readonly struct Colour4 : IEquatable<Colour4>
+    public readonly record struct Colour4
     {
         /// <summary>
         /// <see cref="Vector4"/> representation of the colour, where XYZW maps to RGBA,
@@ -23,17 +24,17 @@ namespace osu.Framework.Graphics
         public readonly Vector4 Vector;
 
         /// <summary>
-        /// Represents the red component of the linear RGBA colour in the 0-1 range.
+        /// Represents the red component of the RGBA colour in the 0-1 range.
         /// </summary>
         public float R => Vector.X;
 
         /// <summary>
-        /// Represents the green component of the linear RGBA colour in the 0-1 range.
+        /// Represents the green component of the RGBA colour in the 0-1 range.
         /// </summary>
         public float G => Vector.Y;
 
         /// <summary>
-        /// Represents the blue component of the linear RGBA colour in the 0-1 range.
+        /// Represents the blue component of the RGBA colour in the 0-1 range.
         /// </summary>
         public float B => Vector.Z;
 
@@ -52,8 +53,8 @@ namespace osu.Framework.Graphics
         /// <param name="b">The blue component, in the 0-1 range.</param>
         /// <param name="a">The alpha component, in the 0-1 range.</param>
         public Colour4(float r, float g, float b, float a)
+            : this(new Vector4(r, g, b, a))
         {
-            Vector = new Vector4(r, g, b, a);
         }
 
         /// <summary>
@@ -64,12 +65,8 @@ namespace osu.Framework.Graphics
         /// <param name="b">The blue component, in the 0-255 range.</param>
         /// <param name="a">The alpha component, in the 0-255 range.</param>
         public Colour4(byte r, byte g, byte b, byte a)
+            : this(new Vector4(r, g, b, a) / byte.MaxValue)
         {
-            Vector = new Vector4(
-                r / (float)byte.MaxValue,
-                g / (float)byte.MaxValue,
-                b / (float)byte.MaxValue,
-                a / (float)byte.MaxValue);
         }
 
         /// <summary>
@@ -142,7 +139,7 @@ namespace osu.Framework.Graphics
         #region Operator Overloads
 
         /// <summary>
-        /// Multiplies two colours in the linear colour space.
+        /// Multiplies all values of two colours.
         /// </summary>
         /// <param name="first">The left hand side of the multiplication.</param>
         /// <param name="second">The right hand side of the multiplication.</param>
@@ -150,7 +147,7 @@ namespace osu.Framework.Graphics
             new Colour4(first.Vector * second.Vector);
 
         /// <summary>
-        /// Adds two colours in the linear colour space. The final value is clamped to the 0-1 range.
+        /// Adds all values of two colours. The final value is clamped to the 0-1 range.
         /// </summary>
         /// <param name="first">The left hand side of the addition.</param>
         /// <param name="second">The right hand side of the addition.</param>
@@ -166,7 +163,7 @@ namespace osu.Framework.Graphics
             new Colour4(Vector4.Max(first.Vector - second.Vector, Vector4.Zero));
 
         /// <summary>
-        /// Linearly multiplies a colour by a scalar value. The final value is clamped to the 0-1 range.
+        /// Multiplies all colour components by a scalar value. The final values are clamped to the 0-1 range.
         /// </summary>
         /// <param name="colour">The original colour.</param>
         /// <param name="scalar">The scalar value to multiply by. Must not be negative.</param>
@@ -179,7 +176,7 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Linearly divides a colour by a scalar value. The final value is clamped to the 0-1 range.
+        /// Divides all colour components by a scalar value. The final values are clamped to the 0-1 range.
         /// </summary>
         /// <param name="colour">The original colour.</param>
         /// <param name="scalar">The scalar value to divide by. Must be positive.</param>
@@ -190,20 +187,6 @@ namespace osu.Framework.Graphics
 
             return colour * (1 / scalar);
         }
-
-        /// <summary>
-        /// Performs a <see cref="Colour4"/> equality check using the <see cref="IEquatable{T}"/> implementation.
-        /// </summary>
-        /// <param name="first">The left hand side of the equation.</param>
-        /// <param name="second">The right hand side of the equation.</param>
-        public static bool operator ==(Colour4 first, Colour4 second) => first.Equals(second);
-
-        /// <summary>
-        /// Performs a <see cref="Colour4"/> inequality check using the <see cref="IEquatable{T}"/> implementation.
-        /// </summary>
-        /// <param name="first">The left hand side of the equation.</param>
-        /// <param name="second">The right hand side of the equation.</param>
-        public static bool operator !=(Colour4 first, Colour4 second) => !first.Equals(second);
 
         /// <summary>
         /// Converts an osuTK <see cref="Color4"/> to an osu!framework <see cref="Colour4"/>.
@@ -567,15 +550,13 @@ namespace osu.Framework.Graphics
 
         #endregion
 
-        #region Equality
-
-        public bool Equals(Colour4 other) => Vector.Equals(other.Vector);
-
-        public override bool Equals(object obj) => obj is Colour4 other && Equals(other);
-
-        public override int GetHashCode() => Vector.GetHashCode();
-
-        #endregion
+        public void Deconstruct(out float r, out float g, out float b, out float a)
+        {
+            r = R;
+            g = G;
+            b = B;
+            a = A;
+        }
 
         public override string ToString() => $"(R, G, B, A) = ({R:F}, {G:F}, {B:F}, {A:F})";
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -143,11 +143,13 @@ namespace osu.Framework.Graphics.Containers
 
                 Shader.Bind();
 
-                ColourInfo colour = ColourInfo.SingleColour(edgeEffect.Colour);
-                colour.TopLeft.MultiplyAlpha(DrawColourInfo.Colour.TopLeft.Alpha);
-                colour.BottomLeft.MultiplyAlpha(DrawColourInfo.Colour.BottomLeft.Alpha);
-                colour.TopRight.MultiplyAlpha(DrawColourInfo.Colour.TopRight.Alpha);
-                colour.BottomRight.MultiplyAlpha(DrawColourInfo.Colour.BottomRight.Alpha);
+                ColourInfo colour = new ColourInfo
+                {
+                    TopLeft = edgeEffect.Colour.MultiplyAlpha(DrawColourInfo.Colour.TopLeft.Alpha),
+                    BottomLeft = edgeEffect.Colour.MultiplyAlpha(DrawColourInfo.Colour.BottomLeft.Alpha),
+                    TopRight = edgeEffect.Colour.MultiplyAlpha(DrawColourInfo.Colour.TopRight.Alpha),
+                    BottomRight = edgeEffect.Colour.MultiplyAlpha(DrawColourInfo.Colour.BottomRight.Alpha),
+                };
 
                 renderer.DrawQuad(
                     renderer.WhitePixel,


### PR DESCRIPTION
The changes in this PR are the additions needed to implement the proposal as a usable API. More things might need to be added later. Breaking changes are described below but not included in the PR so that reading the code is easier.

Keep in mind that this is a proposal and while the commits in this PR could be merged, they exist more to demonstrate the API as code. I don't mind changing stuff.

## API overview

- `ColourInfo`: Semantically unchanged. Describes the colours of the four vertices of a quad.
- `SRGBColour`: Main single-colour type that framework users interact with. Contains a gamma-corrected sRGB colour. Thin wrapper around `Colour4`. The type discourages invalid things like gamma-incorrect colour math[^1].
- `LinearColour` (new): Secondary colour type for framework users. Contains a linear-light sRGB colour[^2]. Thin wrapper around `Colour4`. Basically only exists to do colour math.
- `Colour4`: Should rarely be used directly. Low level, raw colour values, no inherent colour space. This is where the real math (and optimization) should happen so that all abstractions can benefit.
- `Color4`: Semantically the same as `Colour4`. `Colour4` (no `osuTK` dependency, uses `System.Numerics.Vector4` which should optimise better) should always be preferred over `Color4` unless interacting with an osuTK API that requires it.

## Implementation notes

- Turning `MultiplyAlpha` into a pure method is a hidden trap for existing usage (`[Pure]` should help with this, but not sure it's enough). Renaming it is an alternative, but making it pure is a requirement for a readonly `SRGBColour`.
- The colour constants `Color4.Red` etc. are copies of the CSS [`<named-color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color) values and are [defined](https://developer.mozilla.org/en-US/docs/Web/CSS/named-color#description) to be in the sRGB colour space, so they should live in `SRGBColour`. This is also necessary to remove the implicit conversions `Color4`/`Colour4` <-> `SRGBColour` later on.
- The change from `Color4` to `Colour4` inside `SRGBColour` is most likely going to have performance implications. I am not sure how to test this because colours are used everywhere, and I do not have enough insight into the renderer implementations to know how this impacts them.

## Next steps

This list is mostly unordered.

- [X] Update `Colour4` and `ColourInfo` docs
- [X] Make `SRGBColour` readonly and extend API to cover common usage
- [X] Implement LinearColour
- [ ] Remove `SRGBColour.Linear` (**breaking** with low impact)
  - Returns a `Colour4` which loses colour space information
  - `ToLinear()` should be used instead
- [ ] Remove `SRGBColour` operator overloads (`*`, `/`, `+`) (**breaking** with low impact)
  - Use `ToLinear()` and `LinearColour` instead
  - Make the expensive sRGB<->linear conversions explicit
  - Chaining the `SRGBColour` operators is slow and imprecise and turns the operators into a footgun[^3]
- [ ] Replace `Color4` and `Colour4` in public API with `SRGBColour` or maybe `Colour4` instead (**breaking** with very high impact)
  - can be done in steps
  - Notable: `OsuColour`, `Color4Extensions`
- [ ] Remove implicit conversions between `Color4`/`Colour4` and `SRGBColour` (see #5714) (**breaking** with high impact)
- [ ] Remove implicit conversions between `Color4`/`Colour4` and `ColourInfo` (**breaking** with very high impact)
  - This is going to be a huge change (`drawable.Colour = Color4.Red` must be replaced with `drawable.Colour = SRGBColour.Red`), but can often be done with search-and-replace.
  - Benefit: Removes `osuTK` from a lot of places.
- [ ] Figure out what to do with colour-related `Bindable` types
- [ ] Figure out what to do with colour pickers
- [ ] Maybe move hexcode parsing and related code to `SRGBColour` (these are also semantically sRGB)
- [ ] Maybe remove colour constants in `Colour4`

[^1]: Gamma-incorrect operations could be done with helper functions.
[^2]: [As described here](https://developer.mozilla.org/en-US/docs/Glossary/Color_space) (search for "srgb-linear"). [Can also be called](https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ) "linear sRGB" or "gamma-expanded sRGB". This is usually called "linear colour"/"linear colour space" in and around o!f, which is why the struct is named `LinearColour`.
[^3]: For example, `a * b * c` will: Convert `a` and `b` to linear. Multiply those two. Convert the result back to sRGB. Convert the first result and `c` to linear. Multiply those two. Convert that result back to sRGB.