### PR TITLE
Fix `KeyCombination.IsPressed()` tripping assertions when empty 

### DIFF
--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Input.States;
+using osuTK.Input;
 
 namespace osu.Framework.Tests.Input
 {
@@ -64,6 +67,17 @@ namespace osu.Framework.Tests.Input
 
             Assert.That(keyCombination.Keys[0], Is.EqualTo(InputKey.Control));
             Assert.That(keyCombination.Keys[1], Is.EqualTo(InputKey.A));
+        }
+
+        [Test]
+        public void TestEmptyCombinationIsNeverPressed()
+        {
+            var keyCombination = new KeyCombination(Array.Empty<InputKey>());
+
+            var state = new InputState();
+            state.Keyboard.Keys.SetPressed(Key.X, true);
+
+            Assert.That(keyCombination.IsPressed(new KeyCombination(InputKey.X), state, KeyCombinationMatchingMode.Any), Is.False);
         }
     }
 }

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -102,6 +102,9 @@ namespace osu.Framework.Input.Bindings
             if (Keys == pressedKeys.Keys) // Fast test for reference equality of underlying array
                 return true;
 
+            if (Keys.SequenceEqual(none))
+                return false;
+
             return ContainsAll(Keys, pressedKeys.Keys, matchingMode);
         }
 


### PR DESCRIPTION
Found this while checking something else.

After https://github.com/ppy/osu-framework/pull/6229, `KeyCombination.IsPressed()` can trip on an assertion:

	System.AggregateException : One or more errors occurred. (: )
	  ----> NUnit.Framework.AssertionException : :
	   at osu.Framework.Testing.TestScene.checkForErrors() in /home/dachb/Documents/opensource/osu-framework/osu.Framework/Testing/TestScene.cs:line 502
	   at osu.Framework.Testing.TestScene.UseTestSceneRunnerAttribute.AfterTest(ITest test) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Testing/TestScene.cs:line 563
	   at NUnit.Framework.Internal.Commands.TestActionCommand.<>c__DisplayClass0_0.<.ctor>b__1(TestExecutionContext context)
	   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__1()
	   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
	--AssertionException
	   at osu.Framework.Logging.ThrowingTraceListener.Fail(String message1, String message2) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Logging/ThrowingTraceListener.cs:line 27
	   at System.Diagnostics.TraceInternal.Fail(String message, String detailMessage)
	   at System.Diagnostics.Debug.Fail(String message, String detailMessage)
	   at osu.Framework.Input.Bindings.KeyCombination.IsPressed(ImmutableArray`1 pressedPhysicalKeys, InputKey candidateKey) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Input/Bindings/KeyCombination.cs:line 206
	   at osu.Framework.Input.Bindings.KeyCombination.IsPressed(KeyCombination pressedKeys, InputState inputState, KeyCombinationMatchingMode matchingMode) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Input/Bindings/KeyCombination.cs:line 105
	   at osu.Framework.Input.Bindings.KeyBindingContainer`1.handleNewPressed(InputState state, InputKey newKey, Nullable`1 scrollDelta, Boolean isPrecise) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:line 227
	   at osu.Framework.Input.Bindings.KeyBindingContainer`1.Handle(UIEvent e) in
	/home/dachb/Documents/opensource/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:line 125
	   at osu.Framework.Graphics.Drawable.OnMouseDown(MouseDownEvent e) in /home/dachb/Documents/opensource/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2157
	   at osu.Framework.Graphics.Drawable.TriggerEvent(UIEvent e) in /home/dachb/Documents/opensource/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2033

This is happening game-side when a keybinding is vacated, at which point it is represented by `KeyCombination.none` or equivalent, i.e. a `KeyCombination` with its only key being `InputKey.None`.

`InputKey.None` is defined to be neither physical or virtual, which trips the aforementioned assertion. To bypass that entire debacle altogether, add an early return path that just returns false if the key combination being tested for being pressed is equivalent to `none`.

(It cannot be a reference equality check, I checked against game. Sequence equality is required. Something in game is probably instantiating anew. Probably something to do with how keybindings are materialised from realm.)