### PR TITLE
Remove OS username from log headers

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -47,11 +47,6 @@ namespace osu.Framework.Logging
         public static LogLevel Level = DebugUtils.IsDebugBuild ? LogLevel.Debug : LogLevel.Verbose;
 
         /// <summary>
-        /// An identifier used in log file headers to figure where the log file came from.
-        /// </summary>
-        public static string UserIdentifier = Environment.UserName;
-
-        /// <summary>
         /// An identifier for the game written to log file headers to indicate where the log file came from.
         /// </summary>
         public static string GameIdentifier = @"game";
@@ -395,7 +390,7 @@ namespace osu.Framework.Logging
                     if (!headerAdded)
                     {
                         writer.WriteLine("----------------------------------------------------------");
-                        writer.WriteLine($"{Name} Log for {UserIdentifier} (LogLevel: {Level})");
+                        writer.WriteLine($"{Name} Log (LogLevel: {Level})");
                         writer.WriteLine($"Running {GameIdentifier} {VersionIdentifier} on .NET {Environment.Version}");
                         writer.WriteLine($"Environment: {RuntimeInfo.OS} ({Environment.OSVersion}), {Environment.ProcessorCount} cores ");
                         writer.WriteLine("----------------------------------------------------------");


### PR DESCRIPTION
Discussed in [ppy/osu#28243](https://github.com/ppy/osu/discussions/28243#discussioncomment-9548742)

This PR removes the `UserIdentifier` from log headers, along with the field itself.

I also looked into the possibility of setting the `UserIdentifier` from game code. For osu!, this would be using the account username when logged in. I found this unpractical as it depends on the user being authenticated before the header (and subsequently, the first log line) is written.

To my knowledge, no consuming projects use this field to set a custom username.