### PR TITLE
Ignore editlist when decoding mp4/mov videos

### DIFF
--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -15,6 +15,10 @@ namespace osu.Framework.Graphics.Video
     {
         #region Delegates
 
+        public delegate int AvDictSetDelegate(AVDictionary** pm, [MarshalAs(UnmanagedType.LPUTF8Str)] string key, [MarshalAs(UnmanagedType.LPUTF8Str)] string value, int flags);
+
+        public delegate void AvDictFreeDelegate(AVDictionary** m);
+
         public delegate AVFrame* AvFrameAllocDelegate();
 
         public delegate void AvFrameFreeDelegate(AVFrame** frame);
@@ -89,6 +93,8 @@ namespace osu.Framework.Graphics.Video
 
         #endregion
 
+        public AvDictSetDelegate av_dict_set;
+        public AvDictFreeDelegate av_dict_free;
         public AvFrameAllocDelegate av_frame_alloc;
         public AvFrameFreeDelegate av_frame_free;
         public AvFrameUnrefDelegate av_frame_unref;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/13696.

The editlist would cause storyboard videos to not play back the same way stable (and most other video players) plays them back.

It took me about 2 hours to figure out how to call this, and only managed to do it thanks to github-wide search [returning something that looked like what I wanted](https://github.com/codec-foundation/adobe-cc/blob/302805206994c45675b77e4a8b137bdd487ae080/source/session/movie_reader.cpp#L63-L73) after a lot of time wasted staring at ffmpeg docs, and ffmpeg source, and debugging ffplay to figure out how the hell it was passing everything and not being able to tell. C is a hell of a drug.