### PR TITLE
Add virtualised list container

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -999,4 +999,5 @@ private void load()
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=localisable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaders/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Veldrid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Veldrid/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=virtualised/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
@@ -1,0 +1,144 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    [TestFixture]
+    public partial class TestSceneVirtualisedListContainer : FrameworkTestScene
+    {
+        [Test]
+        public void TestNaiveList()
+        {
+            AddStep("create list", () => Child = new BasicScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    ChildrenEnumerable = Enumerable.Range(1, 10000).Select(i => new DrawableItem { Current = { Value = $"Item #{i}" } })
+                }
+            });
+        }
+
+        [Test]
+        public void TestVirtualisedList()
+        {
+            AddStep("create list", () =>
+            {
+                ExampleVirtualisedList list;
+                Child = list = new ExampleVirtualisedList
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+                list.RowData.AddRange(Enumerable.Range(1, 10000).Select(i => $"Item #{i}"));
+            });
+        }
+
+        [Test]
+        public void TestCollectionChangeHandling()
+        {
+            ExampleVirtualisedList list = null!;
+
+            AddStep("create list", () =>
+            {
+                Child = list = new ExampleVirtualisedList
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+                list.RowData.AddRange(Enumerable.Range(1, 10).Select(i => $"Item #{i}"));
+            });
+
+            AddStep("insert at start", () => list.RowData.Insert(0, "first"));
+            AddStep("insert at end", () => list.RowData.Add("last"));
+            AddStep("remove from middle", () => list.RowData.RemoveAt(5));
+            AddStep("move forward", () => list.RowData.Move(0, 4));
+            AddStep("move back", () => list.RowData.Move(5, 2));
+            AddStep("replace", () => list.RowData[3] = "replacing");
+            AddStep("clear", () => list.RowData.Clear());
+        }
+
+        private partial class DrawableItem : PoolableDrawable, IHasCurrentValue<string>
+        {
+            public const int HEIGHT = 25;
+
+            private readonly BindableWithCurrent<string> current = new BindableWithCurrent<string>();
+
+            private Box background = null!;
+            private SpriteText text = null!;
+
+            public Bindable<string> Current
+            {
+                get => current.Current;
+                set => current.Current = value;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.X;
+                Height = HEIGHT;
+                InternalChildren = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = FrameworkColour.GreenDark,
+                    },
+                    text = new SpriteText
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Margin = new MarginPadding { Left = 10, },
+                        Anchor = Anchor.CentreLeft,
+                        Origin = Anchor.CentreLeft,
+                    }
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Current.BindValueChanged(_ => text.Text = Current.Value, true);
+                updateState();
+                FinishTransforms(true);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                updateState();
+                return true;
+            }
+
+            private void updateState() => background.FadeTo(IsHovered ? 1 : 0, 300, Easing.OutQuint);
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                updateState();
+            }
+        }
+
+        private partial class ExampleVirtualisedList : VirtualisedListContainer<string, DrawableItem>
+        {
+            public ExampleVirtualisedList()
+                : base(DrawableItem.HEIGHT, 50)
+            {
+            }
+
+            protected override ScrollContainer<Drawable> CreateScrollContainer() => new BasicScrollContainer();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -12,7 +12,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Logging;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -75,8 +74,6 @@ namespace osu.Framework.Graphics.Containers
         {
             visibilityCache.Invalidate();
             Items.Height = rowHeight * RowData.Count;
-
-            Logger.Log(string.Join(Environment.NewLine, RowData.Select(d => d.ToString())));
 
             var items = Items.FlowingChildren.ToArray();
 

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -220,7 +220,7 @@ namespace osu.Framework.Graphics.Containers
                 }
             }
 
-            public bool Visible { get; set; }
+            public bool Visible { get; private set; }
 
             private readonly DrawablePool<TDrawable> pool;
 

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -229,6 +229,12 @@ namespace osu.Framework.Graphics.Containers
                 Row = row;
                 this.pool = pool;
                 RelativeSizeAxes = Axes.X;
+
+                // to avoid overheads from input handling (or, to be more specific, from constructing input queues),
+                // the row manages its own lifetime.
+                // if the row is not alive, it is not in `AliveInternalChildren` of its parent,
+                // which means that it is omitted from consideration in `Build(Non)PositionalInputQueue()` et al.
+                LifetimeEnd = double.NegativeInfinity;
             }
 
             public void Load()

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -81,15 +81,17 @@ namespace osu.Framework.Graphics.Containers
             {
                 case NotifyCollectionChangedAction.Add:
                 {
+                    Debug.Assert(e.NewItems != null);
+
                     if (e.NewStartingIndex >= 0)
                     {
                         for (int i = e.NewStartingIndex; i < items.Length; ++i)
-                            Items.SetLayoutPosition(items[i], i + e.NewItems!.Count);
+                            Items.SetLayoutPosition(items[i], i + e.NewItems.Count);
                     }
 
-                    for (int i = 0; i < e.NewItems!.Count; ++i)
+                    for (int i = 0; i < e.NewItems.Count; ++i)
                     {
-                        Items.Insert(Math.Max(e.NewStartingIndex, 0) + i, new ItemRow((TData)e.NewItems![i]!, pool)
+                        Items.Insert(Math.Max(e.NewStartingIndex, 0) + i, new ItemRow((TData)e.NewItems[i]!, pool)
                         {
                             Height = rowHeight,
                             LifetimeEnd = double.NegativeInfinity,
@@ -101,11 +103,13 @@ namespace osu.Framework.Graphics.Containers
 
                 case NotifyCollectionChangedAction.Remove:
                 {
-                    for (int i = 0; i < e.OldItems!.Count; ++i)
+                    Debug.Assert(e.OldItems != null);
+
+                    for (int i = 0; i < e.OldItems.Count; ++i)
                         Items.Remove(items[e.OldStartingIndex + i], true);
 
-                    for (int i = e.OldStartingIndex + e.OldItems!.Count; i < items.Length; ++i)
-                        Items.SetLayoutPosition(items[i], i - e.OldItems!.Count);
+                    for (int i = e.OldStartingIndex + e.OldItems.Count; i < items.Length; ++i)
+                        Items.SetLayoutPosition(items[i], i - e.OldItems.Count);
                     break;
                 }
 

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -1,0 +1,250 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Caching;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// This class is an alternative to combined <see cref="ScrollContainer{T}"/> / <see cref="FlowContainer{T}"/> usage
+    /// for large lists (think thousands of items).
+    /// This class efficiently handles collection change events, as well as applies pooling to only allocate drawables for what is actually visible
+    /// on screen.
+    /// The trade-off is that every row has to have an estimated or fixed height so that layout can be estimated cheaply pre-emptively.
+    /// </summary>
+    public abstract partial class VirtualisedListContainer<TData, TDrawable> : CompositeDrawable
+        where TData : notnull
+        where TDrawable : PoolableDrawable, IHasCurrentValue<TData>, new()
+    {
+        public BindableList<TData> RowData { get; } = new BindableList<TData>();
+
+        protected ScrollContainer<Drawable> Scroll { get; private set; } = null!;
+        protected ItemFlow Items { get; private set; } = null!;
+
+        private readonly float rowHeight;
+        private readonly int initialPoolSize;
+
+        private (float min, float max) visibleRange;
+        private readonly Cached visibilityCache = new Cached();
+
+        private DrawablePool<TDrawable> pool = null!;
+
+        protected VirtualisedListContainer(float rowHeight, int initialPoolSize)
+        {
+            this.rowHeight = rowHeight;
+            this.initialPoolSize = initialPoolSize;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                pool = new DrawablePool<TDrawable>(initialPoolSize),
+                Scroll = CreateScrollContainer().With(s =>
+                {
+                    s.RelativeSizeAxes = Axes.Both;
+                    s.Child = Items = new ItemFlow
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Direction = FillDirection.Vertical,
+                    };
+                })
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            RowData.BindCollectionChanged(itemsChanged, true);
+        }
+
+        private void itemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            visibilityCache.Invalidate();
+            Items.Height = rowHeight * RowData.Count;
+
+            Logger.Log(string.Join(Environment.NewLine, RowData.Select(d => d.ToString())));
+
+            var items = Items.FlowingChildren.ToArray();
+
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                {
+                    if (e.NewStartingIndex >= 0)
+                    {
+                        for (int i = e.NewStartingIndex; i < items.Length; ++i)
+                            Items.SetLayoutPosition(items[i], i + e.NewItems!.Count);
+                    }
+
+                    for (int i = 0; i < e.NewItems!.Count; ++i)
+                    {
+                        Items.Insert(Math.Max(e.NewStartingIndex, 0) + i, new ItemRow((TData)e.NewItems![i]!, pool)
+                        {
+                            Height = rowHeight,
+                            LifetimeEnd = double.NegativeInfinity,
+                        });
+                    }
+
+                    break;
+                }
+
+                case NotifyCollectionChangedAction.Remove:
+                {
+                    for (int i = 0; i < e.OldItems!.Count; ++i)
+                        Items.Remove(items[e.OldStartingIndex + i], true);
+
+                    for (int i = e.OldStartingIndex + e.OldItems!.Count; i < items.Length; ++i)
+                        Items.SetLayoutPosition(items[i], i - e.OldItems!.Count);
+                    break;
+                }
+
+                case NotifyCollectionChangedAction.Replace:
+                {
+                    Items[e.OldStartingIndex].Row = (TData)e.NewItems![0]!;
+                    break;
+                }
+
+                case NotifyCollectionChangedAction.Move:
+                {
+                    var allMoves = new List<(ItemRow, float)>();
+
+                    for (int i = Math.Min(e.OldStartingIndex, e.NewStartingIndex); i <= Math.Max(e.OldStartingIndex, e.NewStartingIndex); ++i)
+                    {
+                        if (i == e.OldStartingIndex)
+                            allMoves.Add((items[i], e.NewStartingIndex));
+                        else if (e.NewStartingIndex < e.OldStartingIndex)
+                            allMoves.Add((items[i], i + 1));
+                        else
+                            allMoves.Add((items[i], i - 1));
+                    }
+
+                    foreach (var (item, newPosition) in allMoves)
+                        Items.SetLayoutPosition(item, newPosition);
+
+                    break;
+                }
+
+                case NotifyCollectionChangedAction.Reset:
+                {
+                    Items.Clear();
+                    break;
+                }
+            }
+
+            assertCorrectOrder();
+        }
+
+        [Conditional("DEBUG")]
+        private void assertCorrectOrder()
+        {
+            var children = Items.FlowingChildren.ToArray();
+
+            for (int i = 0; i < children.Length; ++i)
+            {
+                float expected = i;
+                float actual = Items.GetLayoutPosition(children[i]);
+                Debug.Assert(expected == actual, $"Index mismatch when handling collection change callback in VirtualisedListContainer: expected {expected} actual {actual}");
+            }
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var currentVisibleRange = (Scroll.Current, Scroll.Current + Scroll.DrawHeight);
+
+            if (currentVisibleRange != visibleRange)
+            {
+                visibilityCache.Invalidate();
+                visibleRange = currentVisibleRange;
+            }
+
+            if (!visibilityCache.IsValid)
+            {
+                var children = Items.FlowingChildren.ToArray();
+
+                for (int i = 0; i < children.Length; ++i)
+                {
+                    var row = children[i];
+
+                    float minY = row.IsLoaded ? row.DrawPosition.Y : i * rowHeight;
+                    float maxY = minY + rowHeight;
+
+                    if ((maxY < visibleRange.min || minY > visibleRange.max) && row.Visible)
+                        row.Unload();
+
+                    if ((maxY >= visibleRange.min && minY <= visibleRange.max) && !row.Visible)
+                        row.Load();
+                }
+
+                visibilityCache.Validate();
+            }
+        }
+
+        protected partial class ItemFlow : FillFlowContainer<ItemRow>
+        {
+            public override IEnumerable<ItemRow> FlowingChildren => InternalChildren.Where(d => d.IsPresent).OrderBy(GetLayoutPosition).Cast<ItemRow>();
+        }
+
+        protected partial class ItemRow : CompositeDrawable
+        {
+            public override bool RemoveWhenNotAlive => false;
+            public override bool DisposeOnDeathRemoval => false;
+
+            private TData row;
+
+            public TData Row
+            {
+                get => row;
+                [MemberNotNull(nameof(row))]
+                set
+                {
+                    row = value;
+                    if (InternalChildren.SingleOrDefault() is TDrawable rowDrawable)
+                        rowDrawable.Current.Value = value;
+                }
+            }
+
+            public bool Visible { get; set; }
+
+            private readonly DrawablePool<TDrawable> pool;
+
+            public ItemRow(TData row, DrawablePool<TDrawable> pool)
+            {
+                Row = row;
+                this.pool = pool;
+                RelativeSizeAxes = Axes.X;
+            }
+
+            public void Load()
+            {
+                InternalChild = pool.Get(d => d.Current.Value = Row);
+                Visible = true;
+                LifetimeEnd = double.PositiveInfinity;
+            }
+
+            public void Unload()
+            {
+                ClearInternal(false);
+                Visible = false;
+                LifetimeEnd = double.NegativeInfinity;
+            }
+        }
+
+        protected abstract ScrollContainer<Drawable> CreateScrollContainer();
+    }
+}


### PR DESCRIPTION
RFC.

Game-side, we have a few lists/tables which perform dreadfully when stressed by a large number of rows/columns. Two of them reside in the editor, namely: the timing table and the verify issue list table.

The primary overheads in both are:
- All of the rows' content is constructed, loaded, and placed in the hierarchy eagerly, which causes a long freeze on first show.
- Even though 99.999999% of the content is not visible, it is still present in various places where it is causing trouble. While masking does cull *some* of it, the big killer is input handling - if any ancestor of a table row _might_ handle e.g. mouse input because they are all alive, all of them get shoved into the input queue and then all need to be checked on every mouse movement. (See https://github.com/ppy/osu-framework/pull/6282.) Mitigation of this has been applied via ~~dumb~~ hacks like having the _background_ of the table be a separate drawable under it and have it handle input. I was sorta hoping `ShouldBeConsideredForInput` could maybe fix this but it regretfully does not (it reduces *some* overhead but not enough to be acceptable yet).
- For mutable lists, 99% of usage sites will not handle the args carefully, but rather just clear everything and reconstruct from scratch, which is obviously rather expensive for long lists.

What *this* pull is intended to introduce is a sort of [`UITableView`](https://developer.apple.com/documentation/uikit/uitableview) but for osu!framework usage out-of-the-box.

- Exposes a "virtualised list" data-oriented interface. You derive from `VirtualisedListContainer`, and give a model and a drawable for it via the generic specs.
- The list item must be poolable and must have a bindable model on it (can't use `ModelBackedDrawable` because I can't inherit from both `PoolableDrawable` and that, so `IHasCurrentValue` it is)
- List items are assumed to have fixed heights so that layout can be ballparked in advance without items being physically present in the hierarchy.

For testing there is the test scene added here, but there's also [this branch](https://github.com/bdach/osu/compare/control-point-table-is-bad?expand=1) (needs to be cleaned up yet, very PoC). In my vague "performance testing" (read: looking at frame graph times), on a stress test like https://osu.ppy.sh/beatmapsets/1238185#mania/2574372 this can improve FPS by factors of 5 to even an order of magnitude:

- timing - 170fps -> 1000fps
- verify - 13fps -> 400fps

(both tested on release configuration, with static mouse).

The pooling takes care of the drawable construction overheads, and the lifetime games this container plays help with input handling (if a child isn't alive, [it doesn't get looked at with respect to input at all](https://github.com/ppy/osu-framework/blob/98617abd34280121f64967173cc42b915216dab7/osu.Framework/Graphics/Containers/CompositeDrawable.cs#L1428-L1432)). Collection changes are handled _somewhat_ efficiently (better than reconstructing everything from scratch, at least).

The one case that is still not as fast as I perhaps would have hoped for is active scrolling, but it's still better than it was.