### PR TITLE
Fix video decoding failing on Android due to missing `av_dict_{set,free}`

### DIFF
--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -5,6 +5,7 @@
 
 using System.Runtime.InteropServices;
 using FFmpeg.AutoGen;
+using JetBrains.Annotations;
 
 // ReSharper disable InconsistentNaming
 #pragma warning disable IDE1006 // Naming style
@@ -93,8 +94,12 @@ namespace osu.Framework.Graphics.Video
 
         #endregion
 
+        [CanBeNull]
         public AvDictSetDelegate av_dict_set;
+
+        [CanBeNull]
         public AvDictFreeDelegate av_dict_free;
+
         public AvFrameAllocDelegate av_frame_alloc;
         public AvFrameFreeDelegate av_frame_free;
         public AvFrameUnrefDelegate av_frame_unref;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -351,9 +351,9 @@ namespace osu.Framework.Graphics.Video
 
             AVDictionary* options = null;
             // see https://github.com/ppy/osu/issues/13696 for reasoning
-            ffmpeg.av_dict_set(&options, "ignore_editlist", "1", 0);
+            ffmpeg.av_dict_set?.Invoke(&options, "ignore_editlist", "1", 0);
             int openInputResult = ffmpeg.avformat_open_input(&fcPtr, "pipe:", null, &options);
-            ffmpeg.av_dict_free(&options);
+            ffmpeg.av_dict_free?.Invoke(&options);
 
             inputOpened = openInputResult >= 0;
             if (!inputOpened)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28578.

Apparently on Android (and maybe iOS?) these point to null. Probably related to the fact that we're not building our own for these platforms yet. Best-effort fix for now.