### PR TITLE
Fix clicking on padded dropdown search bars not opening the menu

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -11,6 +11,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
@@ -708,6 +709,31 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         #endregion
 
+        [Test]
+        public void TestPaddedSearchBar()
+        {
+            SearchBarPaddedDropdown dropdown = null!;
+
+            AddStep("setup dropdown", () =>
+            {
+                Child = dropdown = new SearchBarPaddedDropdown
+                {
+                    Position = new Vector2(50f, 50f),
+                    Width = 150f,
+                    Items = new TestModel("test").Yield(),
+                };
+            });
+
+            AddStep("click on padded area", () =>
+            {
+                RectangleF area = dropdown.Header.ScreenSpaceDrawQuad.AABBFloat;
+                InputManager.MoveMouseTo(new Vector2(area.Right - 5, area.Centre.Y));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("dropdown is open", () => dropdown.Menu.State, () => Is.EqualTo(MenuState.Open));
+        }
+
         private TestDropdown createDropdown() => createDropdowns(1).Single();
 
         private TestDropdown[] createDropdowns(int count) => createDropdowns<TestDropdown>(count);
@@ -808,6 +834,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 Assert.That(text, Is.Not.Null);
                 return $"{text}: {base.GenerateItemText(item)}";
+            }
+        }
+
+        private partial class SearchBarPaddedDropdown : TestDropdown
+        {
+            protected override DropdownHeader CreateHeader() => new PaddedHeader();
+
+            private partial class PaddedHeader : BasicDropdownHeader
+            {
+                protected override DropdownSearchBar CreateSearchBar() => base.CreateSearchBar().With(d =>
+                {
+                    d.Padding = new MarginPadding { Right = 25 };
+                });
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -98,6 +98,11 @@ namespace osu.Framework.Graphics.UserInterface
                     AutoSizeAxes = Axes.Y
                 },
                 SearchBar = CreateSearchBar(),
+                new ClickHandler
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Click = onClick
+                }
             };
         }
 
@@ -127,6 +132,22 @@ namespace osu.Framework.Graphics.UserInterface
         {
             Colour = Enabled.Value ? Color4.White : DisabledColour;
             Background.Colour = IsHovered && Enabled.Value ? BackgroundColourHover : BackgroundColour;
+        }
+
+        /// <summary>
+        /// Handles clicks on the header to open/close the menu.
+        /// </summary>
+        private bool onClick(ClickEvent e)
+        {
+            // Allow input to fall through to the search bar (and its contained textbox) if it's visible.
+            if (SearchBar.State.Value == Visibility.Visible)
+                return false;
+
+            // Otherwise, the header acts as a button to show/hide the menu.
+            dropdown.ToggleMenu();
+
+            // And importantly, when the menu is closed as a result of the above toggle, block the search bar from receiving input.
+            return dropdown.MenuState == MenuState.Closed;
         }
 
         public override bool HandleNonPositionalInput => IsHovered;
@@ -183,6 +204,12 @@ namespace osu.Framework.Graphics.UserInterface
             Last,
             FirstVisible,
             LastVisible
+        }
+
+        private partial class ClickHandler : Drawable
+        {
+            public required Func<ClickEvent, bool> Click { get; init; }
+            protected override bool OnClick(ClickEvent e) => Click(e);
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
-using osu.Framework.Input.Events;
 using osu.Framework.Platform;
 using osuTK;
 
@@ -56,12 +54,7 @@ namespace osu.Framework.Graphics.UserInterface
                     t.ReleaseFocusOnCommit = true;
                     t.CommitOnFocusLost = false;
                     t.OnCommit += onTextBoxCommit;
-                }),
-                new ClickHandler
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Click = onClick
-                }
+                })
             };
 
             dropdown.MenuStateChanged += onMenuStateChanged;
@@ -164,23 +157,6 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Handles clicks on the search bar.
-        /// </summary>
-        private bool onClick(ClickEvent e)
-        {
-            // Allow input to fall through to the textbox if it's visible.
-            if (State.Value == Visibility.Visible)
-                return false;
-
-            // Otherwise, the search box acts as a button to show/hide the menu.
-            dropdown.ToggleMenu();
-
-            // And importantly, when the menu is closed as a result of the above toggle,
-            // block the textbox from receiving input so that it doesn't get re-focused.
-            return dropdown.MenuState == MenuState.Closed;
-        }
-
-        /// <summary>
         /// Creates the <see cref="TextBox"/>.
         /// </summary>
         protected abstract TextBox CreateTextBox();
@@ -201,12 +177,6 @@ namespace osu.Framework.Graphics.UserInterface
                 return false;
 
             return dropdown.ChangeFocus(potentialFocusTarget);
-        }
-
-        private partial class ClickHandler : Drawable
-        {
-            public required Func<ClickEvent, bool> Click { get; init; }
-            protected override bool OnClick(ClickEvent e) => Click(e);
         }
 
         private class DropdownTextInputSource : TextInputSource


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/28594

In hindsight, it's probably not a good idea to handle click-to-open input in something like a "search bar".

In osu!, the search bar is padded to add space for the down-arrow icon: https://github.com/ppy/osu/blob/9039ec34bae03a9b20e43b2161cc5c9e767c3889/osu.Game/Graphics/UserInterface/OsuDropdown.cs#L405-L408

I also explored the option of moving the padding to the textbox proper, but textboxes don't seem to properly handle padding at all.