### PR TITLE
Fix `VirtualisedListContainer` rows not returning child to pool on disposal

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
@@ -37,14 +37,19 @@ namespace osu.Framework.Tests.Visual.Containers
         [Test]
         public void TestVirtualisedList()
         {
+            ExampleVirtualisedList list = null!;
             AddStep("create list", () =>
             {
-                ExampleVirtualisedList list;
                 Child = list = new ExampleVirtualisedList
                 {
                     RelativeSizeAxes = Axes.Both,
                 };
                 list.RowData.AddRange(Enumerable.Range(1, 10000).Select(i => $"Item #{i}"));
+            });
+            AddStep("replace items", () =>
+            {
+                list.RowData.Clear();
+                list.RowData.AddRange(Enumerable.Range(10001, 10000).Select(i => $"Item #{i}"));
             });
         }
 

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -250,6 +250,19 @@ namespace osu.Framework.Graphics.Containers
                 Visible = false;
                 LifetimeEnd = double.NegativeInfinity;
             }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                // CompositeDrawable only disposes the child pooled drawable (if any).
+                // This is generally not what we want for two reasons:
+                // - We want to try to return the pooled drawable to the pool so that it can be reused.
+                //   Disposing it obviously makes reuse impossible.
+                // - Secondly, pooled drawables return to pool when they lose their parent.
+                // Thus, we proactively clear the pool drawable from ourselves here.
+                Unload();
+
+                base.Dispose(isDisposing);
+            }
         }
 
         protected abstract ScrollContainer<Drawable> CreateScrollContainer();


### PR DESCRIPTION
`CompositeDrawable.Dispose()` doesn't do anything to its children except dispose them, which is problematic, since it leads to two things happening in the context of `VirtualisedListContainer`:

- The pooled child is never returned to pool (because returning happens automagically on parent change, which doesn't happen here)
- However, the pool continues to retain the reference to a disposed pooled drawable, which means that it (a) keeps drawables that will blow up if they were ever to be used, which isn't possible because (b) these drawables are never returned, which means that the pool will inevitably start overflowing.

Thus, aggressively remove the pooled child at the start of disposal to counteract this happening.

Can be semi-manually tested using 0b7106bd277885ab2afcb491892175c200be1260:

- Open test scene
- Open performance tool window (ctrl-f2)
- Scroll to the part that shows active / total pool capacity
- Spam the added "replace items" test step
- Watch the pool begin to overflow.