### PR TITLE
Remove faulty assertion in scroll container

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -345,7 +345,8 @@ namespace osu.Framework.Graphics.Containers
             float scrollOffset = -childDelta[ScrollDim];
             float clampedScrollOffset = Clamp(Target + scrollOffset) - Clamp(Target);
 
-            Debug.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
+            // todo: this assertion fails when the difference between the values become too small to contain in float precision (see https://github.com/ppy/osu-framework/issues/2697)
+            // Debug.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
 
             // If we are dragging past the extent of the scrollable area, half the offset
             // such that the user can feel it.

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -345,9 +345,6 @@ namespace osu.Framework.Graphics.Containers
             float scrollOffset = -childDelta[ScrollDim];
             float clampedScrollOffset = Clamp(Target + scrollOffset) - Clamp(Target);
 
-            // todo: this assertion fails when the difference between the values become too small to contain in float precision (see https://github.com/ppy/osu-framework/issues/2697)
-            // Debug.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
-
             // If we are dragging past the extent of the scrollable area, half the offset
             // such that the user can feel it.
             scrollOffset = clampedScrollOffset + (scrollOffset - clampedScrollOffset) / 2;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/2697

Hit this multiple times while just wanting to scroll through a zoomed-in editor timeline in osu!. Discussed removing assertion in [discord](https://discord.com/channels/188630481301012481/589331078574112768/1255759444739096606).