### PR TITLE
Fix `VirtualisedListContainer` rows not returning pooled content in a different way

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVirtualisedListContainer.cs
@@ -54,6 +54,30 @@ namespace osu.Framework.Tests.Visual.Containers
         }
 
         [Test]
+        public void TestVirtualisedListDisposal()
+        {
+            ExampleVirtualisedList list = null!;
+            AddStep("create list nested in container", () =>
+            {
+                Child = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = list = new ExampleVirtualisedList
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                        }
+                    }
+                };
+                list.RowData.AddRange(Enumerable.Range(1, 10000).Select(i => $"Item #{i}"));
+            });
+            AddStep("clear", Clear);
+            AddUntilStep("wait for async disposal", () => list.IsDisposed);
+        }
+
+        [Test]
         public void TestCollectionChangeHandling()
         {
             ExampleVirtualisedList list = null!;

--- a/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
+++ b/osu.Framework/Graphics/Containers/VirtualisedListContainer.cs
@@ -106,7 +106,11 @@ namespace osu.Framework.Graphics.Containers
                     Debug.Assert(e.OldItems != null);
 
                     for (int i = 0; i < e.OldItems.Count; ++i)
-                        Items.Remove(items[e.OldStartingIndex + i], true);
+                    {
+                        var item = items[e.OldStartingIndex + i];
+                        item.Unload();
+                        Items.Remove(item, true);
+                    }
 
                     for (int i = e.OldStartingIndex + e.OldItems.Count; i < items.Length; ++i)
                         Items.SetLayoutPosition(items[i], i - e.OldItems.Count);
@@ -249,19 +253,6 @@ namespace osu.Framework.Graphics.Containers
                 ClearInternal(false);
                 Visible = false;
                 LifetimeEnd = double.NegativeInfinity;
-            }
-
-            protected override void Dispose(bool isDisposing)
-            {
-                // CompositeDrawable only disposes the child pooled drawable (if any).
-                // This is generally not what we want for two reasons:
-                // - We want to try to return the pooled drawable to the pool so that it can be reused.
-                //   Disposing it obviously makes reuse impossible.
-                // - Secondly, pooled drawables return to pool when they lose their parent.
-                // Thus, we proactively clear the pool drawable from ourselves here.
-                Unload();
-
-                base.Dispose(isDisposing);
             }
         }
 


### PR DESCRIPTION
Paper trail:

- https://github.com/ppy/osu-framework/pull/6316
- https://github.com/ppy/osu/pull/28613#issuecomment-2191818044

Test coverage for this mode of failure added in d88015a233a4105646a5251aefdb5588c8aa22bc.