### PR TITLE
Make time move along at the same rate in all threads during headless execution

### DIFF
--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Rendering.Dummy;
@@ -109,8 +110,9 @@ namespace osu.Framework.Platform
         {
             private readonly double increment;
             private readonly GameThread[] gameThreads;
-            private double time;
+            private readonly Stopwatch stopwatch = new Stopwatch();
 
+            private double time;
             private ulong? lastFrameIndex;
 
             /// <summary>
@@ -129,11 +131,14 @@ namespace osu.Framework.Platform
             {
                 get
                 {
+                    double realElapsedTime = stopwatch.Elapsed.TotalMilliseconds;
+                    stopwatch.Restart();
+
                     ulong frameIndex = gameThreads.Min(t => t.FrameIndex);
 
                     // Don't increment the current time until all threads have advanced at least one frame.
                     if (frameIndex == lastFrameIndex)
-                        return time;
+                        return time += realElapsedTime;
 
                     time += increment;
                     lastFrameIndex = frameIndex;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -143,6 +143,11 @@ namespace osu.Framework.Threading
         internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
 
         /// <summary>
+        /// The amount of times this thread has run.
+        /// </summary>
+        internal ulong FrameIndex { get; private set; }
+
+        /// <summary>
         /// The main work which is fired on each frame.
         /// </summary>
         protected event Action? OnNewFrame;
@@ -439,6 +444,8 @@ namespace osu.Framework.Threading
 
             try
             {
+                FrameIndex++;
+
                 Monitor?.NewFrame();
 
                 using (Monitor?.BeginCollecting(PerformanceCollectionType.Scheduler))


### PR DESCRIPTION
RFC. Primarily, this should fix the osu!-side macOS test failures when running under MultiThread execution mode. This will also likely fix other unexplainable flaky tests.

Unfortunately, I don't _think_ this is or I can't reason as to why it would be related to the clock running backwards (https://github.com/ppy/osu/issues/26879), as I'd hoped to find :(

## Reproduction:

Local osu!-framework checkout with:
```diff
diff --git a/osu.Framework/Threading/AudioThread.cs b/osu.Framework/Threading/AudioThread.cs
index 171f43280..4debaad82 100644
--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -65,6 +65,8 @@ private void onNewFrame()
                     m.Update();
                 }
             }
+
+            System.Threading.Thread.Sleep(200);
         }

         internal void RegisterManager(AudioManager manager)
```

Run test `TestSceneCatchModNoScope.TestVisibleDuringBreak`.

## Investigation

As far as I could deduce, this is caused by the audio thread running much slower than the update thread.

`FastClock` increments `CurrentTime` by 33ms every time it is referenced. In headless execution, this happens once per frame, as mandated by the `FramedClock` wrapping it.

https://github.com/ppy/osu-framework/blob/4f516283dbe9e8b079e1b26783624ecab8a30546/osu.Framework/Platform/HeadlessGameHost.cs#L71-L92

osu! tests use the test scene's clock (which is the framed `FastClock` from above) as the reference clock for the beatmap, allowing gameplay tests to execute at non-realtime speeds:

https://github.com/ppy/osu/blob/95783bd6c2543f15d71f89c6a3469a0d0fcfaba6/osu.Game/Tests/Visual/OsuTestScene.cs#L321-L322

The `TrackVirtualManual` referencing that clock is only updated from the audio thread.

https://github.com/ppy/osu/blob/95783bd6c2543f15d71f89c6a3469a0d0fcfaba6/osu.Game/Tests/Visual/OsuTestScene.cs#L497-L518

So, the failure case seems to be as follows:
- The update thread is running much faster than the audio thread (could be CI runner resource exhaustion/etc - these failures started coming up after the runner was moved to ARM64). I've observed the imbalance up to 2 orders of magnitude.
- This results in the `FastClock` updating very frequently, but the `TrackVirtualManual` updating very _in_frequently.
- When the `TrackVirtualManual` finally updates, it skips forward several seconds in execution, which gameplay also follows.
- Because of the skip, certain test steps aren't executed fast enough (only executed every 200ms) while their expected gameplay state has been skipped.

Using `TestVisibleDuringBreak` as an example, here's a visual simulation. Only the audio thread is being paused here (for 4s):

https://github.com/ppy/osu-framework/assets/1329837/15d2f41e-e8a3-451b-a4e4-a15f2ab4140f

This also makes it intuitive why single-threaded execution is unaffected.

## Fix

I would say that the fix here is a little bit of a workaround. We're preventing the threads from getting too far out-of-sync time-wise without limiting their run rate, matching a little bit closer to reality.