### PR TITLE
Fix intermittent `Playing` state on short looping samples

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -19,7 +19,18 @@ namespace osu.Framework.Audio.Sample
         /// <remarks>
         /// This is set to <c>true</c> immediately upon <see cref="Play"/>, but the channel may not be audibly playing yet.
         /// </remarks>
-        public override bool Playing => playing || enqueuedPlaybackStart;
+        public override bool Playing
+        {
+            get
+            {
+                // When short samples loop (especially within mixers), there's a small window where the ChannelIsActive state could be Stopped.
+                // In order to not provide a "stale" value here, we'll not trust the internal playing state from BASS.
+                if (Looping && userRequestedPlay)
+                    return true;
+
+                return playing || enqueuedPlaybackStart;
+            }
+        }
 
         private volatile bool playing;
 


### PR DESCRIPTION
un4seen thread: https://www.un4seen.com/forum/?topic=20453.0

This fixes the test failures in https://github.com/ppy/osu-framework/pull/6327. Why did they come up? In that PR, the update thread is running slower time-wise because the audio thread is lagging behind. This means that steps are updated later than they normally would and there's a greater chance that they trigger right when the audio thread processes a frame.  
The failures in that PR can be simulated by adding a `Thread.Sleep(200)` in the update thread.

## Reproduction

Repro (not committed because this is untestable - the until-step should not pass):

```csharp
[HeadlessTest]
public partial class TestSceneScratch : FrameworkTestScene
{
    private Sample? sample;
    private SampleChannel? channel;

    [Resolved]
    private AudioManager audioManager { get; set; } = null!;

    [Test]
    public void Test()
    {
        AddUntilStep("audio device ready", () => audioManager.IsLoaded);

        AddStep("play sample", () =>
        {
            sample = audioManager.Samples.Get("tone.wav");

            channel = sample.GetChannel();
            channel.Looping = true;

            // reduce volume of the tone due to how loud it normally is.
            channel.Volume.Value = 0.05;
            channel.Play();
        });

        AddUntilStep("wait until not playing", () => !channel!.Playing);
    }

    protected override void Dispose(bool isDisposing)
    {
        sample?.Dispose();
        base.Dispose(isDisposing);
    }
}
```
