### PR TITLE
Reduce macOS CI test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: dotnet build -c ${{matrix.os.configuration}} -warnaserror osu-framework.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/**/*.Tests/bin/${{matrix.os.configuration}}/*/*.Tests.dll --no-build --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
+        run: dotnet test $pwd/**/*.Tests/bin/${{matrix.os.configuration}}/*/*.Tests.dll --no-build --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
         shell: pwsh
 
       # Attempt to upload results even if test fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         run: dotnet build -c ${{matrix.os.configuration}} -warnaserror osu-framework.Desktop.slnf
 
       - name: Test
-        run: dotnet test $pwd/**/*.Tests/bin/${{matrix.os.configuration}}/*/*.Tests.dll --no-build --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx"
+        run: dotnet test $pwd/**/*.Tests/bin/${{matrix.os.configuration}}/*/*.Tests.dll --no-build --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}-${{matrix.os.configuration}}.trx" -- NUnit.ConsoleOut=0
         shell: pwsh
 
       # Attempt to upload results even if test fails.

--- a/build/vstestconfig.runsettings
+++ b/build/vstestconfig.runsettings
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-   <MSTest>
-      <TestTimeout>300000</TestTimeout>
-   </MSTest>
-</RunSettings>


### PR DESCRIPTION
I was looking into a test failure and noticed the macOS runner is specifically outputting every test result, which is totally unreadable: https://github.com/ppy/osu-framework/actions/runs/9970267947/job/27548828465?pr=6314

This doesn't happen osu!-side, which is drilled down to only failed tests, see: https://github.com/ppy/osu/actions/runs/9967138608/job/27540336842

I made two changes here:
1. o!f provides custom test runner settings, setting a 300s test runner timeout. osu! doesn't have this, so I've removed it.
2. o!f doesn't pass the `NUnit.ConsoleOut=0` argument. osu! does, so I've added it.

Result: https://github.com/smoogipoo/osu-framework/actions/runs/9970690756/job/27550138301 (or in this PR)