### PR TITLE
Fix popovers one-frame-twitching in specific circumstances

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -572,6 +572,30 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
         }
 
+        [Test]
+        public void TestComponentOffScreen()
+        {
+            DrawableWithPopover target = null!;
+
+            AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
+            {
+                Width = 200,
+                Height = 30,
+                Anchor = Anchor.TopLeft,
+                Origin = Anchor.TopLeft,
+                RelativePositionAxes = Axes.Both,
+                Text = "open",
+                CreateContent = _ => new BasicPopover
+                {
+                    AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight },
+                    Child = new SpriteText { Text = "no twitching!" }
+                }
+            });
+
+            AddStep("show popover", () => target.ShowPopover());
+            AddStep("move off screen", () => target.Y = 20);
+        }
+
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)
             => AddStep("create content", () =>
             {

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Input;
 
@@ -99,6 +101,8 @@ namespace osu.Framework.Graphics.UserInterface
         protected internal Container Body { get; }
 
         protected override Container<Drawable> Content { get; } = new Container { AutoSizeAxes = Axes.Both };
+
+        protected override bool ComputeIsMaskedAway(RectangleF maskingBounds) => !Precision.AlmostIntersects(maskingBounds, Content.ScreenSpaceDrawQuad.AABBFloat);
 
         protected Popover()
         {

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -111,7 +111,10 @@ namespace osu.Framework.Graphics.UserInterface
                 AutoSizeAxes = Axes.Both,
                 Children = new[]
                 {
-                    Arrow = CreateArrow(),
+                    Arrow = CreateArrow().With(arr =>
+                    {
+                        arr.BypassAutoSizeAxes = Axes.Both;
+                    }),
                     Body = new Container
                     {
                         AutoSizeAxes = Axes.Both,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/28865.

The issue is caused specifically by the "arrow" part of the popover. The feedback loop involved in this is as follows:

- A popover is added to the scene graph. The automatic anchor selection logic chooses an anchor and a position for it. For the arrow part specifically, this is compounded with a counteracting adjustment that ensures that the popover arrow continues to point at its target drawable:

    https://github.com/ppy/osu-framework/blob/691d8671be5f65f76b4800e85141bb6fde67e139/osu.Framework/Graphics/Cursor/PopoverContainer.cs#L143-L147

- The base `Popover` class uses autosize on both axes of its `BoundingBoxContainer`, whose bounds are used to calculate the best anchor:

    https://github.com/ppy/osu-framework/blob/691d8671be5f65f76b4800e85141bb6fde67e139/osu.Framework/Graphics/UserInterface/Popover.cs#L21

  The arrow is under the bounding box container. Adjusting a drawable's position affects autosize by way of changing
  `RequiredParentSizeToFit`, which means that if the drawable's target is significantly off screen, the calculated autosize of the container rapidly balloons.

- If the popover size increases enough, then no anchors will be considered fitting (because to the automatic layouting logic, it looks like the popover won't fit in *any* direction). Thus, the popover's anchor is changed from whatever it was on the previous frame to `Centre`, and the arrow's position is reset to zero.

- The resetting of the arrow position to zero brings us back to the situation from the first point, completing the feedback cycle.

To counteract this, exclude the popover arrow from participating in autosize calculations.

Also includes https://github.com/ppy/osu-framework/commit/4367d01a1b24c5c8b5cead18df7d31c53189c0e7 which fell out in testing.