### PR TITLE
Keep `PassThroughInputManager` in input queue even while parent input is disabled

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -253,46 +253,6 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("pass-through handled mouse", () => testInputManager.CurrentState.Mouse.Buttons.Single() == MouseButton.Left);
         }
 
-        /// <summary>
-        /// Ensures that <see cref="PassThroughInputManager"/> does not handle input within the frame that <see cref="PassThroughInputManager.UseParentInput"/> is enabled.
-        /// </summary>
-        [Test]
-        public void TestInputPropagation()
-        {
-            addTestInputManagerStep();
-            AddStep("setup hierarchy", () =>
-            {
-                Add(new HandlingBox
-                {
-                    Alpha = 0.5f,
-                    RelativeSizeAxes = Axes.Both,
-                    OnHandle = e =>
-                    {
-                        if (e is KeyDownEvent keyDown && !keyDown.Repeat)
-                            testInputManager.UseParentInput = true;
-
-                        return false;
-                    }
-                });
-            });
-
-            AddStep("turn off parent input", () => testInputManager.UseParentInput = false);
-            AddStep("press key", () => InputManager.PressKey(Key.A));
-            AddAssert("key not pressed in pass-through", () => !keyboard.IsPressed(Key.A));
-            AddAssert("no key down event inside pass-through", () => testInputManager.Status.KeyDownCount == 0);
-
-            // parent input should be turned on by the box handler above.
-            AddAssert("parent input turned on", () => testInputManager.UseParentInput);
-            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
-
-            AddStep("press key", () => InputManager.PressKey(Key.A));
-            AddStep("turn off parent input", () => testInputManager.UseParentInput = false);
-            AddAssert("key pressed in pass-through", () => keyboard.IsPressed(Key.A));
-
-            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
-            AddAssert("key still pressed in pass-through", () => keyboard.IsPressed(Key.A));
-        }
-
         public partial class TestInputManager : ManualInputManager
         {
             public readonly TestSceneInputManager.ContainingInputManagerStatusText Status;

--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -122,6 +122,19 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
+        public void TestPressKeyThenReleaseWhileDisabled()
+        {
+            addTestInputManagerStep();
+            AddStep("press key", () => InputManager.PressKey(Key.A));
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
+            AddStep("press key again", () => InputManager.PressKey(Key.A));
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("key released", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+        }
+
+        [Test]
         public void TestTouchInput()
         {
             addTestInputManagerStep();

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -57,9 +57,6 @@ namespace osu.Framework.Input
             parentInputManager = GetContainingInputManager();
         }
 
-        public override bool PropagateNonPositionalInputSubTree => UseParentInput;
-        public override bool PropagatePositionalInputSubTree => UseParentInput;
-
         public override bool HandleHoverEvents => parentInputManager != null && UseParentInput ? parentInputManager.HandleHoverEvents : base.HandleHoverEvents;
 
         internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)


### PR DESCRIPTION
- Direct revert of https://github.com/ppy/osu-framework/pull/6225

Attached a vital failing test case that deems this to be an incorrect approach (coming from https://github.com/ppy/osu/issues/28931). When the `PassThroughInputManager` is hidden from the input queue, if there is a key pressed before parent input is enabled again, releasing the key after parent input is enabled does not trigger a `KeyUpEvent` on the PTIM, as demonstrated in the failing test case.

The purpose of hiding PTIM from the input queue in the first place is to prevent it from receiving a `KeyDownEvent` if parent input is enabled by another drawable that received the `KeyDownEvent` before the PTIM does (in osu! case, the PTIM is the gameplay input manager and the drawable is the osu! click-to-resume cursor; see `OnPressed` handling in the cursor).

To keep the osu!-side issue resolved (https://github.com/ppy/osu/issues/9658), this will be fixed differently by locally scheduling the resume operation one frame after the `KeyDownEvent`, so that the ruleset input manager does not see the event and no press is triggered on resume.