### PR TITLE
Add notification tray icon on windows (boss key)

### DIFF
--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -265,5 +265,11 @@ namespace osu.Framework.Platform
         /// The window title.
         /// </summary>
         string Title { get; set; }
+
+        IBindable<NotificationTrayIcon?> TrayIcon { get; }
+
+        public void CreateNotificationTrayIcon(string text, Action? onClick);
+
+        public void RemoveNotificationTrayIcon();
     }
 }

--- a/osu.Framework/Platform/NotificationTrayIcon.cs
+++ b/osu.Framework/Platform/NotificationTrayIcon.cs
@@ -1,4 +1,5 @@
 using System;
+using osu.Framework.Platform.Windows;
 
 namespace osu.Framework.Platform
 {
@@ -19,6 +20,12 @@ namespace osu.Framework.Platform
 
         public static NotificationTrayIcon Create(string text, Action? onClick, IWindow window)
         {
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.Windows:
+                    return new WindowsNotificationTrayIcon(text, onClick, window);
+            }
+
             throw new PlatformNotSupportedException();
         }
 

--- a/osu.Framework/Platform/NotificationTrayIcon.cs
+++ b/osu.Framework/Platform/NotificationTrayIcon.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Represents an icon located in the OS notification tray.
+    /// </summary>
+    public abstract class NotificationTrayIcon : IDisposable
+    {
+        /// <summary>
+        /// The hint text shown when hovering over the icon with the cursor
+        /// </summary>
+        public string Text { get; init; }
+
+        /// <summary>
+        /// The action to perform when the icon gets clicked
+        /// </summary>
+        public Action? OnClick { get; init; }
+
+        public static NotificationTrayIcon Create(string text, Action? onClick, IWindow window)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public abstract void Dispose();
+    }
+}

--- a/osu.Framework/Platform/SDL2/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Window.cs
@@ -469,6 +469,27 @@ namespace osu.Framework.Platform.SDL2
             });
         }
 
+        public IBindable<NotificationTrayIcon?> TrayIcon => trayIcon;
+
+        private Bindable<NotificationTrayIcon?> trayIcon = new Bindable<NotificationTrayIcon?>(null);
+
+        public virtual void CreateNotificationTrayIcon(string text, Action? onClick)
+        {
+            if (trayIcon.Value is not null)
+            {
+                throw new InvalidOperationException("a notification tray icon already exists!");
+            }
+
+            NotificationTrayIcon icon = NotificationTrayIcon.Create(text, onClick, this);
+            trayIcon.Value = icon;
+        }
+
+        public virtual void RemoveNotificationTrayIcon()
+        {
+            trayIcon.Value?.Dispose();
+            trayIcon.Value = null;
+        }
+
         #region SDL Event Handling
 
         /// <summary>

--- a/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
+++ b/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using SDL;
 using static SDL.SDL3;
 
@@ -19,6 +20,16 @@ namespace osu.Framework.Platform.SDL3
             SDL_SetWindowFullscreen(SDLWindowHandle, SDL_bool.SDL_TRUE);
 
             // Don't run base logic at all. Let's keep things simple.
+        }
+
+        public override void CreateNotificationTrayIcon(string text, Action? onClick)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public override void RemoveNotificationTrayIcon()
+        {
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -440,6 +440,27 @@ namespace osu.Framework.Platform.SDL3
             });
         }
 
+        public IBindable<NotificationTrayIcon?> TrayIcon => trayIcon;
+
+        private Bindable<NotificationTrayIcon?> trayIcon = new Bindable<NotificationTrayIcon?>(null);
+
+        public virtual void CreateNotificationTrayIcon(string text, Action? onClick)
+        {
+            if (trayIcon.Value is not null)
+            {
+                throw new InvalidOperationException("a notification tray icon already exists!");
+            }
+
+            NotificationTrayIcon icon = NotificationTrayIcon.Create(text, onClick, this);
+            trayIcon.Value = icon;
+        }
+
+        public virtual void RemoveNotificationTrayIcon()
+        {
+            trayIcon.Value?.Dispose();
+            trayIcon.Value = null;
+        }
+
         #region SDL Event Handling
 
         /// <summary>

--- a/osu.Framework/Platform/Windows/SDL2WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/SDL2WindowsWindow.cs
@@ -25,8 +25,8 @@ namespace osu.Framework.Platform.Windows
         private const int large_icon_size = 256;
         private const int small_icon_size = 16;
 
-        private Icon? smallIcon;
-        private Icon? largeIcon;
+        internal Icon? smallIcon;
+        internal Icon? largeIcon;
 
         private const int wm_killfocus = 8;
 
@@ -99,6 +99,12 @@ namespace osu.Framework.Platform.Windows
 
                 switch (m.msg)
                 {
+                    case WindowsNotificationTrayIcon.TRAYICON:
+                        if (WindowsNotificationTrayIcon.IsClick(m.lParam))
+                        {
+                            TrayIcon.Value?.OnClick?.Invoke();
+                        }
+                        break;
                     case wm_killfocus:
                         warpCursorFromFocusLoss();
                         break;

--- a/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
@@ -29,8 +29,8 @@ namespace osu.Framework.Platform.Windows
         private const int large_icon_size = 256;
         private const int small_icon_size = 16;
 
-        private Icon? smallIcon;
-        private Icon? largeIcon;
+        internal Icon? smallIcon;
+        internal Icon? largeIcon;
 
         /// <summary>
         /// Whether to apply the <see cref="windows_borderless_width_hack"/>.
@@ -82,6 +82,12 @@ namespace osu.Framework.Platform.Windows
         {
             switch (msg.message)
             {
+                case WindowsNotificationTrayIcon.TRAYICON:
+                    if (WindowsNotificationTrayIcon.IsClick(msg.lParam))
+                    {
+                        TrayIcon.Value?.OnClick?.Invoke();
+                    }
+                    break;
                 case Imm.WM_IME_STARTCOMPOSITION:
                 case Imm.WM_IME_COMPOSITION:
                 case Imm.WM_IME_ENDCOMPOSITION:

--- a/osu.Framework/Platform/Windows/WindowsNotificationTrayIcon.cs
+++ b/osu.Framework/Platform/Windows/WindowsNotificationTrayIcon.cs
@@ -1,0 +1,176 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Platform.Windows
+{
+    /// <summary>
+    /// A windows specific notification tray icon, 
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    internal partial class WindowsNotificationTrayIcon : NotificationTrayIcon
+    {
+        internal IWindowsWindow window = null!;
+
+        private NOTIFYICONDATAW inner;
+
+        internal WindowsNotificationTrayIcon(string text, Action? onClick, IWindow win)
+        {
+
+            if (win is not IWindowsWindow w)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            window = w;
+            Text = text;
+            OnClick = onClick;
+
+            NotifyIconFlags flags = NotifyIconFlags.NIF_MESSAGE | NotifyIconFlags.NIF_ICON | NotifyIconFlags.NIF_TIP | NotifyIconFlags.NIF_SHOWTIP;
+            IntPtr iconHandle = IntPtr.Zero;
+            IntPtr hwnd;
+
+            if (window is SDL3WindowsWindow w3)
+            {
+                hwnd = w3.WindowHandle;
+                if (w3.largeIcon is not null)
+                {
+                    iconHandle = w3.largeIcon.Handle;
+                }
+                else if (w3.smallIcon is not null)
+                {
+                    iconHandle = w3.smallIcon.Handle;
+                }
+            }
+            else if (window is SDL2WindowsWindow w2)
+            {
+                hwnd = w2.WindowHandle;
+                if (w2.largeIcon is not null)
+                {
+                    iconHandle = w2.largeIcon.Handle;
+                }
+                else if (w2.smallIcon is not null)
+                {
+                    iconHandle = w2.smallIcon.Handle;
+                }
+            }
+            else
+            {
+                throw new PlatformNotSupportedException("Invalid windowing backend");
+            }
+
+            inner = new NOTIFYICONDATAW
+            {
+                cbSize = Marshal.SizeOf(inner),
+                uFlags = flags,
+                hIcon = iconHandle,
+                hWnd = hwnd,
+                szTip = text,
+                uCallbackMessage = TRAYICON
+            };
+
+            bool ret = Shell_NotifyIconW(NotifyIconAction.NIM_ADD, ref inner);
+
+            inner.uTimeoutOrVersion = NOTIFYICON_VERSION_4;
+
+            Shell_NotifyIconW(NotifyIconAction.NIM_SETVERSION, ref inner);
+
+            if (!ret)
+            {
+                int err = Marshal.GetLastWin32Error();
+                Logger.Log($"Error {err} while creating notification tray icon", LoggingTarget.Runtime, LogLevel.Error);
+            }
+        }
+
+        public override void Dispose()
+        {
+            bool ret = Shell_NotifyIconW(NotifyIconAction.NIM_DELETE, ref inner);
+
+            if (!ret)
+            {
+                int err = Marshal.GetLastWin32Error();
+                Logger.Log($"Error {err} while removing notification tray icon", LoggingTarget.Runtime, LogLevel.Error);
+            }
+        }
+
+        private const int NOTIFYICON_VERSION_4 = 4;
+
+        internal const int TRAYICON = 0x0400 + 1024;
+        internal const int WM_LBUTTONUP = 0x0202;
+        internal const int WM_RBUTTONUP = 0x0205;
+        internal const int WM_MBUTTONUP = 0x0208;
+        internal const int NIN_SELECT = 0x400;
+
+        internal static bool IsClick(long lParam)
+        {
+            switch ((short)lParam)
+            {
+                case WM_LBUTTONUP:
+                case WM_RBUTTONUP:
+                case WM_MBUTTONUP:
+                case NIN_SELECT:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        [Flags]
+        internal enum NotifyIconAction : uint
+        {
+            NIM_ADD = 0x00000000,
+            NIM_DELETE = 0x00000002,
+            NIM_SETVERSION = 0x00000004,
+        }
+
+        [DllImport("shell32.dll")]
+        internal static extern bool Shell_NotifyIconW(NotifyIconAction dwMessage, [In] ref NOTIFYICONDATAW pnid);
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct NOTIFYICONDATAW
+    {
+        public int cbSize;
+        public IntPtr hWnd;
+        public int uID;
+        public NotifyIconFlags uFlags;
+        public int uCallbackMessage;
+        public IntPtr hIcon;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string szTip;
+        public int dwState;
+        public int dwStateMask;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public string szInfo;
+        public int uTimeoutOrVersion;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+        public string szInfoTitle;
+        public int dwInfoFlags;
+        public Guid guidItem;
+        public IntPtr hBalloonIcon;
+    }
+
+        [Flags]
+        public enum NotifyIconFlags : uint
+        {
+            NIF_MESSAGE = 0x00000001,
+            NIF_ICON = 0x00000002,
+            NIF_TIP = 0x00000004,
+            NIF_STATE = 0x00000008,
+            NIF_INFO = 0x00000010,
+            NIF_GUID = 0x00000020,
+            NIF_SHOWTIP = 0x00000080
+        }
+
+        internal enum ToolTipIcon
+        {
+            None = 0,
+            Info = 1,
+            Warning = 2,
+            Error = 3
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for creating/removing notification tray icons, needed for boss key support.

This implementation is windows-only, i have a linux one half working but it'll be its own separate patch.

On windows, notification tray icons are closely intertwined with windowing logic, so i had to add 2 methods to `IWindow` to handle that.

https://github.com/user-attachments/assets/254eb751-b93b-483a-905d-779fe20a3098

In my testing there's a problem with hiding the game window, and it looks like there's 2 windows, one that gets hidden and the other that remains, but i don't know if that's a framework issue or an osu! side issue.

![image](https://github.com/user-attachments/assets/67bfea13-df36-4543-b2b7-4ab3bb6a826b)
