### PR TITLE
Do not unfocus on click if the focused drawable changed during the click

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
@@ -284,6 +285,48 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkFocused(() => focusableBox);
             checkNotFocused(() => noFocusChangeBox);
             AddAssert("no focus change box received click", () => noFocusChangeBox.ClickCount, () => Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void TestChangeFocusDuringInputHandling_ShouldRetainFocus()
+        {
+            BasicButton button = null!;
+            FocusBox box = null!;
+
+            AddStep("setup", () =>
+            {
+                FocusBox b = new FocusBox
+                {
+                    Position = new Vector2(0, 75)
+                };
+
+                Children =
+                [
+                    button = new BasicButton
+                    {
+                        Size = new Vector2(150, 50),
+                        Text = "Focus the box",
+                        Action = () => b.GetContainingFocusManager()!.ChangeFocus(b)
+                    },
+                    box = b
+                ];
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("box is focused", () => box.HasFocus, () => Is.True);
+
+            AddStep("click button again", () =>
+            {
+                InputManager.MoveMouseTo(button);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("box is still focused", () => box.HasFocus, () => Is.True);
         }
 
         private void checkFocused(Func<Drawable> d) => AddAssert("check focus", () => d().HasFocus);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1491,7 +1491,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <returns>The first parent <see cref="InputManager"/>.</returns>
         [CanBeNull]
-        public InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
+        protected internal InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
 
         /// <summary>
         /// Retrieve the first parent in the tree which implements <see cref="IFocusManager"/>.
@@ -1499,7 +1499,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <returns>The first parent <see cref="IFocusManager"/>.</returns>
         [CanBeNull]
-        public IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
+        protected internal IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
 
         private CompositeDrawable parent;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1491,7 +1491,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <returns>The first parent <see cref="InputManager"/>.</returns>
         [CanBeNull]
-        protected InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
+        public InputManager GetContainingInputManager() => this.FindClosestParent<InputManager>();
 
         /// <summary>
         /// Retrieve the first parent in the tree which implements <see cref="IFocusManager"/>.
@@ -1499,7 +1499,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <returns>The first parent <see cref="IFocusManager"/>.</returns>
         [CanBeNull]
-        protected IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
+        public IFocusManager GetContainingFocusManager() => this.FindClosestParent<IFocusManager>();
 
         private CompositeDrawable parent;
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -51,6 +51,12 @@ namespace osu.Framework.Input
         /// </summary>
         public Drawable FocusedDrawable { get; internal set; }
 
+        /// <summary>
+        /// Any drawable that was focused directly via <see cref="ChangeFocus"/> during the handling of a click,
+        /// and <i>not</i> as a result of the automatic post-process change of focus from the click.
+        /// </summary>
+        internal Drawable FocusedDrawableThisClick;
+
         protected abstract ImmutableArray<InputHandler> InputHandlers { get; }
 
         private double keyboardRepeatTime;
@@ -400,7 +406,10 @@ namespace osu.Framework.Input
         protected bool ChangeFocus(Drawable potentialFocusTarget, InputState state)
         {
             if (potentialFocusTarget == FocusedDrawable)
+            {
+                FocusedDrawableThisClick = FocusedDrawable;
                 return true;
+            }
 
             if (potentialFocusTarget != null && (!isDrawableValidForFocus(potentialFocusTarget) || !potentialFocusTarget.AcceptsFocus))
                 return false;
@@ -426,6 +435,8 @@ namespace osu.Framework.Input
                 FocusedDrawable.HasFocus = true;
                 FocusedDrawable.TriggerEvent(new FocusEvent(state, previousFocus));
             }
+
+            FocusedDrawableThisClick = FocusedDrawable;
 
             return true;
         }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Input
         public Drawable FocusedDrawable { get; internal set; }
 
         /// <summary>
-        /// Any drawable that was focused directly via <see cref="ChangeFocus"/> during the handling of a click,
+        /// Any drawable that was focused directly via <see cref="ChangeFocus(Drawable, InputState)"/> during the handling of a click,
         /// and <i>not</i> as a result of the automatic post-process change of focus from the click.
         /// </summary>
         internal Drawable FocusedDrawableThisClick;

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -159,6 +159,7 @@ namespace osu.Framework.Input
             Drawable? clicked = PropagateButtonEvent(drawables, new ClickEvent(state, Button, MouseDownPosition));
             ClickedDrawable.SetTarget(clicked!);
 
+            // Focus shall only change if it wasn't explicitly changed during the click (for example, using a button to open a menu).
             if (InputManager.FocusedDrawableThisClick == null)
             {
                 if (ChangeFocusOnClick && clicked?.ChangeFocusOnClick != false)

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -154,21 +154,18 @@ namespace osu.Framework.Input
             var drawables = targets.Intersect(InputQueue)
                                    .Where(t => t.IsAlive && t.IsPresent && t.ReceivePositionalInputAt(state.Mouse.Position));
 
-            Drawable focusedDrawableBeforeClick = InputManager.FocusedDrawable;
-            InputManager.FocusedDrawable = null;
+            InputManager.FocusedDrawableThisClick = null;
 
             Drawable? clicked = PropagateButtonEvent(drawables, new ClickEvent(state, Button, MouseDownPosition));
             ClickedDrawable.SetTarget(clicked!);
 
-            // Focus shall only change if it wasn't changed during the click (for example, using a button to open a menu).
-            if (InputManager.FocusedDrawable == null)
+            if (InputManager.FocusedDrawableThisClick == null)
             {
-                // Restore the previous focus target (it may get unfocused below).
-                InputManager.FocusedDrawable = focusedDrawableBeforeClick;
-
                 if (ChangeFocusOnClick && clicked?.ChangeFocusOnClick != false)
                     InputManager.ChangeFocusFromClick(clicked);
             }
+
+            InputManager.FocusedDrawableThisClick = null;
 
             if (clicked != null)
                 Logger.Log($"MouseClick handled by {clicked}.", LoggingTarget.Runtime, LogLevel.Debug);


### PR DESCRIPTION
RFC.

I'm not happy with this because means that `FocusedDrawable` is `null` during `OnClick()` handling. What I'd really like to do is "snapshot" `FocusedDrawable`. I'm not sure/don't think anything expects `FocusedDrawable` to be correct during click handling, though.