### PR TITLE
Fix `PassThroughInputManager` not always releasing input

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -132,6 +132,25 @@ namespace osu.Framework.Tests.Visual.Input
             AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
             AddStep("release key", () => InputManager.ReleaseKey(Key.A));
             AddAssert("key released", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+
+            AddStep("press key", () => InputManager.PressKey(Key.A));
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+
+            AddStep("add blocking layer", () => Add(new HandlingBox
+            {
+                RelativeSizeAxes = Axes.Both,
+                OnHandle = _ => true,
+            }));
+
+            // with a blocking layer existing, the next key press will not be seen by PassThroughInputManager...
+            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
+            AddStep("press key again", () => InputManager.PressKey(Key.A));
+
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+
+            // ...but ensure it'll still release the key regardless of not seeing the corresponding press event (it does that by syncing releases every frame).
+            AddStep("release key", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("key released", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
         }
 
         [Test]

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -173,6 +173,18 @@ namespace osu.Framework.Input
             return false;
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            // There are scenarios wherein we cannot receive the release events of pressed inputs. For simplicity, sync every frame.
+            if (UseParentInput)
+            {
+                syncReleasedInputs();
+                syncJoystickAxes();
+            }
+        }
+
         /// <summary>
         /// Updates state of any buttons that have been released by parent while <see cref="UseParentInput"/> was disabled.
         /// </summary>


### PR DESCRIPTION
In order for a `PassThroughInputManager` to receive the release event of any input at any time, it must've seen the corresponding press event, even if the press was performed while `UseParentInput` is turned off.

This behaviour doesn't really make sense, and is broken in osu! right now when there are drawables in front of gameplay that block input (e.g. pause overlay handling `Space` key as the select action while playing mania wherein `Space` corresponds to the special key action).

Before:

https://github.com/user-attachments/assets/b3d15938-5938-4b4e-998a-9315fa858010

After:

https://github.com/user-attachments/assets/ea6da4bb-6c64-4733-ae5d-1b0701ab0212

(key is stuck in "Before" because pause overlay handled the space key press to select the continue button, but it's fixed in "After")