### PR TITLE
Allow clicking on empty search header to close dropdown

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -735,7 +735,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestDoubleClickOnHeader()
+        public void TestDoubleClickOnHeader([Values] bool alwaysShowSearchBar)
         {
             TestDropdown testDropdown = null!;
             bool wasOpened = false;
@@ -747,6 +747,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 wasClosed = false;
 
                 testDropdown = createDropdown();
+                testDropdown.AlwaysShowSearchBar = alwaysShowSearchBar;
+
                 testDropdown.Menu.StateChanged += s =>
                 {
                     wasOpened |= s == MenuState.Open;

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -139,8 +139,8 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private bool onClick(ClickEvent e)
         {
-            // Allow input to fall through to the search bar (and its contained textbox) if it's visible.
-            if (SearchBar.State.Value == Visibility.Visible)
+            // Allow input to fall through to the search bar (and its contained textbox) if there's any search text.
+            if (SearchBar.State.Value == Visibility.Visible && !string.IsNullOrEmpty(SearchTerm.Value))
                 return false;
 
             // Otherwise, the header acts as a button to show/hide the menu.

--- a/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownSearchBar.cs
@@ -150,6 +150,8 @@ namespace osu.Framework.Graphics.UserInterface
             }
             else
                 dropdown.ChangeFocus(textBox);
+
+            updateTextBoxVisibility();
         }
 
         /// <summary>


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu-framework/pull/6346#issuecomment-2277354452

I might take a look at input in dropdown again at some point, I don't really like that it's scattered between `DropdownHeader` and `DropdownSearchBar`. Until then please live with it...

https://github.com/user-attachments/assets/ddc3ab8b-4f80-4a3e-bd09-3331caf9dfb0

