### PR TITLE
Revert BindableList GC reduction change

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -20,13 +20,6 @@ namespace osu.Framework.Benchmarks
         }
 
         [Benchmark]
-        public void Add()
-        {
-            for (int i = 0; i < 10; i++)
-                list.Add(i);
-        }
-
-        [Benchmark]
         public int Enumerate()
         {
             int result = 0;

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Bindables
         public T this[int index]
         {
             get => collection[index];
-            set => setIndex(index, value, getRecursionList());
+            set => setIndex(index, value, new HashSet<BindableList<T>>());
         }
 
         private void setIndex(int index, T item, HashSet<BindableList<T>> appliedInstances)
@@ -85,7 +85,7 @@ namespace osu.Framework.Bindables
         /// <param name="item">The item to be added.</param>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public void Add(T item)
-            => add(item, getRecursionList());
+            => add(item, new HashSet<BindableList<T>>());
 
         private void add(T item, HashSet<BindableList<T>> appliedInstances)
         {
@@ -118,7 +118,7 @@ namespace osu.Framework.Bindables
         /// <param name="item">The item to insert.</param>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public void Insert(int index, T item)
-            => insert(index, item, getRecursionList());
+            => insert(index, item, new HashSet<BindableList<T>>());
 
         private void insert(int index, T item, HashSet<BindableList<T>> appliedInstances)
         {
@@ -142,7 +142,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public void Clear()
-            => clear(getRecursionList());
+            => clear(new HashSet<BindableList<T>>());
 
         private void clear(HashSet<BindableList<T>> appliedInstances)
         {
@@ -182,7 +182,7 @@ namespace osu.Framework.Bindables
         /// <returns><code>true</code> if the removal was successful.</returns>
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(T item)
-            => remove(item, getRecursionList());
+            => remove(item, new HashSet<BindableList<T>>());
 
         private bool remove(T item, HashSet<BindableList<T>> appliedInstances)
         {
@@ -224,7 +224,7 @@ namespace osu.Framework.Bindables
         /// <param name="count">The count of items to be removed.</param>
         public void RemoveRange(int index, int count)
         {
-            removeRange(index, count, getRecursionList());
+            removeRange(index, count, new HashSet<BindableList<T>>());
         }
 
         private void removeRange(int index, int count, HashSet<BindableList<T>> appliedInstances)
@@ -259,7 +259,7 @@ namespace osu.Framework.Bindables
         /// <param name="index">The index of the item to remove.</param>
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public void RemoveAt(int index)
-            => removeAt(index, getRecursionList());
+            => removeAt(index, new HashSet<BindableList<T>>());
 
         private void removeAt(int index, HashSet<BindableList<T>> appliedInstances)
         {
@@ -285,7 +285,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="match">The predicate.</param>
         public int RemoveAll(Predicate<T> match)
-            => removeAll(match, getRecursionList());
+            => removeAll(match, new HashSet<BindableList<T>>());
 
         private int removeAll(Predicate<T> match, HashSet<BindableList<T>> appliedInstances)
         {
@@ -319,7 +319,7 @@ namespace osu.Framework.Bindables
         /// <param name="count">The count of items to be removed.</param>
         /// <param name="newItems">The items to replace the removed items with.</param>
         public void ReplaceRange(int index, int count, IEnumerable<T> newItems)
-            => replaceRange(index, count, newItems as IList ?? newItems.ToArray(), getRecursionList());
+            => replaceRange(index, count, newItems as IList ?? newItems.ToArray(), new HashSet<BindableList<T>>());
 
         private void replaceRange(int index, int count, IList newItems, HashSet<BindableList<T>> appliedInstances)
         {
@@ -542,7 +542,7 @@ namespace osu.Framework.Bindables
         /// <param name="items">The collection whose items should be added to this collection.</param>
         /// <exception cref="InvalidOperationException">Thrown if this collection is <see cref="Disabled"/></exception>
         public void AddRange(IEnumerable<T> items)
-            => addRange(items as IList ?? items.ToArray(), getRecursionList());
+            => addRange(items as IList ?? items.ToArray(), new HashSet<BindableList<T>>());
 
         private void addRange(IList items, HashSet<BindableList<T>> appliedInstances)
         {
@@ -567,7 +567,7 @@ namespace osu.Framework.Bindables
         /// <param name="oldIndex">The index of the item to move.</param>
         /// <param name="newIndex">The index specifying the new location of the item.</param>
         public void Move(int oldIndex, int newIndex)
-            => move(oldIndex, newIndex, getRecursionList());
+            => move(oldIndex, newIndex, new HashSet<BindableList<T>>());
 
         private void move(int oldIndex, int newIndex, HashSet<BindableList<T>> appliedInstances)
         {
@@ -691,15 +691,5 @@ namespace osu.Framework.Bindables
         public bool IsDefault => Count == 0;
 
         string IFormattable.ToString(string format, IFormatProvider formatProvider) => ((FormattableString)$"{GetType().ReadableName()}({nameof(Count)}={Count})").ToString(formatProvider);
-
-        [ThreadStatic]
-        private static HashSet<BindableList<T>> recursionList;
-
-        private static HashSet<BindableList<T>> getRecursionList()
-        {
-            recursionList ??= new HashSet<BindableList<T>>();
-            recursionList.Clear();
-            return recursionList;
-        }
     }
 }


### PR DESCRIPTION
This reverts commit af4e54d7af31fadd43024dbf796f917f3d89dd52, reversing changes made to 4779e1b82e5b03daff7210786200d2c14e8deaee.

See test failures in https://github.com/ppy/osu/pull/29367 . I don't really want to bother with figuring out how to make this work nicely without developer overhead. Might take a different approach in the future - dunno.