### PR TITLE
Make `PerformanceOverlay` public

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -49,8 +49,6 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.IgnoredInputHandlers, string.Empty);
             SetDefault(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
 #pragma warning restore 618
-
-            SetDefault(FrameworkSetting.PerformanceOverlayScale, 1.0f, 0.01f, 1.0f, 0.01f);
         }
 
         public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
@@ -116,7 +114,5 @@ namespace osu.Framework.Configuration
 
         [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         MapAbsoluteInputToWindow,
-
-        PerformanceOverlayScale,
     }
 }

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -49,6 +49,8 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.IgnoredInputHandlers, string.Empty);
             SetDefault(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
 #pragma warning restore 618
+
+            SetDefault(FrameworkSetting.PerformanceOverlayScale, 1.0f, 0.01f, 1.0f, 0.01f);
         }
 
         public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
@@ -114,5 +116,7 @@ namespace osu.Framework.Configuration
 
         [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         MapAbsoluteInputToWindow,
+
+        PerformanceOverlayScale,
     }
 }

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -34,6 +34,7 @@ namespace osu.Framework.Graphics.Performance
 
         private TextFlowContainer? infoText;
 
+        private Bindable<float> configScale = null!;
         private Bindable<FrameSync> configFrameSync = null!;
         private Bindable<ExecutionMode> configExecutionMode = null!;
         private Bindable<WindowMode> configWindowMode = null!;
@@ -66,6 +67,9 @@ namespace osu.Framework.Graphics.Performance
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            configScale = config.GetBindable<float>(FrameworkSetting.PerformanceOverlayScale);
+            configScale.BindValueChanged(s => Scale = new Vector2(s.NewValue), true);
 
             configFrameSync = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             configFrameSync.BindValueChanged(_ => updateInfoText());

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -22,7 +22,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance
 {
-    internal partial class PerformanceOverlay : FillFlowContainer, IStateful<FrameStatisticsMode>
+    public partial class PerformanceOverlay : FillFlowContainer, IStateful<FrameStatisticsMode>
     {
         [Resolved]
         private GameHost host { get; set; } = null!;

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -34,7 +34,6 @@ namespace osu.Framework.Graphics.Performance
 
         private TextFlowContainer? infoText;
 
-        private Bindable<float> configScale = null!;
         private Bindable<FrameSync> configFrameSync = null!;
         private Bindable<ExecutionMode> configExecutionMode = null!;
         private Bindable<WindowMode> configWindowMode = null!;
@@ -67,9 +66,6 @@ namespace osu.Framework.Graphics.Performance
         protected override void LoadComplete()
         {
             base.LoadComplete();
-
-            configScale = config.GetBindable<float>(FrameworkSetting.PerformanceOverlayScale);
-            configScale.BindValueChanged(s => Scale = new Vector2(s.NewValue), true);
 
             configFrameSync = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             configFrameSync.BindValueChanged(_ => updateInfoText());


### PR DESCRIPTION
Useful for keeping the performance overlay open at a low scale so it doesn't bother me when I'm playing while waiting for a random stutter to hit.