### PR TITLE
Remove unnecessary boxing allocation

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="frameBuffer">The <see cref="IFrameBuffer"/> to bind.</param>
         /// <returns>A token that must be disposed upon finishing use of <paramref name="frameBuffer"/>.</returns>
-        protected IDisposable BindFrameBuffer(IFrameBuffer frameBuffer)
+        protected ValueInvokeOnDisposal<IFrameBuffer> BindFrameBuffer(IFrameBuffer frameBuffer)
         {
             // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
             frameBuffer.Size = frameBufferSize;
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics
             return new ValueInvokeOnDisposal<IFrameBuffer>(frameBuffer, static b => b.Unbind());
         }
 
-        private IDisposable establishFrameBufferViewport(IRenderer renderer)
+        private ValueInvokeOnDisposal<(BufferedDrawNode node, IRenderer renderer)> establishFrameBufferViewport(IRenderer renderer)
         {
             // Disable masking for generating the frame buffer since masking will be re-applied
             // when actually drawing later on anyways. This allows more information to be captured


### PR DESCRIPTION
Profiling over around 10s in `TestSceneBufferingPerformance`:

| Before | After |
| --- | --- |
| <img width="832" alt="image" src="https://github.com/user-attachments/assets/1a4931fc-f05d-4281-bc36-d03abf40aff4"> | <img width="834" alt="image" src="https://github.com/user-attachments/assets/362a189b-9015-4c82-873e-d897f658c793"> |

This is a bit of an edge case, but it is a potential source of per-frame allocations nonetheless.