### PR TITLE
Fix Android safe area

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
 using Android.OS;
-using Android.Views;
 using ManagedBass;
 using Org.Libsdl.App;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -55,11 +53,6 @@ namespace osu.Framework.Android
             System.Environment.CurrentDirectory = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
 
             base.OnCreate(savedInstanceState);
-
-            if (OperatingSystem.IsAndroidVersionAtLeast(28))
-            {
-                Window.AsNonNull().Attributes.AsNonNull().LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
-            }
         }
 
         protected override void OnStop()

--- a/osu.Framework.Android/AndroidGameSurface.cs
+++ b/osu.Framework.Android/AndroidGameSurface.cs
@@ -58,10 +58,10 @@ namespace osu.Framework.Android
             isSurfaceReady = true;
         }
 
-        public override WindowInsets? OnApplyWindowInsets(WindowInsets? insets)
+        public override WindowInsets? OnApplyWindowInsets(View? view, WindowInsets? insets)
         {
             updateSafeArea(insets);
-            return base.OnApplyWindowInsets(insets);
+            return base.OnApplyWindowInsets(view, insets);
         }
 
         /// <summary>


### PR DESCRIPTION
SDL3 started to provide safe area, and it uses [`setOnApplyWindowInsetsListener`](https://developer.android.com/reference/android/view/View#setOnApplyWindowInsetsListener(android.view.View.OnApplyWindowInsetsListener)) which overrides `View.onApplyWindowInsets` with `View.OnApplyWindowInsetsListener.onApplyWindowInsets`.

This PR makes AndroidGameSurface override `View.OnApplyWindowInsetsListener.onApplyWindowInsets` instead, and removes `LayoutInDisplayCutoutMode` as it is now set in SDL side.

I also tried using SDL-provided safe area, but it doesn't seem to work like our current implementation, so I think we can still keep ours for now.