### PR TITLE
Implement native method for `PresentFileExternally` in MacOS

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestScenePresentFileExternally.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestScenePresentFileExternally.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -78,7 +79,7 @@ namespace osu.Framework.Tests.Visual.Platform
                     ),
                     new ButtonWithDescription
                     (
-                        () => logStorage.PresentFileExternally(@"runtime.log"),
+                        () => logStorage.PresentFileExternally(logStorage.GetFiles(string.Empty, "*runtime*").First()),
                         @"show runtime.log",
                         @"Opens: 'logs'   Selected: 'runtime.log'"
                     ),

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -7,10 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.MacOS
 {
@@ -63,6 +65,11 @@ namespace osu.Framework.Platform.MacOS
             }
 
             return handlers;
+        }
+
+        public override bool PresentFileExternally(string filename)
+        {
+            return Finder.OpenFolderAndSelectItem(filename.TrimDirectorySeparator());
         }
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => KeyBindings;

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -7,11 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using osu.Framework.Extensions;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Logging;
 using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.MacOS
@@ -53,6 +53,29 @@ namespace osu.Framework.Platform.MacOS
                 Renderer.WaitUntilIdle();
         }
 
+        public override bool PresentFileExternally(string filename)
+        {
+            string folderPath = Path.GetDirectoryName(filename);
+
+            if (folderPath == null)
+            {
+                Logger.Log($"Failed to get directory for {filename}", level: LogLevel.Debug);
+                return false;
+            }
+
+            if (!File.Exists(filename) && !Directory.Exists(filename))
+            {
+                Logger.Log($"Cannot find file for '{filename}'", level: LogLevel.Debug);
+
+                // Open the folder without the file selected if we can't find the file
+                OpenFileExternally(folderPath);
+                return true;
+            }
+
+            Finder.OpenFolderAndSelectItem(filename);
+            return true;
+        }
+
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers()
         {
             var handlers = base.CreateAvailableInputHandlers();
@@ -65,11 +88,6 @@ namespace osu.Framework.Platform.MacOS
             }
 
             return handlers;
-        }
-
-        public override bool PresentFileExternally(string filename)
-        {
-            return Finder.OpenFolderAndSelectItem(filename.TrimDirectorySeparator());
         }
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => KeyBindings;

--- a/osu.Framework/Platform/MacOS/Native/Finder.cs
+++ b/osu.Framework/Platform/MacOS/Native/Finder.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    public class Finder
+    {
+        internal static bool OpenFolderAndSelectItem(string filename)
+        {
+            IntPtr nsWorkspace = Class.Get("NSWorkspace");
+            IntPtr sharedWorkspaceSelector = Selector.Get("sharedWorkspace");
+            IntPtr sharedWorkspace = Cocoa.SendIntPtr(nsWorkspace, sharedWorkspaceSelector);
+
+            IntPtr filePathNSString = Cocoa.ToNSString(filename);
+            IntPtr selector = Selector.Get("selectFile:inFileViewerRootedAtPath:");
+
+            return Cocoa.SendBool(sharedWorkspace, selector, filePathNSString);
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Finder.cs
+++ b/osu.Framework/Platform/MacOS/Native/Finder.cs
@@ -1,22 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using System.Threading.Tasks;
 
 namespace osu.Framework.Platform.MacOS.Native
 {
-    public class Finder
+    internal static class Finder
     {
-        internal static bool OpenFolderAndSelectItem(string filename)
+        private static readonly NSWorkspace shared_workspace = NSWorkspace.SharedWorkspace();
+
+        internal static void OpenFolderAndSelectItem(string filename)
         {
-            IntPtr nsWorkspace = Class.Get("NSWorkspace");
-            IntPtr sharedWorkspaceSelector = Selector.Get("sharedWorkspace");
-            IntPtr sharedWorkspace = Cocoa.SendIntPtr(nsWorkspace, sharedWorkspaceSelector);
-
-            IntPtr filePathNSString = Cocoa.ToNSString(filename);
-            IntPtr selector = Selector.Get("selectFile:inFileViewerRootedAtPath:");
-
-            return Cocoa.SendBool(sharedWorkspace, selector, filePathNSString);
+            Task.Run(() =>
+            {
+                shared_workspace.SelectFile(filename);
+            });
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/NSWorkspace.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSWorkspace.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal readonly struct NSWorkspace
+    {
+        internal IntPtr Handle { get; }
+
+        private static readonly IntPtr class_pointer = Class.Get("NSWorkspace");
+        private static readonly IntPtr sel_shared_workspace = Selector.Get("sharedWorkspace");
+        private static readonly IntPtr sel_select_file = Selector.Get("selectFile:inFileViewerRootedAtPath:");
+
+        internal NSWorkspace(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal static NSWorkspace SharedWorkspace() => new NSWorkspace(Cocoa.SendIntPtr(class_pointer, sel_shared_workspace));
+
+        internal bool SelectFile(string file) => Cocoa.SendBool(Handle, sel_select_file, Cocoa.ToNSString(file));
+    }
+}


### PR DESCRIPTION
apple doc: https://developer.apple.com/documentation/appkit/nsworkspace/1524399-selectfile

This API only overrides PresentFileExternally as it can only highlight the incoming file in its parent directory. 

We check if the file exists first (see https://github.com/ppy/osu-framework/commit/c1fd9561adb518b3f3d8af119b1614433d5cc38d), because if the file doesn't exist, the API won't do anything so we will fall back to `OpenFileExternally`, which then uses `openUsingShellExecute`.

![4e5ebb047b21fa55a49d17a7b49b52fe](https://github.com/user-attachments/assets/b40bcdb2-6a2a-4bfc-b616-8bc4c8068f64)
