### PR TITLE
Fix renderers can't batch vertices with the same blending parameters in some cases

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -176,6 +176,9 @@ namespace osu.Framework.Graphics.Containers
                     quadBatch = renderer.CreateQuadBatch<TexturedVertex2D>(100, 1000);
             }
 
+            // Children will set their own blending parameters.
+            internal override bool SetBlending => false;
+
             protected override void Draw(IRenderer renderer)
             {
                 updateQuadBatch(renderer);

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -68,6 +68,11 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
+        /// Whether the renderer should set blending parameters of this <see cref="DrawNode"/>.
+        /// </summary>
+        internal virtual bool SetBlending => true;
+
+        /// <summary>
         /// Draws this <see cref="DrawNode"/> to the screen.
         /// </summary>
         /// <remarks>
@@ -76,7 +81,9 @@ namespace osu.Framework.Graphics
         /// <param name="renderer">The renderer to draw with.</param>
         protected virtual void Draw(IRenderer renderer)
         {
-            renderer.SetBlend(DrawColourInfo.Blending);
+            if (SetBlending)
+                renderer.SetBlend(DrawColourInfo.Blending);
+
             renderer.BackbufferDepth.Set(drawDepth);
         }
 


### PR DESCRIPTION
Consider the [following scenario](https://github.com/user-attachments/assets/2d8c5bc0-d2ca-47d6-ac2d-f0424ef3d9cb).
You may assume that these boxes will be batched and drawn in a single draw call, however this is not the case:
![master-blending](https://github.com/user-attachments/assets/7b075569-fe24-49b0-947a-2dbe55c4fa49)
That's because each `DrawNode` sets its blending parameters [inside `Draw` method](https://github.com/ppy/osu-framework/blob/4e3ef471300c27e7d8da42682343bc85812df729/osu.Framework/Graphics/DrawNode.cs#L79) and the problem here is that `CompositeDrawNode` does the same. But this is not needed since each child will set their own blending later on (which is computed with `DrawColourInfo` and [inherited from the parent](https://github.com/ppy/osu-framework/blob/4e3ef471300c27e7d8da42682343bc85812df729/osu.Framework/Graphics/Drawable.cs#L1644)), thus making blending update inside composite practically useless.
Result (both boxes drawn together):
![pr-blending](https://github.com/user-attachments/assets/8a7edd37-58d4-4c55-bbef-580afa4b6f4e)
