### PR TITLE
Fix alloc overhead in hot path for keyboard checks

### DIFF
--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -207,7 +207,14 @@ namespace osu.Framework.Input.Bindings
                 return pressedPhysicalKeys.Contains(candidateKey);
 
             Debug.Assert(candidateKey.IsVirtual());
-            return pressedPhysicalKeys.Any(k => getVirtualKey(k) == candidateKey);
+
+            foreach (var pk in pressedPhysicalKeys)
+            {
+                if (getVirtualKey(pk) == candidateKey)
+                    return true;
+            }
+
+            return false;
         }
 
         public bool Equals(KeyCombination other) => Keys.SequenceEqual(other.Keys);


### PR DESCRIPTION
Just a quick one I couldn't ignore.

| Before | After |
| :---: | :---: |
| ![JetBrains Rider 2024-09-04 at 06 33 56](https://github.com/user-attachments/assets/a93d9723-9a4a-4929-96b9-02380c9e94ab) | ![JetBrains Rider 2024-09-04 at 06 34 56](https://github.com/user-attachments/assets/22e181e5-2d51-4db2-be43-3d3b46748610) |

Want to get this in the imminent framework release just to tidy up allocs.