### PR TITLE
Remove closure allocations in VeldridStagingTexturePool

### DIFF
--- a/osu.Framework/Graphics/Rendering/Deferred/Allocation/DeviceBufferPool.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Allocation/DeviceBufferPool.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Allocation
 
         public IPooledDeviceBuffer Get()
         {
-            if (TryGet(_ => true, out IPooledDeviceBuffer? existing))
+            if (TryGet(out IPooledDeviceBuffer? existing))
                 return existing;
 
             existing = new PooledDeviceBuffer(Pipeline, bufferSize, usage);

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingResourcePool.cs
@@ -32,7 +32,10 @@ namespace osu.Framework.Graphics.Veldrid
             pipeline.ExecutionFinished += executionFinished;
         }
 
-        protected bool TryGet(Predicate<T> match, [NotNullWhen(true)] out T? resource)
+        protected bool TryGet([NotNullWhen(true)] out T? resource)
+            => TryGet<object>(static (_, _) => true, null, out resource);
+
+        protected bool TryGet<TState>(Func<T, TState?, bool> match, TState? state, [NotNullWhen(true)] out T? resource)
         {
             // Reverse iteration is important to prefer reusing recently returned textures.
             // This avoids the case of a large pool being constantly cycled and therefore never
@@ -41,7 +44,7 @@ namespace osu.Framework.Graphics.Veldrid
             {
                 var existing = available[i];
 
-                if (match(existing.Resource))
+                if (match(existing.Resource, state))
                 {
                     existing.FrameUsageIndex = currentExecutionIndex;
 

--- a/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridStagingTexturePool.cs
@@ -15,12 +15,17 @@ namespace osu.Framework.Graphics.Veldrid
 
         public Texture Get(int width, int height, PixelFormat format)
         {
-            if (TryGet(t => t.Width >= width && t.Height >= height && t.Format == format, out var texture))
+            if (TryGet(match, new TextureLookup(width, height, format), out var texture))
                 return texture;
 
             texture = Pipeline.Factory.CreateTexture(TextureDescription.Texture2D((uint)width, (uint)height, 1, 1, format, TextureUsage.Staging));
             AddNewResource(texture);
             return texture;
         }
+
+        private static bool match(Texture texture, TextureLookup lookup)
+            => texture.Width >= lookup.Width && texture.Height >= lookup.Height && texture.Format == lookup.Format;
+
+        private readonly record struct TextureLookup(int Width, int Height, PixelFormat Format);
     }
 }


### PR DESCRIPTION
Trying to not overcomplicate this one too much.

Over about 10 seconds idle with frame time statistics graphs open:

| before | after |
| --- | --- |
| <img width="597" alt="image" src="https://github.com/user-attachments/assets/95213525-05e7-4974-bae5-682d13a0073c"> | <img width="601" alt="image" src="https://github.com/user-attachments/assets/4973d0bf-355c-403d-85bb-f1adca9347d5"> |