### PR TITLE
Update SDL3-CS

### DIFF
--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.SDL3-CS.Android" Version="2024.807.1" />
+    <PackageReference Include="ppy.SDL3-CS.Android" Version="2024.916.0" />
     <PackageReference Include="Xamarin.AndroidX.Window" Version="1.2.0.1" PrivateAssets="compile" />
   </ItemGroup>
 </Project>

--- a/osu.Framework/Platform/SDL3/SDL3Clipboard.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Clipboard.cs
@@ -128,15 +128,14 @@ namespace osu.Framework.Platform.SDL3
             // TODO: support multiple mime types in a single callback
             fixed (byte* ptr = Encoding.UTF8.GetBytes(mimeType + '\0'))
             {
-                int ret = SDL_SetClipboardData(&dataCallback, &cleanupCallback, objectHandle.Handle, &ptr, 1);
-
-                if (ret < 0)
+                if (SDL_SetClipboardData(&dataCallback, &cleanupCallback, objectHandle.Handle, &ptr, 1) == SDL_bool.SDL_FALSE)
                 {
                     objectHandle.Dispose();
                     Logger.Log($"Failed to set clipboard data callback. SDL error: {SDL_GetError()}");
+                    return false;
                 }
 
-                return ret == 0;
+                return true;
             }
         }
 

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -156,7 +156,7 @@ namespace osu.Framework.Platform.SDL3
 
             SDL_SetHint(SDL_HINT_APP_NAME, appName);
 
-            if (SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO | SDL_InitFlags.SDL_INIT_GAMEPAD) < 0)
+            if (SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO | SDL_InitFlags.SDL_INIT_GAMEPAD) == SDL_bool.SDL_FALSE)
             {
                 throw new InvalidOperationException($"Failed to initialise SDL: {SDL_GetError()}");
             }
@@ -320,23 +320,23 @@ namespace osu.Framework.Platform.SDL3
         }
 
         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-        private static int eventFilter(IntPtr userdata, SDL_Event* eventPtr)
+        private static SDL_bool eventFilter(IntPtr userdata, SDL_Event* eventPtr)
         {
             var handle = new ObjectHandle<SDL3Window>(userdata);
             if (handle.GetTarget(out SDL3Window window))
                 window.HandleEventFromFilter(*eventPtr);
 
-            return 1;
+            return SDL_bool.SDL_TRUE;
         }
 
         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-        private static int eventWatch(IntPtr userdata, SDL_Event* eventPtr)
+        private static SDL_bool eventWatch(IntPtr userdata, SDL_Event* eventPtr)
         {
             var handle = new ObjectHandle<SDL3Window>(userdata);
             if (handle.GetTarget(out SDL3Window window))
                 window.HandleEventFromWatch(*eventPtr);
 
-            return 1;
+            return SDL_bool.SDL_TRUE;
         }
 
         private bool firstDraw = true;

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -573,6 +573,20 @@ namespace osu.Framework.Platform.SDL3
                 case SDL_EventType.SDL_EVENT_DROP_COMPLETE:
                     handleDropEvent(e.drop);
                     break;
+
+                case SDL_EventType.SDL_EVENT_PEN_DOWN:
+                case SDL_EventType.SDL_EVENT_PEN_UP:
+                    handlePenTouchEvent(e.ptouch);
+                    break;
+
+                case SDL_EventType.SDL_EVENT_PEN_BUTTON_DOWN:
+                case SDL_EventType.SDL_EVENT_PEN_BUTTON_UP:
+                    handlePenButtonEvent(e.pbutton);
+                    break;
+
+                case SDL_EventType.SDL_EVENT_PEN_MOTION:
+                    handlePenMotionEvent(e.pmotion);
+                    break;
             }
         }
 

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Platform.SDL3
                     throw new InvalidOperationException($"Cannot set {nameof(RelativeMouseMode)} to true when the cursor is not hidden via {nameof(CursorState)}.");
 
                 relativeMouseMode = value;
-                ScheduleCommand(() => SDL_SetRelativeMouseMode(value ? SDL_bool.SDL_TRUE : SDL_bool.SDL_FALSE));
+                ScheduleCommand(() => SDL_SetWindowRelativeMouseMode(SDLWindowHandle, value ? SDL_bool.SDL_TRUE : SDL_bool.SDL_FALSE));
                 updateCursorConfinement();
             }
         }

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -151,7 +151,9 @@ namespace osu.Framework.Platform.SDL3
 
         private PointF previousPolledPoint = PointF.Empty;
 
-        private SDL_MouseButtonFlags pressedButtons;
+        private SDL_MouseButtonFlags mousePressedButtons;
+
+        private SDL_MouseButtonFlags penPressedButtons;
 
         private void pollMouse()
         {
@@ -170,7 +172,7 @@ namespace osu.Framework.Platform.SDL3
             }
 
             // a button should be released if it was pressed and its current global state differs (its bit in globalButtons is set to 0)
-            SDL_MouseButtonFlags buttonsToRelease = pressedButtons & (globalButtons ^ pressedButtons);
+            SDL_MouseButtonFlags buttonsToRelease = mousePressedButtons & (globalButtons ^ mousePressedButtons) & ~penPressedButtons;
 
             // the outer if just optimises for the common case that there are no buttons to release.
             if (buttonsToRelease != 0)
@@ -180,6 +182,8 @@ namespace osu.Framework.Platform.SDL3
                 if (buttonsToRelease.HasFlagFast(SDL_MouseButtonFlags.SDL_BUTTON_RMASK)) MouseUp?.Invoke(MouseButton.Right);
                 if (buttonsToRelease.HasFlagFast(SDL_MouseButtonFlags.SDL_BUTTON_X1MASK)) MouseUp?.Invoke(MouseButton.Button1);
                 if (buttonsToRelease.HasFlagFast(SDL_MouseButtonFlags.SDL_BUTTON_X2MASK)) MouseUp?.Invoke(MouseButton.Button2);
+
+                mousePressedButtons &= ~buttonsToRelease;
             }
         }
 
@@ -437,12 +441,24 @@ namespace osu.Framework.Platform.SDL3
             switch (evtButton.type)
             {
                 case SDL_EventType.SDL_EVENT_MOUSE_BUTTON_DOWN:
-                    pressedButtons |= mask;
+                    if (penPressedButtons.HasFlagFast(mask))
+                    {
+                        Logger.Log("Mouse tried pressing a button already pressed by tablet!", level: LogLevel.Debug);
+                        return;
+                    }
+
+                    mousePressedButtons |= mask;
                     MouseDown?.Invoke(button);
                     break;
 
                 case SDL_EventType.SDL_EVENT_MOUSE_BUTTON_UP:
-                    pressedButtons &= ~mask;
+                    if (!mousePressedButtons.HasFlagFast(mask))
+                    {
+                        Logger.Log("Mouse tried releasing a button already released by tablet!", level: LogLevel.Debug);
+                        return;
+                    }
+
+                    mousePressedButtons &= ~mask;
                     MouseUp?.Invoke(button);
                     break;
             }
@@ -450,7 +466,7 @@ namespace osu.Framework.Platform.SDL3
 
         private void handleMouseMotionEvent(SDL_MouseMotionEvent evtMotion)
         {
-            if (SDL_GetRelativeMouseMode() == SDL_bool.SDL_FALSE)
+            if (SDL_GetWindowRelativeMouseMode(SDLWindowHandle) == SDL_bool.SDL_FALSE)
                 MouseMove?.Invoke(new Vector2(evtMotion.x * Scale, evtMotion.y * Scale));
             else
                 MouseMoveRelative?.Invoke(new Vector2(evtMotion.xrel * Scale, evtMotion.yrel * Scale));
@@ -494,6 +510,55 @@ namespace osu.Framework.Platform.SDL3
 
         private void handleKeymapChangedEvent() => KeymapChanged?.Invoke();
 
+        private void handlePenMotionEvent(SDL_PenMotionEvent evtPenMotion)
+        {
+            MouseMove?.Invoke(new Vector2(evtPenMotion.x * Scale, evtPenMotion.y * Scale));
+        }
+
+        private void handlePenTouchEvent(SDL_PenTouchEvent evtPenTouch)
+        {
+            if (evtPenTouch.eraser == SDL_bool.SDL_TRUE)
+                return;
+
+            handlePenPressEvent(0, evtPenTouch.down == SDL_bool.SDL_TRUE);
+        }
+
+        private void handlePenButtonEvent(SDL_PenButtonEvent evtPenButton)
+        {
+            handlePenPressEvent(evtPenButton.button, evtPenButton.down == SDL_bool.SDL_TRUE);
+        }
+
+        private void handlePenPressEvent(byte penButton, bool pressed)
+        {
+            mouseButtonFromPen(pressed, penButton, out MouseButton button, out SDL_MouseButtonFlags mask);
+
+            if (mask == 0)
+                return;
+
+            if (pressed)
+            {
+                if (mousePressedButtons.HasFlagFast(mask))
+                {
+                    Logger.Log("Tablet tried pressing a button already pressed by mouse!", level: LogLevel.Debug);
+                    return;
+                }
+
+                penPressedButtons |= mask;
+                MouseDown?.Invoke(button);
+            }
+            else
+            {
+                if (!penPressedButtons.HasFlagFast(mask))
+                {
+                    Logger.Log("Tablet tried releasing a button already released by mouse!", level: LogLevel.Debug);
+                    return;
+                }
+
+                penPressedButtons &= ~mask;
+                MouseUp?.Invoke(button);
+            }
+        }
+
         private MouseButton mouseButtonFromEvent(SDLButton button)
         {
             switch (button)
@@ -516,6 +581,43 @@ namespace osu.Framework.Platform.SDL3
                 default:
                     Logger.Log($"unknown mouse button: {button}, defaulting to left button");
                     return MouseButton.Left;
+            }
+        }
+
+        private void mouseButtonFromPen(bool pressed, byte penButton, out MouseButton button, out SDL_MouseButtonFlags buttonFlag)
+        {
+            switch (penButton)
+            {
+                case 0:
+                    button = MouseButton.Left;
+                    buttonFlag = SDL_MouseButtonFlags.SDL_BUTTON_LMASK;
+                    break;
+
+                case 1:
+                    button = MouseButton.Right;
+                    buttonFlag = SDL_MouseButtonFlags.SDL_BUTTON_RMASK;
+                    break;
+
+                case 2:
+                    button = MouseButton.Middle;
+                    buttonFlag = SDL_MouseButtonFlags.SDL_BUTTON_MMASK;
+                    break;
+
+                case 3:
+                    button = MouseButton.Button1;
+                    buttonFlag = SDL_MouseButtonFlags.SDL_BUTTON_X1MASK;
+                    break;
+
+                case 4:
+                    button = MouseButton.Button2;
+                    buttonFlag = SDL_MouseButtonFlags.SDL_BUTTON_X2MASK;
+                    break;
+
+                default:
+                    Logger.Log($"unknown pen button index: {penButton}, ignoring...");
+                    button = MouseButton.Button3;
+                    buttonFlag = 0;
+                    break;
             }
         }
 

--- a/osu.Framework/Platform/SDL3/SDL3Window_Windowing.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Windowing.cs
@@ -356,7 +356,7 @@ namespace osu.Framework.Platform.SDL3
 
             SDL_Rect rect;
 
-            if (SDL_GetDisplayBounds(displayID, &rect) < 0)
+            if (SDL_GetDisplayBounds(displayID, &rect) == SDL_bool.SDL_FALSE)
             {
                 Logger.Log($"Failed to get display bounds for display at index ({displayIndex}). SDL Error: {SDL_GetError()}");
                 display = null;
@@ -874,14 +874,14 @@ namespace osu.Framework.Platform.SDL3
 
             SDL_DisplayMode mode;
 
-            if (SDL_GetClosestFullscreenDisplayMode(displayID, size.Width, size.Height, requestedMode.RefreshRate, SDL_bool.SDL_TRUE, &mode) == 0)
+            if (SDL_GetClosestFullscreenDisplayMode(displayID, size.Width, size.Height, requestedMode.RefreshRate, SDL_bool.SDL_TRUE, &mode) == SDL_bool.SDL_TRUE)
                 return mode;
 
             Logger.Log(
                 $"Unable to get preferred display mode (try #1/2). Target display: {display.Index}, mode: {size.Width}x{size.Height}@{requestedMode.RefreshRate}. SDL error: {SDL3Extensions.GetAndClearError()}");
 
             // fallback to current display's native bounds
-            if (SDL_GetClosestFullscreenDisplayMode(displayID, display.Bounds.Width, display.Bounds.Height, 0f, SDL_bool.SDL_TRUE, &mode) != 0)
+            if (SDL_GetClosestFullscreenDisplayMode(displayID, display.Bounds.Width, display.Bounds.Height, 0f, SDL_bool.SDL_TRUE, &mode) == SDL_bool.SDL_TRUE)
                 return mode;
 
             Logger.Log(

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
-    <PackageReference Include="ppy.SDL3-CS" Version="2024.807.1" />
+    <PackageReference Include="ppy.SDL3-CS" Version="2024.916.0" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2023.720.0" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
Pulls in https://github.com/ppy/SDL3-CS/pull/129

- Due to SDL_pen API rework, SDL no longer produces mouse events for pen inputs. I tried emulating mouse in the above o!f branch, but I'm not sure if it's in the right direction. We cannot adjust output area in this API, so making another handler for this felt too much to me. Please give it a test/review!<br /><br /> You need to be on macOS/Linux(X11/Wayland) to test this since they don't have backends for other platforms yet. Disable in-game tablet driver, and use Artist Mode if you use desktop OTD on Linux before testing this.

- `SDL_bool` is now C `bool` and more widely used. Every function that returns error with SDL_SetError now returns SDL_bool instead of int. It probably needs review.