### PR TITLE
Expose `LocalisationManager.GetLocalisedString()` as public

### DIFF
--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Localisation
         /// To facilitate tracking changes to the localised value across <see cref="CurrentParameters"/> changes, use <see cref="GetLocalisedBindableString"/>
         /// and subscribe to its <see cref="Bindable{T}.ValueChanged"/> instead.
         /// </remarks>
-        internal string GetLocalisedString(LocalisableString text)
+        public string GetLocalisedString(LocalisableString text)
         {
             switch (text.Data)
             {


### PR DESCRIPTION
The initial rationale for it being internal was likely that there was never going to be any meaningful external usage of it, but as it turns out, there are cases where you want this, one of them being https://github.com/ppy/osu/pull/29913 - without having the non-bindable variant exposed, weird games of taking out the bindable and then manually unbinding it immediately after use have to be played to avoid reference leaks.

The pre-existing xmldoc should do the job when it comes to warning users that the method will likely not do what they want it to in most cases.