### PR TITLE
Fix DecouplingFramedClock retaining old lastSeekFailed

### DIFF
--- a/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
@@ -502,6 +502,26 @@ namespace osu.Framework.Tests.Clocks
             Assert.That(source.IsRunning, Is.False);
         }
 
+        [Test]
+        public void TestPlayDifferentSourceAfterSeekFailure()
+        {
+            decouplingClock.AllowDecoupling = true;
+
+            var firstSource = (TestClockWithRange)source;
+            firstSource.MaxTime = 100;
+
+            decouplingClock.Seek(1000);
+
+            Assert.That(firstSource.IsRunning, Is.False);
+
+            var secondSource = new TestClockWithRange();
+
+            decouplingClock.ChangeSource(secondSource);
+            decouplingClock.Start();
+
+            Assert.That(secondSource.IsRunning, Is.True);
+        }
+
         #endregion
 
         private class TestClockWithRange : TestClock

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -155,6 +155,7 @@ namespace osu.Framework.Timing
             adjustableSourceClock = adjustableSource;
             currentTime = adjustableSource.CurrentTime;
             shouldBeRunning = adjustableSource.IsRunning;
+            lastSeekFailed = false;
         }
 
         #endregion


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/29946

This PR fixes an issue where DecouplingFramedClock retains old lastSeekFailed after changing its source.

It only happens on Windows because it only has platform offset due to new BASS versions. Seeking to 0 in EditorClock is practically seeking to -15, so TrackVirtual fails to seek to negative position, which in turn sets lastSeekFailed to true, but DecouplingFramedClock doesn't reset the variable after changing the source, so it just keeps interpolating instead of actually playing the source.