### PR TITLE
Expose slider bar commit method as virtual

### DIFF
--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -145,7 +145,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (handleClick)
             {
                 handleMouseInput(e);
-                commit();
+                Commit();
             }
 
             return true;
@@ -170,7 +170,7 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
-        protected override void OnDragEnd(DragEndEvent e) => commit();
+        protected override void OnDragEnd(DragEndEvent e) => Commit();
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
@@ -203,12 +203,12 @@ namespace osu.Framework.Graphics.UserInterface
         protected override void OnKeyUp(KeyUpEvent e)
         {
             if (e.Key == Key.Left || e.Key == Key.Right)
-                commit();
+                Commit();
         }
 
         private bool uncommittedChanges;
 
-        private bool commit()
+        protected virtual bool Commit()
         {
             if (!uncommittedChanges)
                 return false;


### PR DESCRIPTION
For use with https://github.com/ppy/osu/issues/30112. Without this, it is difficult to tell when a slider is done applying its changes, as there are several pathways for this (drag operation / keyboard stepping / direct single click).