### PR TITLE
Hide iOS home indicator by default

### DIFF
--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -40,6 +40,8 @@ namespace osu.Framework.iOS
 
         public override void Create()
         {
+            SDL_SetHint(SDL_HINT_IOS_HIDE_HOME_INDICATOR, "2"u8);
+
             base.Create();
 
             window = Runtime.GetNSObject<UIWindow>(WindowHandle);


### PR DESCRIPTION
This broke when we moved over from osuTK in https://github.com/ppy/osu-framework/pull/5698.

See: https://wiki.libsdl.org/SDL3/SDL_HINT_IOS_HIDE_HOME_INDICATOR

Same as https://github.com/ppy/osu-framework/pull/5009.