### PR TITLE
Enable NRT in `LocalisableStringEqualityComparer`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -99,6 +99,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestLocalisableStringDoesNotEqualNull()
         {
             testEquals(false, new LocalisableString(), new RomanisableString(makeStringA, makeStringB));
+            testEquals(false, new RomanisableString(makeStringA, makeStringB), new LocalisableString());
         }
 
         [Test]

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -17,14 +15,14 @@ namespace osu.Framework.Localisation
 
         public bool Equals(LocalisableString x, LocalisableString y)
         {
-            object xData = x.Data;
-            object yData = y.Data;
-
-            if (ReferenceEquals(null, xData) != ReferenceEquals(null, yData))
-                return false;
+            object? xData = x.Data;
+            object? yData = y.Data;
 
             if (ReferenceEquals(null, xData))
-                return true;
+                return ReferenceEquals(null, yData);
+
+            if (ReferenceEquals(null, yData))
+                return false;
 
             if (xData.GetType() != yData.GetType())
                 return EqualityComparer<object>.Default.Equals(xData, yData);


### PR DESCRIPTION
Needed to do this after https://github.com/ppy/osu/pull/30199 (`default` -> `Data = null`).