### PR TITLE
Allow slider bar to take focus and accept keyboard input while not hovered

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -113,6 +113,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             sliderBar.Current.Disabled = false;
             sliderBar.Current.Value = 0;
+            sliderBar.GetContainingFocusManager()!.ChangeFocus(null);
+            sliderBarWithNub.GetContainingFocusManager()!.ChangeFocus(null);
         });
 
         [Test]
@@ -126,6 +128,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.75f, 1f))); });
             AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
             checkValue(0);
+            AddAssert("Slider has no focus", () => !sliderBar.HasFocus);
         }
 
         [Test]
@@ -140,13 +143,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Drag Up", () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.25f, 0.5f))); });
             AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
             checkValue(0);
+            AddAssert("Slider has focus", () => sliderBar.HasFocus);
         }
 
         [Test]
         public void TestKeyboardInput()
         {
-            AddStep("Unfocus slider", () => sliderBar.GetContainingFocusManager()!.ChangeFocus(null));
-
             AddStep("Press right arrow key", () =>
             {
                 InputManager.PressKey(Key.Right);
@@ -266,6 +268,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 () => { InputManager.MoveMouseTo(sliderBarWithNub.ToScreenSpace(sliderBarWithNub.DrawSize * new Vector2(0.4f, 1f))); });
             AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
             checkValue(-2);
+            AddAssert("Slider has focus", () => sliderBarWithNub.HasFocus);
         }
 
         [Test]
@@ -279,6 +282,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 () => { InputManager.MoveMouseTo(sliderBarWithNub.ToScreenSpace(sliderBarWithNub.DrawSize * new Vector2(0.75f, 1f))); });
             AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
             checkValue(3);
+            AddAssert("Slider has focus", () => sliderBarWithNub.HasFocus);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -141,6 +141,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestKeyboardInput()
         {
+            AddStep("Unfocus slider", () => sliderBar.GetContainingFocusManager()!.ChangeFocus(null));
+
             AddStep("Press right arrow key", () =>
             {
                 InputManager.PressKey(Key.Right);
@@ -161,7 +163,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
             checkValue(1);
 
-            AddStep("Focus slider", () => GetContainingFocusManager().ChangeFocus(sliderBar));
+            AddStep("Focus slider", () => sliderBar.GetContainingFocusManager()!.ChangeFocus(sliderBar));
 
             AddStep("move mouse outside", () =>
             {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -169,7 +169,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
             checkValue(1);
 
-            AddStep("Focus slider", () => sliderBar.GetContainingFocusManager()!.ChangeFocus(sliderBar));
+            AddStep("Click slider", () => InputManager.Click(MouseButton.Left));
+            checkValue(-5);
+
+            AddAssert("Slider has focus", () => sliderBar.HasFocus);
 
             AddStep("move mouse outside", () =>
             {
@@ -181,7 +184,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.PressKey(Key.Right);
                 InputManager.ReleaseKey(Key.Right);
             });
-            checkValue(2);
+            checkValue(-4);
         }
 
         [TestCase(false)]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -160,6 +160,20 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.ReleaseKey(Key.Right);
             });
             checkValue(1);
+
+            AddStep("Focus slider", () => GetContainingFocusManager().ChangeFocus(sliderBar));
+
+            AddStep("move mouse outside", () =>
+            {
+                InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(2f, 0.5f)));
+            });
+
+            AddStep("Press right arrow key", () =>
+            {
+                InputManager.PressKey(Key.Right);
+                InputManager.ReleaseKey(Key.Right);
+            });
+            checkValue(2);
         }
 
         [TestCase(false)]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -59,6 +59,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 50),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
+                        FocusColour = Color4.Purple,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -72,6 +73,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         RangePadding = 20,
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
+                        FocusColour = Color4.Purple,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -85,6 +87,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 10),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
+                        FocusColour = Color4.Purple,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -97,6 +100,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 10),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
+                        FocusColour = Color4.Purple,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 50),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
-                        FocusColour = Color4.Purple,
+                        FocusColour = Color4.OrangeRed,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -73,7 +73,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         RangePadding = 20,
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
-                        FocusColour = Color4.Purple,
+                        FocusColour = Color4.OrangeRed,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -87,7 +87,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 10),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
-                        FocusColour = Color4.Purple,
+                        FocusColour = Color4.OrangeRed,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
@@ -100,7 +100,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 10),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
-                        FocusColour = Color4.Purple,
+                        FocusColour = Color4.OrangeRed,
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -18,16 +18,10 @@ namespace osu.Framework.Graphics.UserInterface
             set => Box.Colour = value;
         }
 
-        private Color4 selectionColour = FrameworkColour.Yellow;
-
         public Color4 SelectionColour
         {
-            get => selectionColour;
-            set
-            {
-                selectionColour = value;
-                updateColour();
-            }
+            get => SelectionBox.Colour;
+            set => SelectionBox.Colour = value;
         }
 
         private Color4 focusColour = FrameworkColour.YellowGreen;
@@ -38,7 +32,7 @@ namespace osu.Framework.Graphics.UserInterface
             set
             {
                 focusColour = value;
-                updateColour();
+                updateFocus();
             }
         }
 
@@ -56,28 +50,37 @@ namespace osu.Framework.Graphics.UserInterface
                 },
                 SelectionBox = new Box
                 {
+                    Colour = FrameworkColour.Yellow,
                     RelativeSizeAxes = Axes.Both,
                 }
             };
 
-            updateColour();
-        }
-
-        private void updateColour()
-        {
-            SelectionBox.Colour = HasFocus ? FocusColour : SelectionColour;
+            Masking = true;
         }
 
         protected override void OnFocus(FocusEvent e)
         {
-            updateColour();
+            updateFocus();
             base.OnFocus(e);
         }
 
         protected override void OnFocusLost(FocusLostEvent e)
         {
-            updateColour();
+            updateFocus();
             base.OnFocusLost(e);
+        }
+
+        private void updateFocus()
+        {
+            if (HasFocus)
+            {
+                BorderThickness = 3;
+                BorderColour = FocusColour;
+            }
+            else
+            {
+                BorderThickness = 0;
+            }
         }
 
         protected override void UpdateValue(float value)

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -4,6 +4,7 @@
 using System.Numerics;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using Vector2 = osuTK.Vector2;
 
 namespace osu.Framework.Graphics.UserInterface
@@ -17,10 +18,28 @@ namespace osu.Framework.Graphics.UserInterface
             set => Box.Colour = value;
         }
 
+        private Color4 selectionColour = FrameworkColour.Yellow;
+
         public Color4 SelectionColour
         {
-            get => SelectionBox.Colour;
-            set => SelectionBox.Colour = value;
+            get => selectionColour;
+            set
+            {
+                selectionColour = value;
+                updateColour();
+            }
+        }
+
+        private Color4 focusColour = FrameworkColour.YellowGreen;
+
+        public Color4 FocusColour
+        {
+            get => focusColour;
+            set
+            {
+                focusColour = value;
+                updateColour();
+            }
         }
 
         protected readonly Box SelectionBox;
@@ -38,9 +57,27 @@ namespace osu.Framework.Graphics.UserInterface
                 SelectionBox = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = FrameworkColour.Yellow,
                 }
             };
+
+            updateColour();
+        }
+
+        private void updateColour()
+        {
+            SelectionBox.Colour = HasFocus ? FocusColour : SelectionColour;
+        }
+
+        protected override void OnFocus(FocusEvent e)
+        {
+            updateColour();
+            base.OnFocus(e);
+        }
+
+        protected override void OnFocusLost(FocusLostEvent e)
+        {
+            updateColour();
+            base.OnFocusLost(e);
         }
 
         protected override void UpdateValue(float value)

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -179,6 +179,9 @@ namespace osu.Framework.Graphics.UserInterface
             if (currentNumberInstantaneous.Disabled)
                 return false;
 
+            if (!IsHovered && !HasFocus)
+                return false;
+
             float step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToSingle(currentNumberInstantaneous.MaxValue) - Convert.ToSingle(currentNumberInstantaneous.MinValue)) / 20;
             if (currentNumberInstantaneous.IsInteger) step = MathF.Ceiling(step);
 

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -166,6 +166,7 @@ namespace osu.Framework.Graphics.UserInterface
                 return false;
             }
 
+            GetContainingFocusManager()?.ChangeFocus(this);
             handleMouseInput(e);
             return true;
         }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -172,12 +172,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override void OnDragEnd(DragEndEvent e) => Commit();
 
+        public override bool AcceptsFocus => true;
+
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             if (currentNumberInstantaneous.Disabled)
-                return false;
-
-            if (!IsHovered)
                 return false;
 
             float step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToSingle(currentNumberInstantaneous.MaxValue) - Convert.ToSingle(currentNumberInstantaneous.MinValue)) / 20;


### PR DESCRIPTION
This change would allow you to click the slider bar, have it gain focus, and then adjust the slider bar with the keyboard while the cursor is not hovering the slider bar.

This matches the user expectation because you can do the same thing in osu! stable.
In current lazer the only way to do this is click away to unfocus everything, then hover the slider bar while using keyboard. This flow is apparently so confusing that someone in Discord thought it wasn't possible at all.

![Discord_XhhdbulGlk](https://github.com/user-attachments/assets/7968d979-554a-4c49-b507-35875abf7e6c)

https://github.com/user-attachments/assets/19d901c3-4130-48f8-be75-bedc75a6676f

![Discord_5hnRVUNu9n](https://github.com/user-attachments/assets/7c56742c-cc1d-47ac-b57c-9cc8fdc75726)

