### PR TITLE
Use `SDL_DelayNS` for lower thread jitter on non-Windows platforms

### DIFF
--- a/osu.Framework/Platform/Windows/Native/Execution.cs
+++ b/osu.Framework/Platform/Windows/Native/Execution.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace osu.Framework.Platform.Windows.Native
 {
@@ -21,37 +20,5 @@ namespace osu.Framework.Platform.Windows.Native
             SystemRequired = 0x00000001,
             UserPresent = 0x00000004,
         }
-
-        [DllImport("kernel32.dll")]
-        internal static extern bool SetWaitableTimerEx(IntPtr hTimer, in FILETIME lpDueTime, int lPeriod, TimerApcProc? routine, IntPtr lpArgToCompletionRoutine, IntPtr reason, uint tolerableDelay);
-
-        [DllImport("kernel32.dll")]
-        internal static extern IntPtr CreateWaitableTimerEx(IntPtr lpTimerAttributes, string? lpTimerName, CreateWaitableTimerFlags dwFlags, uint dwDesiredAccess);
-
-        internal const uint TIMER_ALL_ACCESS = 2031619U;
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-        public delegate void TimerApcProc([In] IntPtr lpArgToCompletionRoutine, uint dwTimerLowValue, uint dwTimerHighValue);
-
-        [Flags]
-        internal enum CreateWaitableTimerFlags : uint
-        {
-            CREATE_WAITABLE_TIMER_MANUAL_RESET = 0x00000001,
-            CREATE_WAITABLE_TIMER_HIGH_RESOLUTION = 0x00000002,
-        }
-
-        public const uint INFINITE = 0xffffffff;
-
-        [DllImport("kernel32.dll")]
-        internal static extern bool WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
-
-        internal static FILETIME CreateFileTime(TimeSpan ts)
-        {
-            ulong ul = unchecked((ulong)-ts.Ticks);
-            return new FILETIME { dwHighDateTime = (int)(ul >> 32), dwLowDateTime = (int)(ul & 0xFFFFFFFF) };
-        }
-
-        [DllImport("kernel32.dll")]
-        public static extern bool CloseHandle(IntPtr hObject);
     }
 }

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -498,7 +498,6 @@ namespace osu.Framework.Threading
                 {
                     case GameThreadState.Exited:
                         Monitor?.Dispose();
-                        Clock.Dispose();
 
                         if (initializedEvent.IsNotNull())
                             initializedEvent.Dispose();

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -3,16 +3,14 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using osu.Framework.Platform.Windows.Native;
+using SDL;
 
 namespace osu.Framework.Timing
 {
     /// <summary>
     /// A FrameClock which will limit the number of frames processed by adding Thread.Sleep calls on each ProcessFrame.
     /// </summary>
-    public class ThrottledFrameClock : FramedClock, IDisposable
+    public class ThrottledFrameClock : FramedClock
     {
         /// <summary>
         /// The target number of updates per second. Only used when <see cref="Throttling"/> is <c>true</c>.
@@ -31,13 +29,6 @@ namespace osu.Framework.Timing
         /// The time spent in a Thread.Sleep state during the last frame.
         /// </summary>
         public double TimeSlept { get; private set; }
-
-        private IntPtr waitableTimer;
-
-        internal ThrottledFrameClock()
-        {
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows) createWaitableTimer();
-        }
 
         public override void ProcessFrame()
         {
@@ -89,53 +80,9 @@ namespace osu.Framework.Timing
 
             double before = CurrentTime;
 
-            TimeSpan timeSpan = TimeSpan.FromMilliseconds(milliseconds);
-
-            if (!waitWaitableTimer(timeSpan))
-                Thread.Sleep(timeSpan);
+            SDL3.SDL_DelayNS((ulong)(milliseconds * SDL3.SDL_NS_PER_MS));
 
             return (CurrentTime = SourceTime) - before;
-        }
-
-        public void Dispose()
-        {
-            if (waitableTimer != IntPtr.Zero)
-                Execution.CloseHandle(waitableTimer);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool waitWaitableTimer(TimeSpan timeSpan)
-        {
-            if (waitableTimer == IntPtr.Zero) return false;
-
-            // Not sure if we want to fall back to Thread.Sleep on failure here, needs further investigation.
-            if (Execution.SetWaitableTimerEx(waitableTimer, Execution.CreateFileTime(timeSpan), 0, null, default, IntPtr.Zero, 0))
-            {
-                Execution.WaitForSingleObject(waitableTimer, Execution.INFINITE);
-                return true;
-            }
-
-            return false;
-        }
-
-        private void createWaitableTimer()
-        {
-            try
-            {
-                // Attempt to use CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, only available since Windows 10, version 1803.
-                waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null,
-                    Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET | Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, Execution.TIMER_ALL_ACCESS);
-
-                if (waitableTimer == IntPtr.Zero)
-                {
-                    // Fall back to a more supported version. This is still far more accurate than Thread.Sleep.
-                    waitableTimer = Execution.CreateWaitableTimerEx(IntPtr.Zero, null, Execution.CreateWaitableTimerFlags.CREATE_WAITABLE_TIMER_MANUAL_RESET, Execution.TIMER_ALL_ACCESS);
-                }
-            }
-            catch
-            {
-                // Any kind of unexpected exception should fall back to Thread.Sleep.
-            }
         }
     }
 }


### PR DESCRIPTION
This PR uses `SDL_DelayNS` to improve thread pacing on all platforms except Windows where a high resolution timer was already used. As of https://github.com/libsdl-org/SDL/commit/c8f5f6d47a2036df4a5966e65021957154ee55d4, `SDL_DelayNS` no longer busy-loops and instead uses the high precision OS delay functions. This PR also removes osu!framework's current implementation as `SDL_DelayNS` uses the same Windows high resolution timers.

Tested to work the same on Windows and have lower thread jitter on Linux, but I was unable to test mobile and macOS. Runs fine under both SDL2 and SDL3 because according to @hwsmm in the SDL3-CS bindings update https://github.com/ppy/SDL3-CS/pull/165, `SDL_DelayNS` doesn't require SDL3 init.

Testing:
* [X] Windows
* [ ] macOS
* [X] Linux
* [ ] iOS
* [ ] Android