### PR TITLE
Add `BackdropBlurContainer`

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
@@ -72,12 +72,12 @@ namespace osu.Framework.Tests.Visual.Containers
 
             AddSliderStep("fbo scale (x)", 0.01f, 4f, 1f, scale =>
             {
-                buffer.FrameBufferScale = buffer.FrameBufferScale with { X = scale };
+                buffer.EffectBufferScale = buffer.FrameBufferScale with { X = scale };
             });
 
             AddSliderStep("fbo scale (y)", 0.01f, 4f, 1f, scale =>
             {
-                buffer.FrameBufferScale = buffer.FrameBufferScale with { Y = scale };
+                buffer.EffectBufferScale = buffer.FrameBufferScale with { Y = scale };
             });
         }
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Lines;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public partial class TestSceneBackdropBlur : TestSceneMasking
+    {
+        public TestSceneBackdropBlur()
+        {
+            Remove(TestContainer, false);
+
+            BackdropBlurContainer buffer;
+            Path path;
+
+            Add(new BufferedContainer
+            {
+                BackgroundColour = FrameworkColour.YellowGreenDark,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    TestContainer,
+                    buffer = new BackdropBlurContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = Color4.Red,
+                        Padding = new MarginPadding(100),
+                        Children = new[]
+                        {
+                            path = new GradientPath
+                            {
+                                PathRadius = 50,
+                                Vertices = new[]
+                                {
+                                    new Vector2(0, 0),
+                                    new Vector2(150, 50),
+                                    new Vector2(250, -25),
+                                    new Vector2(400, 25)
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            AddSliderStep("blur", 0f, 20f, 5f, blur =>
+            {
+                buffer.BlurTo(new Vector2(blur));
+            });
+
+            AddSliderStep("container alpha", 0f, 1f, 1f, alpha =>
+            {
+                buffer.Alpha = alpha;
+            });
+
+            AddSliderStep("child alpha", 0f, 1f, 0.5f, alpha =>
+            {
+                path.Alpha = alpha;
+            });
+
+            AddSliderStep("mask cutoff", 0f, 1f, 0.0f, cutoff =>
+            {
+                buffer.MaskCutoff = cutoff;
+            });
+
+            AddSliderStep("fbo scale (x)", 0.01f, 4f, 1f, scale =>
+            {
+                buffer.FrameBufferScale = buffer.FrameBufferScale with { X = scale };
+            });
+
+            AddSliderStep("fbo scale (y)", 0.01f, 4f, 1f, scale =>
+            {
+                buffer.FrameBufferScale = buffer.FrameBufferScale with { Y = scale };
+            });
+        }
+
+        private partial class GradientPath : SmoothPath
+        {
+            protected override Color4 ColourAt(float position)
+            {
+                return base.ColourAt(position) with { A = 0.5f + position * 0.5f };
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneBackdropBlur.cs
@@ -72,12 +72,12 @@ namespace osu.Framework.Tests.Visual.Containers
 
             AddSliderStep("fbo scale (x)", 0.01f, 4f, 1f, scale =>
             {
-                buffer.EffectBufferScale = buffer.FrameBufferScale with { X = scale };
+                buffer.EffectBufferScale = buffer.EffectBufferScale with { X = scale };
             });
 
             AddSliderStep("fbo scale (y)", 0.01f, 4f, 1f, scale =>
             {
-                buffer.EffectBufferScale = buffer.FrameBufferScale with { Y = scale };
+                buffer.EffectBufferScale = buffer.EffectBufferScale with { Y = scale };
             });
         }
 

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -146,12 +146,14 @@ namespace osu.Framework.Graphics
         protected ValueInvokeOnDisposal<IFrameBuffer> BindFrameBuffer(IFrameBuffer frameBuffer)
         {
             // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
-            frameBuffer.Size = frameBufferSize;
+            frameBuffer.Size = GetFrameBufferSize(frameBuffer);
 
             frameBuffer.Bind();
 
             return new ValueInvokeOnDisposal<IFrameBuffer>(frameBuffer, static b => b.Unbind());
         }
+
+        protected virtual Vector2 GetFrameBufferSize(IFrameBuffer frameBuffer) => frameBufferSize;
 
         private ValueInvokeOnDisposal<(BufferedDrawNode node, IRenderer renderer)> establishFrameBufferViewport(IRenderer renderer)
         {

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics
         private readonly RenderBufferFormat[] mainBufferFormats;
         private readonly TextureFilteringMode filterMode;
 
-        private IRenderer renderer;
+        protected IRenderer Renderer;
         private IFrameBuffer mainBuffer;
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The <see cref="IFrameBuffer"/> which contains the original version of the rendered <see cref="Drawable"/>.
         /// </summary>
-        public IFrameBuffer MainBuffer => mainBuffer ??= renderer.CreateFrameBuffer(mainBufferFormats, filterMode);
+        public IFrameBuffer MainBuffer => mainBuffer ??= Renderer.CreateFrameBuffer(mainBufferFormats, filterMode);
 
         public void Initialise(IRenderer renderer)
         {
-            this.renderer = renderer;
+            Renderer = renderer;
             IsInitialised = true;
         }
 
@@ -110,7 +110,7 @@ namespace osu.Framework.Graphics
             return getEffectBufferAtIndex(currentEffectBuffer);
         }
 
-        private IFrameBuffer getEffectBufferAtIndex(int index) => effectBuffers[index] ??= renderer.CreateFrameBuffer(filteringMode: filterMode);
+        private IFrameBuffer getEffectBufferAtIndex(int index) => effectBuffers[index] ??= Renderer.CreateFrameBuffer(filteringMode: filterMode);
 
         /// <summary>
         /// Resets <see cref="CurrentEffectBuffer"/>.
@@ -120,7 +120,7 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
-            renderer?.ScheduleDisposal(d => d.Dispose(true), this);
+            Renderer?.ScheduleDisposal(d => d.Dispose(true), this);
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -189,6 +189,26 @@ namespace osu.Framework.Graphics.Colour
             return result;
         }
 
+        public readonly ColourInfo MultiplyAlpha(ColourInfo other)
+        {
+            if (other.HasSingleColour && other.singleColour.Alpha == 1.0)
+                return this;
+
+            if (TryExtractSingleColour(out SRGBColour single) && other.TryExtractSingleColour(out SRGBColour alphaSingle))
+            {
+                single.MultiplyAlpha(alphaSingle.Alpha);
+                return single;
+            }
+
+            ColourInfo result = this;
+            result.TopLeft.MultiplyAlpha(other.TopLeft.Alpha);
+            result.BottomLeft.MultiplyAlpha(other.BottomLeft.Alpha);
+            result.TopRight.MultiplyAlpha(other.TopRight.Alpha);
+            result.BottomRight.MultiplyAlpha(other.BottomRight.Alpha);
+
+            return result;
+        }
+
         public readonly bool Equals(ColourInfo other)
         {
             if (!HasSingleColour)

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
@@ -13,7 +13,7 @@ using osuTK.Graphics;
 namespace osu.Framework.Graphics.Containers
 {
     /// <summary>
-    /// A container that blurs the content of its nearest parent <see cref="IBufferedContainer"/> behind its children.
+    /// A container that blurs the content of its nearest parent <see cref="IBackbufferProvider"/> behind its children.
     /// If all children are of a specific non-<see cref="Drawable"/> type, use the
     /// generic version <see cref="BackdropBlurContainer{T}"/>.
     /// </summary>

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
@@ -103,5 +103,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         public Vector2 FrameBufferScale { get; set; } = Vector2.One;
+
+        public Vector2 EffectBufferScale { get; set; } = Vector2.One;
     }
 }

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer.cs
@@ -1,0 +1,107 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A container that blurs the content of its nearest parent <see cref="IBufferedContainer"/> behind its children.
+    /// If all children are of a specific non-<see cref="Drawable"/> type, use the
+    /// generic version <see cref="BackdropBlurContainer{T}"/>.
+    /// </summary>
+    public partial class BackdropBlurContainer : BackdropBlurContainer<Drawable>
+    {
+    }
+
+    /// <summary>
+    /// A container that blurs the content of its nearest parent <see cref="IBufferedContainer"/> behind its children.
+    /// </summary>
+    public partial class BackdropBlurContainer<T> : Container<T>, IBufferedContainer, IBufferedDrawable where T : Drawable
+    {
+        [Resolved]
+        private IBufferedContainer parentBufferedContainer { get; set; } = null!;
+
+        /// <summary>
+        /// Controls the amount of blurring in two orthogonal directions (X and Y if
+        /// <see cref="BlurRotation"/> is zero).
+        /// Blur is parametrized by a gaussian image filter. This property controls
+        /// the standard deviation (sigma) of the gaussian kernel.
+        /// </summary>
+        public Vector2 BlurSigma { get; set; } = Vector2.Zero;
+
+        /// <summary>
+        /// Rotates the blur kernel clockwise. In degrees. Has no effect if
+        /// <see cref="BlurSigma"/> has the same magnitude in both directions.
+        /// </summary>
+        public float BlurRotation;
+
+        /// <summary>
+        /// The multiplicative colour of drawn buffered object after applying all effects (e.g. blur). Default is <see cref="Color4.White"/>.
+        /// </summary>
+        public ColourInfo EffectColour = Color4.White;
+
+        /// <summary>
+        /// The alpha at which the content is no longer considered opaque & the background will not be blurred behind it.
+        /// </summary>
+        public float MaskCutoff;
+
+        public IShader TextureShader { get; private set; } = null!;
+
+        private IShader blurShader = null!;
+
+        private IShader textureMaskShader = null!;
+
+        private readonly BackdropBlurContainerDrawNodeSharedData sharedData;
+
+        public BackdropBlurContainer(RenderBufferFormat[]? formats = null, bool pixelSnapping = false)
+        {
+            sharedData = new BackdropBlurContainerDrawNodeSharedData(formats, pixelSnapping);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+            blurShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.BLUR);
+            textureMaskShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_MASK);
+        }
+
+        protected override DrawNode CreateDrawNode() => new BackdropBlurDrawNode(this, sharedData);
+
+        private RectangleF lastParentDrawRect;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            Invalidate(Invalidation.DrawNode);
+
+            lastParentDrawRect = parentBufferedContainer.ScreenSpaceDrawQuad.AABBFloat;
+        }
+
+        public Color4 BackgroundColour => Color4.Transparent;
+        public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
+
+        // Children should not receive the true colour to avoid colour doubling when the frame-buffers are rendered to the back-buffer.
+        public override DrawColourInfo DrawColourInfo
+        {
+            get
+            {
+                // Todo: This is incorrect.
+                var blending = Blending;
+                blending.ApplyDefaultToInherited();
+
+                return new DrawColourInfo(Color4.White, blending);
+            }
+        }
+
+        public Vector2 FrameBufferScale { get; set; } = Vector2.One;
+    }
+}

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
@@ -1,0 +1,202 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Shaders.Types;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Containers
+{
+    public partial class BackdropBlurContainer<T>
+    {
+        private class BackdropBlurDrawNode : BufferedDrawNode, ICompositeDrawNode
+        {
+            protected new BackdropBlurContainer<T> Source => (BackdropBlurContainer<T>)base.Source;
+
+            protected new CompositeDrawableDrawNode Child => (CompositeDrawableDrawNode)base.Child;
+
+            protected new BackdropBlurContainerDrawNodeSharedData SharedData => (BackdropBlurContainerDrawNodeSharedData)base.SharedData;
+
+            private ColourInfo effectColour;
+
+            private Vector2 blurSigma;
+            private Vector2I blurRadius;
+            private float blurRotation;
+
+            private float maskCutoff;
+
+            private IShader blurShader;
+            private IShader textureMaskShader;
+
+            private RectangleF parentDrawRect;
+
+            public BackdropBlurDrawNode(BackdropBlurContainer<T> source, BackdropBlurContainerDrawNodeSharedData sharedData)
+                : base(source, new CompositeDrawableDrawNode(source), sharedData)
+            {
+            }
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                parentDrawRect = Source.lastParentDrawRect;
+
+                effectColour = Source.EffectColour;
+
+                blurSigma = Source.BlurSigma;
+                blurRadius = new Vector2I(Blur.KernelSize(blurSigma.X), Blur.KernelSize(blurSigma.Y));
+                blurRotation = Source.BlurRotation;
+
+                maskCutoff = Source.MaskCutoff;
+
+                blurShader = Source.blurShader;
+                textureMaskShader = Source.textureMaskShader;
+            }
+
+            protected override void PopulateContents(IRenderer renderer)
+            {
+                base.PopulateContents(renderer);
+
+                if (blurRadius.X > 0 || blurRadius.Y > 0)
+                {
+                    renderer.PushScissorState(false);
+
+                    renderer.PushDepthInfo(new DepthInfo(false));
+
+                    if (blurRadius.X > 0) drawBlurredFrameBuffer(renderer, blurRadius.X, blurSigma.X, blurRotation);
+                    if (blurRadius.Y > 0) drawBlurredFrameBuffer(renderer, blurRadius.Y, blurSigma.Y, blurRotation + 90);
+
+                    renderer.PopDepthInfo();
+
+                    renderer.PopScissorState();
+                }
+            }
+
+            private IUniformBuffer<MaskParameters> maskParametersBuffer;
+
+            protected override void DrawContents(IRenderer renderer)
+            {
+                ColourInfo finalEffectColour = DrawColourInfo.Colour;
+                finalEffectColour.ApplyChild(effectColour);
+
+                renderer.SetBlend(DrawColourInfo.Blending);
+
+                if (blurRadius.X > 0 || blurRadius.Y > 0)
+                {
+                    maskParametersBuffer ??= renderer.CreateUniformBuffer<MaskParameters>();
+
+                    maskParametersBuffer.Data = maskParametersBuffer.Data with
+                    {
+                        MaskCutoff = maskCutoff,
+                    };
+
+                    renderer.BindTexture(SharedData.MainBuffer.Texture, 1);
+
+                    textureMaskShader.BindUniformBlock("m_MaskParameters", maskParametersBuffer);
+                    textureMaskShader.Bind();
+                    renderer.DrawFrameBuffer(SharedData.CurrentEffectBuffer, DrawRectangle, effectColour.MultiplyAlpha(DrawColourInfo.Colour));
+                    textureMaskShader.Unbind();
+                }
+
+                base.DrawContents(renderer);
+            }
+
+            private IUniformBuffer<BlurParameters> blurParametersBuffer;
+
+            private void drawBlurredFrameBuffer(IRenderer renderer, int kernelRadius, float sigma, float blurRotation)
+            {
+                blurParametersBuffer ??= renderer.CreateUniformBuffer<BlurParameters>();
+
+                IFrameBuffer current = SharedData.GetCurrentSourceBuffer(out bool isBackBuffer);
+                IFrameBuffer target = SharedData.GetNextEffectBuffer();
+
+                renderer.SetBlend(BlendingParameters.None);
+
+                using (BindFrameBuffer(target))
+                {
+                    float radians = float.DegreesToRadians(blurRotation);
+
+                    blurParametersBuffer.Data = blurParametersBuffer.Data with
+                    {
+                        Radius = kernelRadius,
+                        Sigma = sigma,
+                        TexSize = current.Size,
+                        Direction = new Vector2(MathF.Cos(radians), MathF.Sin(radians))
+                    };
+
+                    var rect = isBackBuffer
+                        ? parentDrawRect.RelativeIn(DrawRectangle) * target.Size
+                        : new RectangleF(0, 0, current.Texture.Width, current.Texture.Height);
+
+                    blurShader.BindUniformBlock("m_BlurParameters", blurParametersBuffer);
+                    blurShader.Bind();
+                    renderer.DrawFrameBuffer(current, rect, ColourInfo.SingleColour(Color4.White));
+                    blurShader.Unbind();
+                }
+            }
+
+            public List<DrawNode> Children
+            {
+                get => Child.Children;
+                set => Child.Children = value;
+            }
+
+            public bool AddChildDrawNodes => RequiresRedraw;
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                blurParametersBuffer?.Dispose();
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private record struct BlurParameters
+            {
+                public UniformVector2 TexSize;
+                public UniformInt Radius;
+                public UniformFloat Sigma;
+                public UniformVector2 Direction;
+                private readonly UniformPadding8 pad1;
+            }
+
+            [StructLayout(LayoutKind.Sequential, Pack = 1)]
+            private record struct MaskParameters
+            {
+                public UniformFloat MaskCutoff;
+                private readonly UniformPadding12 pad1;
+            }
+        }
+
+        private class BackdropBlurContainerDrawNodeSharedData : BufferedDrawNodeSharedData
+        {
+            public BackdropBlurContainerDrawNodeSharedData(RenderBufferFormat[] mainBufferFormats, bool pixelSnapping)
+                : base(2, mainBufferFormats, pixelSnapping, true)
+            {
+            }
+
+            public IFrameBuffer GetCurrentSourceBuffer(out bool isBackBuffer)
+            {
+                var buffer = base.CurrentEffectBuffer;
+
+                if (buffer == MainBuffer && Renderer.FrameBuffer != null)
+                {
+                    isBackBuffer = true;
+                    return Renderer.FrameBuffer;
+                }
+
+                isBackBuffer = false;
+                return buffer;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
@@ -40,6 +40,9 @@ namespace osu.Framework.Graphics.Containers
 
             private RectangleF parentDrawRect;
 
+            private Vector2 effectBufferScale;
+            private Vector2 effectBufferSize;
+
             public BackdropBlurDrawNode(BackdropBlurContainer<T> source, BackdropBlurContainerDrawNodeSharedData sharedData)
                 : base(source, new CompositeDrawableDrawNode(source), sharedData)
             {
@@ -53,7 +56,10 @@ namespace osu.Framework.Graphics.Containers
 
                 effectColour = Source.EffectColour;
 
-                blurSigma = Source.BlurSigma;
+                effectBufferScale = Source.EffectBufferScale;
+                effectBufferSize = new Vector2(MathF.Ceiling(DrawRectangle.Width * effectBufferScale.X), MathF.Ceiling(DrawRectangle.Height * effectBufferScale.Y));
+
+                blurSigma = Source.BlurSigma * effectBufferScale;
                 blurRadius = new Vector2I(Blur.KernelSize(blurSigma.X), Blur.KernelSize(blurSigma.Y));
                 blurRotation = Source.BlurRotation;
 
@@ -145,6 +151,14 @@ namespace osu.Framework.Graphics.Containers
                 }
             }
 
+            protected override Vector2 GetFrameBufferSize(IFrameBuffer frameBuffer)
+            {
+                if (frameBuffer != SharedData.MainBuffer)
+                    return effectBufferSize;
+
+                return base.GetFrameBufferSize(frameBuffer);
+            }
+
             public List<DrawNode> Children
             {
                 get => Child.Children;
@@ -186,7 +200,7 @@ namespace osu.Framework.Graphics.Containers
 
             public IFrameBuffer GetCurrentSourceBuffer(out bool isBackBuffer)
             {
-                var buffer = base.CurrentEffectBuffer;
+                var buffer = CurrentEffectBuffer;
 
                 if (buffer == MainBuffer && Renderer.FrameBuffer != null)
                 {

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Graphics.Containers
 
                     textureMaskShader.BindUniformBlock("m_MaskParameters", maskParametersBuffer);
                     textureMaskShader.Bind();
-                    renderer.DrawFrameBuffer(SharedData.CurrentEffectBuffer, DrawRectangle, effectColour.MultiplyAlpha(DrawColourInfo.Colour));
+                    renderer.DrawFrameBuffer(SharedData.CurrentEffectBuffer, DrawRectangle, finalEffectColour.MultiplyAlpha(DrawColourInfo.Colour));
                     textureMaskShader.Unbind();
                 }
 

--- a/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BackdropBlurContainer_DrawNode.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Containers
                 effectBufferScale = Source.EffectBufferScale;
                 effectBufferSize = new Vector2(MathF.Ceiling(DrawRectangle.Width * effectBufferScale.X), MathF.Ceiling(DrawRectangle.Height * effectBufferScale.Y));
 
-                blurSigma = Source.BlurSigma * effectBufferScale;
+                blurSigma = Source.BlurSigma;
                 blurRadius = new Vector2I(Blur.KernelSize(blurSigma.X), Blur.KernelSize(blurSigma.Y));
                 blurRotation = Source.BlurRotation;
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Graphics.Containers
     /// appearance of the container at the cost of performance. Such effects include
     /// uniform fading of children, blur, and other post-processing effects.
     /// </summary>
-    public partial class BufferedContainer<T> : Container<T>, IBufferedContainer, IBufferedDrawable
+    public partial class BufferedContainer<T> : Container<T>, IBufferedContainer, IBufferedDrawable, IBackbufferProvider
         where T : Drawable
     {
         private bool drawOriginal;

--- a/osu.Framework/Graphics/Containers/IBackbufferProvider.cs
+++ b/osu.Framework/Graphics/Containers/IBackbufferProvider.cs
@@ -5,6 +5,9 @@ using osu.Framework.Allocation;
 
 namespace osu.Framework.Graphics.Containers
 {
+    /// <summary>
+    /// A container which ensures that its children are drawn to a framebuffer.
+    /// </summary>
     [Cached]
     public interface IBackbufferProvider : IContainer
     {

--- a/osu.Framework/Graphics/Containers/IBackbufferProvider.cs
+++ b/osu.Framework/Graphics/Containers/IBackbufferProvider.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+
+namespace osu.Framework.Graphics.Containers
+{
+    [Cached]
+    public interface IBackbufferProvider : IContainer
+    {
+    }
+}

--- a/osu.Framework/Graphics/Containers/IBufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/IBufferedContainer.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
 using osuTK;
 
 namespace osu.Framework.Graphics.Containers
 {
+    [Cached]
     public interface IBufferedContainer : IContainer
     {
         Vector2 BlurSigma { get; set; }

--- a/osu.Framework/Graphics/Containers/RefCountedBackbufferProvider.cs
+++ b/osu.Framework/Graphics/Containers/RefCountedBackbufferProvider.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A container which, when a child requests it, will wrap its content in a <see cref="BufferedContainer"/>.
+    /// </summary>
+    [Cached]
+    public partial class RefCountedBackbufferProvider : Container, IBackbufferProvider
+    {
+        private volatile int refCount;
+
+        private readonly Container content = new Container { RelativeSizeAxes = Axes.Both };
+
+        private BufferedContainer? bufferedContainer;
+
+        protected override Container<Drawable> Content => content;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(content);
+        }
+
+        internal void Increment() => Interlocked.Increment(ref refCount);
+
+        internal void Decrement() => Interlocked.Decrement(ref refCount);
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            Debug.Assert(refCount >= 0);
+
+            if (refCount > 0 && bufferedContainer == null)
+            {
+                Logger.Log($@"{nameof(RefCountedBackbufferProvider)} became active.");
+
+                ClearInternal(false);
+                AddInternal(bufferedContainer = new BufferedContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = content
+                });
+            }
+            else if (refCount == 0 && bufferedContainer != null)
+            {
+                Logger.Log($@"{nameof(RefCountedBackbufferProvider)} became inactive.");
+
+                bufferedContainer?.Clear(false);
+                bufferedContainer = null;
+
+                ClearInternal(false);
+                AddInternal(content);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/RefCountedBackbufferProvider.cs
+++ b/osu.Framework/Graphics/Containers/RefCountedBackbufferProvider.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Graphics.Containers
                 bufferedContainer?.Clear(false);
                 bufferedContainer = null;
 
-                ClearInternal(false);
+                ClearInternal();
                 AddInternal(content);
             }
         }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -149,6 +149,11 @@ namespace osu.Framework.Graphics.Rendering
         bool UsingBackbuffer { get; }
 
         /// <summary>
+        /// The current framebuffer, or null if the backbuffer is used.
+        /// </summary>
+        public IFrameBuffer? FrameBuffer { get; }
+
+        /// <summary>
         /// The texture for a white pixel.
         /// </summary>
         Texture WhitePixel { get; }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -88,7 +88,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The current framebuffer, or null if the backbuffer is used.
         /// </summary>
-        protected IFrameBuffer? FrameBuffer { get; private set; }
+        public IFrameBuffer? FrameBuffer { get; private set; }
 
         /// <summary>
         /// The current shader, or null if no shader is currently bound.

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -159,5 +159,6 @@ namespace osu.Framework.Graphics.Shaders
         public const string GLOW = "Glow";
         public const string BLUR = "Blur";
         public const string VIDEO = "Video";
+        public const string TEXTURE_MASK = "TextureMask";
     }
 }

--- a/osu.Framework/Resources/Shaders/sh_TextureMask.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureMask.fs
@@ -1,0 +1,37 @@
+#ifndef TEXTURE_MASK_FS
+#define TEXTURE_MASK_FS
+
+#include "sh_Utils.h"
+#include "sh_Masking.h"
+#include "sh_TextureWrapping.h"
+
+layout(location = 2) in mediump vec2 v_TexCoord;
+
+layout(std140, set = 0, binding = 0) uniform m_MaskParameters
+{
+	mediump float g_MaskCutoff;
+};
+
+layout(set = 1, binding = 0) uniform highp texture2D m_Texture;
+layout(set = 1, binding = 1) uniform highp sampler m_Sampler;
+
+layout(set = 2, binding = 0) uniform lowp texture2D m_Mask;
+layout(set = 2, binding = 1) uniform lowp sampler m_MaskSampler;
+
+
+
+layout(location = 0) out vec4 o_Colour;
+
+void main(void)
+{
+    vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
+
+    vec4 mask = wrappedSampler(wrappedCoord, v_TexRect, m_Mask, m_MaskSampler, -0.9);
+
+    if (mask.a <= g_MaskCutoff)
+        discard;
+
+    o_Colour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
+}
+
+#endif


### PR DESCRIPTION
Companion to ppy/osu#30347

Adds a `BackdropBlurContainer` container that blurs the background behind it's children.
It requires a parent of type `IBackbufferProvider` (a `BufferedContainer` or a `RefCountedBackbufferProvider`), who's framebuffer it will blur & then draw it back onto the framebuffer with a masking shader based on the `BackdropBlurContainer`'s children.

Also adds a `RefCountedBackbufferProvider` which can be used to i.e. wrap the entire game in an on-demand buffercontainer, which automatically gets enabled when any of it's children need a backbuffer.

There's still a bit of weirdness with texture clamping going on when `EffectBufferScale` goes above 1, but I couldn't quite figure that out on my own.

https://github.com/user-attachments/assets/06b5eb69-de6a-4d75-9983-39fd0167700a

