### PR TITLE
Allow to overwrite BufferedContainer's TextureShader and inherit from its DrawNode

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -234,11 +234,11 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private long updateVersion;
 
-        public IShader TextureShader { get; private set; }
+        public IShader TextureShader { get; protected set; }
 
         private IShader blurShader;
 
-        private readonly BufferedContainerDrawNodeSharedData sharedData;
+        protected readonly BufferedContainerDrawNodeSharedData SharedData;
 
         /// <summary>
         /// Constructs an empty buffered container.
@@ -257,7 +257,7 @@ namespace osu.Framework.Graphics.Containers
         {
             UsingCachedFrameBuffer = cachedFrameBuffer;
 
-            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !cachedFrameBuffer);
+            SharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !cachedFrameBuffer);
 
             AddLayout(screenSpaceSizeBacking);
         }
@@ -269,7 +269,7 @@ namespace osu.Framework.Graphics.Containers
             blurShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.BLUR);
         }
 
-        protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData);
+        protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, SharedData);
 
         public override bool UpdateSubTreeMasking()
         {
@@ -350,7 +350,7 @@ namespace osu.Framework.Graphics.Containers
         /// Creates a view which can be added to a container to display the content of this <see cref="BufferedContainer{T}"/>.
         /// </summary>
         /// <returns>The view.</returns>
-        public BufferedContainerView<T> CreateView() => new BufferedContainerView<T>(this, sharedData);
+        public BufferedContainerView<T> CreateView() => new BufferedContainerView<T>(this, SharedData);
 
         public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
 
@@ -371,7 +371,7 @@ namespace osu.Framework.Graphics.Containers
         {
             base.Dispose(isDisposing);
 
-            sharedData.Dispose();
+            SharedData.Dispose();
         }
     }
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Containers
 {
     public partial class BufferedContainer<T>
     {
-        private class BufferedContainerDrawNode : BufferedDrawNode, ICompositeDrawNode
+        protected class BufferedContainerDrawNode : BufferedDrawNode, ICompositeDrawNode
         {
             protected new BufferedContainer<T> Source => (BufferedContainer<T>)base.Source;
 
@@ -149,7 +149,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private class BufferedContainerDrawNodeSharedData : BufferedDrawNodeSharedData
+        protected class BufferedContainerDrawNodeSharedData : BufferedDrawNodeSharedData
         {
             public BufferedContainerDrawNodeSharedData(RenderBufferFormat[] mainBufferFormats, bool pixelSnapping, bool clipToRootNode)
                 : base(2, mainBufferFormats, pixelSnapping, clipToRootNode)


### PR DESCRIPTION
This is needed to allow custom effects to be applied to BufferedContainer without redrawing the internal children.

Companion to https://github.com/ppy/osu/pull/30391