### PR TITLE
Dispose SampleChannel in Sample if it is not disposed yet

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -115,5 +115,17 @@ namespace osu.Framework.Tests.Audio
             bass.RunOnAudioThread(() => channel.Stop());
             Assert.That(channel.Playing, Is.False);
         }
+
+        [Test]
+        public void TestChannelLifetime()
+        {
+            channel = sample.Play();
+            bass.Update();
+
+            bass.RunOnAudioThread(() => channel.Stop());
+            bass.Update();
+
+            Assert.That(channel.IsDisposed, Is.True);
+        }
     }
 }

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -110,7 +110,9 @@ namespace osu.Framework.Audio
 
         #region IDisposable Support
 
-        protected volatile bool IsDisposed;
+        public bool IsDisposed => isDisposed;
+
+        private volatile bool isDisposed;
 
         public void Dispose()
         {
@@ -122,7 +124,7 @@ namespace osu.Framework.Audio
 
         protected virtual void Dispose(bool disposing)
         {
-            IsDisposed = true;
+            isDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -53,5 +53,18 @@ namespace osu.Framework.Audio.Sample
         /// </summary>
         /// <returns>The <see cref="SampleChannel"/> for the playback.</returns>
         protected abstract SampleChannel CreateChannel();
+
+        // SampleChannel IsAlive can be false if Playing is not true, even if it is not disposed yet.
+        // Mixer removes the channel from itself after playing to the end, so if we don't dispose this item here, it's forever lost.
+        protected override void ItemRemoved(SampleChannel item)
+        {
+            base.ItemRemoved(item);
+
+            if (!item.IsDisposed)
+            {
+                item.Dispose();
+                item.Update();
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where SampleChannel never gets disposed until the parent Sample is disposed.

SampleChannel.IsAlive can be false if Playing is not true, even if it is not disposed yet.
Mixer removes the channel from itself after playing to the end, so if we don't dispose this item in ItemRemoved, it's forever lost.

It can be proven with the below patch. In Samples test scene, you can only see `createCount` going up continuously, but `disposeCount` going up only when you exit the scene, and `SampleChannel`s that were already removed both from Mixer and from Sample at that point are already cleared by GC without calling `Dispose`. If you run osu! with this, you can see that `SampleChannelBass got disposed` never gets printed without this PR.

This issue also can get fixed by adding a finalizer in SampleChannel, but I think this way is better considering how many SampleChannels are created during runtime.

```diff
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -212,11 +212,15 @@ private void ensureChannel() => EnqueueAction(() =>
             if (!hasChannel)
                 return;
 
+            Logging.Logger.Log($"SampleChannelBass got created {++createCount} times so far");
+
             setLoopFlag(Looping);
 
             relativeFrequencyHandler.SetChannel(channel);
         });
 
+        private static int createCount = 0;
+
         #region Mixing
 
         private BassAudioMixer bassMixer => (BassAudioMixer)Mixer.AsNonNull();
@@ -231,6 +235,8 @@ private void ensureChannel() => EnqueueAction(() =>
 
         #endregion
 
+        private static int disposeCount = 0;
+
         protected override void Dispose(bool disposing)
         {
             if (IsDisposed)
@@ -238,6 +244,7 @@ protected override void Dispose(bool disposing)
 
             if (hasChannel)
             {
+                Logging.Logger.Log($"SampleChannelBass got disposed {++disposeCount} times so far");
                 bassMixer.StreamFree(this);
                 channel = 0;
             }

```

I also added a test case for this, but I'm not sure about the lifetime of SampleChannel. As far as I know, it should be fire-and-forget, so I guess this is fine.