### PR TITLE
Sync initial input state of `PassThroughInputManager` from parent

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -116,6 +116,11 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
         }
 
+        /// <summary>
+        /// Unlike <see cref="TestPressKeyBeforeKeyBindingContainerAdded"/>, when an intermediate input manager is involved,
+        /// we expect the key binding container to be fed with any previously pressed key
+        /// (consider an osu!catch player pressing the left/right/dash keys before entering gameplay).
+        /// </summary>
         [Test]
         public void TestPressKeyBeforeKeyBindingContainerAdded_WithPassThroughInputManager()
         {
@@ -142,15 +147,22 @@ namespace osu.Framework.Tests.Visual.Input
                 };
             });
 
+            AddAssert("only one action pressed", () => pressedActions, () => Has.Count.EqualTo(1));
+            AddAssert("ActionEnter pressed", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionEnter));
+            AddAssert("no actions released", () => releasedActions, () => Is.Empty);
+
             AddStep("press key A", () => InputManager.PressKey(Key.A));
-            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
-            AddAssert("ActionA triggered", () => pressedActions[0], () => Is.EqualTo(TestAction.ActionA));
+            AddAssert("two actions pressed", () => pressedActions, () => Has.Count.EqualTo(2));
+            AddAssert("ActionA pressed", () => pressedActions[1], () => Is.EqualTo(TestAction.ActionA));
             AddAssert("no actions released", () => releasedActions, () => Is.Empty);
 
             AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
-            AddAssert("only one action triggered", () => pressedActions, () => Has.Count.EqualTo(1));
-            AddAssert("only one action released", () => releasedActions, () => Has.Count.EqualTo(1));
+            AddAssert("one action released", () => releasedActions, () => Has.Count.EqualTo(1));
             AddAssert("ActionA released", () => releasedActions[0], () => Is.EqualTo(TestAction.ActionA));
+
+            AddStep("release enter", () => InputManager.ReleaseKey(Key.Enter));
+            AddAssert("two actions released", () => releasedActions, () => Has.Count.EqualTo(2));
+            AddAssert("ActionEnter released", () => releasedActions[1], () => Is.EqualTo(TestAction.ActionEnter));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -51,6 +51,26 @@ namespace osu.Framework.Tests.Visual.Input
         });
 
         [Test]
+        public void TestInitialState()
+        {
+            AddStep("Press buttons", () =>
+            {
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.PressKey(Key.A);
+                InputManager.PressJoystickButton(JoystickButton.Button1);
+            });
+            addTestInputManagerStep();
+            AddAssert("pressed", () => mouse.IsPressed(MouseButton.Left) && keyboard.IsPressed(Key.A) && joystick.IsPressed(JoystickButton.Button1));
+            AddStep("Release on parent", () =>
+            {
+                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.ReleaseKey(Key.A);
+                InputManager.ReleaseJoystickButton(JoystickButton.Button1);
+            });
+            AddAssert("released", () => !mouse.IsPressed(MouseButton.Left) && !keyboard.IsPressed(Key.A) && !joystick.IsPressed(JoystickButton.Button1));
+        }
+
+        [Test]
         public void UseParentInputChange()
         {
             addTestInputManagerStep();

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Input
 
             // allow a frame for children to be prepared before passing input from parent.
             // this is especially necessary if our child is a KeyBindingContainer since the key bindings are not prepared until LoadComplete is called on it.
-            Schedule(() => Schedule(syncInitialState));
+            ScheduleAfterChildren(syncInitialState);
         }
 
         public override bool HandleHoverEvents => parentInputManager != null && UseParentInput ? parentInputManager.HandleHoverEvents : base.HandleHoverEvents;


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/29090

~~The double-schedule is ugly, but mandatory to ensure the syncing process does not apply until  the entire drawable hierarchy contained by the input manager is loaded / ready to handle input via event handlers.~~

~~While it's somewhat obvious, note that scheduling twice inside a `LoadComplete` means to execute in the next update frame rather than the current one, since `LoadComplete` comes before updating the scheduler in the current update frame (see [this](https://github.com/ppy/osu-framework/blob/b4ed7217c1b2f66e27c96cc264a53fbde1cd7948/osu.Framework/Graphics/Drawable.cs#L478-L492))~~

See: https://github.com/ppy/osu-framework/pull/6398#discussion_r1845482174