### PR TITLE
Add an option to change behavior of `IsAlive` in SampleChannel

### DIFF
--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -37,5 +37,11 @@ namespace osu.Framework.Audio.Sample
         /// Whether playback should repeat.
         /// </summary>
         bool Looping { get; set; }
+
+        /// <summary>
+        /// By default, <see cref="ISampleChannel"/> is not resumable after <see cref="Stop"/> or the end of playback.
+        /// Setting this as true will disable automatic cleanup, and the channel will live until it gets disposed manually.
+        /// </summary>
+        bool ManualFree { get; set; }
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Audio.Sample
 
         public virtual bool Looping { get; set; }
 
-        public override bool IsAlive => base.IsAlive && Playing;
+        public override bool IsAlive => ManualFree ? base.IsAlive : base.IsAlive && Playing;
 
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
 
@@ -61,6 +61,8 @@ namespace osu.Framework.Audio.Sample
         Task IAudioChannel.EnqueueAction(Action action) => EnqueueAction(action);
 
         #endregion
+
+        public bool ManualFree { get; set; }
 
         protected override void Dispose(bool disposing)
         {

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using ManagedBass;
 using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Audio.Track;
@@ -117,6 +118,9 @@ namespace osu.Framework.Audio.Sample
 
         public override void Play()
         {
+            // Check if this channel is disposed first to not set enqueuedPlaybackStart to true, as it makes Playing true.
+            ObjectDisposedException.ThrowIf(IsDisposed, this);
+
             userRequestedPlay = true;
 
             // Pin Playing and IsAlive to true so that the channel isn't killed by the next update. This is only reset after playback is started.


### PR DESCRIPTION
This PR provides an option to change behavior of `IsAlive` in SampleChannel. To make auto-free work, https://github.com/ppy/osu-framework/pull/6397 is required.

If `ManualFree` is false (default), it works the same as before: `IsAlive` will be false after `Stop` or the end of playback.
If `ManualFree` is true, `IsAlive` will never be true until the user explicitly calls `Dispose`.

It also contains a fix for an issue where calling `Play` after disposal makes `Playing` true.