### PR TITLE
Allow to do DrawNode invalidation on cached `BufferedContainer` without redrawing the framebuffer

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -30,6 +30,8 @@ namespace osu.Framework.Tests.Visual.Containers
                 "uncached with parent scale&fade",
                 "cached with parent scale&fade",
                 "cached with no redraw on parent scale&fade",
+                "cached with drawnode invalidation",
+                "cached with force redraw",
             };
 
             var boxes = new List<ContainingBox>();
@@ -48,9 +50,14 @@ namespace osu.Framework.Tests.Visual.Containers
                         Text = labels[i],
                         Font = new FontUsage(size: 20),
                     },
-                    box = new ContainingBox(i >= 6, i >= 8)
+                    box = new ContainingBox(i >= 6 && i <= 10, i >= 8 && i <= 10)
                     {
-                        Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5, cached: i % 2 == 1 || i == 10)
+                        Child = new CountingBox(
+                            rotating: i == 2 || i == 3,
+                            moving: i == 4 || i == 5,
+                            invalidate: i == 11,
+                            forceRedraw: i == 12,
+                            cached: i % 2 == 1 || i == 10 || i == 12)
                         {
                             RedrawOnScale = i != 10
                         },
@@ -67,7 +74,8 @@ namespace osu.Framework.Tests.Visual.Containers
             AddAssert("even box counts equal", () =>
                 boxes[0].Count == boxes[2].Count &&
                 boxes[2].Count == boxes[4].Count &&
-                boxes[4].Count == boxes[6].Count);
+                boxes[4].Count == boxes[6].Count &&
+                boxes[6].Count == boxes[8].Count);
 
             // ensure cached is never updating children.
             AddAssert("box 1 count is 1", () => boxes[1].Count == 1);
@@ -86,6 +94,12 @@ namespace osu.Framework.Tests.Visual.Containers
             AddAssert("box 7 count equals box 8 count", () => boxes[7].Count == boxes[8].Count);
 
             AddAssert("box 10 count is 1", () => boxes[10].Count == 1);
+
+            // ensure drawnode invalidation doesn't invalidate cache.
+            AddAssert("box 11 count is 1", () => boxes[11].Count == 1);
+
+            // ensure force redraw always invalidates cache.
+            AddAssert("box 12 count equals box 0 count", () => boxes[12].Count == boxes[0].Count);
         }
 
         private partial class ContainingBox : Container<CountingBox>
@@ -117,13 +131,17 @@ namespace osu.Framework.Tests.Visual.Containers
 
             private readonly bool rotating;
             private readonly bool moving;
+            private readonly bool invalidate;
+            private readonly bool forceRedraw;
             private readonly SpriteText count;
 
-            public CountingBox(bool rotating = false, bool moving = false, bool cached = false)
+            public CountingBox(bool rotating = false, bool moving = false, bool invalidate = false, bool forceRedraw = false, bool cached = false)
                 : base(cachedFrameBuffer: cached)
             {
                 this.rotating = rotating;
                 this.moving = moving;
+                this.invalidate = invalidate;
+                this.forceRedraw = forceRedraw;
                 RelativeSizeAxes = Axes.Both;
                 Origin = Anchor.Centre;
                 Anchor = Anchor.Centre;
@@ -152,6 +170,16 @@ namespace osu.Framework.Tests.Visual.Containers
             protected override void Update()
             {
                 base.Update();
+
+                if (invalidate)
+                {
+                    Invalidate(Invalidation.DrawNode);
+                }
+
+                if (forceRedraw)
+                {
+                    ForceRedraw();
+                }
 
                 if (RequiresChildrenUpdate)
                 {

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Graphics.Containers
                     return;
 
                 effectColour = value;
-                Invalidate(Invalidation.DrawNode);
+                ForceRedraw();
             }
         }
 
@@ -137,7 +137,7 @@ namespace osu.Framework.Graphics.Containers
                     return;
 
                 effectBlending = value;
-                Invalidate(Invalidation.DrawNode);
+                ForceRedraw();
             }
         }
 
@@ -156,7 +156,7 @@ namespace osu.Framework.Graphics.Containers
                     return;
 
                 effectPlacement = value;
-                Invalidate(Invalidation.DrawNode);
+                ForceRedraw();
             }
         }
 
@@ -223,7 +223,11 @@ namespace osu.Framework.Graphics.Containers
         /// Forces a redraw of the framebuffer before it is blitted the next time.
         /// Only relevant if <see cref="UsingCachedFrameBuffer"/> is true.
         /// </summary>
-        public void ForceRedraw() => Invalidate(Invalidation.DrawNode);
+        public void ForceRedraw()
+        {
+            ++updateVersion;
+            Invalidate(Invalidation.DrawNode);
+        }
 
         /// <summary>
         /// In order to signal the draw thread to re-draw the buffered container we version it.
@@ -293,7 +297,11 @@ namespace osu.Framework.Graphics.Containers
 
             if ((invalidation & Invalidation.DrawNode) > 0)
             {
-                ++updateVersion;
+                if (source == InvalidationSource.Child)
+                {
+                    ++updateVersion;
+                }
+
                 result = true;
             }
 


### PR DESCRIPTION
This is needed for changing the parameters of a custom shader on `BufferedContainer` without tanking the performance (example: https://github.com/ppy/osu/pull/30391#discussion_r1815242461)

Cached framebuffer is redrawn only if DrawNode invalidation comes from a child or if it is explicitly requested via `ForceRedraw()` method.

Companion to https://github.com/ppy/osu/pull/30391