### PR TITLE
Disable configuring frame limiter when using single-threaded mode under Metal

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -100,7 +100,15 @@ namespace osu.Framework.Configuration
         Renderer,
         WindowMode,
         ConfineMouseMode,
+
+        /// <summary>
+        /// Controls the frame limiter used for the game threads.
+        /// </summary>
+        /// <remarks>
+        /// Take into account the state of <see cref="GameHost.AllowConfiguringFrameSync"/> when exposing this setting for user configuration.
+        /// </remarks>
         FrameSync,
+
         ExecutionMode,
 
         ShowUnicode,

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -374,6 +374,9 @@ namespace osu.Framework
                     return true;
 
                 case FrameworkAction.CycleFrameSync:
+                    if (!Host.AllowConfiguringFrameSync.Value)
+                        return true;
+
                     var nextFrameSync = frameSyncMode.Value + 1;
 
                     if (nextFrameSync > FrameSync.Unlimited)


### PR DESCRIPTION
- Part of https://github.com/ppy/osu/issues/30397

Rather than directly bindable-disabling the `FrameSync` setting at a global level, I've went with a soft approach on this, by adding a separate bindable in `GameHost` indicating whether frame sync is configurable in the current combination of renderer & threading mode.

If this feels too soft, I can go the aggressive route, I'm just mainly concerned it may trip us in the future for when we invent a new place to configure the frame limiter.