### PR TITLE
Disable `OnScreenKeyboardOverlapsGameWindow` on iOS when hardware keyboard is attached

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Foundation;
+using GameController;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -38,7 +39,7 @@ namespace osu.Framework.iOS
             base.SetupConfig(defaultOverrides);
         }
 
-        public override bool OnScreenKeyboardOverlapsGameWindow => true;
+        public override bool OnScreenKeyboardOverlapsGameWindow => !OperatingSystem.IsIOSVersionAtLeast(14) || GCKeyboard.CoalescedKeyboard == null;
 
         public override bool CanExit => false;
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Foundation;
-using GameController;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -38,8 +37,6 @@ namespace osu.Framework.iOS
 
             base.SetupConfig(defaultOverrides);
         }
-
-        public override bool OnScreenKeyboardOverlapsGameWindow => !OperatingSystem.IsIOSVersionAtLeast(14) || GCKeyboard.CoalescedKeyboard == null;
 
         public override bool CanExit => false;
 

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -11,7 +11,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osu.Framework.Platform.SDL3;
-using SDL;
 using static SDL.SDL3;
 using UIKit;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -122,7 +122,8 @@ namespace osu.Framework.Platform
         public event Func<IpcMessage, IpcMessage> MessageReceived;
 
         /// <summary>
-        /// Whether the on screen keyboard covers a portion of the game window when presented to the user.
+        /// Whether the on-screen keyboard covers a portion of the game window when presented to the user.
+        /// This is usually true on mobile platforms, but may change to false if a hardware keyboard is connected.
         /// </summary>
         public virtual bool OnScreenKeyboardOverlapsGameWindow => false;
 

--- a/osu.Framework/Platform/ISDLWindow.cs
+++ b/osu.Framework/Platform/ISDLWindow.cs
@@ -39,6 +39,7 @@ namespace osu.Framework.Platform
         bool MouseAutoCapture { set; }
         bool RelativeMouseMode { get; set; }
         bool CapsLockPressed { get; }
+        bool KeyboardAttached { get; }
 
         void UpdateMousePosition(Vector2 position);
 

--- a/osu.Framework/Platform/SDL2/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Window.cs
@@ -165,6 +165,8 @@ namespace osu.Framework.Platform.SDL2
 
         public bool CapsLockPressed => SDL_GetModState().HasFlagFast(SDL_Keymod.KMOD_CAPS);
 
+        public bool KeyboardAttached => true; // SDL2 has no way of knowing whether a keyboard is attached, assume true.
+
         // references must be kept to avoid GC, see https://stackoverflow.com/a/6193914
 
         [UsedImplicitly]

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -145,6 +145,8 @@ namespace osu.Framework.Platform.SDL3
 
         public bool CapsLockPressed => SDL_GetModState().HasFlagFast(SDL_Keymod.SDL_KMOD_CAPS);
 
+        public bool KeyboardAttached => SDL_HasKeyboard();
+
         /// <summary>
         /// Represents a handle to this <see cref="SDL3Window"/> instance, used for unmanaged callbacks.
         /// </summary>

--- a/osu.Framework/Platform/SDLGameHost.cs
+++ b/osu.Framework/Platform/SDLGameHost.cs
@@ -20,6 +20,8 @@ namespace osu.Framework.Platform
     {
         public override bool CapsLockEnabled => (Window as ISDLWindow)?.CapsLockPressed == true;
 
+        public override bool OnScreenKeyboardOverlapsGameWindow => (Window as ISDLWindow)?.KeyboardAttached == false;
+
         protected SDLGameHost(string gameName, HostOptions? options = null)
             : base(gameName, options)
         {


### PR DESCRIPTION
Noticed while working on fixing iOS hardware keyboard issues. When a hardware keyboard is attached, the software keyboard no longer shows and "overlaps with the game window", so it's more ideal for the `OnScreenKeyboardOverlapsGameWindow` flag to remain false in that case, so that search text boxes on osu! still gain focus when they are present (i.e. when opening song select or opening settings overlay).

An Android companion to this should be in place if this change can be agreed upon. 

Also note that this implementation can be simply replaced with `!SDL_HasKeyboard()`, and we can also just replace these overrides with a single override at `SDLGameHost` that returns `!SDL_HasKeyboard()` (usually always false on desktop platforms, and true on mobile platforms if there are no hardware keyboards attached). I can go with that approach if it makes more sense (although I would have to test if it actually works as expected).