### PR TITLE
Fix texture wrapping not updating when atlas is already bound

### DIFF
--- a/osu.Framework.Tests/Graphics/RendererTest.cs
+++ b/osu.Framework.Tests/Graphics/RendererTest.cs
@@ -26,5 +26,28 @@ namespace osu.Framework.Tests.Graphics
             Assert.That(renderer.CurrentWrapModeS, Is.EqualTo(WrapMode.None));
             Assert.That(renderer.CurrentWrapModeS, Is.EqualTo(WrapMode.None));
         }
+
+        [Test]
+        public void TestTextureAtlasReuseUpdatesTextureWrapping()
+        {
+            DummyRenderer renderer = new DummyRenderer();
+
+            TextureAtlas atlas = new TextureAtlas(renderer, 1024, 1024);
+
+            Texture textureWrapNone = atlas.Add(100, 100, WrapMode.None, WrapMode.None)!;
+            Texture textureWrapClamp = atlas.Add(100, 100, WrapMode.ClampToEdge, WrapMode.ClampToEdge)!;
+
+            renderer.BindTexture(textureWrapNone, 0, null, null);
+            Assert.That(renderer.CurrentWrapModeS, Is.EqualTo(WrapMode.None));
+            Assert.That(renderer.CurrentWrapModeT, Is.EqualTo(WrapMode.None));
+
+            renderer.BindTexture(textureWrapClamp, 0, null, null);
+            Assert.That(renderer.CurrentWrapModeS, Is.EqualTo(WrapMode.ClampToEdge));
+            Assert.That(renderer.CurrentWrapModeT, Is.EqualTo(WrapMode.ClampToEdge));
+
+            renderer.BindTexture(textureWrapNone, 0, null, null);
+            Assert.That(renderer.CurrentWrapModeS, Is.EqualTo(WrapMode.None));
+            Assert.That(renderer.CurrentWrapModeT, Is.EqualTo(WrapMode.None));
+        }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -818,7 +818,10 @@ namespace osu.Framework.Graphics.Rendering
         public bool BindTexture(INativeTexture texture, int unit = 0, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
         {
             if (lastActiveTextureUnit == unit && lastBoundTexture[unit] == texture)
+            {
+                setWrapMode(wrapModeS, wrapModeT);
                 return true;
+            }
 
             FlushCurrentBatch(FlushBatchSource.BindTexture);
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/6409