### PR TITLE
Add attribute to hide arbitrary drawables from draw visualiser

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -207,6 +207,8 @@ namespace osu.Framework.Graphics.Visualisation
             overlay.Target = Searching ? cursorTarget : inputManager.HoveredDrawables.OfType<VisualisedDrawable>().FirstOrDefault()?.Target;
         }
 
+        private static readonly Dictionary<Type, bool> is_type_valid_target_cache = new Dictionary<Type, bool>();
+
         private void updateCursorTarget()
         {
             Drawable drawableTarget = null;
@@ -268,30 +270,32 @@ namespace osu.Framework.Graphics.Visualisation
                     if (!validForTarget(drawable))
                         return;
 
-                    // Special case for full-screen overlays that act as input receptors, but don't display anything
-                    if (!hasCustomDrawNode(drawable))
-                        return;
-
                     drawableTarget = drawable;
                 }
             }
 
             // Valid if the drawable contains the mouse position and the position wouldn't be masked by the parent
             bool validForTarget(Drawable drawable)
-                => drawable.ScreenSpaceDrawQuad.Contains(inputManager.CurrentState.Mouse.Position)
-                   && maskingQuad?.Contains(inputManager.CurrentState.Mouse.Position) != false;
-        }
+            {
+                if (!drawable.ScreenSpaceDrawQuad.Contains(inputManager.CurrentState.Mouse.Position)
+                    || maskingQuad?.Contains(inputManager.CurrentState.Mouse.Position) == false)
+                {
+                    return false;
+                }
 
-        private static readonly Dictionary<Type, bool> has_custom_drawnode_cache = new Dictionary<Type, bool>();
+                Type type = drawable.GetType();
 
-        private bool hasCustomDrawNode(Drawable drawable)
-        {
-            var type = drawable.GetType();
+                if (is_type_valid_target_cache.TryGetValue(type, out bool valid))
+                    return valid;
 
-            if (has_custom_drawnode_cache.TryGetValue(type, out bool existing))
-                return existing;
+                // Exclude "overlay" objects (Component/etc) that don't draw anything and don't override CreateDrawNode().
+                valid = type.GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
 
-            return has_custom_drawnode_cache[type] = type.GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
+                // Exclude objects that specify they should be hidden anyway.
+                valid &= !type.GetCustomAttributes<DrawVisualiserHiddenAttribute>(true).Any();
+
+                return is_type_valid_target_cache[type] = valid;
+            }
         }
 
         public bool Searching { get; private set; }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiserHiddenAttribute.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiserHiddenAttribute.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    /// <summary>
+    /// Indicates that instances of this type or any subtype should not be valid targets for the draw visualiser.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DrawVisualiserHiddenAttribute : Attribute;
+}


### PR DESCRIPTION
When trying to use the draw visualiser during gameplay, you can't target anything other than the cursor trail.

```diff
diff --git a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
index a4bccb0aff..5132dc2859 100644
--- a/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
+++ b/osu.Game.Rulesets.Osu/UI/Cursor/CursorTrail.cs
@@ -14,6 +14,7 @@
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Visualisation;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Timing;
@@ -23,6 +24,7 @@
 
 namespace osu.Game.Rulesets.Osu.UI.Cursor
 {
+    [DrawVisualiserHidden]
     public partial class CursorTrail : Drawable, IRequireHighFrequencyMousePosition
     {
         private const int max_sprites = 2048;

```