### PR TITLE
Use value equality to determine uniform buffer equivalence

### DIFF
--- a/osu.Framework/Graphics/Rendering/IUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/IUniformBuffer.cs
@@ -8,8 +8,9 @@ namespace osu.Framework.Graphics.Rendering
     /// <summary>
     /// A buffer which stores data for a uniform block.
     /// </summary>
-    public interface IUniformBuffer : IDisposable
+    public interface IUniformBuffer : IDisposable, IEquatable<IUniformBuffer>
     {
+        bool IEquatable<IUniformBuffer>.Equals(IUniformBuffer? other) => false;
     }
 
     /// <inheritdoc cref="IUniformBuffer"/>
@@ -21,5 +22,13 @@ namespace osu.Framework.Graphics.Rendering
         /// The data contained by this <see cref="IUniformBuffer{TData}"/>.
         /// </summary>
         TData Data { get; set; }
+
+        bool IEquatable<IUniformBuffer>.Equals(IUniformBuffer? otherBuffer)
+        {
+            if (otherBuffer is not IUniformBuffer<TData> tdataBuffer)
+                return false;
+
+            return tdataBuffer.Data.Equals(Data);
+        }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -1085,7 +1085,7 @@ namespace osu.Framework.Graphics.Rendering
 
         public void BindUniformBuffer(string blockName, IUniformBuffer buffer)
         {
-            if (boundUniformBuffers.TryGetValue(blockName, out IUniformBuffer? current) && current == buffer)
+            if (boundUniformBuffers.TryGetValue(blockName, out IUniformBuffer? current) && current.Equals(buffer))
                 return;
 
             FlushCurrentBatch(FlushBatchSource.BindBuffer);


### PR DESCRIPTION
The previous reference-equality guaranteed that DrawNodes that bind uniform blocks will break batches, even if the uniform block data is identical to an adjacent DrawNode for the same shader. 

Value equality allows adjacent DrawNodes with the same uniform data to share the same uniform block, and therefore the same batch.

A possible problem with this solution is that it depends on the uniform data being set _before_ binding, where the check occurs, resulting in incorrect uniform data being used during drawing. However, all code in osu/framework binds _after_ setting uniform data, so I don't feel like it is a problem in general. 

