### PR TITLE
Use SDL3 text editing events on windows

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -501,11 +501,11 @@ namespace osu.Framework.Platform.SDL3
                     break;
 
                 case SDL_EventType.SDL_EVENT_TEXT_EDITING:
-                    HandleTextEditingEvent(e.edit);
+                    handleTextEditingEvent(e.edit);
                     break;
 
                 case SDL_EventType.SDL_EVENT_TEXT_INPUT:
-                    HandleTextInputEvent(e.text);
+                    handleTextInputEvent(e.text);
                     break;
 
                 case SDL_EventType.SDL_EVENT_KEYMAP_CHANGED:

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -472,18 +472,18 @@ namespace osu.Framework.Platform.SDL3
                 MouseMoveRelative?.Invoke(new Vector2(evtMotion.xrel * Scale, evtMotion.yrel * Scale));
         }
 
-        protected virtual void HandleTextInputEvent(SDL_TextInputEvent evtText)
+        private void handleTextInputEvent(SDL_TextInputEvent evtText)
         {
             string? text = evtText.GetText();
             Debug.Assert(text != null);
-            TriggerTextInput(text);
+            TextInput?.Invoke(text);
         }
 
-        protected virtual void HandleTextEditingEvent(SDL_TextEditingEvent evtEdit)
+        private void handleTextEditingEvent(SDL_TextEditingEvent evtEdit)
         {
             string? text = evtEdit.GetText();
             Debug.Assert(text != null);
-            TriggerTextEditing(text, evtEdit.start, evtEdit.length);
+            TextEditing?.Invoke(text, evtEdit.start, evtEdit.length);
         }
 
         private void handleKeyboardEvent(SDL_KeyboardEvent evtKey)
@@ -713,14 +713,10 @@ namespace osu.Framework.Platform.SDL3
         /// </summary>
         public event Action<string>? TextInput;
 
-        protected void TriggerTextInput(string text) => TextInput?.Invoke(text);
-
         /// <summary>
         /// Invoked when an IME text editing event occurs.
         /// </summary>
         public event TextEditingDelegate? TextEditing;
-
-        protected void TriggerTextEditing(string text, int start, int length) => TextEditing?.Invoke(text, start, length);
 
         /// <inheritdoc cref="IWindow.KeymapChanged"/>
         public event Action? KeymapChanged;


### PR DESCRIPTION
Previously, it would use a custom implementation. That implementation is still used for windows SDL2.
There is still some windows-specific code that handles `AllowIme` and cancelling the active composition.

The SDL3 text editing events work well (even better than the custom impl in some cases). The only issue I ran into when testing is that the caps lock key would sometimes gets stuck (<kbd>Ctrl</kbd>/<kbd>Alt</kbd> + <kbd>Caps Lock</kbd> is used to change kana mode on Japanese IME), but this also happened with the custom implementation so it's not a regression. (I use programs that change keyboard behaviour, so it might be a me problem.)