### PR TITLE
Fix error triggered in label step execution not being logged

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -590,7 +590,7 @@ namespace osu.Framework.Testing
         private void runTests(Action onCompletion)
         {
             int actualStepCount = 0;
-            CurrentTest.RunAllSteps(onCompletion, e => Logger.Log($@"Error on step: {e}"), s =>
+            CurrentTest.RunAllSteps(onCompletion, (s, e) => Logger.Error(e, $"Step {s} triggered an error"), s =>
             {
                 if (!interactive || RunAllSteps.Value)
                     return false;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.Testing
         private ScheduledDelegate stepRunner;
         private readonly ScrollContainer<Drawable> scroll;
 
-        public void RunAllSteps(Action onCompletion = null, Action<Exception> onError = null, Func<StepButton, bool> stopCondition = null, StepButton startFromStep = null)
+        public void RunAllSteps(Action onCompletion = null, Action<StepButton, Exception> onError = null, Func<StepButton, bool> stopCondition = null, StepButton startFromStep = null)
         {
             // schedule once as we want to ensure we have run our LoadComplete before attempting to execute steps.
             // a user may be adding a step in LoadComplete.
@@ -222,7 +222,7 @@ namespace osu.Framework.Testing
 
         private StepButton loadableStep => actionIndex >= 0 ? StepsContainer.Children.ElementAtOrDefault(actionIndex) as StepButton : null;
 
-        private void runNextStep(Action onCompletion, Action<Exception> onError, Func<StepButton, bool> stopCondition)
+        private void runNextStep(Action onCompletion, Action<StepButton, Exception> onError, Func<StepButton, bool> stopCondition)
         {
             try
             {
@@ -242,7 +242,7 @@ namespace osu.Framework.Testing
                     : "💥 Failed");
 
                 LoadingComponentsLogger.LogAndFlush();
-                onError?.Invoke(e);
+                onError?.Invoke(loadableStep, e);
                 return;
             }
 
@@ -306,7 +306,7 @@ namespace osu.Framework.Testing
 
                     // kinda hacky way to avoid this doesn't get triggered by automated runs.
                     if (step.IsHovered)
-                        RunAllSteps(startFromStep: step, stopCondition: s => s is LabelStep);
+                        RunAllSteps(startFromStep: step, stopCondition: s => s is LabelStep, onError: (s, e) => Logger.Error(e, $"Step {s} triggered error"));
                 },
             });
         }

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Testing
                     test.RunAllSteps(() =>
                     {
                         Scheduler.AddDelayed(complete, time_between_tests);
-                    }, e =>
+                    }, (_, e) =>
                     {
                         exception = ExceptionDispatchInfo.Capture(e);
                         complete();


### PR DESCRIPTION
- [x] Depends on #6418 for mergeability / less conflicts

When executing a group of steps by clicking on the label, if a step fails, it does not get logged. Fix is pretty simple, don't need to waste my breath. I've also made the error message consistent with [this](https://github.com/ppy/osu-framework/blob/94bd9c2f73f0bb72af93ef175e4c169d1440c03b/osu.Framework/Testing/Drawables/Steps/StepButton.cs#L96-L95).