### PR TITLE
Add helper for resetting all AdjustableProperty types

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -68,6 +68,8 @@ namespace osu.Framework.Audio
 
         public void RemoveAllAdjustments(AdjustableProperty type) => Adjustments.RemoveAllAdjustments(type);
 
+        public void RemoveAdjustmentsFromAllProperties() => Adjustments.RemoveAdjustmentsFromAllProperties();
+
         private bool invalidationPending;
 
         internal void InvalidateState(ValueChangedEvent<double>? valueChangedEvent = null)

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -96,6 +96,12 @@ namespace osu.Framework.Audio
             aggregate.AddSource(getProperty(type));
         }
 
+        public void RemoveAdjustmentsFromAllProperties()
+        {
+            foreach (AdjustableProperty property in all_adjustments)
+                RemoveAllAdjustments(property);
+        }
+
         private ref AggregateBindable<double> getAggregate(AdjustableProperty type)
         {
             switch (type)

--- a/osu.Framework/Audio/IAdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/IAdjustableAudioComponent.cs
@@ -61,6 +61,11 @@ namespace osu.Framework.Audio
         /// </summary>
         /// <param name="type">The target type to remove all adjustments of.</param>
         void RemoveAllAdjustments(AdjustableProperty type);
+
+        /// <summary>
+        /// Removes all adjustments from all types.
+        /// </summary>
+        void RemoveAdjustmentsFromAllProperties();
     }
 
     public static class AdjustableAudioComponentExtensions

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -164,6 +164,8 @@ namespace osu.Framework.Graphics.Audio
 
         public void RemoveAllAdjustments(AdjustableProperty type) => adjustments.RemoveAllAdjustments(type);
 
+        public void RemoveAdjustmentsFromAllProperties() => adjustments.RemoveAdjustmentsFromAllProperties();
+
         public IBindable<double> AggregateVolume => adjustments.AggregateVolume;
 
         public IBindable<double> AggregateBalance => adjustments.AggregateBalance;


### PR DESCRIPTION
Implements a helper method for resetting audio adjustments on all AdjustableProperty types (`Volume`, `Balance`, `Frequency`, `Tempo`) as requested within a [TODO in the osu repo](https://github.com/ppy/osu/blob/b82f420b52bb6bcdca521c0edf4688fc07a543e3/osu.Game/Overlays/MusicController.cs#L588) with the aim of reducing repeated usage of `RemoveAllAdjustments`.

Prerequisite for https://github.com/ppy/osu/pull/30605