### PR TITLE
Fix `RearrangeableListContainer<>` crashing on replacement operations

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
@@ -333,6 +333,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddUntilStep("wait for items to load", () => list.ItemMap.Values.All(i => i.IsLoaded));
         }
 
+        [Test]
+        public void TestPartialReplace()
+        {
+            addItems(5);
+
+            AddStep("replace list", () => list.Items.ReplaceRange(2, 2, [100, 101]));
+            AddUntilStep("wait for items to load", () => list.ItemMap.Values.All(i => i.IsLoaded));
+        }
+
         private void addDragSteps(int from, int to, int[] expectedSequence)
         {
             AddStep($"move to {from}", () =>

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -21,9 +19,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public partial class TestSceneRearrangeableListContainer : ManualInputManagerTestScene
     {
-        private TestRearrangeableList list;
-
-        private Container listContainer;
+        private TestRearrangeableList list = null!;
+        private Container listContainer = null!;
 
         [SetUp]
         public void Setup() => Schedule(() =>
@@ -85,7 +82,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             addItems(item_count);
 
-            List<Drawable> items = null;
+            List<Drawable> items = null!;
 
             AddStep("get item references", () => items = new List<Drawable>(list.ItemMap.Values.ToList()));
 
@@ -278,7 +275,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestRemoveDuringLoadAndReAdd()
         {
-            TestDelayedLoadRearrangeableList delayedList = null;
+            TestDelayedLoadRearrangeableList delayedList = null!;
 
             AddStep("create list", () => Child = delayedList = new TestDelayedLoadRearrangeableList());
 
@@ -325,6 +322,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 var item = (BasicRearrangeableListItem<int>)another.ListContainer.FlowingChildren.Last();
                 return item.Model == 0;
             });
+        }
+
+        [Test]
+        public void TestReplaceEntireList()
+        {
+            addItems(1);
+
+            AddStep("replace list", () => list.Items.ReplaceRange(0, list.Items.Count, [100]));
+            AddUntilStep("wait for items to load", () => list.ItemMap.Values.All(i => i.IsLoaded));
         }
 
         private void addDragSteps(int from, int to, int[] expectedSequence)

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -183,11 +183,15 @@ namespace osu.Framework.Graphics.Containers
         {
             for (int i = 0; i < Items.Count; i++)
             {
-                var drawable = itemMap[Items[i]];
+                // A drawable for the item may not exist yet, for example in a replace-range operation where the removal happens first.
+                if (!itemMap.TryGetValue(Items[i], out var drawable))
+                    continue;
 
-                // If the async load didn't complete, the item wouldn't exist in the container and an exception would be thrown
-                if (drawable.Parent == ListContainer)
-                    ListContainer!.SetLayoutPosition(drawable, i);
+                // The item may not be loaded yet, because add operations are asynchronous.
+                if (drawable.Parent != ListContainer)
+                    continue;
+
+                ListContainer!.SetLayoutPosition(drawable, i);
             }
         }
 


### PR DESCRIPTION
When handling range replacements, it first does a remove, then a sort, then an add, then a sort. The sort is intended to operate on drawable objects, but these do not yet exist because they haven't been added yet. In other words, the sort in-between the add and remove is causing the crash.

I've gone with the likely least-regressing path of making the `sortItems()` handle this case. I'd considered moving the events to the callback and doing a sort of "transaction", but there's quite a bit involved due to the sometimes-asynchronous operation of this container.  
Maybe things could be better if we removed the asynchronous `Add`...