### PR TITLE
Make `RearrangeableListContainer<>` only replace differences

### DIFF
--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -21,6 +19,7 @@ namespace osu.Framework.Graphics.Containers
     /// </remarks>
     /// <typeparam name="TModel">The type of rearrangeable item.</typeparam>
     public abstract partial class RearrangeableListContainer<TModel> : CompositeDrawable
+        where TModel : notnull
     {
         private const float exp_base = 1.05f;
 
@@ -50,7 +49,7 @@ namespace osu.Framework.Graphics.Containers
         protected IReadOnlyDictionary<TModel, RearrangeableListItem<TModel>> ItemMap => itemMap;
 
         private readonly Dictionary<TModel, RearrangeableListItem<TModel>> itemMap = new Dictionary<TModel, RearrangeableListItem<TModel>>();
-        private RearrangeableListItem<TModel> currentlyDraggedItem;
+        private RearrangeableListItem<TModel>? currentlyDraggedItem;
         private Vector2 screenSpaceDragPosition;
 
         /// <summary>
@@ -81,7 +80,7 @@ namespace osu.Framework.Graphics.Containers
         {
         }
 
-        private void collectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void collectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             switch (e.Action)
             {
@@ -193,7 +192,7 @@ namespace osu.Framework.Graphics.Containers
                 if (drawable.Parent != ListContainer)
                     continue;
 
-                ListContainer!.SetLayoutPosition(drawable, i);
+                ListContainer.SetLayoutPosition(drawable, i);
             }
         }
 
@@ -218,9 +217,7 @@ namespace osu.Framework.Graphics.Containers
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
-
-            if (currentlyDraggedItem != null)
-                updateArrangement();
+            updateArrangement();
         }
 
         private void updateScrollPosition()
@@ -245,6 +242,9 @@ namespace osu.Framework.Graphics.Containers
 
         private void updateArrangement()
         {
+            if (currentlyDraggedItem == null)
+                return;
+
             var localPos = ListContainer.ToLocalSpace(screenSpaceDragPosition);
             int srcIndex = Items.IndexOf(currentlyDraggedItem.Model);
 

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -87,11 +86,11 @@ namespace osu.Framework.Graphics.Containers
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    addItems(e.NewItems);
+                    addItems(e.NewItems?.Cast<TModel>() ?? []);
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
-                    removeItems(e.OldItems);
+                    removeItems(e.OldItems?.Cast<TModel>() ?? []);
 
                     // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
                     // scroll position if we quickly add new items after calling a Clear().
@@ -107,8 +106,11 @@ namespace osu.Framework.Graphics.Containers
                     break;
 
                 case NotifyCollectionChangedAction.Replace:
-                    removeItems(e.OldItems);
-                    addItems(e.NewItems);
+                    IEnumerable<TModel> tOldItems = e.OldItems?.Cast<TModel>() ?? [];
+                    IEnumerable<TModel> tNewItems = e.NewItems?.Cast<TModel>() ?? [];
+
+                    removeItems(tOldItems.Except(tNewItems));
+                    addItems(tNewItems.Except(tOldItems));
                     break;
 
                 case NotifyCollectionChangedAction.Move:
@@ -118,9 +120,9 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private void removeItems(IList items)
+        private void removeItems(IEnumerable<TModel> items)
         {
-            foreach (var item in items.Cast<TModel>())
+            foreach (var item in items)
             {
                 if (currentlyDraggedItem != null && EqualityComparer<TModel>.Default.Equals(currentlyDraggedItem.Model, item))
                     currentlyDraggedItem = null;
@@ -137,11 +139,11 @@ namespace osu.Framework.Graphics.Containers
             OnItemsChanged();
         }
 
-        private void addItems(IList items)
+        private void addItems(IEnumerable<TModel> items)
         {
             var drawablesToAdd = new List<Drawable>();
 
-            foreach (var item in items.Cast<TModel>())
+            foreach (var item in items)
             {
                 if (itemMap.ContainsKey(item))
                 {


### PR DESCRIPTION
When using `ReplaceRange()` it will no longer re-add items that were previously and still are in the list.