### PR TITLE
Revert "Use SDL3 windowing by default"

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -53,7 +53,7 @@ namespace osu.Framework
             if (DebugUtils.IsDebugBuild)
                 AllowInsecureRequests = parseBool(Environment.GetEnvironmentVariable("OSU_INSECURE_REQUESTS")) ?? false;
 
-            UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? true);
+            UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
         }
 
         private static bool? parseBool(string? value)


### PR DESCRIPTION
Reverts ppy/osu-framework#6396

Rationale:

- https://github.com/ppy/osu/issues/30641
- https://github.com/ppy/osu/issues/28222
- Apparent general unspecified severe issues with macOS windowing (https://discord.com/channels/188630481301012481/188630652340404224/1306507518134194176)
- https://github.com/ppy/osu/discussions/30647 (wayland issue, so weak reason)

None of this seems hotfixable and users are reporting mass breakage using several communication channels, most of which is a variation of any of the three points above. See

- https://osu.ppy.sh/community/forums/5
- https://osu.ppy.sh/home/changelog/lazer/2024.1115.1

I think this is the best move forward in terms of a hotfix, and we shouldn't attempt SDL3 again until these issues are fixed either by us or upstream (*or both...*)