### PR TITLE
Remove SourceLink package reference

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="managed-midi" Version="1.10.1" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />


### PR DESCRIPTION
We've been seeing some hot reload failures of the form: `error ENC0003: Updating 'attribute' requires restarting the application`

This is caused by SourceLink, which wants to write the git hash to the `AssemblyInfo` obj file.

Trail starts here: https://github.com/dotnet/sourcelink/pull/1144

SourceLink is included starting with the .NET 8 SDK, and I've tested that SourceLink is still working - `dotnet pack` and check the `.nuspec` in the contained package:
    ```sh
    $ cat ppy.osu.Framework.nuspec | grep rep
    <repository type="git" url="https://github.com/ppy/osu-framework" commit="270b29d58b736deca2b6d76fe9907b2554d5979f" />
    ```