### PR TITLE
Factor window scale in `UserInputManager.mouseOutsideAllDisplays`

### DIFF
--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -87,6 +87,9 @@ namespace osu.Framework.Input
         {
             Point windowLocation;
 
+            float scale = Host.Window is ISDLWindow window ? window.Scale : 1;
+            mousePosition /= scale;
+
             switch (Host.Window.WindowMode.Value)
             {
                 case WindowMode.Windowed:

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -87,9 +87,6 @@ namespace osu.Framework.Input
         {
             Point windowLocation;
 
-            float scale = Host.Window is ISDLWindow window ? window.Scale : 1;
-            mousePosition /= scale;
-
             switch (Host.Window.WindowMode.Value)
             {
                 case WindowMode.Windowed:
@@ -100,6 +97,9 @@ namespace osu.Framework.Input
                     windowLocation = Host.Window.CurrentDisplayBindable.Value.Bounds.Location;
                     break;
             }
+
+            float scale = Host.Window is ISDLWindow window ? window.Scale : 1;
+            mousePosition /= scale;
 
             int x = (int)MathF.Floor(windowLocation.X + mousePosition.X);
             int y = (int)MathF.Floor(windowLocation.Y + mousePosition.Y);


### PR DESCRIPTION
The mouse position is in pixel/client coordinates, while window and displays positions are in window coordinates.

Proof of coordinate spaces for display position (on a 3456x2234 macbook):

![image](https://github.com/user-attachments/assets/4cb269fa-6f2d-4f12-851d-57b5daf74238)

(Image taken from https://discord.com/channels/188630481301012481/188630652340404224/1308162379045011506)

---

We should probably have `IWindow.ClientToDisplay(Vector2)` that takes in a client (game screen space) vector and converts it to display coordinates. Would the need for `ISDLWindow` type checks from this code.