### PR TITLE
Update transitive vulnerable dependencies for source generation tests

### DIFF
--- a/osu.Framework.SourceGeneration.Tests/Dependencies/DependencyInjectionMultiPhaseSourceGeneratorTests.cs
+++ b/osu.Framework.SourceGeneration.Tests/Dependencies/DependencyInjectionMultiPhaseSourceGeneratorTests.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.SourceGeneration.Tests.Dependencies
 
         [Theory]
         [MemberData(nameof(CheckWithStatisticsData))]
-        public void CheckWithStatistics(string name, (int, int, int)[] expectedStatistics)
+        public void CheckWithStatistics(string name, (int syntaxTargetCreated, int semanticTargetCreated, int emitHits)[] expectedStatistics)
         {
             GetTestSources(name,
                 out (string filename, string content)[] commonSources,

--- a/osu.Framework.SourceGeneration.Tests/GeneratorTestHelper.cs
+++ b/osu.Framework.SourceGeneration.Tests/GeneratorTestHelper.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.SourceGeneration.Tests
         {
             Compilation = CSharpCompilation.Create("test",
                 references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
-                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Release));
         }
 
         public GeneratorDriverRunResult RunGenerators(ref GeneratorDriver driver)

--- a/osu.Framework.SourceGeneration.Tests/GeneratorTestHelper.cs
+++ b/osu.Framework.SourceGeneration.Tests/GeneratorTestHelper.cs
@@ -7,7 +7,6 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace osu.Framework.SourceGeneration.Tests
 {
@@ -57,7 +56,7 @@ namespace osu.Framework.SourceGeneration.Tests
 
                 string actual = source.SourceText.ToString();
 
-                new XUnitVerifier().EqualOrDiff(content, actual, $"Phase {phase}: Generated source {filename} did not match expected content");
+                new DefaultVerifier().EqualOrDiff(content, actual, $"Phase {phase}: Generated source {filename} did not match expected content");
 
                 matches++;
             }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/AcceptsFocusProperty/Generated/g_AcceptsFocusProperty_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/AcceptsFocusProperty/Generated/g_AcceptsFocusProperty_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class AcceptsFocusProperty : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::AcceptsFocusProperty);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/CommonGenerated/g_osu.Framework.Graphics.Drawable_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/CommonGenerated/g_osu.Framework.Graphics.Drawable_HandleInput.txt
@@ -7,7 +7,9 @@ namespace osu.Framework.Graphics
     partial class Drawable : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
     {
         global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::osu.Framework.Graphics.Drawable);
+
         bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => false;
+
         bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => false;
     }
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandleMethod/Generated/g_HandleMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandleMethod/Generated/g_HandleMethod_HandleInput.txt
@@ -5,6 +5,8 @@
 partial class HandleMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::HandleMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandleNonPositionalInputProperty/Generated/g_HandleNonPositionalInputProperty_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandleNonPositionalInputProperty/Generated/g_HandleNonPositionalInputProperty_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class HandleNonPositionalInputProperty : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::HandleNonPositionalInputProperty);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandlePositionalInputProperty/Generated/g_HandlePositionalInputProperty_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/HandlePositionalInputProperty/Generated/g_HandlePositionalInputProperty_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class HandlePositionalInputProperty : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::HandlePositionalInputProperty);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasContextMenuInterface/Generated/g_IHasContextMenuInterface_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasContextMenuInterface/Generated/g_IHasContextMenuInterface_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class IHasContextMenuInterface : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::IHasContextMenuInterface);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasCustomTooltipInterface/Generated/g_IHasCustomTooltipInterface_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasCustomTooltipInterface/Generated/g_IHasCustomTooltipInterface_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class IHasCustomTooltipInterface : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::IHasCustomTooltipInterface);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasPopoverInterface/Generated/g_IHasPopoverInterface_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasPopoverInterface/Generated/g_IHasPopoverInterface_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class IHasPopoverInterface : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::IHasPopoverInterface);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasTooltipInterface/Generated/g_IHasTooltipInterface_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IHasTooltipInterface/Generated/g_IHasTooltipInterface_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class IHasTooltipInterface : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::IHasTooltipInterface);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IKeyBindingHandlerInterface/Generated/g_IKeyBindingHandlerInterface_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IKeyBindingHandlerInterface/Generated/g_IKeyBindingHandlerInterface_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class IKeyBindingHandlerInterface : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::IKeyBindingHandlerInterface);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IntermediateNonPartial/Generated/g_PartialClass_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/IntermediateNonPartial/Generated/g_PartialClass_HandleInput.txt
@@ -5,6 +5,8 @@
 partial class PartialClass : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::PartialClass);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnClickMethod/Generated/g_OnClickMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnClickMethod/Generated/g_OnClickMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnClickMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnClickMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDoubleClickMethod/Generated/g_OnDoubleClickMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDoubleClickMethod/Generated/g_OnDoubleClickMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnDoubleClickMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnDoubleClickMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragEndMethod/Generated/g_OnDragEndMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragEndMethod/Generated/g_OnDragEndMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnDragEndMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnDragEndMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragMethod/Generated/g_OnDragMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragMethod/Generated/g_OnDragMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnDragMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnDragMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragStartMethod/Generated/g_OnDragStartMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnDragStartMethod/Generated/g_OnDragStartMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnDragStartMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnDragStartMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnFocusLostMethod/Generated/g_OnFocusLostMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnFocusLostMethod/Generated/g_OnFocusLostMethod_HandleInput.txt
@@ -5,6 +5,8 @@
 partial class OnFocusLostMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnFocusLostMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnFocusMethod/Generated/g_OnFocusMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnFocusMethod/Generated/g_OnFocusMethod_HandleInput.txt
@@ -5,6 +5,8 @@
 partial class OnFocusMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnFocusMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnHoverLostMethod/Generated/g_OnHoverLostMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnHoverLostMethod/Generated/g_OnHoverLostMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnHoverLostMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnHoverLostMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnHoverMethod/Generated/g_OnHoverMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnHoverMethod/Generated/g_OnHoverMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnHoverMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnHoverMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickAxisMoveMethod/Generated/g_OnJoystickAxisMoveMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickAxisMoveMethod/Generated/g_OnJoystickAxisMoveMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnJoystickAxisMoveMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnJoystickAxisMoveMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickPressMethod/Generated/g_OnJoystickPressMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickPressMethod/Generated/g_OnJoystickPressMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnJoystickPressMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnJoystickPressMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickReleaseMethod/Generated/g_OnJoystickReleaseMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnJoystickReleaseMethod/Generated/g_OnJoystickReleaseMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnJoystickReleaseMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnJoystickReleaseMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnKeyDownMethod/Generated/g_OnKeyDownMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnKeyDownMethod/Generated/g_OnKeyDownMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnKeyDownMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnKeyDownMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnKeyUpMethod/Generated/g_OnKeyUpMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnKeyUpMethod/Generated/g_OnKeyUpMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnKeyUpMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnKeyUpMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMidiDownMethod/Generated/g_OnMidiDownMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMidiDownMethod/Generated/g_OnMidiDownMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnMidiDownMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnMidiDownMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMidiUpMethod/Generated/g_OnMidiUpMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMidiUpMethod/Generated/g_OnMidiUpMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnMidiUpMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnMidiUpMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseDownMethod/Generated/g_OnMouseDownMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseDownMethod/Generated/g_OnMouseDownMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnMouseDownMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnMouseDownMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseMoveMethod/Generated/g_OnMouseMoveMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseMoveMethod/Generated/g_OnMouseMoveMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnMouseMoveMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnMouseMoveMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseUpMethod/Generated/g_OnMouseUpMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnMouseUpMethod/Generated/g_OnMouseUpMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnMouseUpMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnMouseUpMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnScrollMethod/Generated/g_OnScrollMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnScrollMethod/Generated/g_OnScrollMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnScrollMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnScrollMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletAuxiliaryButtonPressMethod/Generated/g_OnTabletAuxiliaryButtonPressMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletAuxiliaryButtonPressMethod/Generated/g_OnTabletAuxiliaryButtonPressMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTabletAuxiliaryButtonPressMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTabletAuxiliaryButtonPressMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletAuxiliaryButtonReleaseMethod/Generated/g_OnTabletAuxiliaryButtonReleaseMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletAuxiliaryButtonReleaseMethod/Generated/g_OnTabletAuxiliaryButtonReleaseMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTabletAuxiliaryButtonReleaseMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTabletAuxiliaryButtonReleaseMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsNonPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletPenButtonPressMethod/Generated/g_OnTabletPenButtonPressMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletPenButtonPressMethod/Generated/g_OnTabletPenButtonPressMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTabletPenButtonPressMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTabletPenButtonPressMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletPenButtonReleaseMethod/Generated/g_OnTabletPenButtonReleaseMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTabletPenButtonReleaseMethod/Generated/g_OnTabletPenButtonReleaseMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTabletPenButtonReleaseMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTabletPenButtonReleaseMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchDownMethod/Generated/g_OnTouchDownMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchDownMethod/Generated/g_OnTouchDownMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTouchDownMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTouchDownMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchMoveMethod/Generated/g_OnTouchMoveMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchMoveMethod/Generated/g_OnTouchMoveMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTouchMoveMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTouchMoveMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchUpMethod/Generated/g_OnTouchUpMethod_HandleInput.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/HandleInput/OnTouchUpMethod/Generated/g_OnTouchUpMethod_HandleInput.txt
@@ -5,5 +5,6 @@
 partial class OnTouchUpMethod : global::osu.Framework.Input.ISourceGeneratedHandleInputCache
 {
     global::System.Type global::osu.Framework.Input.ISourceGeneratedHandleInputCache.KnownType => typeof(global::OnTouchUpMethod);
+
     bool global::osu.Framework.Input.ISourceGeneratedHandleInputCache.RequestsPositionalInput => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/LongRunningLoad/CommonGenerated/g_osu.Framework.Graphics.Drawable_LongRunningLoad.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/LongRunningLoad/CommonGenerated/g_osu.Framework.Graphics.Drawable_LongRunningLoad.txt
@@ -7,6 +7,7 @@ namespace osu.Framework.Graphics
     partial class Drawable : global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache
     {
         global::System.Type global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache.KnownType => typeof(global::osu.Framework.Graphics.Drawable);
+
         bool global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache.IsLongRunning => false;
     }
 }

--- a/osu.Framework.SourceGeneration.Tests/Resources/LongRunningLoad/LongRunningType/Generated/g_LongRunningType_LongRunningLoad.txt
+++ b/osu.Framework.SourceGeneration.Tests/Resources/LongRunningLoad/LongRunningType/Generated/g_LongRunningType_LongRunningLoad.txt
@@ -5,5 +5,6 @@
 partial class LongRunningType : global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache
 {
     global::System.Type global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache.KnownType => typeof(global::LongRunningType);
+
     bool global::osu.Framework.Allocation.ISourceGeneratedLongRunningLoadCache.IsLongRunning => true;
 }

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpMultiPhaseSourceGeneratorVerifier_Test.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpMultiPhaseSourceGeneratorVerifier_Test.cs
@@ -35,8 +35,6 @@ namespace osu.Framework.SourceGeneration.Tests.Verifiers
                 driver = CSharpGeneratorDriver.Create(generator = new TSourceGenerator());
                 driver = driver.WithUpdatedParseOptions(CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion));
 
-                generator.ForceRun = true;
-
                 this.commonSources = commonSources;
                 this.commonGenerated = commonGenerated;
                 this.multiPhaseSources = multiPhaseSources;

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using osu.Framework.SourceGeneration.Generators;
 
 namespace osu.Framework.SourceGeneration.Tests.Verifiers
@@ -14,14 +14,11 @@ namespace osu.Framework.SourceGeneration.Tests.Verifiers
     public partial class CSharpSourceGeneratorVerifier<TSourceGenerator>
         where TSourceGenerator : AbstractIncrementalGenerator, new()
     {
-        public class Test : CSharpSourceGeneratorTest<EmptySourceGeneratorProvider, XUnitVerifier>
+        public class Test : CSharpSourceGeneratorTest<EmptySourceGeneratorProvider, DefaultVerifier>
         {
             public LanguageVersion LanguageVersion { get; set; } = LanguageVersion.Default;
 
-            protected override IEnumerable<ISourceGenerator> GetSourceGenerators() => new[]
-            {
-                new TSourceGenerator { ForceRun = true }.AsSourceGenerator()
-            };
+            protected override IEnumerable<Type> GetSourceGenerators() => [typeof(TSourceGenerator)];
 
             protected override ParseOptions CreateParseOptions()
             {

--- a/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
+++ b/osu.Framework.SourceGeneration.Tests/Verifiers/CSharpSourceGeneratorVerifier_Test.cs
@@ -20,6 +20,11 @@ namespace osu.Framework.SourceGeneration.Tests.Verifiers
 
             protected override IEnumerable<Type> GetSourceGenerators() => [typeof(TSourceGenerator)];
 
+            protected override CompilationOptions CreateCompilationOptions()
+            {
+                return base.CreateCompilationOptions().WithOptimizationLevel(OptimizationLevel.Release);
+            }
+
             protected override ParseOptions CreateParseOptions()
             {
                 return ((CSharpParseOptions)base.CreateParseOptions()).WithLanguageVersion(LanguageVersion);

--- a/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
+++ b/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
+++ b/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221003-04" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
+++ b/osu.Framework.SourceGeneration/Generators/AbstractIncrementalGenerator.cs
@@ -14,11 +14,6 @@ namespace osu.Framework.SourceGeneration.Generators
     {
         public readonly GeneratorEventDriver EventDriver = new GeneratorEventDriver();
 
-        /// <summary>
-        /// Whether the generator should be forcefully run, even if building as debug.
-        /// </summary>
-        public bool ForceRun;
-
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             // Stage 1: Create SyntaxTarget objects for all classes.
@@ -28,7 +23,7 @@ namespace osu.Framework.SourceGeneration.Generators
                            (ctx, _) => returnWithEvent(new IncrementalSyntaxTarget((ClassDeclarationSyntax)ctx.Node, ctx.SemanticModel), EventDriver.OnSyntaxTargetCreated))
                        .Select((t, _) => t.WithName())
                        .Combine(context.CompilationProvider)
-                       .Where(c => ForceRun || c.Right.Options.OptimizationLevel == OptimizationLevel.Release)
+                       .Where(c => c.Right.Options.OptimizationLevel == OptimizationLevel.Release)
                        .Select((t, _) => t.Item1)
                        .Select((t, _) => returnWithEvent(t.WithSemanticTarget(CreateSemanticTarget), EventDriver.OnSemanticTargetCreated));
 


### PR DESCRIPTION
The updated packages were bringing vulnerable dependencies like NETStandard.Libraries and NuGet.Common. This will cause visible warnings when building inside VS or command line with .NET 9 SDK.

The compiler packages are updated to 4.8.0, which is the lowest version that's capable to compile targeting .NET 8.

Unfortunately, the test driver package are having behavioral breaking changes, which are not hard to resolve.