### PR TITLE
Work around Android CI workflow errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,10 @@ jobs:
           dotnet-version: "8.0.x"
 
       - name: Restore .NET workloads
-        run: dotnet workload install android
+        # since windows image 20241113.3.0, not specifying a version here
+        # installs the .NET 7 version of android workload for very unknown reasons.
+        # revisit once we upgrade to .NET 9, it's probably fixed there.
+        run: dotnet workload install android --version (dotnet --version)
 
       - name: Compile
         run: dotnet build -c Debug osu-framework.Android.slnf

--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -131,7 +131,10 @@ jobs:
           java-version: 11
 
       - name: Restore .NET workloads
-        run: dotnet workload install android
+        # since windows image 20241113.3.0, not specifying a version here
+        # installs the .NET 7 version of android workload for very unknown reasons.
+        # revisit once we upgrade to .NET 9, it's probably fixed there.
+        run: dotnet workload install android --version (dotnet --version)
 
       - name: Pack (Android Framework)
         run: dotnet pack -c Release osu.Framework.Android /p:Version=${{ github.ref_name }} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}


### PR DESCRIPTION
- Related: https://github.com/dotnet/sdk/issues/45204

Something extremely funny is happening straight from Windows Runner Image 20241113.3.0, where installing workloads without specifying a version installs ones from .NET 7(????)

[This part](https://github.com/frenzibyte/osu/actions/runs/12062014593/job/33635009500#step:7:10) should be enough to show how messed up the situation seems to be. The command execution shows that the used .NET SDK is correct, but the installed workloads point to .NET 7 versions. Moreover, the workload install output shows that it is installing both [.NET 6](https://github.com/frenzibyte/osu/actions/runs/12062014593/job/33635009500#step:5:32) and [.NET 7](https://github.com/frenzibyte/osu/actions/runs/12062014593/job/33635009500#step:5:52) versions of the workflow, which is just ??????

Fortunately, with the assumption that a workload manifest is published for every .NET SDK release, the pushed workaround which explicitly specifies the .NET SDK version we're using should hold enough until we move to .NET 9