### PR TITLE
Clean up `IWindow` and remove platform-agnostic code probing `ISDLWindow`

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private readonly SpriteText currentWindowMode = new SpriteText();
         private readonly SpriteText currentDisplay = new SpriteText();
 
-        private ISDLWindow? window;
+        private IWindow? window;
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
         public TestSceneBorderless()
@@ -57,7 +57,7 @@ namespace osu.Framework.Tests.Visual.Platform
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config, GameHost host)
         {
-            window = host.Window as ISDLWindow;
+            window = host.Window;
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
 
             windowMode.BindValueChanged(mode => currentWindowMode.Text = $"Window Mode: {mode.NewValue}", true);

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -129,7 +129,7 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window.SupportedWindowModes.Contains(WindowMode.Fullscreen))
             {
                 AddStep("change to fullscreen", () => windowMode.Value = WindowMode.Fullscreen);
-                AddAssert("window position updated", () => ((ISDLWindow)window).Position, () => Is.EqualTo(window.CurrentDisplayBindable.Value.Bounds.Location));
+                AddAssert("window position updated", () => window.Position, () => Is.EqualTo(window.CurrentDisplayBindable.Value.Bounds.Location));
                 testResolution(1920, 1080);
                 testResolution(1280, 960);
                 testResolution(9999, 9999);

--- a/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneWindowed.cs
@@ -31,12 +31,12 @@ namespace osu.Framework.Tests.Visual.Platform
         [Resolved]
         private FrameworkConfigManager config { get; set; }
 
-        private ISDLWindow sdlWindow;
+        private IWindow window;
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            sdlWindow = (ISDLWindow)host.Window;
+            window = host.Window;
             Children = new Drawable[]
             {
                 new FillFlowContainer
@@ -64,12 +64,12 @@ namespace osu.Framework.Tests.Visual.Platform
         }
 
         [SetUp]
-        public void SetUp() => Schedule(() => sdlWindow.Resizable = true);
+        public void SetUp() => Schedule(() => window.Resizable = true);
 
         [Test]
         public void TestToggleResizable()
         {
-            AddToggleStep("toggle resizable", state => sdlWindow.Resizable = state);
+            AddToggleStep("toggle resizable", state => window.Resizable = state);
         }
 
         [Test]
@@ -79,16 +79,16 @@ namespace osu.Framework.Tests.Visual.Platform
             const int min_height = 768;
 
             AddStep("reset window to valid size", () => setWindowSize(new Size(640, 480)));
-            AddStep("set minimum size above client size", () => sdlWindow.MinSize = new Size(min_width, min_height));
+            AddStep("set minimum size above client size", () => window.MinSize = new Size(min_width, min_height));
             assertWindowSize(new Size(min_width, min_height));
 
             AddStep("reset window to valid size", () => setWindowSize(new Size(1280, 960)));
             AddStep("set client size below minimum size", () => setWindowSize(new Size(640, 480)));
             assertWindowSize(new Size(min_width, min_height));
 
-            AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MinSize = sdlWindow.MaxSize + new Size(1, 1)));
-            AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MinSize = new Size(-1, -1)));
-            AddStep("reset minimum size", () => sdlWindow.MinSize = new Size(640, 480));
+            AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => window.MinSize = window.MaxSize + new Size(1, 1)));
+            AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => window.MinSize = new Size(-1, -1)));
+            AddStep("reset minimum size", () => window.MinSize = new Size(640, 480));
         }
 
         [Test]
@@ -98,27 +98,27 @@ namespace osu.Framework.Tests.Visual.Platform
             const int max_height = 768;
 
             AddStep("reset window to valid size", () => setWindowSize(new Size(1280, 960)));
-            AddStep("set maximum size below client size", () => sdlWindow.MaxSize = new Size(max_width, max_height));
+            AddStep("set maximum size below client size", () => window.MaxSize = new Size(max_width, max_height));
             assertWindowSize(new Size(max_width, max_height));
 
             // when the maximum window size changes to a value below the current size, the window implicitly enters maximised state.
             // when in maximised state, the "windowed size" config bindable is ineffective until the window goes back to normal.
-            AddStep("reset window to normal state", () => sdlWindow.WindowState = WindowState.Normal);
+            AddStep("reset window to normal state", () => window.WindowState = WindowState.Normal);
 
             AddStep("reset window to valid size", () => setWindowSize(new Size(640, 480)));
             AddStep("set client size above maximum size", () => setWindowSize(new Size(1280, 960)));
             assertWindowSize(new Size(max_width, max_height));
 
-            AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = sdlWindow.MinSize - new Size(1, 1)));
-            AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => sdlWindow.MaxSize = new Size(-1, -1)));
-            AddStep("reset maximum size", () => sdlWindow.MaxSize = new Size(65536, 65536));
+            AddStep("overlapping size throws", () => Assert.Throws<InvalidOperationException>(() => window.MaxSize = window.MinSize - new Size(1, 1)));
+            AddStep("negative size throws", () => Assert.Throws<InvalidOperationException>(() => window.MaxSize = new Size(-1, -1)));
+            AddStep("reset maximum size", () => window.MaxSize = new Size(65536, 65536));
         }
 
         private void setWindowSize(Size size) => config.SetValue(FrameworkSetting.WindowedSize, size);
 
         private void assertWindowSize(Size size)
         {
-            AddAssert($"client size = {size.Width}x{size.Height} (with scale)", () => sdlWindow.ClientSize == (size * sdlWindow.Scale).ToSize());
+            AddAssert($"client size = {size.Width}x{size.Height} (with scale)", () => window.ClientSize == (size * window.Scale).ToSize());
             AddAssert($"size in config = {size.Width}x{size.Height}", () => config.Get<Size>(FrameworkSetting.WindowedSize) == size);
         }
     }

--- a/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
+++ b/osu.Framework.Tests/Visual/Platform/WindowDisplaysPreview.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private static readonly Color4 window_fill = new Color4(95, 113, 197, 255);
         private static readonly Color4 window_stroke = new Color4(36, 59, 166, 255);
 
-        private ISDLWindow? window;
+        private IWindow? window;
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
         private readonly Bindable<Display> currentDisplay = new Bindable<Display>();
 
@@ -90,7 +90,7 @@ namespace osu.Framework.Tests.Visual.Platform
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config, GameHost host)
         {
-            window = host.Window as ISDLWindow;
+            window = host.Window;
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
 
             if (window != null)

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Drawing;
-using ManagedBass;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers;

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Drawing;
-using osu.Framework.Configuration;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
@@ -85,20 +84,8 @@ namespace osu.Framework.Input
 
         private bool mouseOutsideAllDisplays(Vector2 mousePosition)
         {
-            Point windowLocation;
-
-            switch (Host.Window.WindowMode.Value)
-            {
-                case WindowMode.Windowed:
-                    windowLocation = Host.Window is ISDLWindow sdlWindow ? sdlWindow.Position : Point.Empty;
-                    break;
-
-                default:
-                    windowLocation = Host.Window.CurrentDisplayBindable.Value.Bounds.Location;
-                    break;
-            }
-
-            float scale = Host.Window is ISDLWindow window ? window.Scale : 1;
+            Point windowLocation = Host.Window.Position;
+            float scale = Host.Window.Scale;
             mousePosition /= scale;
 
             int x = (int)MathF.Floor(windowLocation.X + mousePosition.X);

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Drawing;
+using ManagedBass;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
@@ -84,7 +86,19 @@ namespace osu.Framework.Input
 
         private bool mouseOutsideAllDisplays(Vector2 mousePosition)
         {
-            Point windowLocation = Host.Window.Position;
+            Point windowLocation;
+
+            switch (Host.Window.WindowMode.Value)
+            {
+                case WindowMode.Windowed:
+                    windowLocation = Host.Window.Position;
+                    break;
+
+                default:
+                    windowLocation = Host.Window.CurrentDisplayBindable.Value.Bounds.Location;
+                    break;
+            }
+
             float scale = Host.Window.Scale;
             mousePosition /= scale;
 

--- a/osu.Framework/Platform/ISDLWindow.cs
+++ b/osu.Framework/Platform/ISDLWindow.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Drawing;
 using osu.Framework.Bindables;
 using osu.Framework.Input;
 using osuTK;
@@ -27,14 +26,8 @@ namespace osu.Framework.Platform
         event Action<Key> KeyUp;
         event Action<string> TextInput;
         event TextEditingDelegate TextEditing;
-        event Action<WindowState> WindowStateChanged;
 
         Bindable<CursorState> CursorStateBindable { get; }
-
-        Point Position { get; }
-        Size Size { get; }
-        float Scale { get; }
-        bool Resizable { get; set; }
 
         bool MouseAutoCapture { set; }
         bool RelativeMouseMode { get; set; }

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -237,12 +237,14 @@ namespace osu.Framework.Platform
         /// Convert a screen based coordinate to local window space.
         /// </summary>
         /// <param name="point"></param>
+        [Obsolete("This member should not be used. It was never properly implemented for cross-platform use.")] // can be removed 20250528
         Point PointToClient(Point point);
 
         /// <summary>
         /// Convert a window based coordinate to global screen space.
         /// </summary>
         /// <param name="point"></param>
+        [Obsolete("This member should not be used. It was never properly implemented for cross-platform use.")] // can be removed 20250528
         Point PointToScreen(Point point);
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked when the user drops a file into the window.
         /// </summary>
-        public event Action<string>? DragDrop;
+        event Action<string>? DragDrop;
 
         /// <summary>
         /// Whether the OS cursor is currently contained within the game window.
@@ -230,7 +230,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Sets the window icon to the provided <paramref name="imageStream"/>.
         /// </summary>
-        public void SetIconFromStream(Stream imageStream);
+        void SetIconFromStream(Stream imageStream);
 
         /// <summary>
         /// Convert a screen based coordinate to local window space.

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -225,6 +225,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Whether the window currently has focus.
         /// </summary>
+        [Obsolete("Use IWindow.IsActive.Value instead.")] // can be removed 20250528
         bool Focused { get; }
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -39,6 +39,22 @@ namespace osu.Framework.Platform
         void Create();
 
         /// <summary>
+        /// Start the window's run loop.
+        /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
+        /// </summary>
+        void Run();
+
+        /// <summary>
+        /// Invoked once a draw session has finished.
+        /// </summary>
+        void OnDraw();
+
+        /// <summary>
+        /// Forcefully closes the window.
+        /// </summary>
+        void Close();
+
+        /// <summary>
         /// Invoked once every window event loop.
         /// </summary>
         event Action? Update;
@@ -162,11 +178,6 @@ namespace osu.Framework.Platform
         IBindable<DisplayMode> CurrentDisplayMode { get; }
 
         /// <summary>
-        /// Forcefully closes the window.
-        /// </summary>
-        void Close();
-
-        /// <summary>
         /// Attempts to raise the window, bringing it above other windows and requesting input focus.
         /// </summary>
         void Raise();
@@ -210,17 +221,6 @@ namespace osu.Framework.Platform
         /// Disable any system level timers that might dim or turn off the screen.
         /// </summary>
         void DisableScreenSuspension();
-
-        /// <summary>
-        /// Start the window's run loop.
-        /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
-        /// </summary>
-        void Run();
-
-        /// <summary>
-        /// Invoked once a draw session has finished.
-        /// </summary>
-        void OnDraw();
 
         /// <summary>
         /// Whether the window currently has focus.

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -125,6 +125,11 @@ namespace osu.Framework.Platform
         WindowState WindowState { get; set; }
 
         /// <summary>
+        /// Invoked when <see cref="WindowState"/> changes.
+        /// </summary>
+        event Action<WindowState>? WindowStateChanged;
+
+        /// <summary>
         /// Returns the default <see cref="WindowMode"/> for the implementation.
         /// </summary>
         WindowMode DefaultWindowMode { get; }
@@ -248,9 +253,24 @@ namespace osu.Framework.Platform
         Point PointToScreen(Point point);
 
         /// <summary>
-        /// The client size of the window (excluding any window decoration/border).
+        /// The client size of the window in pixels (excluding any window decoration/border).
         /// </summary>
         Size ClientSize { get; }
+
+        /// <summary>
+        /// The position of the window.
+        /// </summary>
+        Point Position { get; }
+
+        /// <summary>
+        /// The size of the window in scaled pixels (excluding any window decoration/border).
+        /// </summary>
+        Size Size { get; }
+
+        /// <summary>
+        /// The ratio of <see cref="ClientSize"/> and <see cref="Size"/>.
+        /// </summary>
+        float Scale { get; }
 
         /// <summary>
         /// The minimum size of the window.
@@ -263,6 +283,11 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when setting a negative or zero size, or a size less than <see cref="MinSize"/>.</exception>
         Size MaxSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the window is user-resizable.
+        /// </summary>
+        bool Resizable { get; set; }
 
         /// <summary>
         /// The window title.

--- a/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
+++ b/osu.Framework/Platform/Windows/WindowsGLRenderer.cs
@@ -28,8 +28,6 @@ namespace osu.Framework.Platform.Windows
         {
             base.Initialise(graphicsSurface);
 
-            ISDLWindow windowsWindow = (ISDLWindow)host.Window;
-
             bool isIntel = GL.GetString(StringName.Vendor).Trim() == "Intel";
 
             if (isIntel)
@@ -40,9 +38,9 @@ namespace osu.Framework.Platform.Windows
             else
             {
                 // For all other vendors, support depends on the system setup - e.g. NVIDIA Optimus doesn't support exclusive fullscreen with OpenGL.
-                windowsWindow.IsActive.BindValueChanged(_ => detectFullscreenCapability(windowsWindow));
-                windowsWindow.WindowStateChanged += _ => detectFullscreenCapability(windowsWindow);
-                detectFullscreenCapability(windowsWindow);
+                host.Window.IsActive.BindValueChanged(_ => detectFullscreenCapability(host.Window));
+                host.Window.WindowStateChanged += _ => detectFullscreenCapability(host.Window);
+                detectFullscreenCapability(host.Window);
             }
         }
 


### PR DESCRIPTION
`Focused`, `PointToClient()` and `PointToScreen()` in `IWindow` are made obsolete as they are not useful. See commits for more details.

Moves some members from `ISDLWindow` to `IWindow`. This makes it so platform-agnostic code no longer needs to cast to `ISDLWindow` (in `UserInputManager` and tests).
