### PR TITLE
Always use window position in `UserInputManager`

### DIFF
--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -85,19 +85,7 @@ namespace osu.Framework.Input
 
         private bool mouseOutsideAllDisplays(Vector2 mousePosition)
         {
-            Point windowLocation;
-
-            switch (Host.Window.WindowMode.Value)
-            {
-                case WindowMode.Windowed:
-                    windowLocation = Host.Window.Position;
-                    break;
-
-                default:
-                    windowLocation = Host.Window.CurrentDisplayBindable.Value.Bounds.Location;
-                    break;
-            }
-
+            Point windowLocation = Host.Window.Position;
             float scale = Host.Window.Scale;
             mousePosition /= scale;
 


### PR DESCRIPTION
- Extracted from https://github.com/ppy/osu-framework/pull/6438#discussion_r1862723911

The [window position is updated](https://github.com/ppy/osu-framework/blob/7bfc9fe53202873c9d4ebcde5530a8dd23222942/osu.Framework/Platform/SDL2/SDL2Window_Windowing.cs#L468-L475) when `SDL_WINDOWEVENT_MOVED` is sent (which does get sent when changing to fullscreen or borderless) and [SDL returns the display position when fullscreen](https://github.com/libsdl-org/SDL/blob/d53241a29911011f4846af9be19d497d4c5046fa/src/video/SDL_video.c#L2827).