### PR TITLE
Switch to using named pipes for IPC

### DIFF
--- a/osu.Framework.Tests/Platform/IPCTest.cs
+++ b/osu.Framework.Tests/Platform/IPCTest.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Platform;
+using osu.Framework.Tests.IO;
+
+namespace osu.Framework.Tests.Platform
+{
+    [TestFixture]
+    public partial class IPCTest
+    {
+        [Test]
+        public void TestNoPipeNameSpecifiedCoexist()
+        {
+            using (var host1 = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPipeName = null }))
+            using (var host2 = new HeadlessGameHost(@"client", new HostOptions { IPCPipeName = null }))
+            {
+                Assert.IsTrue(host1.IsPrimaryInstance, @"Host 1 wasn't able to bind");
+                Assert.IsTrue(host2.IsPrimaryInstance, @"Host 2 wasn't able to bind");
+            }
+        }
+
+        [Test]
+        public void TestDifferentPipeNamesCoexist()
+        {
+            using (var host1 = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPipeName = "test-app" }))
+            using (var host2 = new HeadlessGameHost(@"client", new HostOptions { IPCPipeName = "test-app-2" }))
+            {
+                Assert.IsTrue(host1.IsPrimaryInstance, @"Host 1 wasn't able to bind");
+                Assert.IsTrue(host2.IsPrimaryInstance, @"Host 2 wasn't able to bind");
+            }
+        }
+
+        [Test]
+        public void TestOneWay()
+        {
+            using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPipeName = "test-app" }))
+            using (var client = new HeadlessGameHost(@"client", new HostOptions { IPCPipeName = "test-app" }))
+            {
+                Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
+                Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");
+
+                var serverChannel = new IpcChannel<Foobar, object>(server);
+                var clientChannel = new IpcChannel<Foobar, object>(client);
+
+                async Task waitAction()
+                {
+                    using (var received = new SemaphoreSlim(0))
+                    {
+                        serverChannel.MessageReceived += message =>
+                        {
+                            Assert.AreEqual("example", message.Bar);
+                            // ReSharper disable once AccessToDisposedClosure
+                            received.Release();
+                            return null;
+                        };
+
+                        await clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).ConfigureAwait(false);
+
+                        if (!await received.WaitAsync(10000).ConfigureAwait(false))
+                            throw new TimeoutException("Message was not received in a timely fashion");
+                    }
+                }
+
+                Assert.IsTrue(Task.Run(waitAction).Wait(10000), @"Message was not received in a timely fashion");
+            }
+        }
+
+        [Test]
+        public void TestTwoWay()
+        {
+            using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPipeName = "test-app" }))
+            using (var client = new HeadlessGameHost(@"client", new HostOptions { IPCPipeName = "test-app" }))
+            {
+                Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
+                Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");
+
+                var serverChannel = new IpcChannel<Foobar, Foobar>(server);
+                var clientChannel = new IpcChannel<Foobar, Foobar>(client);
+
+                async Task waitAction()
+                {
+                    using (var received = new SemaphoreSlim(0))
+                    {
+                        serverChannel.MessageReceived += message =>
+                        {
+                            Assert.AreEqual("example", message.Bar);
+                            // ReSharper disable once AccessToDisposedClosure
+                            received.Release();
+
+                            return new Foobar { Bar = "test response" };
+                        };
+
+                        var response = await clientChannel.SendMessageWithResponseAsync(new Foobar { Bar = "example" }).ConfigureAwait(false);
+
+                        if (!await received.WaitAsync(10000).ConfigureAwait(false))
+                            throw new TimeoutException("Message was not received in a timely fashion");
+
+                        Assert.That(response?.Bar, Is.EqualTo("test response"));
+                    }
+                }
+
+                Assert.IsTrue(Task.Run(waitAction).Wait(10000), @"Message was not received in a timely fashion");
+            }
+        }
+
+        [Test]
+        public void TestIpcLegacyPortSupport()
+        {
+#pragma warning disable CS0612 // Type or member is obsolete
+            using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPort = 45356 }))
+            using (var client = new HeadlessGameHost(@"client", new HostOptions { IPCPort = 45356 }))
+#pragma warning restore CS0612 // Type or member is obsolete
+            {
+                Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
+                Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");
+
+                var serverChannel = new IpcChannel<Foobar, object>(server);
+                var clientChannel = new IpcChannel<Foobar, object>(client);
+
+                async Task waitAction()
+                {
+                    using (var received = new SemaphoreSlim(0))
+                    {
+                        serverChannel.MessageReceived += message =>
+                        {
+                            Assert.AreEqual("example", message.Bar);
+                            // ReSharper disable once AccessToDisposedClosure
+                            received.Release();
+                            return null;
+                        };
+
+                        await clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).ConfigureAwait(false);
+
+                        if (!await received.WaitAsync(10000).ConfigureAwait(false))
+                            throw new TimeoutException("Message was not received in a timely fashion");
+                    }
+                }
+
+                Assert.IsTrue(Task.Run(waitAction).Wait(10000), @"Message was not received in a timely fashion");
+            }
+        }
+
+        private class Foobar
+        {
+            public string Bar;
+        }
+    }
+}

--- a/osu.Framework.Tests/Platform/IPCTest.cs
+++ b/osu.Framework.Tests/Platform/IPCTest.cs
@@ -113,10 +113,10 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void TestIpcLegacyPortSupport()
         {
-#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             using (var server = new BackgroundGameHeadlessGameHost(@"server", new HostOptions { IPCPort = 45356 }))
             using (var client = new HeadlessGameHost(@"client", new HostOptions { IPCPort = 45356 }))
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
                 Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");

--- a/osu.Framework.Tests/Platform/IPCTest.cs
+++ b/osu.Framework.Tests/Platform/IPCTest.cs
@@ -46,8 +46,8 @@ namespace osu.Framework.Tests.Platform
                 Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
                 Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");
 
-                var serverChannel = new IpcChannel<Foobar, object>(server);
-                var clientChannel = new IpcChannel<Foobar, object>(client);
+                var serverChannel = new IpcChannel<Foobar>(server);
+                var clientChannel = new IpcChannel<Foobar>(client);
 
                 async Task waitAction()
                 {

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void IsAliveTest()
         {
-            using (var client = new TestHeadlessGameHost(@"client", 45356))
+            using (var client = new TestHeadlessGameHost(@"client"))
             {
                 var testGame = new TestTestGame();
                 client.Run(testGame);
@@ -25,8 +25,8 @@ namespace osu.Framework.Tests.Platform
         {
             public Drawable CurrentRoot => Root;
 
-            public TestHeadlessGameHost(string gameName, int? ipcPort)
-                : base(gameName, new HostOptions { IPCPort = ipcPort })
+            public TestHeadlessGameHost(string gameName)
+                : base(gameName, new HostOptions { IPCPipeName = gameName })
             {
             }
         }

--- a/osu.Framework/HostOptions.cs
+++ b/osu.Framework/HostOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Globalization;
 using osu.Framework.Platform;
 
 namespace osu.Framework
@@ -11,12 +13,20 @@ namespace osu.Framework
     public class HostOptions
     {
         /// <summary>
-        /// The IPC port to bind. This port should be between 1024 and 49151,
-        /// should be shared by all instances of a given osu!framework app,
-        /// but be distinct from IPC ports specified by other osu!framework apps.
+        /// Use <see cref="IPCPipeName"/> instead.
+        /// </summary>
+        [Obsolete("Use IPCPipeName instead.")] // can be removed 20250603.
+        public int? IPCPort
+        {
+            set => IPCPipeName = value?.ToString(CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// The IPC pipe name to bind. This should be shared by all instances of
+        /// an osu!framework app that want to perform inter-process communications.
         /// See <see cref="IIpcHost"/> for more details on usage.
         /// </summary>
-        public int? IPCPort { get; set; }
+        public string? IPCPipeName { get; set; }
 
         /// <summary>
         /// Whether this is a portable installation. Will cause all game files to be placed alongside the executable, rather than in the standard data directory.

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Platform
 {
     public abstract class DesktopGameHost : SDLGameHost
     {
-        private TcpIpcProvider ipcProvider;
+        private NamedPipeIpcProvider ipcProvider;
         private readonly int? ipcPort;
 
         protected DesktopGameHost(string gameName, HostOptions options = null)
@@ -61,7 +61,7 @@ namespace osu.Framework.Platform
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new TcpIpcProvider(ipcPort.Value);
+            ipcProvider = new NamedPipeIpcProvider(ipcPort.Value);
             ipcProvider.MessageReceived += OnMessageReceived;
 
             IsPrimaryInstance = ipcProvider.Bind();

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -16,12 +16,12 @@ namespace osu.Framework.Platform
     public abstract class DesktopGameHost : SDLGameHost
     {
         private NamedPipeIpcProvider ipcProvider;
-        private readonly int? ipcPort;
+        private readonly string ipcPipeName;
 
         protected DesktopGameHost(string gameName, HostOptions options = null)
             : base(gameName, options)
         {
-            ipcPort = Options.IPCPort;
+            ipcPipeName = Options.IPCPipeName;
             IsPortableInstallation = Options.PortableInstallation;
         }
 
@@ -55,13 +55,13 @@ namespace osu.Framework.Platform
 
         private void ensureIPCReady()
         {
-            if (ipcPort == null)
+            if (ipcPipeName == null)
                 return;
 
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new NamedPipeIpcProvider(ipcPort.Value);
+            ipcProvider = new NamedPipeIpcProvider(ipcPipeName);
             ipcProvider.MessageReceived += OnMessageReceived;
 
             IsPrimaryInstance = ipcProvider.Bind();

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Platform
             return true;
         }
 
-        private void openUsingShellExecute(string path) => Process.Start(new ProcessStartInfo
+        private static void openUsingShellExecute(string path) => Process.Start(new ProcessStartInfo
         {
             FileName = path,
             UseShellExecute = true //see https://github.com/dotnet/corefx/issues/10361
@@ -108,6 +108,13 @@ namespace osu.Framework.Platform
             ensureIPCReady();
 
             return ipcProvider.SendMessageAsync(message);
+        }
+
+        public override Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message)
+        {
+            ensureIPCReady();
+
+            return ipcProvider.SendMessageWithResponseAsync(message);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -144,6 +144,9 @@ namespace osu.Framework.Platform
         protected IpcMessage OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
 
         public virtual Task SendMessageAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
+        public virtual Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
+
+        public virtual Task SendM(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
 
         /// <summary>
         /// Requests that a file or folder be opened externally with an associated application, if available.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -146,8 +146,6 @@ namespace osu.Framework.Platform
         public virtual Task SendMessageAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
         public virtual Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
 
-        public virtual Task SendM(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
-
         /// <summary>
         /// Requests that a file or folder be opened externally with an associated application, if available.
         /// </summary>

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Platform
         /// Invoked when a message is received by this IPC server.
         /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
         /// </summary>
-        event Func<IpcMessage, IpcMessage> MessageReceived;
+        event Func<IpcMessage, IpcMessage?>? MessageReceived;
 
         /// <summary>
         /// Asynchronously send a message to the IPC server.

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -15,9 +15,16 @@ namespace osu.Framework.Platform
         event Func<IpcMessage, IpcMessage> MessageReceived;
 
         /// <summary>
-        /// Send a message to the IPC server.
+        /// Asynchronously send a message to the IPC server.
         /// </summary>
         /// <param name="ipcMessage">The message to send.</param>
         Task SendMessageAsync(IpcMessage ipcMessage);
+
+        /// <summary>
+        /// Asynchronously send a message to the IPC server and receive a response.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <returns>The response from the server.</returns>
+        Task<IpcMessage?> SendMessageWithResponseAsync(IpcMessage message);
     }
 }

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -7,17 +7,29 @@ using System.Threading.Tasks;
 namespace osu.Framework.Platform
 {
     /// <summary>
-    /// Setup an IPC channel which supports sending a specific pair of well-defined types.
+    /// Define an IPC channel which supports sending a specific well-defined type.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <typeparam name="TResponse"></typeparam>
+    /// <typeparam name="T">The type to send.</typeparam>
+    public class IpcChannel<T> : IpcChannel<T, object> where T : class
+    {
+        public IpcChannel(IIpcHost host)
+            : base(host)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Define an IPC channel which supports sending and receiving a specific well-defined type.
+    /// </summary>
+    /// <typeparam name="T">The type to send.</typeparam>
+    /// <typeparam name="TResponse">The type to receive.</typeparam>
     public class IpcChannel<T, TResponse> : IDisposable
         where T : class
         where TResponse : class
     {
         private readonly IIpcHost host;
 
-        public event Func<T, TResponse>? MessageReceived;
+        public event Func<T, TResponse?>? MessageReceived;
 
         public IpcChannel(IIpcHost host)
         {
@@ -37,7 +49,7 @@ namespace osu.Framework.Platform
             {
                 Type = typeof(T).AssemblyQualifiedName,
                 Value = message,
-            });
+            }).ConfigureAwait(false);
 
             if (response == null)
                 return null;

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace osu.Framework.Platform
 {
@@ -20,6 +21,13 @@ namespace osu.Framework.Platform
         }
 
         public Task SendMessageAsync(T message) => host.SendMessageAsync(new IpcMessage
+        {
+            Type = typeof(T).AssemblyQualifiedName,
+            Value = message,
+        });
+
+        [ItemCanBeNull]
+        public Task<IpcMessage> SendMessageWithResponseAsync(T message) => host.SendMessageWithResponseAsync(new IpcMessage
         {
             Type = typeof(T).AssemblyQualifiedName,
             Value = message,

--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Platform
 
         private readonly CancellationTokenSource cancellationSource = new CancellationTokenSource();
 
-        private readonly int port;
+        private readonly string pipeName;
 
         private Task? listenTask;
 
@@ -37,10 +37,10 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Create a new provider.
         /// </summary>
-        /// <param name="port">The port to operate on.</param>
-        public NamedPipeIpcProvider(int port)
+        /// <param name="pipeName">The port to operate on.</param>
+        public NamedPipeIpcProvider(string pipeName)
         {
-            this.port = port;
+            this.pipeName = pipeName;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace osu.Framework.Platform
 
             try
             {
-                pipe = new NamedPipeServerStream($"osu-framework-{port}", PipeDirection.InOut);
+                pipe = new NamedPipeServerStream($"osu-framework-{pipeName}", PipeDirection.InOut);
 
                 listenTask = listen(pipe);
 
@@ -119,7 +119,7 @@ namespace osu.Framework.Platform
         /// <param name="message">The message to send.</param>
         public async Task SendMessageAsync(IpcMessage message)
         {
-            using (var client = new NamedPipeClientStream($"osu-framework-{port}"))
+            using (var client = new NamedPipeClientStream($"osu-framework-{pipeName}"))
             {
                 await client.ConnectAsync().ConfigureAwait(false);
                 await send(client, message).ConfigureAwait(false);
@@ -133,7 +133,7 @@ namespace osu.Framework.Platform
         /// <returns>The response from the server.</returns>
         public async Task<IpcMessage?> SendMessageWithResponseAsync(IpcMessage message)
         {
-            using (var client = new NamedPipeClientStream($"osu-framework-{port}"))
+            using (var client = new NamedPipeClientStream($"osu-framework-{pipeName}"))
             {
                 await client.ConnectAsync().ConfigureAwait(false);
                 await send(client, message).ConfigureAwait(false);

--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using osu.Framework.Extensions;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// An inter-process communication provider that runs over a specified named pipe.
+    /// This single class handles both binding as a server, or messaging another bound instance that is acting as a server.
+    /// </summary>
+    public class NamedPipeIpcProvider : IDisposable
+    {
+        /// <summary>
+        /// Invoked when a message is received when running as a server.
+        /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
+        /// </summary>
+        public event Func<IpcMessage, IpcMessage?>? MessageReceived;
+
+        private readonly CancellationTokenSource cancellationSource = new CancellationTokenSource();
+
+        private readonly int port;
+
+        private Task? listenTask;
+
+        private NamedPipeServerStream? pipe;
+
+        /// <summary>
+        /// Create a new provider.
+        /// </summary>
+        /// <param name="port">The port to operate on.</param>
+        public NamedPipeIpcProvider(int port)
+        {
+            this.port = port;
+        }
+
+        /// <summary>
+        /// Attempt to bind to the named pipe as a server, and start listening for incoming connections if successful.
+        /// </summary>
+        /// <returns>
+        /// Whether the bind was successful.
+        /// If <c>false</c>, another instance is likely already running (and can be messaged using <see cref="SendMessageAsync"/> or <see cref="SendMessageWithResponseAsync"/>).
+        /// </returns>
+        public bool Bind()
+        {
+            if (pipe != null)
+                throw new InvalidOperationException($"Can't {nameof(Bind)} more than once.");
+
+            try
+            {
+                pipe = new NamedPipeServerStream($"osu-framework-{port}", PipeDirection.InOut);
+
+                listenTask = listen(pipe);
+
+                return true;
+            }
+            catch (IOException ex)
+            {
+                Logger.Error(ex, "Unable to bind IPC server");
+                return false;
+            }
+        }
+
+        private async Task listen(NamedPipeServerStream pipe)
+        {
+            var token = cancellationSource.Token;
+
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    await pipe.WaitForConnectionAsync(token);
+
+                    try
+                    {
+                        var message = await receive(pipe, token);
+
+                        if (message == null)
+                            continue;
+
+                        var response = MessageReceived?.Invoke(message);
+
+                        if (response != null)
+                            await send(pipe, response).WaitAsync(token);
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error(e, "Error handling incoming IPC request.");
+                    }
+                }
+            }
+            catch (TaskCanceledException)
+            {
+            }
+            finally
+            {
+                try
+                {
+                    pipe.Disconnect();
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        public async Task SendMessageAsync(IpcMessage message)
+        {
+            using (var client = new NamedPipeClientStream($"osu-framework-{port}"))
+            {
+                await client.ConnectAsync().ConfigureAwait(false);
+                await send(client, message).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <returns>The response from the server.</returns>
+        public async Task<IpcMessage?> SendMessageWithResponseAsync(IpcMessage message)
+        {
+            using (var client = new NamedPipeClientStream($"osu-framework-{port}"))
+            {
+                await client.ConnectAsync().ConfigureAwait(false);
+                await send(client, message).ConfigureAwait(false);
+                return await receive(client).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task send(Stream stream, IpcMessage message)
+        {
+            string str = JsonConvert.SerializeObject(message, Formatting.None);
+            byte[] data = Encoding.UTF8.GetBytes(str);
+            byte[] header = BitConverter.GetBytes(data.Length);
+
+            await stream.WriteAsync(header.AsMemory()).ConfigureAwait(false);
+            await stream.WriteAsync(data.AsMemory()).ConfigureAwait(false);
+            await stream.FlushAsync().ConfigureAwait(false);
+        }
+
+        private static async Task<IpcMessage?> receive(Stream stream, CancellationToken cancellationToken = default)
+        {
+            const int header_length = sizeof(int);
+
+            byte[] header = new byte[header_length];
+
+            int read = await stream.ReadAsync(header.AsMemory(), cancellationToken).ConfigureAwait(false);
+
+            if (read < header_length)
+                return null;
+
+            int contentLength = BitConverter.ToInt32(header, 0);
+
+            if (contentLength == 0)
+                return null;
+
+            byte[] data = await stream.ReadBytesToArrayAsync(contentLength, cancellationToken).ConfigureAwait(false);
+
+            string str = Encoding.UTF8.GetString(data);
+
+            var json = JToken.Parse(str);
+
+            string? typeName = json["Type"]?.Value<string>();
+
+            if (typeName == null) throw new InvalidOperationException("Response JSON has missing Type field.");
+
+            var type = Type.GetType(typeName);
+            var value = json["Value"];
+
+            if (type == null) throw new InvalidOperationException($"Response type could not be mapped ({typeName}).");
+            if (value == null) throw new InvalidOperationException("Response JSON has missing Value field.");
+
+            return new IpcMessage
+            {
+                Type = type.AssemblyQualifiedName,
+                Value = JsonConvert.DeserializeObject(value.ToString(), type),
+            };
+        }
+
+        public void Dispose()
+        {
+            const int thread_join_timeout = 2000;
+
+            cancellationSource.Cancel();
+
+            if (listenTask != null)
+            {
+                try
+                {
+                    listenTask.Wait(thread_join_timeout);
+                }
+                catch
+                {
+                    Logger.Log($"IPC thread failed to exit in allocated time ({thread_join_timeout}ms).", LoggingTarget.Runtime, LogLevel.Important);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -78,11 +78,11 @@ namespace osu.Framework.Platform
             {
                 while (!token.IsCancellationRequested)
                 {
-                    await pipe.WaitForConnectionAsync(token);
-
                     try
                     {
-                        var message = await receive(pipe, token);
+                        await pipe.WaitForConnectionAsync(token).ConfigureAwait(false);
+
+                        var message = await receive(pipe, token).ConfigureAwait(false);
 
                         if (message == null)
                             continue;
@@ -90,7 +90,9 @@ namespace osu.Framework.Platform
                         var response = MessageReceived?.Invoke(message);
 
                         if (response != null)
-                            await send(pipe, response).WaitAsync(token);
+                            await send(pipe, response).ConfigureAwait(false);
+
+                        pipe.Disconnect();
                     }
                     catch (Exception e)
                     {
@@ -202,6 +204,7 @@ namespace osu.Framework.Platform
                 try
                 {
                     listenTask.Wait(thread_join_timeout);
+                    pipe?.Dispose();
                 }
                 catch
                 {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/30783.

Has come up a few times in recent months so worthwhile fixing.

I've used this opportunity to also make the API a touch more robust and lock in the bidirectional messaging API too.

## Breaking Changes

### osu!framework now uses named pipes for IPC instead of TCP ports

This resolves cases where other applications may be reserving ranges of ports on localhost (as we found is common of WSL). Things should still work out-of-the-box if you are already using IPC, but you may want to update your usage as we've obsoleted the port specification:

```diff
diff --git a/osu.Desktop/Program.cs b/osu.Desktop/Program.cs
index 1a9aade377..bb9b0c30fa 100644
--- a/osu.Desktop/Program.cs
+++ b/osu.Desktop/Program.cs
@@ -99,7 +99,7 @@ public static void Main(string[] args)
 
             var hostOptions = new HostOptions
             {
-                IPCPort = 12345,
+                IPCPipeName = "my-app-unique-id",
                 FriendlyGameName = OsuGameBase.GAME_NAME,
             };
 

```

In addition, there's now a new `SendMessageWithResponseAsync` exposed by `GameHost` which can be used for bidirectional messaging. If you wish to make use of this, you should make an `IpcChannel<T,TResponse>` with well defined types for the sending and responding messages.