### PR TITLE
Fix Rider support of .globalconfig

### DIFF
--- a/CodeAnalysis/osu-framework.globalconfig
+++ b/CodeAnalysis/osu-framework.globalconfig
@@ -1,5 +1,6 @@
 # .NET Code Style
 # IDE styles reference: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/
+is_global = true
 
 # IDE0001: Simplify names
 dotnet_diagnostic.IDE0001.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,8 @@
   <ItemGroup Label="Code Analysis">
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.3" PrivateAssets="All" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis\BannedSymbols.txt" />
+    <!-- Rider compatibility: .globalconfig needs to be explicitly referenced instead of using the global file name. -->
+    <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis\osu-framework.globalconfig" />
   </ItemGroup>
   <PropertyGroup Label="Code Analysis">
     <AnalysisMode>Default</AnalysisMode>

--- a/osu-framework.sln
+++ b/osu-framework.sln
@@ -28,7 +28,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D29A2153-C171-457E-A147-720976BA430F}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		.globalconfig = .globalconfig
 		Directory.Build.props = Directory.Build.props
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json
@@ -73,6 +72,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.SourceGenerat
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeAnalysis", "CodeAnalysis", "{50334A1F-990D-45FA-A1FE-C92F1994D97B}"
 	ProjectSection(SolutionItems) = preProject
+		CodeAnalysis\osu-framework.globalconfig = CodeAnalysis\osu-framework.globalconfig
 		CodeAnalysis\BannedSymbols.txt = CodeAnalysis\BannedSymbols.txt
 	EndProjectSection
 EndProject


### PR DESCRIPTION
Rider doesn't recognize the implicitly named `.globalconfig` files. Reference it explicitly in msbuild props instead.