### PR TITLE
Fix unobserved exceptions on named pipe shutdown

### DIFF
--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -94,6 +94,9 @@ namespace osu.Framework.Platform
 
                         pipe.Disconnect();
                     }
+                    catch (OperationCanceledException)
+                    {
+                    }
                     catch (Exception e)
                     {
                         Logger.Error(e, "Error handling incoming IPC request.");

--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Platform
                     }
                 }
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
             }
             finally


### PR DESCRIPTION
https://sentry.ppy.sh/organizations/ppy/issues/67405/?alert_rule_id=4&alert_timestamp=1733713067444&alert_type=email&environment=production&project=2&referrer=alert_email

Not hotfix worthy, but worth fixing.