### PR TITLE
Deactivate game on iOS when sent to background or an incoming call is triggered 

### DIFF
--- a/osu.Framework.iOS/IOSCallObserver.cs
+++ b/osu.Framework.iOS/IOSCallObserver.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using CallKit;
+using Foundation;
+
+namespace osu.Framework.iOS
+{
+    internal class IOSCallObserver : NSObject, ICXCallObserverDelegate
+    {
+        private readonly Action incomingCall;
+        private readonly Action endedCall;
+
+        private readonly CXCallController callController;
+
+        public IOSCallObserver(Action incomingCall, Action endedCall)
+        {
+            this.incomingCall = incomingCall;
+            this.endedCall = endedCall;
+
+            callController = new CXCallController();
+            callController.CallObserver.SetDelegate(this, null);
+        }
+
+        public void CallChanged(CXCallObserver callObserver, CXCall call)
+        {
+            if (!call.HasEnded)
+                incomingCall();
+            else
+                endedCall();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            callController.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/osu.Framework.iOS/IOSCallObserver.cs
+++ b/osu.Framework.iOS/IOSCallObserver.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using CallKit;
 using Foundation;
 
@@ -9,26 +10,29 @@ namespace osu.Framework.iOS
 {
     internal class IOSCallObserver : NSObject, ICXCallObserverDelegate
     {
-        private readonly Action incomingCall;
-        private readonly Action endedCall;
+        private readonly Action onCall;
+        private readonly Action onCallEnded;
 
         private readonly CXCallController callController;
 
-        public IOSCallObserver(Action incomingCall, Action endedCall)
+        public IOSCallObserver(Action onCall, Action onCallEnded)
         {
-            this.incomingCall = incomingCall;
-            this.endedCall = endedCall;
+            this.onCall = onCall;
+            this.onCallEnded = onCallEnded;
 
             callController = new CXCallController();
             callController.CallObserver.SetDelegate(this, null);
+
+            if (callController.CallObserver.Calls.Any(c => !c.HasEnded))
+                onCall();
         }
 
         public void CallChanged(CXCallObserver callObserver, CXCall call)
         {
             if (!call.HasEnded)
-                incomingCall();
+                onCall();
             else
-                endedCall();
+                onCallEnded();
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -43,8 +43,11 @@ namespace osu.Framework.iOS
 
             base.Create();
 
-            window = Runtime.GetNSObject<UIWindow>(WindowHandle);
+            window = Runtime.GetNSObject<UIWindow>(WindowHandle)!;
             updateSafeArea();
+
+            UIScene.Notifications.ObserveWillDeactivate(window.WindowScene!, (_, _) => Focused = false);
+            UIScene.Notifications.ObserveDidActivate(window.WindowScene!, (_, _) => Focused = true);
         }
 
         protected override unsafe void RunMainLoop()

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.iOS
     internal class IOSWindow : SDL3MobileWindow
     {
         private UIWindow? window;
+        private IOSCallObserver callObserver;
 
         public override Size Size
         {
@@ -48,6 +49,10 @@ namespace osu.Framework.iOS
 
             UIScene.Notifications.ObserveWillDeactivate(window.WindowScene!, (_, _) => Focused = false);
             UIScene.Notifications.ObserveDidActivate(window.WindowScene!, (_, _) => Focused = true);
+
+            callObserver = new IOSCallObserver(
+                incomingCall: () => Focused = false,
+                endedCall: () => Focused = true);
         }
 
         protected override unsafe void RunMainLoop()


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/4565

Was hoping that iOS doesn't make me add extra handling for the "incoming call" part but turns out it does (presumably because calls changed from a full app transition to a status bar notification). I considered not handling it altogether but as soon as the user receives a call, the beatmap freezes (as per the issue thread) as the audio is taken away by the presence of the call, and the freeze does not go away until the call is gone. If enough time passes while the beatmap is frozen, osu! dismisses the score from submission due to the audio playback error.