### PR TITLE
Fix multiple instances of a game being allowed to start concurrently

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -50,8 +50,10 @@ namespace osu.Framework.Tests.Visual.Drawables
             });
         }
 
+        // Fails once in a blue moon due to loose (but maybe-not-loose-enough) timing requirements. If we break things, it will fail every time so this is fine.
         [TestCase(false)]
         [TestCase(true)]
+        [FlakyTest]
         public void TestManyChildren(bool instant)
         {
             AddStep("create children", () =>

--- a/osu.Framework/Platform/NamedPipeIpcProvider.cs
+++ b/osu.Framework/Platform/NamedPipeIpcProvider.cs
@@ -122,7 +122,8 @@ namespace osu.Framework.Platform
             {
                 try
                 {
-                    pipe.Disconnect();
+                    if (pipe.IsConnected)
+                        pipe.Disconnect();
                 }
                 catch
                 {


### PR DESCRIPTION
Regressed with https://github.com/ppy/osu-framework/pull/6442. Closes https://github.com/ppy/osu/issues/31072.

Was not visible in test coverage because as per the inline comment, this is an exceptional case where two different processes bind.

I'm not sure how to add test coverage for this, but I have tested manually on both windows and macOS.

Can test using this:

```diff
diff --git a/SampleGame.Desktop/Program.cs b/SampleGame.Desktop/Program.cs
index 4756edbaa..ae5075535 100644
--- a/SampleGame.Desktop/Program.cs
+++ b/SampleGame.Desktop/Program.cs
@@ -12,9 +12,17 @@ public static class Program
         [STAThread]
         public static void Main(string[] args)
         {
-            using (GameHost host = Host.GetSuitableDesktopHost(@"sample-game"))
+            using (GameHost host = Host.GetSuitableDesktopHost(@"sample-game", new HostOptions
+                   {
+                       IPCPipeName = "wang"
+                   }))
             using (Game game = new SampleGameGame())
+            {
+                if (host.IsPrimaryInstance)
+                    return;
+
                 host.Run(game);
+            }
         }
     }
 }

```
