### PR TITLE
Use premultiplied colours in rendering

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneComplexBlending.cs
@@ -220,7 +220,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             colourEquation.Current.Value = foregroundContainer.Blending.RGBEquation;
             alphaEquation.Current.Value = foregroundContainer.Blending.AlphaEquation;
 
-            blendingSrcDropdown.Current.Value = BlendingType.SrcAlpha;
+            blendingSrcDropdown.Current.Value = BlendingType.One;
             blendingDestDropdown.Current.Value = BlendingType.OneMinusSrcAlpha;
             blendingAlphaSrcDropdown.Current.Value = BlendingType.One;
             blendingAlphaDestDropdown.Current.Value = BlendingType.One;

--- a/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneShaderStorageBufferObject.cs
@@ -7,12 +7,14 @@ using System.Runtime.InteropServices;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shaders.Types;
 using osuTK;
+using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Tests.Visual.Graphics
@@ -116,7 +118,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                     var rng = new Random(1337);
 
                     for (int i = 0; i < colourBuffer.Size; i++)
-                        colourBuffer[i] = new ColourData { Colour = new Vector4(rng.NextSingle(), rng.NextSingle(), rng.NextSingle(), 1) };
+                        colourBuffer[i] = new ColourData { Colour = PremultipliedColour.FromStraight(new Color4(rng.NextSingle(), rng.NextSingle(), rng.NextSingle(), 1)) };
                 }
 
                 // Bind the custom shader and SSBO.
@@ -212,7 +214,7 @@ namespace osu.Framework.Tests.Visual.Graphics
 
                 for (int i = 0; i < areas.Count; i++)
                 {
-                    int colourIndex = colourBuffer.Push(new ColourData { Colour = new Vector4(rng.NextSingle(), rng.NextSingle(), rng.NextSingle(), 1) });
+                    int colourIndex = colourBuffer.Push(new ColourData { Colour = PremultipliedColour.FromStraight(new Color4(rng.NextSingle(), rng.NextSingle(), rng.NextSingle(), 1)) });
 
                     // Bind the SSBO. This may change between iterations if a buffer transition happens via the above push.
                     shader.BindUniformBlock("g_ColourBuffer", colourBuffer.CurrentBuffer);
@@ -260,7 +262,7 @@ namespace osu.Framework.Tests.Visual.Graphics
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         private record struct ColourData
         {
-            public UniformVector4 Colour;
+            public UniformColour Colour;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
@@ -15,7 +15,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.Input
@@ -33,12 +32,12 @@ namespace osu.Framework.Tests.Visual.Input
         {
             const int width = 2;
             Texture gradientTexture = renderer.CreateTexture(width, 1, true);
-            var image = new Image<Rgba32>(width, 1);
+            var image = new PremultipliedImage(width, 1);
 
             for (int i = 0; i < width; ++i)
             {
                 byte brightnessByte = (byte)((float)i / (width - 1) * 255);
-                image[i, 0] = new Rgba32(brightnessByte, brightnessByte, brightnessByte);
+                image.Premultiplied[i, 0] = new Rgba32(brightnessByte, brightnessByte, brightnessByte);
             }
 
             gradientTexture.SetData(new TextureUpload(image));

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -73,7 +73,7 @@ namespace osu.Framework.Tests.Visual.Platform
                 clipboardImage = image!.Clone();
 
                 var texture = renderer.CreateTexture(image.Width, image.Height);
-                texture.SetData(new TextureUpload(image));
+                texture.SetData(new TextureUpload(PremultipliedImage.FromStraight(image)));
 
                 Child = new Sprite
                 {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 var image = t.GetResultSafely();
 
                 var tex = renderer.CreateTexture(image.Width, image.Height);
-                tex.SetData(new TextureUpload(image));
+                tex.SetData(new TextureUpload(PremultipliedImage.FromStraight(image)));
 
                 display.Texture = tex;
                 background.Show();

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularBlob.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularBlob.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
@@ -32,31 +31,31 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             const int width = 128;
 
-            var image = new Image<Rgba32>(width, 1);
+            var image = new PremultipliedImage(width, 1);
 
             gradientTextureHorizontal = renderer.CreateTexture(width, 1, true);
 
             for (int i = 0; i < width; ++i)
             {
                 float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+                image.Premultiplied[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
             }
 
             gradientTextureHorizontal.SetData(new TextureUpload(image));
 
-            image = new Image<Rgba32>(width, 1);
+            image = new PremultipliedImage(width, 1);
 
             gradientTextureVertical = renderer.CreateTexture(1, width, true);
 
             for (int i = 0; i < width; ++i)
             {
                 float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+                image.Premultiplied[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
             }
 
             gradientTextureVertical.SetData(new TextureUpload(image));
 
-            image = new Image<Rgba32>(width, width);
+            image = new PremultipliedImage(width, width);
 
             gradientTextureBoth = renderer.CreateTexture(width, width, true);
 
@@ -66,7 +65,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     float brightness = (float)i / (width - 1);
                     float brightness2 = (float)j / (width - 1);
-                    image[i, j] = new Rgba32(
+                    image.Premultiplied[i, j] = new Rgba32(
                         (byte)(128 + (1 + brightness - brightness2) / 2 * 127),
                         (byte)(128 + (1 + brightness2 - brightness) / 2 * 127),
                         (byte)(128 + (brightness + brightness2) / 2 * 127),

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osuTK;
 using osuTK.Graphics;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
@@ -38,31 +37,31 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             const int width = 128;
 
-            var image = new Image<Rgba32>(width, 1);
+            var image = new PremultipliedImage(width, 1);
 
             gradientTextureHorizontal = renderer.CreateTexture(width, 1, true);
 
             for (int i = 0; i < width; ++i)
             {
                 float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+                image.Premultiplied[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
             }
 
             gradientTextureHorizontal.SetData(new TextureUpload(image));
 
-            image = new Image<Rgba32>(width, 1);
+            image = new PremultipliedImage(width, 1);
 
             gradientTextureVertical = renderer.CreateTexture(1, width, true);
 
             for (int i = 0; i < width; ++i)
             {
                 float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+                image.Premultiplied[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
             }
 
             gradientTextureVertical.SetData(new TextureUpload(image));
 
-            image = new Image<Rgba32>(width, width);
+            image = new PremultipliedImage(width, width);
 
             gradientTextureBoth = renderer.CreateTexture(width, width, true);
 
@@ -72,7 +71,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     float brightness = (float)i / (width - 1);
                     float brightness2 = (float)j / (width - 1);
-                    image[i, j] = new Rgba32(
+                    image.Premultiplied[i, j] = new Rgba32(
                         (byte)(128 + (1 + brightness - brightness2) / 2 * 127),
                         (byte)(128 + (1 + brightness2 - brightness) / 2 * 127),
                         (byte)(128 + (brightness + brightness2) / 2 * 127),

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
@@ -29,12 +28,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [BackgroundDependencyLoader]
         private void load(IRenderer renderer)
         {
-            var image = new Image<Rgba32>(texture_width, 1);
+            var image = new PremultipliedImage(texture_width, 1);
 
             for (int i = 0; i < texture_width; ++i)
             {
                 byte brightnessByte = (byte)((float)i / (texture_width - 1) * 255);
-                image[i, 0] = new Rgba32(255, 255, 255, brightnessByte);
+                image.Premultiplied[i, 0] = new Rgba32(brightnessByte, brightnessByte, brightnessByte, brightnessByte);
             }
 
             gradientTexture = renderer.CreateTexture(texture_width, 1, true);

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -8,6 +8,7 @@ using Foundation;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using UIKit;
 
 namespace osu.Framework.iOS.Graphics.Textures
@@ -19,7 +20,7 @@ namespace osu.Framework.iOS.Graphics.Textures
         {
         }
 
-        protected override Image<TPixel> ImageFromStream<TPixel>(Stream stream)
+        protected override PremultipliedImage ImageFromStream(Stream stream)
         {
             using (var nativeData = NSData.FromStream(stream))
             {
@@ -39,9 +40,11 @@ namespace osu.Framework.iOS.Graphics.Textures
                     using (CGBitmapContext textureContext = new CGBitmapContext(data, width, height, 8, width * 4, CGColorSpace.CreateDeviceRGB(), CGImageAlphaInfo.PremultipliedLast))
                         textureContext.DrawImage(new CGRect(0, 0, width, height), uiImage.CGImage);
 
-                    var image = Image.LoadPixelData<TPixel>(data, width, height);
+                    var image = Image.LoadPixelData<Rgba32>(data, width, height);
 
-                    return image;
+                    // UIImage/CGBitmapContext already produce images in premultiplied form,
+                    // so we can directly wrap the image without performing any conversion.
+                    return PremultipliedImage.FromPremultiplied(image);
                 }
             }
         }

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -4,6 +4,7 @@
 using osuTK.Graphics;
 using System;
 using System.Globalization;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Extensions.Color4Extensions
 {
@@ -288,5 +289,12 @@ namespace osu.Framework.Extensions.Color4Extensions
 
             return (h, s, v);
         }
+
+        /// <summary>
+        /// Converts a <see cref="Color4"/> to premultiplied alpha and returns a resultant <see cref="PremultipliedColour"/>.
+        /// The input colour is assumed to be in straight-alpha form.
+        /// </summary>
+        /// <param name="colour">The colour as straight-alpha.</param>
+        public static PremultipliedColour ToPremultiplied(this Color4 colour) => PremultipliedColour.FromStraight(colour);
     }
 }

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics
 
         public static BlendingParameters Mixture => new BlendingParameters
         {
-            Source = BlendingType.SrcAlpha,
+            Source = BlendingType.One,
             Destination = BlendingType.OneMinusSrcAlpha,
             SourceAlpha = BlendingType.One,
             DestinationAlpha = BlendingType.One,
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics
 
         public static BlendingParameters Additive => new BlendingParameters
         {
-            Source = BlendingType.SrcAlpha,
+            Source = BlendingType.One,
             Destination = BlendingType.One,
             SourceAlpha = BlendingType.One,
             DestinationAlpha = BlendingType.One,
@@ -123,7 +123,7 @@ namespace osu.Framework.Graphics
         public void ApplyDefaultToInherited()
         {
             if (Source == BlendingType.Inherit)
-                Source = BlendingType.SrcAlpha;
+                Source = BlendingType.One;
 
             if (Destination == BlendingType.Inherit)
                 Destination = BlendingType.OneMinusSrcAlpha;

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -5,6 +5,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Statistics;
@@ -99,7 +100,7 @@ namespace osu.Framework.Graphics
                         // We need to draw children as if they were zero-based to the top-left of the texture.
                         // We can do this by adding a translation component to our (orthogonal) projection matrix.
                         renderer.PushOrtho(screenSpaceDrawRectangle);
-                        renderer.Clear(new ClearInfo(backgroundColour));
+                        renderer.Clear(new ClearInfo(backgroundColour.ToPremultiplied()));
 
                         DrawOther(Child, renderer);
 

--- a/osu.Framework/Graphics/Colour/PremultipliedColour.cs
+++ b/osu.Framework/Graphics/Colour/PremultipliedColour.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Colour
+{
+    /// <summary>
+    /// Represents a <see cref="Color4"/> provided in premultiplied-alpha form.
+    /// </summary>
+    public readonly struct PremultipliedColour : IEquatable<PremultipliedColour>
+    {
+        /// <summary>
+        /// The <see cref="Color4"/> after alpha multiplication.
+        /// </summary>
+        public readonly Color4 Premultiplied;
+
+        private PremultipliedColour(Color4 premultiplied)
+        {
+            Premultiplied = premultiplied;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PremultipliedColour"/> from a straight-alpha colour.
+        /// </summary>
+        /// <param name="colour">The straight-alpha colour.</param>
+        public static PremultipliedColour FromStraight(Color4 colour)
+        {
+            colour.R *= colour.A;
+            colour.G *= colour.A;
+            colour.B *= colour.A;
+            return new PremultipliedColour(colour);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PremultipliedColour"/> from a premultiplied-alpha colour.
+        /// </summary>
+        /// <param name="colour">The premultiplied-alpha colour.</param>
+        public static PremultipliedColour FromPremultiplied(Color4 colour) => new PremultipliedColour(colour);
+
+        public bool Equals(PremultipliedColour other) => Premultiplied.Equals(other.Premultiplied);
+    }
+}

--- a/osu.Framework/Graphics/Colour4.cs
+++ b/osu.Framework/Graphics/Colour4.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Globalization;
 using System.Numerics;
+using osu.Framework.Graphics.Colour;
 using osuTK.Graphics;
 
 namespace osu.Framework.Graphics
@@ -546,6 +547,12 @@ namespace osu.Framework.Graphics
 
             return new Vector4(hue, saturation, lightness, A);
         }
+
+        /// <summary>
+        /// Converts this <see cref="Colour4"/> to premultiplied alpha and returns a resultant <see cref="PremultipliedColour"/>.
+        /// This colour is assumed to be in straight-alpha form.
+        /// </summary>
+        public PremultipliedColour ToPremultiplied() => PremultipliedColour.FromStraight(this);
 
         private const double gamma = 2.4;
 

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
 using osu.Framework.Graphics.Shaders;
 using System.Diagnostics;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Framework.Graphics.Lines
 {
@@ -105,19 +106,19 @@ namespace osu.Framework.Graphics.Lines
                 {
                     Position = new Vector3(segmentRight.EndPoint.X, segmentRight.EndPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentRight.EndPoint)
+                    Colour = colourAt(segmentRight.EndPoint).ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = new Vector3(segmentRight.StartPoint.X, segmentRight.StartPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentRight.StartPoint)
+                    Colour = colourAt(segmentRight.StartPoint).ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = firstMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = firstMiddleColour
+                    Colour = firstMiddleColour.ToPremultiplied()
                 });
 
                 // Outer quad, triangle 2
@@ -125,19 +126,19 @@ namespace osu.Framework.Graphics.Lines
                 {
                     Position = firstMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = firstMiddleColour
+                    Colour = firstMiddleColour.ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = secondMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = secondMiddleColour
+                    Colour = secondMiddleColour.ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = new Vector3(segmentRight.EndPoint.X, segmentRight.EndPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentRight.EndPoint)
+                    Colour = colourAt(segmentRight.EndPoint).ToPremultiplied()
                 });
 
                 // Inner quad, triangle 1
@@ -145,19 +146,19 @@ namespace osu.Framework.Graphics.Lines
                 {
                     Position = firstMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = firstMiddleColour
+                    Colour = firstMiddleColour.ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = secondMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = secondMiddleColour
+                    Colour = secondMiddleColour.ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = new Vector3(segmentLeft.EndPoint.X, segmentLeft.EndPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentLeft.EndPoint)
+                    Colour = colourAt(segmentLeft.EndPoint).ToPremultiplied()
                 });
 
                 // Inner quad, triangle 2
@@ -165,19 +166,19 @@ namespace osu.Framework.Graphics.Lines
                 {
                     Position = new Vector3(segmentLeft.EndPoint.X, segmentLeft.EndPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentLeft.EndPoint)
+                    Colour = colourAt(segmentLeft.EndPoint).ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = new Vector3(segmentLeft.StartPoint.X, segmentLeft.StartPoint.Y, 0),
                     TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                    Colour = colourAt(segmentLeft.StartPoint)
+                    Colour = colourAt(segmentLeft.StartPoint).ToPremultiplied()
                 });
                 triangleBatch.Add(new TexturedVertex3D
                 {
                     Position = firstMiddlePoint,
                     TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                    Colour = firstMiddleColour
+                    Colour = firstMiddleColour.ToPremultiplied()
                 });
             }
 
@@ -214,7 +215,7 @@ namespace osu.Framework.Graphics.Lines
                     {
                         Position = new Vector3(origin.X, origin.Y, 1),
                         TexturePosition = new Vector2(texRect.Right, texRect.Centre.Y),
-                        Colour = originColour
+                        Colour = originColour.ToPremultiplied()
                     });
 
                     // First outer point
@@ -222,7 +223,7 @@ namespace osu.Framework.Graphics.Lines
                     {
                         Position = new Vector3(current.X, current.Y, 0),
                         TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                        Colour = currentColour
+                        Colour = currentColour.ToPremultiplied()
                     });
 
                     current = i < stepCount ? origin + pointOnCircle(theta0 + i * thetaStep) * radius : end;
@@ -233,7 +234,7 @@ namespace osu.Framework.Graphics.Lines
                     {
                         Position = new Vector3(current.X, current.Y, 0),
                         TexturePosition = new Vector2(texRect.Left, texRect.Centre.Y),
-                        Colour = currentColour
+                        Colour = currentColour.ToPremultiplied()
                     });
                 }
             }

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -75,13 +75,12 @@ namespace osu.Framework.Graphics.Lines
                 float progress = (float)i / (textureWidth - 1);
 
                 var colour = ColourAt(progress);
-                raw[i, 0] = new Rgba32(colour.R, colour.G, colour.B, colour.A * Math.Min(progress / aa_portion, 1));
+                float alpha = Math.Min(progress / aa_portion, 1);
+                raw[i, 0] = new Rgba32(colour.R * alpha, colour.G * alpha, colour.B * alpha, colour.A * alpha);
             }
 
             if (Texture?.Width == textureWidth)
-            {
                 Texture.SetData(new TextureUpload(raw));
-            }
             else
             {
                 var texture = new DisposableTexture(renderer.CreateTexture(textureWidth, 1, true));

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -8,7 +8,6 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osuTK.Graphics;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Lines
@@ -66,7 +65,7 @@ namespace osu.Framework.Graphics.Lines
             int textureWidth = (int)PathRadius * 2;
 
             //initialise background
-            var raw = new Image<Rgba32>(textureWidth, 1);
+            var raw = new PremultipliedImage(textureWidth, 1);
 
             const float aa_portion = 0.02f;
 
@@ -76,7 +75,7 @@ namespace osu.Framework.Graphics.Lines
 
                 var colour = ColourAt(progress);
                 float alpha = Math.Min(progress / aa_portion, 1);
-                raw[i, 0] = new Rgba32(colour.R * alpha, colour.G * alpha, colour.B * alpha, colour.A * alpha);
+                raw.Premultiplied[i, 0] = new Rgba32(colour.R * alpha, colour.G * alpha, colour.B * alpha, colour.A * alpha);
             }
 
             if (Texture?.Width == textureWidth)

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -238,8 +238,8 @@ namespace osu.Framework.Graphics.OpenGL
 
         protected override void ClearImplementation(ClearInfo clearInfo)
         {
-            if (clearInfo.Colour != CurrentClearInfo.Colour)
-                GL.ClearColor(clearInfo.Colour);
+            if (!clearInfo.Colour.Equals(CurrentClearInfo.Colour))
+                GL.ClearColor(clearInfo.Colour.Premultiplied);
 
             if (clearInfo.Depth != CurrentClearInfo.Depth)
             {

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -23,7 +23,6 @@ using osu.Framework.Graphics.Pooling;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Platform;
 using osuTK;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using WindowState = osu.Framework.Platform.WindowState;
 
@@ -255,14 +254,14 @@ namespace osu.Framework.Graphics.Performance
         {
             //initialise background
             var columnUpload = new ArrayPoolTextureUpload(1, HEIGHT);
-            var fullBackground = new Image<Rgba32>(WIDTH, HEIGHT);
+            var fullBackground = new PremultipliedImage(WIDTH, HEIGHT);
 
             addArea(null, null, HEIGHT, amount_ms_steps, columnUpload);
 
             for (int i = 0; i < HEIGHT; i++)
             {
                 for (int k = 0; k < WIDTH; k++)
-                    fullBackground[k, i] = columnUpload.RawData[i];
+                    fullBackground.Premultiplied[k, i] = columnUpload.RawData[i];
             }
 
             addArea(null, null, HEIGHT, amount_count_steps, columnUpload);
@@ -506,7 +505,7 @@ namespace osu.Framework.Graphics.Performance
                 else if (acceptableRange)
                     brightnessAdjust *= 0.8f;
 
-                columnUpload.RawData[i] = new Rgba32(col.R * brightnessAdjust, col.G * brightnessAdjust, col.B * brightnessAdjust, col.A);
+                columnUpload.RawData[i] = new Rgba32(col.R * col.A * brightnessAdjust, col.G * col.A * brightnessAdjust, col.B * col.A * brightnessAdjust, col.A);
 
                 currentHeight--;
             }

--- a/osu.Framework/Graphics/Rendering/ClearInfo.cs
+++ b/osu.Framework/Graphics/Rendering/ClearInfo.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osuTK.Graphics;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Rendering
 {
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// The colour to write to the frame buffer.
         /// </summary>
-        public readonly Color4 Colour;
+        public readonly PremultipliedColour Colour;
 
         /// <summary>
         /// The depth to write to the frame buffer.
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Rendering
         /// </summary>
         public readonly int Stencil;
 
-        public ClearInfo(Color4 colour = default, double depth = 1f, int stencil = 0)
+        public ClearInfo(PremultipliedColour colour = default, double depth = 1f, int stencil = 0)
         {
             Colour = colour;
             Depth = depth;

--- a/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
+++ b/osu.Framework/Graphics/Rendering/GlobalUniformData.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Rendering
         public UniformFloat BorderThickness;
         private readonly UniformPadding12 pad3;
 
-        public UniformMatrix4 BorderColour;
+        public UniformColourInfo BorderColour;
         public UniformFloat MaskingBlendRange;
         public UniformFloat AlphaExponent;
         public UniformVector2 EdgeOffset;

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -975,27 +975,7 @@ namespace osu.Framework.Graphics.Rendering
                         currentMaskingInfo.MaskingRect.Bottom),
                     BorderThickness = currentMaskingInfo.BorderThickness / currentMaskingInfo.BlendRange,
                     BorderColour = currentMaskingInfo.BorderThickness > 0
-                        ? new Matrix4(
-                            // TopLeft
-                            currentMaskingInfo.BorderColour.TopLeft.SRGB.R,
-                            currentMaskingInfo.BorderColour.TopLeft.SRGB.G,
-                            currentMaskingInfo.BorderColour.TopLeft.SRGB.B,
-                            currentMaskingInfo.BorderColour.TopLeft.SRGB.A,
-                            // BottomLeft
-                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.R,
-                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.G,
-                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.B,
-                            currentMaskingInfo.BorderColour.BottomLeft.SRGB.A,
-                            // TopRight
-                            currentMaskingInfo.BorderColour.TopRight.SRGB.R,
-                            currentMaskingInfo.BorderColour.TopRight.SRGB.G,
-                            currentMaskingInfo.BorderColour.TopRight.SRGB.B,
-                            currentMaskingInfo.BorderColour.TopRight.SRGB.A,
-                            // BottomRight
-                            currentMaskingInfo.BorderColour.BottomRight.SRGB.R,
-                            currentMaskingInfo.BorderColour.BottomRight.SRGB.G,
-                            currentMaskingInfo.BorderColour.BottomRight.SRGB.B,
-                            currentMaskingInfo.BorderColour.BottomRight.SRGB.A)
+                        ? currentMaskingInfo.BorderColour
                         : globalUniformBuffer.Data.BorderColour,
                     MaskingBlendRange = currentMaskingInfo.BlendRange,
                     AlphaExponent = currentMaskingInfo.AlphaExponent,
@@ -1281,7 +1261,9 @@ namespace osu.Framework.Graphics.Rendering
                 if (field.FieldType == typeof(UniformMatrix3)
                     || field.FieldType == typeof(UniformMatrix4)
                     || field.FieldType == typeof(UniformVector3)
-                    || field.FieldType == typeof(UniformVector4))
+                    || field.FieldType == typeof(UniformVector4)
+                    || field.FieldType == typeof(UniformColour)
+                    || field.FieldType == typeof(UniformColourInfo))
                 {
                     checkAlignment(field, offset, 16);
                 }
@@ -1310,8 +1292,10 @@ namespace osu.Framework.Graphics.Rendering
                     || field.FieldType == typeof(UniformPadding8)
                     || field.FieldType == typeof(UniformPadding12)
                     || field.FieldType == typeof(UniformVector2)
+                    || field.FieldType == typeof(UniformVector3)
                     || field.FieldType == typeof(UniformVector4)
-                    || field.FieldType == typeof(UniformVector4))
+                    || field.FieldType == typeof(UniformColour)
+                    || field.FieldType == typeof(UniformColourInfo))
                 {
                     return;
                 }

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using osu.Framework.Development;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -265,7 +266,7 @@ namespace osu.Framework.Graphics.Rendering
             PushDepthInfo(DepthInfo.Default);
             PushStencilInfo(StencilInfo.Default);
 
-            Clear(new ClearInfo(Color4.Black));
+            Clear(new ClearInfo(Color4.Black.ToPremultiplied()));
 
             freeUnusedVertexBuffers();
             vboInUse.Value = vertexBuffersInUse.Count;

--- a/osu.Framework/Graphics/Rendering/RendererExtensions.cs
+++ b/osu.Framework/Graphics/Rendering/RendererExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Primitives;
@@ -70,7 +71,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2((inflatedCoordRect.Left + inflatedCoordRect.Right) / 2, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = topColour.SRGB,
+                Colour = topColour.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -78,7 +79,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = drawColour.BottomLeft.SRGB,
+                Colour = drawColour.BottomLeft.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -86,7 +87,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2((inflatedCoordRect.Left + inflatedCoordRect.Right) / 2, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = bottomColour.SRGB,
+                Colour = bottomColour.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -94,7 +95,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = drawColour.BottomRight.SRGB,
+                Colour = drawColour.BottomRight.SRGB.ToPremultiplied(),
             });
 
             long area = (long)vertexTriangle.Area;
@@ -154,7 +155,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.BottomLeft.SRGB,
+                Colour = drawColour.BottomLeft.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -162,7 +163,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.BottomRight.SRGB,
+                Colour = drawColour.BottomRight.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -170,7 +171,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Right, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.TopRight.SRGB,
+                Colour = drawColour.TopRight.SRGB.ToPremultiplied(),
             });
             vertexAction(new TexturedVertex2D(renderer)
             {
@@ -178,7 +179,7 @@ namespace osu.Framework.Graphics.Rendering
                 TexturePosition = new Vector2(inflatedCoordRect.Left, inflatedCoordRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = blendRange,
-                Colour = drawColour.TopLeft.SRGB,
+                Colour = drawColour.TopLeft.SRGB.ToPremultiplied(),
             });
 
             long area = (long)vertexQuad.Area;

--- a/osu.Framework/Graphics/Rendering/Vertices/ParticleVertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/ParticleVertex2D.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering.Vertices
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public Vector2 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 TexturePosition;

--- a/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex2D.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering.Vertices
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public Vector2 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 TexturePosition;

--- a/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex3D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/TexturedVertex3D.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering.Vertices
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public Vector3 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 TexturePosition;

--- a/osu.Framework/Graphics/Rendering/Vertices/TimedTexturedVertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/TimedTexturedVertex2D.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering.Vertices
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public Vector2 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 TexturePosition;

--- a/osu.Framework/Graphics/Rendering/Vertices/Vertex2D.cs
+++ b/osu.Framework/Graphics/Rendering/Vertices/Vertex2D.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
 using osuTK;
-using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Rendering.Vertices
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Rendering.Vertices
         public Vector2 Position;
 
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        public PremultipliedColour Colour;
 
         public readonly bool Equals(Vertex2D other) => Position.Equals(other.Position) && Colour.Equals(other.Colour);
     }

--- a/osu.Framework/Graphics/Shaders/Types/UniformColour.cs
+++ b/osu.Framework/Graphics/Shaders/Types/UniformColour.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Colour;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Shaders.Types
+{
+    /// <summary>
+    /// Must be aligned to a 16-byte boundary. Enforces colours to be in premultiplied-alpha form.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 16)]
+    public record struct UniformColour
+    {
+        public UniformVector4 Value;
+
+        public static implicit operator PremultipliedColour(UniformColour value)
+            => PremultipliedColour.FromPremultiplied(new Color4(value.Value.X, value.Value.Y, value.Value.Z, value.Value.W));
+
+        public static implicit operator UniformColour(PremultipliedColour value) => new UniformColour
+        {
+            Value =
+            {
+                X = value.Premultiplied.R,
+                Y = value.Premultiplied.G,
+                Z = value.Premultiplied.B,
+                W = value.Premultiplied.A,
+            }
+        };
+    }
+}

--- a/osu.Framework/Graphics/Shaders/Types/UniformColourInfo.cs
+++ b/osu.Framework/Graphics/Shaders/Types/UniformColourInfo.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.InteropServices;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
+
+namespace osu.Framework.Graphics.Shaders.Types
+{
+    /// <summary>
+    /// Must be aligned to a 16-byte boundary. Wraps <see cref="ColourInfo"/> in a <see cref="UniformMatrix4"/> structure
+    /// with the rows containing top-left, bottom-left, top-right, bottom-right respectively. Alpha pre-multiplication is applied.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 64)]
+    public record struct UniformColourInfo
+    {
+        public UniformMatrix4 Value;
+
+        public static implicit operator UniformColourInfo(ColourInfo value) => new UniformColourInfo
+        {
+            Value =
+            {
+                Row0 = ((UniformColour)value.TopLeft.SRGB.ToPremultiplied()).Value,
+                Row1 = ((UniformColour)value.BottomLeft.SRGB.ToPremultiplied()).Value,
+                Row2 = ((UniformColour)value.TopRight.SRGB.ToPremultiplied()).Value,
+                Row3 = ((UniformColour)value.BottomRight.SRGB.ToPremultiplied()).Value,
+            }
+        };
+    }
+}

--- a/osu.Framework/Graphics/Shapes/FastCircle.cs
+++ b/osu.Framework/Graphics/Shapes/FastCircle.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -97,7 +98,7 @@ namespace osu.Framework.Graphics.Shapes
                     TexturePosition = new Vector2(0, drawRectangle.W),
                     TextureRect = drawRectangle,
                     BlendRange = blend,
-                    Colour = DrawColourInfo.Colour.BottomLeft.SRGB,
+                    Colour = DrawColourInfo.Colour.BottomLeft.SRGB.ToPremultiplied(),
                 });
                 vertexAction(new TexturedVertex2D(renderer)
                 {
@@ -105,7 +106,7 @@ namespace osu.Framework.Graphics.Shapes
                     TexturePosition = new Vector2(drawRectangle.Z, drawRectangle.W),
                     TextureRect = drawRectangle,
                     BlendRange = blend,
-                    Colour = DrawColourInfo.Colour.BottomRight.SRGB,
+                    Colour = DrawColourInfo.Colour.BottomRight.SRGB.ToPremultiplied(),
                 });
                 vertexAction(new TexturedVertex2D(renderer)
                 {
@@ -113,7 +114,7 @@ namespace osu.Framework.Graphics.Shapes
                     TexturePosition = new Vector2(drawRectangle.Z, 0),
                     TextureRect = drawRectangle,
                     BlendRange = blend,
-                    Colour = DrawColourInfo.Colour.TopRight.SRGB,
+                    Colour = DrawColourInfo.Colour.TopRight.SRGB.ToPremultiplied(),
                 });
                 vertexAction(new TexturedVertex2D(renderer)
                 {
@@ -121,7 +122,7 @@ namespace osu.Framework.Graphics.Shapes
                     TexturePosition = Vector2.Zero,
                     TextureRect = drawRectangle,
                     BlendRange = blend,
-                    Colour = DrawColourInfo.Colour.TopLeft.SRGB,
+                    Colour = DrawColourInfo.Colour.TopLeft.SRGB.ToPremultiplied(),
                 });
 
                 shader.Unbind();

--- a/osu.Framework/Graphics/Textures/PremultipliedImage.cs
+++ b/osu.Framework/Graphics/Textures/PremultipliedImage.cs
@@ -26,8 +26,8 @@ namespace osu.Framework.Graphics.Textures
         {
         }
 
-        public PremultipliedImage(int width, int height, SRGBColour colour) // todo: colour will be called PremultipliedColour
-            : this(new Image<Rgba32>(width, height, new Rgba32(colour.SRGB.R, colour.SRGB.G, colour.SRGB.B, colour.SRGB.A)))
+        public PremultipliedImage(int width, int height, PremultipliedColour colour)
+            : this(new Image<Rgba32>(width, height, new Rgba32(colour.Premultiplied.R, colour.Premultiplied.G, colour.Premultiplied.B, colour.Premultiplied.A)))
         {
         }
 

--- a/osu.Framework/Graphics/Textures/PremultipliedImage.cs
+++ b/osu.Framework/Graphics/Textures/PremultipliedImage.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Colour;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace osu.Framework.Graphics.Textures
+{
+    public class PremultipliedImage : IDisposable
+    {
+        /// <summary>
+        /// The underlying image in <see cref="Image{TPixel}"/> form.
+        /// </summary>
+        public readonly Image<Rgba32> Premultiplied;
+
+        private PremultipliedImage(Image<Rgba32> premultiplied)
+        {
+            Premultiplied = premultiplied;
+        }
+
+        public PremultipliedImage(int width, int height)
+            : this(new Image<Rgba32>(width, height))
+        {
+        }
+
+        public PremultipliedImage(int width, int height, SRGBColour colour) // todo: colour will be called PremultipliedColour
+            : this(new Image<Rgba32>(width, height, new Rgba32(colour.SRGB.R, colour.SRGB.G, colour.SRGB.B, colour.SRGB.A)))
+        {
+        }
+
+        public PremultipliedImage Clone() => FromPremultiplied(Premultiplied.Clone());
+
+        public void Dispose()
+        {
+            Premultiplied.Dispose();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PremultipliedImage"/> from a non-premultiplied source <see cref="Image{Rgba32}"/> by converting colours to premultiplied.
+        /// </summary>
+        /// <param name="image">The non-premultiplied source image.</param>
+        public static PremultipliedImage FromStraight(Image<Rgba32> image)
+        {
+            var premultiplied = image.Clone();
+            premultiplied.Mutate(p => p.ProcessPixelRowsAsVector4(r =>
+            {
+                foreach (ref var pixel in r)
+                {
+                    pixel.X *= pixel.W;
+                    pixel.Y *= pixel.W;
+                    pixel.Z *= pixel.W;
+                }
+            }));
+
+            return new PremultipliedImage(premultiplied);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PremultipliedImage"/> from a premultiplied source <see cref="Image{Rgba32}"/>. No conversion is done in this method.
+        /// </summary>
+        /// <param name="image">The premultiplied source image.</param>
+        public static PremultipliedImage FromPremultiplied(Image<Rgba32> image) => new PremultipliedImage(image);
+    }
+}

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Numerics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -84,7 +81,7 @@ namespace osu.Framework.Graphics.Textures
 
                 using (var whiteTex = new TextureRegion(atlasTexture, bounds, WrapMode.Repeat, WrapMode.Repeat))
                     // Generate white padding as if the white texture was wrapped, even though it isn't
-                    whiteTex.SetData(new TextureUpload(new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, whiteTex.Width, whiteTex.Height, new Rgba32(Vector4.One))));
+                    whiteTex.SetData(new TextureUpload(new PremultipliedImage(whiteTex.Width, whiteTex.Height, Colour4.White)));
 
                 currentPosition = new Vector2I(PADDING + WHITE_PIXEL_SIZE, PADDING);
             }

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Graphics.Textures
 
                 using (var whiteTex = new TextureRegion(atlasTexture, bounds, WrapMode.Repeat, WrapMode.Repeat))
                     // Generate white padding as if the white texture was wrapped, even though it isn't
-                    whiteTex.SetData(new TextureUpload(new PremultipliedImage(whiteTex.Width, whiteTex.Height, Colour4.White)));
+                    whiteTex.SetData(new TextureUpload(new PremultipliedImage(whiteTex.Width, whiteTex.Height, Colour4.White.ToPremultiplied())));
 
                 currentPosition = new Vector2I(PADDING + WHITE_PIXEL_SIZE, PADDING);
             }

--- a/osu.Framework/Graphics/Textures/TextureAtlas_BackingAtlasTexture.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas_BackingAtlasTexture.cs
@@ -215,10 +215,10 @@ namespace osu.Framework.Graphics.Textures
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void transferBorderPixel(ref Rgba32 dest, Rgba32 source, bool fillOpaque)
             {
-                dest.R = source.R;
-                dest.G = source.G;
-                dest.B = source.B;
                 dest.A = fillOpaque ? source.A : (byte)0;
+                dest.R = (byte)(source.R * (dest.A / 255.0));
+                dest.G = (byte)(source.G * (dest.A / 255.0));
+                dest.B = (byte)(source.B * (dest.A / 255.0));
             }
 
             /// <summary>

--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -9,8 +9,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.IO.Stores;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -38,7 +36,7 @@ namespace osu.Framework.Graphics.Textures
                 using (var stream = store.GetStream(name))
                 {
                     if (stream != null)
-                        return new TextureUpload(ImageFromStream<Rgba32>(stream));
+                        return new TextureUpload(ImageFromStream(stream));
                 }
             }
             catch
@@ -50,8 +48,7 @@ namespace osu.Framework.Graphics.Textures
 
         public Stream GetStream(string name) => store.GetStream(name);
 
-        protected virtual Image<TPixel> ImageFromStream<TPixel>(Stream stream) where TPixel : unmanaged, IPixel<TPixel>
-            => TextureUpload.LoadFromStream<TPixel>(stream);
+        protected virtual PremultipliedImage ImageFromStream(Stream stream) => TextureUpload.LoadFromStream(stream);
 
         public IEnumerable<string> GetAvailableResources() => store.GetAvailableResources();
 

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -38,16 +38,19 @@ namespace osu.Framework.Graphics.Textures
         /// </summary>
         public RectangleI Bounds { get; set; }
 
+        /// <summary>
+        /// Overview of the texture upload's pixels content. The pixel colours are alpha-premultiplied.
+        /// </summary>
         public ReadOnlySpan<Rgba32> Data => pixelMemory.Span;
 
-        public int Width => image?.Width ?? 0;
+        public int Width => image?.Premultiplied.Width ?? 0;
 
-        public int Height => image?.Height ?? 0;
+        public int Height => image?.Premultiplied.Height ?? 0;
 
         /// <summary>
         /// The backing texture. A handle is kept to avoid early GC.
         /// </summary>
-        private readonly Image<Rgba32> image;
+        private readonly PremultipliedImage image;
 
         private ReadOnlyPixelMemory<Rgba32> pixelMemory;
 
@@ -55,10 +58,10 @@ namespace osu.Framework.Graphics.Textures
         /// Create an upload from a <see cref="TextureUpload"/>. This is the preferred method.
         /// </summary>
         /// <param name="image">The texture to upload.</param>
-        public TextureUpload(Image<Rgba32> image)
+        public TextureUpload(PremultipliedImage image)
         {
             this.image = image;
-            pixelMemory = image.CreateReadOnlyPixelMemory();
+            pixelMemory = image.Premultiplied.CreateReadOnlyPixelMemory();
         }
 
         /// <summary>
@@ -68,16 +71,16 @@ namespace osu.Framework.Graphics.Textures
         /// </summary>
         /// <param name="stream">The image content.</param>
         public TextureUpload(Stream stream)
-            : this(LoadFromStream<Rgba32>(stream))
+            : this(LoadFromStream(stream))
         {
         }
 
         private static bool stbiNotFound;
 
-        internal static Image<TPixel> LoadFromStream<TPixel>(Stream stream) where TPixel : unmanaged, IPixel<TPixel>
+        internal static PremultipliedImage LoadFromStream(Stream stream)
         {
             if (stbiNotFound)
-                return Image.Load<TPixel>(stream);
+                return PremultipliedImage.FromStraight(Image.Load<Rgba32>(stream));
 
             long initialPos = stream.Position;
 
@@ -88,7 +91,7 @@ namespace osu.Framework.Graphics.Textures
                     stream.ReadExactly(buffer.Memory.Span);
 
                     using (var stbiImage = Stbi.LoadFromMemory(buffer.Memory.Span, 4))
-                        return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
+                        return PremultipliedImage.FromStraight(Image.LoadPixelData(MemoryMarshal.Cast<byte, Rgba32>(stbiImage.Data), stbiImage.Width, stbiImage.Height));
                 }
             }
             catch (Exception e)
@@ -98,7 +101,7 @@ namespace osu.Framework.Graphics.Textures
 
                 Logger.Log($"Texture could not be loaded via STB; falling back to ImageSharp: {e.Message}");
                 stream.Position = initialPos;
-                return Image.Load<TPixel>(stream);
+                return PremultipliedImage.FromStraight(Image.Load<Rgba32>(stream));
             }
         }
 

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         /// <param name="clearInfo">The clearing parameters.</param>
         public void Clear(ClearInfo clearInfo)
         {
-            Commands.ClearColorTarget(0, clearInfo.Colour.ToRgbaFloat());
+            Commands.ClearColorTarget(0, clearInfo.Colour.Premultiplied.ToRgbaFloat());
 
             var framebuffer = currentFrameBuffer?.Framebuffer ?? Device.SwapchainFramebuffer;
             if (framebuffer.DepthTarget != null)

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Framework.Text;
 using SharpFNT;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -166,7 +165,7 @@ namespace osu.Framework.IO.Stores
             var page = GetPageImage(character.Page);
             LoadedGlyphCount++;
 
-            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, character.Width, character.Height);
+            var image = new PremultipliedImage(character.Width, character.Height);
             var source = page.Data;
 
             // the spritesheet may have unused pixels trimmed
@@ -175,11 +174,11 @@ namespace osu.Framework.IO.Stores
 
             for (int y = 0; y < character.Height; y++)
             {
-                var pixelRowMemory = image.DangerousGetPixelRowMemory(y);
+                var pixelRowMemory = image.Premultiplied.DangerousGetPixelRowMemory(y);
                 int readOffset = (character.Y + y) * page.Width + character.X;
 
                 for (int x = 0; x < character.Width; x++)
-                    pixelRowMemory.Span[x] = x < readableWidth && y < readableHeight ? source[readOffset + x] : new Rgba32(255, 255, 255, 0);
+                    pixelRowMemory.Span[x] = x < readableWidth && y < readableHeight ? source[readOffset + x] : new Rgba32(0, 0, 0, 0);
             }
 
             return new TextureUpload(image);

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.IO.Stores
 
             try
             {
-                var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, character.Width, character.Height);
+                var image = new PremultipliedImage(character.Width, character.Height);
 
                 if (!pageStreamHandles.TryGetValue(page.Filename, out var source))
                     source = pageStreamHandles[page.Filename] = CacheStorage.GetStream(page.Filename);
@@ -156,7 +156,7 @@ namespace osu.Framework.IO.Stores
 
                 for (int y = 0; y < character.Height; y++)
                 {
-                    var pixelRowMemory = image.DangerousGetPixelRowMemory(y);
+                    var pixelRowMemory = image.Premultiplied.DangerousGetPixelRowMemory(y);
                     var span = pixelRowMemory.Span;
                     int readOffset = y * pageWidth + character.X;
 

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -162,7 +162,8 @@ namespace osu.Framework.IO.Stores
 
                     for (int x = 0; x < character.Width; x++)
                     {
-                        span[x] = new Rgba32(255, 255, 255, x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0);
+                        byte val = x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0;
+                        span[x] = new Rgba32(val, val, val, val);
                     }
                 }
 

--- a/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularBlob.fs
@@ -33,7 +33,7 @@ void main(void)
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
 
-    o_Colour = vec4(textureColour.rgb, textureColour.a * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition));
+    o_Colour = textureColour.rgba * blobAlphaAt(pixelPos, innerRadius, texelSize, frequency, amplitude, noisePosition);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -32,7 +32,7 @@ void main(void)
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
 
-    o_Colour = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
+    o_Colour = textureColour.rgba * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_FastCircle.fs
+++ b/osu.Framework/Resources/Shaders/sh_FastCircle.fs
@@ -20,7 +20,7 @@ void main(void)
 
     highp float alpha = v_BlendRange.x == 0.0 ? float(dst < radius) : (clamp(radius - dst, 0.0, v_BlendRange.x) / v_BlendRange.x);
 
-    o_Colour = getRoundedColor(vec4(vec3(1.0), alpha), vec2(0.0));
+    o_Colour = getRoundedColor(vec4(alpha), vec2(0.0));
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -116,15 +116,15 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	lowp vec4 contentColour = v_Colour * texel;
 
 	if (colourWeight == 1.0)
-		return vec4(contentColour.rgb, contentColour.a * alphaFactor);
+		return contentColour.rgba * alphaFactor;
 
 	lowp vec4 borderColour = getBorderColour();
 
 	if (colourWeight <= 0.0)
-		return vec4(borderColour.rgb, borderColour.a * alphaFactor);
+		return borderColour.rgba * alphaFactor;
 
-	contentColour.a *= alphaFactor;
-	borderColour.a *= 1.0 - colourWeight;
+	contentColour.rgba *= alphaFactor;
+	borderColour.rgba *= 1.0 - colourWeight;
 	return blend(borderColour, contentColour);
 }
 

--- a/osu.Framework/Resources/Shaders/sh_Particle.vs
+++ b/osu.Framework/Resources/Shaders/sh_Particle.vs
@@ -23,7 +23,7 @@ void main(void)
 		vec2(0.0, g_Gravity * g_FadeClock * g_FadeClock / 1000000.0);
 
 	gl_Position = g_ProjMatrix * vec4(targetPosition, 1.0, 1.0);
-	v_Colour = vec4(1.0, 1.0, 1.0, 1.0 - clamp(g_FadeClock / m_Time, 0.0, 1.0));
+	v_Colour = vec4(1.0 - clamp(g_FadeClock / m_Time, 0.0, 1.0));
 	v_TexCoord = m_TexCoord;
 }
 

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -8,15 +8,7 @@
 // see http://apoorvaj.io/alpha-compositing-opengl-blending-and-premultiplied-alpha.html
 lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
 {
-    lowp float finalAlpha = src.a + dst.a * (1.0 - src.a);
-
-    if (finalAlpha == 0.0)
-        return vec4(0);
-
-    return vec4(
-        (src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / finalAlpha,
-        finalAlpha
-    );
+    return src.rgba + dst.rgba * (1.0 - src.a);
 }
 
 // http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/3429
- Closes https://github.com/ppy/osu/issues/19957
- Alternative to / closes https://github.com/ppy/osu-framework/pull/6454

RFC, cc @ppy/team-client.

The efforts of this started when I noticed that iOS always outputs premultiplied image pixels when loading them via `UIImage`. Searching on the internet for methods to avoid this behaviour has shown nothing, and after opening a PR manually "fixing" this, https://github.com/ppy/osu-framework/pull/6454#discussion_r1883133383 came up, which shown that we can take a different route and switch permanently to premultiplied colours for textures and shaders, as [discussed](https://discord.com/channels/188630481301012481/589331078574112768/1317061282532429897).

Consider this an initial approach meant to stir discussions on the introduced API and intended direction.

Multiple classes have been introduced to emphasize on the concept of "premultiplied colours" in rendering, most of which are one-way conversion, meaning that a regular (aka straight-alpha) colour transformed into a premultiplied-alpha colour cannot be transformed back, as the conversion is technically lossy when given zero alpha, and I generally want to avoid implicit conversions from/to `Color4` as much as possible.

There is not much to note about the changes, but, as a breakdown of introduced classes:
 - `PremultipliedImage`: Exposes an image with alpha multiplication applied. The image may originally be in straight-alpha form converted using `FromStraight`, or already premultiplied (aka iOS) and wrapped in the structure using `FromPremultiplied`.
 - `PremultipliedColour`: Exposes a `Color4` with alpha multiplication applied. Works similar to `PremultipliedImage`.
 - `UniformColour`: Special version of `UniformVector4` for colours specifically, stores colours as premultiplied. Implicitly converts from/to `PremultipliedColour`.
 - `UniformColourInfo`: This is introduced specifically for border colour specifications, as it was extremely too long and adding premultiplied API warranted this.