### PR TITLE
Invalidate mouse position when releasing final touch

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -277,6 +277,7 @@ namespace osu.Framework.Tests.Visual.Input
             {
                 AddStep($"deactivate {s}", () => InputManager.EndTouch(new Touch(s, getTouchUpPos(s))));
                 AddAssert("no mouse event received", () => receptors[(int)s].MouseEvents.Count == 0);
+                AddAssert("mouse is still valid", () => InputManager.CurrentState.Mouse.IsPositionValid);
             }
 
             AddStep("deactivate last", () =>
@@ -297,6 +298,7 @@ namespace osu.Framework.Tests.Visual.Input
 
                 return firstReceptor.MouseEvents.Count == 0;
             });
+            AddAssert("mouse is invalidated", () => !InputManager.CurrentState.Mouse.IsPositionValid);
 
             AddAssert("all events dequeued", () => receptors.All(r => r.MouseEvents.Count == 0));
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -794,6 +794,7 @@ namespace osu.Framework.Input
             if (!MapMouseToLatestTouch)
                 return false;
 
+            // Update mouse position state
             if (e.IsActive == true || e.LastPosition != null)
             {
                 new MousePositionAbsoluteInputFromTouch(e)
@@ -802,6 +803,7 @@ namespace osu.Framework.Input
                 }.Apply(CurrentState, this);
             }
 
+            // Update mouse button state
             if (e.IsActive != null)
             {
                 if (e.IsActive == true)
@@ -811,6 +813,11 @@ namespace osu.Framework.Input
 
                 updateTouchMouseLeft(e);
             }
+
+            // Invalidate mouse position if releasing last touch. This is done after updating button state
+            // for click events to be processed on the targeted input queue before the position is invalidated.
+            if (e.IsActive == false && !e.State.Touch.ActiveSources.HasAnyButtonPressed)
+                new MouseInvalidatePositionInputFromTouch(e).Apply(CurrentState, this);
 
             updateTouchMouseRight(e);
             return true;

--- a/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
@@ -9,9 +9,9 @@ namespace osu.Framework.Input.StateChanges.Events
     public class MousePositionChangeEvent : InputStateChangeEvent
     {
         /// <summary>
-        /// The last mouse position.
+        /// The last mouse position, or null if the event is invalidation of the mouse position state.
         /// </summary>
-        public readonly Vector2 LastPosition;
+        public readonly Vector2? LastPosition;
 
         public MousePositionChangeEvent(InputState state, IInput input, Vector2 lastPosition)
             : base(state, input)

--- a/osu.Framework/Input/StateChanges/MouseInvalidatePositionInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseInvalidatePositionInput.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+using osu.Framework.Input.States;
+
+namespace osu.Framework.Input.StateChanges
+{
+    /// <summary>
+    /// Denotes an invalidation of the current mouse position,
+    /// mainly used when a single remaining touch source is released,
+    /// or a hovering pen (e.g. Apple Pencil) leaves the screen area.
+    /// </summary>
+    public class MouseInvalidatePositionInput : IInput
+    {
+        public void Apply(InputState state, IInputStateChangeHandler handler)
+        {
+            var mouse = state.Mouse;
+
+            if (mouse.IsPositionValid)
+            {
+                mouse.IsPositionValid = false;
+                mouse.LastSource = this;
+                handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, mouse.Position));
+            }
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/MouseInvalidatePositionInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MouseInvalidatePositionInputFromTouch.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+
+namespace osu.Framework.Input.StateChanges
+{
+    public class MouseInvalidatePositionInputFromTouch : MouseInvalidatePositionInput, ISourcedFromTouch
+    {
+        public MouseInvalidatePositionInputFromTouch(TouchStateChangeEvent touchEvent)
+        {
+            TouchEvent = touchEvent;
+        }
+
+        public TouchStateChangeEvent TouchEvent { get; }
+    }
+}


### PR DESCRIPTION
This fixes an issue in mobile where if a user pressed a specific button in the game, the button will remain in a hovered state because that's where the mouse position was last at. Using the feedback of touch end event, we can put the mouse position in an "invalid" state such that any hovered drawable becomes unhovered, giving a more natural UX for mobile users.

Before:

https://github.com/user-attachments/assets/320cb5dc-d7ad-4e9a-9e52-ac91f4d016d9

After:

https://github.com/user-attachments/assets/5764a371-ebc1-48e6-824f-6d0fed15476a

(notice the buttons don't stay hovered after tapping them)