### PR TITLE
Fix disabling hold-to-right-click not cancelling in-progress actions

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -32,6 +32,8 @@ namespace osu.Framework.Tests.Visual.Input
         [SetUp]
         public new void SetUp() => Schedule(() =>
         {
+            InputManager.RightClickFromLongTouch = true;
+
             Children = new Drawable[]
             {
                 new Container

--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -606,6 +606,25 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("no right click received", () => primaryReceptor.MouseEvents.Count == 0 && secondaryReceptor.MouseEvents.Count == 0);
         }
 
+        [Test]
+        public void TestHoldTouchAndDisableHoldingBeforeRightClick()
+        {
+            InputReceptor primaryReceptor = null;
+
+            AddStep("retrieve primary receptor", () => primaryReceptor = receptors[(int)TouchSource.Touch1]);
+            AddStep("setup handlers to receive mouse-from-touch", () =>
+            {
+                primaryReceptor.HandleTouch = _ => false;
+                primaryReceptor.HandleMouse = e => e is MouseButtonEvent button && button.Button == MouseButton.Right;
+            });
+
+            AddStep("begin touch", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, getTouchDownPos(TouchSource.Touch1))));
+            AddWaitStep("hold shortly", 2);
+            AddStep("turn off hold-to-right-click", () => InputManager.RightClickFromLongTouch = false);
+            AddWaitStep("wait a bit", 4);
+            AddAssert("no right click received", () => primaryReceptor.MouseEvents.Count == 0);
+        }
+
         private partial class InputReceptor : Container
         {
             public readonly TouchSource AssociatedSource;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -507,6 +507,9 @@ namespace osu.Framework.Input
             if (FocusedDrawable == null)
                 focusTopMostRequestingDrawable();
 
+            if (!AllowRightClickFromLongTouch && touchLongPressDelegate != null)
+                cancelTouchLongPress();
+
             base.Update();
         }
 


### PR DESCRIPTION
Noticed in osu! gameplay, where if you press resume from the pause overlay, a right click is always triggered at the point where the button was clicked:

https://github.com/user-attachments/assets/52817b8b-b29a-4825-875d-27f09a54ae06