### PR TITLE
Initial proof of concept for tablet output scaling

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -23,6 +23,11 @@ namespace osu.Framework.Input.Handlers.Tablet
         Bindable<Vector2> AreaSize { get; }
 
         /// <summary>
+        /// The size of the area on the window which the input should be mapped to.
+        /// </summary>
+        Bindable<Vector2> OutputSize { get; }
+
+        /// <summary>
         /// Information on the currently connected tablet device. May be null if no tablet is detected.
         /// </summary>
         IBindable<TabletInfo?> Tablet { get; }

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -38,6 +38,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
 
+        public Bindable<Vector2> OutputSize { get; } = new Bindable<Vector2>();
+
         public Bindable<float> Rotation { get; } = new Bindable<float>();
 
         public IBindable<TabletInfo?> Tablet => tablet;
@@ -52,10 +54,11 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             outputMode = new AbsoluteTabletMode(this);
 
-            host.Window.Resized += () => updateOutputArea(host.Window);
+            host.Window.Resized += updateOutputArea;
 
             AreaOffset.BindValueChanged(_ => updateTabletAndInputArea(device));
             AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device));
+            OutputSize.BindValueChanged(_ => updateOutputArea());
             Rotation.BindValueChanged(_ => updateTabletAndInputArea(device), true);
 
             Enabled.BindValueChanged(enabled =>
@@ -104,7 +107,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                 outputMode.Tablet = device.CreateReference();
 
                 updateTabletAndInputArea(device);
-                updateOutputArea(host.Window);
+                updateOutputArea();
             }
             else
                 tablet.Value = null;
@@ -119,7 +122,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                 handleAuxiliaryReport(auxiliaryReport);
         }
 
-        private void updateOutputArea(IWindow window)
+        private void updateOutputArea()
         {
             if (device == null)
                 return;
@@ -128,14 +131,14 @@ namespace osu.Framework.Input.Handlers.Tablet
             {
                 case AbsoluteOutputMode absoluteOutputMode:
                 {
-                    float outputWidth, outputHeight;
+                    System.Console.WriteLine($"OutputSize {OutputSize.Value}");
 
                     // Set output area in pixels
                     absoluteOutputMode.Output = new Area
                     {
-                        Width = outputWidth = window.ClientSize.Width,
-                        Height = outputHeight = window.ClientSize.Height,
-                        Position = new System.Numerics.Vector2(outputWidth / 2, outputHeight / 2)
+                        Width = OutputSize.Value.X,
+                        Height = OutputSize.Value.Y,
+                        Position = new System.Numerics.Vector2(host.Window.Size.Width / 2f, host.Window.Size.Height / 2f)
                     };
                     break;
                 }


### PR DESCRIPTION
Related to https://github.com/ppy/osu/issues/12098

## WIP

## Description

Based on discussions in the issue, scaling tablet output when UI Scaling mode is set to "Everything" will address the needs of full area tablet players who use screen scaling. With this PR, tablet output will not scale when UI Scaling is set to "Gameplay Only" or "Exclude Overlays" since this results in elements being non-interactable with the tablet, which may or may not be desirable for some users and requires further discussion.

