### PR TITLE
Bump OpenTabletDriver to 0.6.5.0

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.4.0" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.5.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
## Tablet Support

### Added support

- Acepen AP906
- Artist 22
- Artisul D16 Pro
- Gaomon M8
- Huion 1060 Plus
- Huion Kamvas GT-156HD V2
- Huion Kamvas Pro 16
- Huion Kamvas Pro 16 Plus
- Huion Kamvas Pro 19
- Huion Kamvas Pro 22
- Huion RTP-700
- Parblo A610
- Parblo A640
- Trust Flex Design Tablet
- Turcom TS-6580
- UGEE M808
- UGEE M908
- Wacom CTH-300
- Wacom Cintiq 22HD 
- Wacom DTH-271
- XP-Pen Artist 16
- XP-Pen Artist 24 Pro
- XP-Pen Star 03 Pro
- XP-Pen Gen2 tablets
  - Artist Pro 16 Gen 2
  - Deco Pro LW Gen 2
  - Deco Pro XLW Gen 2

### Improved detection

- Artisul M0610 Pro
- Gaomon GM116HD
- Gaomon M10K Pro
- Huion H580X
- Huion H580x
- Huion H950P
- Huion HS64 variant
- Huion HS64
- Huion Kamvas Pro 12
- Huion WH1409 V2
- Kamvas 13
- Kamvas Pro 12
- VEIKK VK430
- Wacom PTH-460
- XP-Pen Deco mini4
- XP-Pen Star G430S
- XP-Pen Star G640
- XP-Pen Star G960S
- Xencelabs Pen Tablet Medium

### Improved support

- Use basic TabletReportParser on Huion 420
- Config naming fixes
- Correct Gaomon M8 internal Name
- Fix ET-0405-U parser
- Fix UC-Logic 1060N configuration

And more.