### PR TITLE
Fix `BindableList` methods crashing with non-`IList` collections

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -476,6 +476,17 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(b4.Count, Is.EqualTo(7));
         }
 
+        [Test]
+        public void TestAddHashSetWithCallback()
+        {
+            var b1 = new BindableList<int>();
+
+            b1.CollectionChanged += (_, _) => { };
+            b1.AddRange(new HashSet<int>([1, 2, 3, 4]));
+
+            Assert.That(b1.Count, Is.EqualTo(4));
+        }
+
         #endregion
 
         #region .Move(item)
@@ -1191,6 +1202,17 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(triggeredArgs.NewStartingIndex, Is.EqualTo(0));
             Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("0"));
             Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestReplaceRangeHashSetWithCallback()
+        {
+            var b1 = new BindableList<int>([1]);
+
+            b1.CollectionChanged += (_, _) => { };
+            b1.ReplaceRange(0, 1, new HashSet<int>([1, 2, 3, 4]));
+
+            Assert.That(b1.Count, Is.EqualTo(4));
         }
 
         #endregion

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -320,9 +320,9 @@ namespace osu.Framework.Bindables
         /// <param name="count">The count of items to be removed.</param>
         /// <param name="newItems">The items to replace the removed items with.</param>
         public void ReplaceRange(int index, int count, IEnumerable<T> newItems)
-            => replaceRange(index, count, newItems as ICollection<T> ?? newItems.ToArray(), new HashSet<BindableList<T>>());
+            => replaceRange(index, count, newItems as IList ?? newItems.ToArray(), new HashSet<BindableList<T>>());
 
-        private void replaceRange(int index, int count, ICollection<T> newItems, HashSet<BindableList<T>> appliedInstances)
+        private void replaceRange(int index, int count, IList newItems, HashSet<BindableList<T>> appliedInstances)
         {
             if (checkAlreadyApplied(appliedInstances)) return;
 
@@ -335,7 +335,7 @@ namespace osu.Framework.Bindables
             List<T> removedItems = CollectionChanged == null ? null : collection.GetRange(index, count);
 
             collection.RemoveRange(index, count);
-            collection.InsertRange(index, newItems);
+            collection.InsertRange(index, (IEnumerable<T>)newItems);
 
             if (bindings != null)
             {
@@ -347,7 +347,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, (IList)newItems, removedItems!, index));
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItems, removedItems!, index));
         }
 
         /// <summary>
@@ -544,15 +544,15 @@ namespace osu.Framework.Bindables
         /// <param name="items">The collection whose items should be added to this collection.</param>
         /// <exception cref="InvalidOperationException">Thrown if this collection is <see cref="Disabled"/></exception>
         public void AddRange(IEnumerable<T> items)
-            => addRange(items as ICollection<T> ?? items.ToArray(), new HashSet<BindableList<T>>());
+            => addRange(items as IList ?? items.ToArray(), new HashSet<BindableList<T>>());
 
-        private void addRange(ICollection<T> items, HashSet<BindableList<T>> appliedInstances)
+        private void addRange(IList items, HashSet<BindableList<T>> appliedInstances)
         {
             if (checkAlreadyApplied(appliedInstances)) return;
 
             ensureMutationAllowed();
 
-            collection.AddRange(items);
+            collection.AddRange((IEnumerable<T>)items);
 
             if (bindings != null)
             {
@@ -560,7 +560,7 @@ namespace osu.Framework.Bindables
                     b.addRange(items, appliedInstances);
             }
 
-            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, (IList)items, collection.Count - items.Count));
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items, collection.Count - items.Count));
         }
 
         /// <summary>


### PR DESCRIPTION
Partial revert to `IList`, with casts to `IEnumerable<T>` instead that are internally optimised by `List<T>`.

While a bit ugly, it's still more performant than the original code that used a `.Cast<T>()` LINQ expression for similar reasons.