### PR TITLE
Use `double` in `ScrollContainer` for scroll tracking

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -525,7 +525,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep($"scroll to {position}", () =>
             {
                 scrollContainer.ScrollTo(position, false);
-                immediateScrollPosition = scrollContainer.Current;
+                immediateScrollPosition = (float)scrollContainer.Current;
             });
 
             AddAssert($"immediately scrolled to {clampedTarget}", () => Precision.AlmostEquals(clampedTarget, immediateScrollPosition, 1));

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainerDoublePrecision.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainerDoublePrecision.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public partial class TestSceneScrollContainerDoublePrecision : ManualInputManagerTestScene
+    {
+        private const float item_height = 5000;
+        private const int item_count = 8000;
+
+        private ScrollContainer<Drawable> scrollContainer = null!;
+
+        [SetUp]
+        public void Setup() => Schedule(Clear);
+
+        [Test]
+        public void TestStandard()
+        {
+            AddStep("Create scroll container", () =>
+            {
+                Add(scrollContainer = new BasicScrollContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    ScrollbarVisible = true,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.7f, 0.9f),
+                });
+
+                for (int i = 0; i < item_count; i++)
+                {
+                    scrollContainer.Add(new BoxWithDouble
+                    {
+                        Colour = new Color4(RNG.NextSingle(1), RNG.NextSingle(1), RNG.NextSingle(1), 1),
+                        RelativeSizeAxes = Axes.X,
+                        Height = item_height,
+                        Y = i * item_height,
+                    });
+                }
+            });
+
+            scrollIntoView(item_count - 2);
+            scrollIntoView(item_count - 1);
+        }
+
+        [Test]
+        public void TestDoublePrecision()
+        {
+            AddStep("Create scroll container", () =>
+            {
+                Add(scrollContainer = new DoubleScrollContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    ScrollbarVisible = true,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.7f, 0.9f),
+                });
+
+                for (int i = 0; i < item_count; i++)
+                {
+                    scrollContainer.Add(new BoxWithDouble
+                    {
+                        Colour = new Color4(RNG.NextSingle(1), RNG.NextSingle(1), RNG.NextSingle(1), 1),
+                        RelativeSizeAxes = Axes.X,
+                        Height = item_height,
+                        DoubleLocation = i * item_height,
+                    });
+                }
+            });
+
+            scrollIntoView(item_count - 2);
+            scrollIntoView(item_count - 1);
+        }
+
+        private void scrollIntoView(int index)
+        {
+            AddStep($"scroll {index} into view", () => scrollContainer.ScrollIntoView(scrollContainer.ChildrenOfType<BoxWithDouble>().Skip(index).First()));
+            AddUntilStep($"{index} is visible", () => !scrollContainer.ChildrenOfType<BoxWithDouble>().Skip(index).First().IsMaskedAway);
+        }
+    }
+
+    public partial class DoubleScrollContainer : BasicScrollContainer
+    {
+        private readonly Container<BoxWithDouble> layoutContent;
+
+        public override void Add(Drawable drawable)
+        {
+            if (drawable is not BoxWithDouble boxWithDouble)
+                throw new InvalidOperationException();
+
+            Add(boxWithDouble);
+        }
+
+        public void Add(BoxWithDouble drawable)
+        {
+            if (drawable is not BoxWithDouble boxWithDouble)
+                throw new InvalidOperationException();
+
+            layoutContent.Height = (float)Math.Max(layoutContent.Height, boxWithDouble.DoubleLocation + boxWithDouble.DrawHeight);
+            layoutContent.Add(drawable);
+        }
+
+        public DoubleScrollContainer()
+        {
+            // Managing our own custom layout within ScrollContent causes feedback with internal ScrollContainer calculations,
+            // so we must maintain one level of separation from ScrollContent.
+            base.Add(layoutContent = new Container<BoxWithDouble>
+            {
+                RelativeSizeAxes = Axes.X,
+            });
+        }
+
+        public override double GetChildPosInContent(Drawable d, Vector2 offset)
+        {
+            if (d is not BoxWithDouble boxWithDouble)
+                return base.GetChildPosInContent(d, offset);
+
+            return boxWithDouble.DoubleLocation + offset.X;
+        }
+
+        protected override void ApplyCurrentToContent()
+        {
+            Debug.Assert(ScrollDirection == Direction.Vertical);
+
+            double scrollableExtent = -Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y;
+
+            foreach (var d in layoutContent)
+                d.Y = (float)(d.DoubleLocation + scrollableExtent);
+        }
+    }
+
+    public partial class BoxWithDouble : Box
+    {
+        public double DoubleLocation { get; set; }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainerDoublePrecision.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainerDoublePrecision.cs
@@ -90,60 +90,60 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep($"scroll {index} into view", () => scrollContainer.ScrollIntoView(scrollContainer.ChildrenOfType<BoxWithDouble>().Skip(index).First()));
             AddUntilStep($"{index} is visible", () => !scrollContainer.ChildrenOfType<BoxWithDouble>().Skip(index).First().IsMaskedAway);
         }
-    }
 
-    public partial class DoubleScrollContainer : BasicScrollContainer
-    {
-        private readonly Container<BoxWithDouble> layoutContent;
-
-        public override void Add(Drawable drawable)
+        public partial class DoubleScrollContainer : BasicScrollContainer
         {
-            if (drawable is not BoxWithDouble boxWithDouble)
-                throw new InvalidOperationException();
+            private readonly Container<BoxWithDouble> layoutContent;
 
-            Add(boxWithDouble);
-        }
-
-        public void Add(BoxWithDouble drawable)
-        {
-            if (drawable is not BoxWithDouble boxWithDouble)
-                throw new InvalidOperationException();
-
-            layoutContent.Height = (float)Math.Max(layoutContent.Height, boxWithDouble.DoubleLocation + boxWithDouble.DrawHeight);
-            layoutContent.Add(drawable);
-        }
-
-        public DoubleScrollContainer()
-        {
-            // Managing our own custom layout within ScrollContent causes feedback with internal ScrollContainer calculations,
-            // so we must maintain one level of separation from ScrollContent.
-            base.Add(layoutContent = new Container<BoxWithDouble>
+            public override void Add(Drawable drawable)
             {
-                RelativeSizeAxes = Axes.X,
-            });
+                if (drawable is not BoxWithDouble boxWithDouble)
+                    throw new InvalidOperationException();
+
+                Add(boxWithDouble);
+            }
+
+            public void Add(BoxWithDouble drawable)
+            {
+                if (drawable is not BoxWithDouble boxWithDouble)
+                    throw new InvalidOperationException();
+
+                layoutContent.Height = (float)Math.Max(layoutContent.Height, boxWithDouble.DoubleLocation + boxWithDouble.DrawHeight);
+                layoutContent.Add(drawable);
+            }
+
+            public DoubleScrollContainer()
+            {
+                // Managing our own custom layout within ScrollContent causes feedback with internal ScrollContainer calculations,
+                // so we must maintain one level of separation from ScrollContent.
+                base.Add(layoutContent = new Container<BoxWithDouble>
+                {
+                    RelativeSizeAxes = Axes.X,
+                });
+            }
+
+            public override double GetChildPosInContent(Drawable d, Vector2 offset)
+            {
+                if (d is not BoxWithDouble boxWithDouble)
+                    return base.GetChildPosInContent(d, offset);
+
+                return boxWithDouble.DoubleLocation + offset.X;
+            }
+
+            protected override void ApplyCurrentToContent()
+            {
+                Debug.Assert(ScrollDirection == Direction.Vertical);
+
+                double scrollableExtent = -Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y;
+
+                foreach (var d in layoutContent)
+                    d.Y = (float)(d.DoubleLocation + scrollableExtent);
+            }
         }
 
-        public override double GetChildPosInContent(Drawable d, Vector2 offset)
+        public partial class BoxWithDouble : Box
         {
-            if (d is not BoxWithDouble boxWithDouble)
-                return base.GetChildPosInContent(d, offset);
-
-            return boxWithDouble.DoubleLocation + offset.X;
+            public double DoubleLocation { get; set; }
         }
-
-        protected override void ApplyCurrentToContent()
-        {
-            Debug.Assert(ScrollDirection == Direction.Vertical);
-
-            double scrollableExtent = -Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y;
-
-            foreach (var d in layoutContent)
-                d.Y = (float)(d.DoubleLocation + scrollableExtent);
-        }
-    }
-
-    public partial class BoxWithDouble : Box
-    {
-        public double DoubleLocation { get; set; }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
@@ -467,7 +467,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private partial class TestRearrangeableList : BasicRearrangeableListContainer<int>
         {
-            public float ScrollPosition => ScrollContainer.Current;
+            public float ScrollPosition => (float)ScrollContainer.Current;
 
             public new IReadOnlyDictionary<int, RearrangeableListItem<int>> ItemMap => base.ItemMap;
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -578,15 +578,19 @@ namespace osu.Framework.Graphics.Containers
             }
 
             if (ScrollDirection == Direction.Horizontal)
-            {
                 Scrollbar.X = ToScrollbarPosition(Current);
-                ScrollContent.X = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.X);
-            }
             else
-            {
                 Scrollbar.Y = ToScrollbarPosition(Current);
+
+            ApplyCurrentToContent();
+        }
+
+        protected virtual void ApplyCurrentToContent()
+        {
+            if (ScrollDirection == Direction.Horizontal)
+                ScrollContent.X = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.X);
+            else
                 ScrollContent.Y = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y);
-            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -587,7 +587,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// This is the final internal step of updating the scroll container, which takes
-        /// <see cref="Current"/> and applied it to <see cref="ScrollContent"/> in order to
+        /// <see cref="Current"/> and applies it to <see cref="ScrollContent"/> in order to
         /// correctly offset children.
         ///
         /// Overriding this method can be used to inhibit this default behaviour, to for instance

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -585,6 +585,14 @@ namespace osu.Framework.Graphics.Containers
             ApplyCurrentToContent();
         }
 
+        /// <summary>
+        /// This is the final internal step of updating the scroll container, which takes
+        /// <see cref="Current"/> and applied it to <see cref="ScrollContent"/> in order to
+        /// correctly offset children.
+        ///
+        /// Overriding this method can be used to inhibit this default behaviour, to for instance
+        /// redirect the positioning to another container or change the way it is applied.
+        /// </summary>
         protected virtual void ApplyCurrentToContent()
         {
             if (ScrollDirection == Direction.Horizontal)

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The current scroll position.
         /// </summary>
-        public float Current { get; private set; }
+        public double Current { get; private set; }
 
         /// <summary>
         /// The target scroll position which is exponentially approached by current via a rate of distance decay.
@@ -126,12 +126,12 @@ namespace osu.Framework.Graphics.Containers
         /// <remarks>
         /// When not animating scroll position, this will always be equal to <see cref="Current"/>.
         /// </remarks>
-        public float Target { get; private set; }
+        public double Target { get; private set; }
 
         /// <summary>
         /// The maximum distance that can be scrolled in the scroll direction.
         /// </summary>
-        public float ScrollableExtent => Math.Max(AvailableContent - DisplayableContent, 0);
+        public double ScrollableExtent => Math.Max(AvailableContent - DisplayableContent, 0);
 
         /// <summary>
         /// The maximum distance that the scrollbar can move in the scroll direction.
@@ -139,14 +139,14 @@ namespace osu.Framework.Graphics.Containers
         /// <remarks>
         /// May not be accurate to actual display of scrollbar if <see cref="ToScrollbarPosition"/> or <see cref="FromScrollbarPosition"/> are overridden.
         /// </remarks>
-        protected float ScrollbarMovementExtent => Math.Max(DisplayableContent - Scrollbar.DrawSize[ScrollDim], 0);
+        protected double ScrollbarMovementExtent => Math.Max(DisplayableContent - Scrollbar.DrawSize[ScrollDim], 0);
 
         /// <summary>
         /// Clamp a value to the available scroll range.
         /// </summary>
         /// <param name="position">The value to clamp.</param>
         /// <param name="extension">An extension value beyond the normal extent.</param>
-        protected float Clamp(float position, float extension = 0) => Math.Max(Math.Min(position, ScrollableExtent + extension), -extension);
+        protected double Clamp(double position, double extension = 0) => Math.Max(Math.Min(position, ScrollableExtent + extension), -extension);
 
         protected override Container<T> Content => ScrollContent;
 
@@ -345,8 +345,8 @@ namespace osu.Framework.Graphics.Containers
 
             Vector2 childDelta = ToLocalSpace(e.ScreenSpaceMousePosition) - ToLocalSpace(e.ScreenSpaceLastMousePosition);
 
-            float scrollOffset = -childDelta[ScrollDim];
-            float clampedScrollOffset = Clamp(Target + scrollOffset) - Clamp(Target);
+            double scrollOffset = -childDelta[ScrollDim];
+            double clampedScrollOffset = Clamp(Target + scrollOffset) - Clamp(Target);
 
             // If we are dragging past the extent of the scrollable area, half the offset
             // such that the user can feel it.
@@ -424,7 +424,7 @@ namespace osu.Framework.Graphics.Containers
             Current += offset;
         }
 
-        private void scrollByOffset(float value, bool animated, double distanceDecay = float.PositiveInfinity) =>
+        private void scrollByOffset(double value, bool animated, double distanceDecay = float.PositiveInfinity) =>
             OnUserScroll(Target + value, animated, distanceDecay);
 
         /// <summary>
@@ -454,7 +454,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="offset">The amount by which we should scroll.</param>
         /// <param name="animated">Whether to animate the movement.</param>
-        public void ScrollBy(float offset, bool animated = true) => scrollTo(Target + offset, animated);
+        public void ScrollBy(double offset, bool animated = true) => scrollTo(Target + offset, animated);
 
         /// <summary>
         /// Handle a scroll to an absolute position from a user input.
@@ -462,7 +462,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="value">The position to scroll to.</param>
         /// <param name="animated">Whether to animate the movement.</param>
         /// <param name="distanceDecay">Controls the rate with which the target position is approached after jumping to a specific location. Default is <see cref="DistanceDecayJump"/>.</param>
-        protected virtual void OnUserScroll(float value, bool animated = true, double? distanceDecay = null) =>
+        protected virtual void OnUserScroll(double value, bool animated = true, double? distanceDecay = null) =>
             ScrollTo(value, animated, distanceDecay);
 
         /// <summary>
@@ -471,9 +471,9 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="value">The position to scroll to.</param>
         /// <param name="animated">Whether to animate the movement.</param>
         /// <param name="distanceDecay">Controls the rate with which the target position is approached after jumping to a specific location. Default is <see cref="DistanceDecayJump"/>.</param>
-        public void ScrollTo(float value, bool animated = true, double? distanceDecay = null) => scrollTo(value, animated, distanceDecay ?? DistanceDecayJump);
+        public void ScrollTo(double value, bool animated = true, double? distanceDecay = null) => scrollTo(value, animated, distanceDecay ?? DistanceDecayJump);
 
-        private void scrollTo(float value, bool animated, double distanceDecay = float.PositiveInfinity)
+        private void scrollTo(double value, bool animated, double distanceDecay = double.PositiveInfinity)
         {
             Target = Clamp(value, ClampExtension);
 
@@ -497,11 +497,11 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="animated">Whether to animate the movement.</param>
         public void ScrollIntoView(Drawable d, bool animated = true)
         {
-            float childPos0 = GetChildPosInContent(d);
-            float childPos1 = GetChildPosInContent(d, d.DrawSize);
+            double childPos0 = GetChildPosInContent(d);
+            double childPos1 = GetChildPosInContent(d, d.DrawSize);
 
-            float minPos = Math.Min(childPos0, childPos1);
-            float maxPos = Math.Max(childPos0, childPos1);
+            double minPos = Math.Min(childPos0, childPos1);
+            double maxPos = Math.Max(childPos0, childPos1);
 
             if (minPos < Current || (minPos > Current && d.DrawSize[ScrollDim] > DisplayableContent))
                 ScrollTo(minPos, animated);
@@ -515,14 +515,14 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="d">The child to get the position from.</param>
         /// <param name="offset">Positional offset in the child's space.</param>
         /// <returns>The position of the child.</returns>
-        public float GetChildPosInContent(Drawable d, Vector2 offset) => d.ToSpaceOfOtherDrawable(offset, ScrollContent)[ScrollDim];
+        public virtual double GetChildPosInContent(Drawable d, Vector2 offset) => d.ToSpaceOfOtherDrawable(offset, ScrollContent)[ScrollDim];
 
         /// <summary>
         /// Determines the position of a child in the content.
         /// </summary>
         /// <param name="d">The child to get the position from.</param>
         /// <returns>The position of the child.</returns>
-        public float GetChildPosInContent(Drawable d) => GetChildPosInContent(d, Vector2.Zero);
+        public double GetChildPosInContent(Drawable d) => GetChildPosInContent(d, Vector2.Zero);
 
         private void updatePosition()
         {
@@ -544,15 +544,15 @@ namespace osu.Framework.Graphics.Containers
                     localDistanceDecay = distance_decay_clamping * 2;
 
                 // Lastly, we gradually nudge the target towards valid bounds.
-                Target = (float)Interpolation.Lerp(Clamp(Target), Target, Math.Exp(-distance_decay_clamping * Time.Elapsed));
+                Target = Interpolation.Lerp(Clamp(Target), Target, Math.Exp(-distance_decay_clamping * Time.Elapsed));
 
-                float clampedTarget = Clamp(Target);
+                double clampedTarget = Clamp(Target);
                 if (Precision.AlmostEquals(clampedTarget, Target))
                     Target = clampedTarget;
             }
 
             // Exponential interpolation between the target and our current scroll position.
-            Current = (float)Interpolation.Lerp(Target, Current, Math.Exp(-localDistanceDecay * Time.Elapsed));
+            Current = Interpolation.Lerp(Target, Current, Math.Exp(-localDistanceDecay * Time.Elapsed));
 
             // This prevents us from entering the de-normalized range of floating point numbers when approaching target closely.
             if (Precision.AlmostEquals(Current, Target))
@@ -580,12 +580,12 @@ namespace osu.Framework.Graphics.Containers
             if (ScrollDirection == Direction.Horizontal)
             {
                 Scrollbar.X = ToScrollbarPosition(Current);
-                ScrollContent.X = -Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.X;
+                ScrollContent.X = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.X);
             }
             else
             {
                 Scrollbar.Y = ToScrollbarPosition(Current);
-                ScrollContent.Y = -Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y;
+                ScrollContent.Y = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y);
             }
         }
 
@@ -594,12 +594,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="scrollPosition">The absolute scroll position (e.g. <see cref="Current"/>).</param>
         /// <returns>The scrollbar position.</returns>
-        protected virtual float ToScrollbarPosition(float scrollPosition)
+        protected virtual float ToScrollbarPosition(double scrollPosition)
         {
             if (Precision.AlmostEquals(0, ScrollableExtent))
                 return 0;
 
-            return ScrollbarMovementExtent * (scrollPosition / ScrollableExtent);
+            return (float)(ScrollbarMovementExtent * (scrollPosition / ScrollableExtent));
         }
 
         /// <summary>
@@ -612,7 +612,7 @@ namespace osu.Framework.Graphics.Containers
             if (Precision.AlmostEquals(0, ScrollbarMovementExtent))
                 return 0;
 
-            return ScrollableExtent * (scrollbarPosition / ScrollbarMovementExtent);
+            return (float)(ScrollableExtent * (scrollbarPosition / ScrollbarMovementExtent));
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -596,9 +596,9 @@ namespace osu.Framework.Graphics.Containers
         protected virtual void ApplyCurrentToContent()
         {
             if (ScrollDirection == Direction.Horizontal)
-                ScrollContent.X = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.X);
+                ScrollContent.X = (float)(-Current + (ScrollableExtent * ScrollContent.RelativeAnchorPosition.X));
             else
-                ScrollContent.Y = (float)(-Current + ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y);
+                ScrollContent.Y = (float)(-Current + (ScrollableExtent * ScrollContent.RelativeAnchorPosition.Y));
         }
 
         /// <summary>


### PR DESCRIPTION
This is the first step towards supporting scrolling over very large amounts of content. With this along, the animation already becomes somewhat smoother (no longer "locking" into place too early) but scroll content will still look jagged when scrolled too far down.

Fixing actual content requires a small amount of extra implementation on top of this. To keep things simple this would be up to the consumer to implement and maintain.

Intended to help fix osu! song select from becoming weird when hundreds of thousands of beatmaps are loaded.

A sample implementation is provided in `TestSceneScrollContainerDoublePrecision`.

master with a `BasicScrollContainer`:

https://github.com/user-attachments/assets/30195f3d-df1d-436b-8350-b7307653d767


This PR with a `BasicScrollContainer`:

https://github.com/user-attachments/assets/f6bb5c04-2545-466a-a950-2357d68826e7

This PR with the custom double implementation:

https://github.com/user-attachments/assets/1ab4dbec-6f3f-43bf-a820-c188ce9e27fb
