### PR TITLE
FFmpeg build: Use macos-13 CI image

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 jobs:
   build-macos:
     name: Build macOS
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +30,7 @@ jobs:
 
   combine-macos:
     name: Combine macOS libs
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build-macos
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
 
   build-iOS:
     name: Build iOS
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         arch: [arm64, simulator-arm64, simulator-x86_64]
@@ -88,7 +88,7 @@ jobs:
 
   combine-iOS:
     name: Combine iOS libs
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build-iOS
     steps:
       - name: Checkout


### PR DESCRIPTION
[Run on my fork](https://github.com/FreezyLemon/osu-framework/actions/runs/12517175492)

The `macos-12` image has been [deprecated and disabled](https://github.com/actions/runner-images/issues/10721) which means the macOS jobs don't even start anymore. I chose version 13 because I assume that the resulting binaries will have better compatibility with older macos versions than ones built on a newer OS version.
