### PR TITLE
Add native macOS image loading support

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -342,6 +342,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=API/@EntryIndexedValue">API</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ARGB/@EntryIndexedValue">ARGB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BPM/@EntryIndexedValue">BPM</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CG/@EntryIndexedValue">CG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FBO/@EntryIndexedValue">FBO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CCL/@EntryIndexedValue">CCL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GC/@EntryIndexedValue">GC</s:String>

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -2,22 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
-using Accelerate;
-using CoreGraphics;
 using Foundation;
-using ObjCRuntime;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Framework.Platform.Apple;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using UIKit;
 
 namespace osu.Framework.iOS.Graphics.Textures
 {
-    public class IOSTextureLoaderStore : TextureLoaderStore
+    internal class IOSTextureLoaderStore : AppleTextureLoaderStore
     {
         public IOSTextureLoaderStore(IResourceStore<byte[]> store)
             : base(store)
@@ -26,81 +20,18 @@ namespace osu.Framework.iOS.Graphics.Textures
 
         protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
-            using (var nativeData = NSData.FromStream(stream))
-            {
-                if (nativeData == null)
-                    throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+            int length = (int)(stream.Length - stream.Position);
+            using var nativeData = NSMutableData.FromLength(length);
 
-                using (var uiImage = UIImage.LoadFromData(nativeData))
-                {
-                    if (uiImage == null) throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+            var bytesSpan = new Span<byte>(nativeData.MutableBytes.ToPointer(), length);
+            stream.ReadExactly(bytesSpan);
 
-                    int width = (int)uiImage.Size.Width;
-                    int height = (int)uiImage.Size.Height;
+            using var uiImage = UIImage.LoadFromData(nativeData);
+            if (uiImage == null)
+                throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-                    var format = new vImage_CGImageFormat
-                    {
-                        BitsPerComponent = 8,
-                        BitsPerPixel = 32,
-                        ColorSpace = CGColorSpace.CreateDeviceRGB().Handle,
-                        // notably, iOS generally uses premultiplied alpha when rendering image to pixels via CGBitmapContext or otherwise,
-                        // but vImage offers using straight alpha directly without any conversion from our side (by specifying Last instead of PremultipliedLast).
-                        BitmapInfo = (CGBitmapFlags)CGImageAlphaInfo.Last,
-                        Decode = null,
-                        RenderingIntent = CGColorRenderingIntent.Default,
-                    };
-
-                    vImageBuffer accelerateImage = default;
-
-                    // perform initial call to retrieve preferred alignment and bytes-per-row values for the given image dimensions.
-                    nuint alignment = (nuint)vImageBuffer_Init(&accelerateImage, (uint)height, (uint)width, 32, vImageFlags.NoAllocate);
-                    Debug.Assert(alignment > 0);
-
-                    // allocate aligned memory region to contain image pixel data.
-                    int bytesPerRow = accelerateImage.BytesPerRow;
-                    int bytesCount = bytesPerRow * accelerateImage.Height;
-                    accelerateImage.Data = (IntPtr)NativeMemory.AlignedAlloc((nuint)bytesCount, alignment);
-
-                    var result = vImageBuffer_InitWithCGImage(&accelerateImage, &format, null, uiImage.CGImage!.Handle, vImageFlags.NoAllocate);
-                    Debug.Assert(result == vImageError.NoError);
-
-                    var image = new Image<TPixel>(width, height);
-                    byte* data = (byte*)accelerateImage.Data;
-
-                    for (int i = 0; i < height; i++)
-                    {
-                        var imageRow = image.DangerousGetPixelRowMemory(i);
-                        var dataRow = new ReadOnlySpan<TPixel>(&data[bytesPerRow * i], width);
-                        dataRow.CopyTo(imageRow.Span);
-                    }
-
-                    NativeMemory.AlignedFree(accelerateImage.Data.ToPointer());
-                    return image;
-                }
-            }
+            var cgImage = new Platform.Apple.Native.CGImage(uiImage.CGImage!.Handle);
+            return ImageFromCGImage<TPixel>(cgImage);
         }
-
-        #region Accelerate API
-
-        [DllImport(Constants.AccelerateLibrary)]
-        private static extern unsafe vImageError vImageBuffer_Init(vImageBuffer* buf, uint height, uint width, uint pixelBits, vImageFlags flags);
-
-        [DllImport(Constants.AccelerateLibrary)]
-        private static extern unsafe vImageError vImageBuffer_InitWithCGImage(vImageBuffer* buf, vImage_CGImageFormat* format, nfloat* backgroundColour, NativeHandle image, vImageFlags flags);
-
-        // ReSharper disable once InconsistentNaming
-        [StructLayout(LayoutKind.Sequential)]
-        public unsafe struct vImage_CGImageFormat
-        {
-            public uint BitsPerComponent;
-            public uint BitsPerPixel;
-            public NativeHandle ColorSpace;
-            public CGBitmapFlags BitmapInfo;
-            public uint Version;
-            public nfloat* Decode;
-            public CGColorRenderingIntent RenderingIntent;
-        }
-
-        #endregion
     }
 }

--- a/osu.Framework/Platform/Apple/AppleTextureLoaderStore.cs
+++ b/osu.Framework/Platform/Apple/AppleTextureLoaderStore.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform.Apple.Native;
+using osu.Framework.Platform.Apple.Native.Accelerate;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Platform.Apple
+{
+    internal abstract class AppleTextureLoaderStore : TextureLoaderStore
+    {
+        protected AppleTextureLoaderStore(IResourceStore<byte[]> store)
+            : base(store)
+        {
+        }
+
+        protected unsafe Image<TPixel> ImageFromCGImage<TPixel>(CGImage cgImage)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            int width = (int)cgImage.Width;
+            int height = (int)cgImage.Height;
+
+            var format = new vImage_CGImageFormat
+            {
+                BitsPerComponent = 8,
+                BitsPerPixel = 32,
+                ColorSpace = CGColorSpace.CreateDeviceRGB(),
+                // notably, macOS & iOS generally use premultiplied alpha when rendering image to pixels via CGBitmapContext or otherwise,
+                // but vImage offers rendering as straight alpha by specifying Last instead of PremultipliedLast.
+                BitmapInfo = (CGBitmapInfo)CGImageAlphaInfo.Last,
+                Decode = null,
+                RenderingIntent = CGColorRenderingIntent.Default,
+            };
+
+            vImage_Buffer accImage = default;
+
+            // perform initial call to retrieve preferred alignment and bytes-per-row values for the given image dimensions.
+            nuint alignment = (nuint)vImage.Init(&accImage, (uint)height, (uint)width, 32, vImage_Flags.NoAllocate);
+            Debug.Assert(alignment > 0);
+
+            // allocate aligned memory region to contain image pixel data.
+            nuint bytesPerRow = accImage.BytesPerRow;
+            nuint bytesCount = bytesPerRow * accImage.Height;
+            accImage.Data = (byte*)NativeMemory.AlignedAlloc(bytesCount, alignment);
+
+            var result = vImage.InitWithCGImage(&accImage, &format, null, cgImage.Handle, vImage_Flags.NoAllocate);
+            Debug.Assert(result == vImage_Error.NoError);
+
+            var image = new Image<TPixel>(width, height);
+
+            for (int i = 0; i < height; i++)
+            {
+                var imageRow = image.DangerousGetPixelRowMemory(i);
+                var dataRow = new ReadOnlySpan<TPixel>(&accImage.Data[(int)bytesPerRow * i], width);
+                dataRow.CopyTo(imageRow.Span);
+            }
+
+            NativeMemory.AlignedFree(accImage.Data);
+            return image;
+        }
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Framework.Platform.Apple.Native.Accelerate
+{
+    internal static unsafe partial class vImage
+    {
+        [LibraryImport(Interop.LIB_ACCELERATE, EntryPoint = "vImageBuffer_Init")]
+        internal static partial vImage_Error Init(vImage_Buffer* buf, uint height, uint width, uint pixelBits, vImage_Flags flags);
+
+        [LibraryImport(Interop.LIB_ACCELERATE, EntryPoint = "vImageBuffer_InitWithCGImage")]
+        internal static partial vImage_Error InitWithCGImage(vImage_Buffer* buf, vImage_CGImageFormat* format, double* backgroundColour, IntPtr image, vImage_Flags flags);
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Buffer.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Buffer.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Framework.Platform.Apple.Native.Accelerate
+{
+    internal unsafe struct vImage_Buffer
+    {
+        public byte* Data;
+        public nuint Height;
+        public nuint Width;
+        public nuint BytesPerRow;
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Buffer.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Buffer.cs
@@ -3,8 +3,11 @@
 
 // ReSharper disable InconsistentNaming
 
+using System.Runtime.InteropServices;
+
 namespace osu.Framework.Platform.Apple.Native.Accelerate
 {
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct vImage_Buffer
     {
         public byte* Data;

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_CGImageFormat.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_CGImageFormat.cs
@@ -3,8 +3,11 @@
 
 // ReSharper disable InconsistentNaming
 
+using System.Runtime.InteropServices;
+
 namespace osu.Framework.Platform.Apple.Native.Accelerate
 {
+    [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct vImage_CGImageFormat
     {
         public uint BitsPerComponent;

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_CGImageFormat.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_CGImageFormat.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Framework.Platform.Apple.Native.Accelerate
+{
+    internal unsafe struct vImage_CGImageFormat
+    {
+        public uint BitsPerComponent;
+        public uint BitsPerPixel;
+        public CGColorSpace ColorSpace;
+        public CGBitmapInfo BitmapInfo;
+        public uint Version;
+        public double* Decode;
+        public CGColorRenderingIntent RenderingIntent;
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Error.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Error.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Framework.Platform.Apple.Native.Accelerate
+{
+    internal enum vImage_Error : long
+    {
+        OutOfPlaceOperationRequired = -21780,
+        ColorSyncIsAbsent = -21779,
+        InvalidImageFormat = -21778,
+        InvalidRowBytes = -21777,
+        InternalError = -21776,
+        UnknownFlagsBit = -21775,
+        BufferSizeMismatch = -21774,
+        InvalidParameter = -21773,
+        NullPointerArgument = -21772,
+        MemoryAllocationError = -21771,
+        InvalidOffsetY = -21770,
+        InvalidOffsetX = -21769,
+        InvalidEdgeStyle = -21768,
+        InvalidKernelSize = -21767,
+        RoiLargerThanInputBuffer = -21766,
+        NoError = 0,
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Flags.cs
+++ b/osu.Framework/Platform/Apple/Native/Accelerate/vImage_Flags.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// ReSharper disable InconsistentNaming
+
+namespace osu.Framework.Platform.Apple.Native.Accelerate
+{
+    internal enum vImage_Flags : uint
+    {
+        NoFlags = 0,
+        LeaveAlphaUnchanged = 1,
+        CopyInPlace = 2,
+        BackgroundColorFill = 4,
+        EdgeExtend = 8,
+        DoNotTile = 16,
+        HighQualityResampling = 32,
+        TruncateKernel = 64,
+        GetTempBufferSize = 128,
+        PrintDiagnosticsToConsole = 256,
+        NoAllocate = 512,
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGBitmapContext.cs
+++ b/osu.Framework/Platform/Apple/Native/CGBitmapContext.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal readonly partial struct CGBitmapContext
+    {
+        internal IntPtr Handle { get; }
+
+        internal CGBitmapContext(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGBitmapContextCreate")]
+        public static partial CGBitmapContext Create(IntPtr data, nuint width, nuint height, nuint bitsPerComponent, nuint bytesPerRow, CGColorSpace colorSpace, CGBitmapInfo bitmapInfo);
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGContextDrawImage")]
+        public static partial void DrawImage(CGBitmapContext context, CGRect rect, CGImage image);
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGBitmapInfo.cs
+++ b/osu.Framework/Platform/Apple/Native/CGBitmapInfo.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    public enum CGBitmapInfo : uint
+    {
+        None,
+        PremultipliedLast,
+        PremultipliedFirst,
+        Last,
+        First,
+        NoneSkipLast,
+        NoneSkipFirst,
+        Only,
+        AlphaInfoMask = 31,
+        FloatInfoMask = 3840,
+        FloatComponents = 256,
+        ByteOrderMask = 28672,
+        ByteOrderDefault = 0,
+        ByteOrder16Little = 4096,
+        ByteOrder32Little = 8192,
+        ByteOrder16Big = 12288,
+        ByteOrder32Big = 16384,
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGColorRenderingIntent.cs
+++ b/osu.Framework/Platform/Apple/Native/CGColorRenderingIntent.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    public enum CGColorRenderingIntent
+    {
+        Default,
+        AbsoluteColorimetric,
+        RelativeColorimetric,
+        Perceptual,
+        Saturation,
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGColorSpace.cs
+++ b/osu.Framework/Platform/Apple/Native/CGColorSpace.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    public readonly partial struct CGColorSpace
+    {
+        internal IntPtr Handle { get; }
+
+        internal CGColorSpace(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGColorSpaceCreateDeviceRGB")]
+        internal static partial CGColorSpace CreateDeviceRGB();
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGImage.cs
+++ b/osu.Framework/Platform/Apple/Native/CGImage.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal readonly partial struct CGImage
+    {
+        internal IntPtr Handle { get; }
+
+        public CGImage(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal nuint Width => GetWidth(this);
+        internal nuint Height => GetHeight(this);
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGImageGetWidth")]
+        internal static partial nuint GetWidth(CGImage image);
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGImageGetHeight")]
+        internal static partial nuint GetHeight(CGImage image);
+
+        [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGImageRelease")]
+        internal static partial void Release(CGImage image);
+
+        [LibraryImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/CoreFoundation", EntryPoint = "CFGetRetainCount")]
+        internal static partial int GetRetainCount(CGImage image);
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGImage.cs
+++ b/osu.Framework/Platform/Apple/Native/CGImage.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Platform.Apple.Native
         [LibraryImport(Interop.LIB_CORE_GRAPHICS, EntryPoint = "CGImageRelease")]
         internal static partial void Release(CGImage image);
 
-        [LibraryImport("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/CoreFoundation", EntryPoint = "CFGetRetainCount")]
+        [LibraryImport(Interop.LIB_CORE_FOUNDATION, EntryPoint = "CFGetRetainCount")]
         internal static partial int GetRetainCount(CGImage image);
     }
 }

--- a/osu.Framework/Platform/Apple/Native/CGImageAlphaInfo.cs
+++ b/osu.Framework/Platform/Apple/Native/CGImageAlphaInfo.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal enum CGImageAlphaInfo : uint
+    {
+        None,
+        PremultipliedLast,
+        PremultipliedFirst,
+        Last,
+        First,
+        NoneSkipLast,
+        NoneSkipFirst,
+        Only,
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGPoint.cs
+++ b/osu.Framework/Platform/Apple/Native/CGPoint.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Runtime.InteropServices;
+
 namespace osu.Framework.Platform.Apple.Native
 {
+    [StructLayout(LayoutKind.Sequential)]
     internal struct CGPoint
     {
         internal double X;

--- a/osu.Framework/Platform/Apple/Native/CGPoint.cs
+++ b/osu.Framework/Platform/Apple/Native/CGPoint.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal struct CGPoint
+    {
+        internal double X;
+        internal double Y;
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGRect.cs
+++ b/osu.Framework/Platform/Apple/Native/CGRect.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Runtime.InteropServices;
+
 namespace osu.Framework.Platform.Apple.Native
 {
+    [StructLayout(LayoutKind.Sequential)]
     internal struct CGRect
     {
         internal CGPoint Origin;

--- a/osu.Framework/Platform/Apple/Native/CGRect.cs
+++ b/osu.Framework/Platform/Apple/Native/CGRect.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal struct CGRect
+    {
+        internal CGPoint Origin;
+        internal CGSize Size;
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/CGSize.cs
+++ b/osu.Framework/Platform/Apple/Native/CGSize.cs
@@ -1,8 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Runtime.InteropServices;
+
 namespace osu.Framework.Platform.Apple.Native
 {
+    [StructLayout(LayoutKind.Sequential)]
     internal struct CGSize
     {
         internal double Width;

--- a/osu.Framework/Platform/Apple/Native/CGSize.cs
+++ b/osu.Framework/Platform/Apple/Native/CGSize.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal struct CGSize
+    {
+        internal double Width;
+        internal double Height;
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/Interop.cs
+++ b/osu.Framework/Platform/Apple/Native/Interop.cs
@@ -13,6 +13,7 @@ namespace osu.Framework.Platform.Apple.Native
         internal const string LIB_OBJ_C = "/usr/lib/libobjc.dylib";
         internal const string LIB_CORE_GRAPHICS = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics";
         internal const string LIB_ACCELERATE = "/System/Library/Frameworks/Accelerate.framework/Accelerate";
+        internal const string LIB_CORE_FOUNDATION = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
 
         internal const int RTLD_NOW = 2;
 

--- a/osu.Framework/Platform/Apple/Native/NSData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSData.cs
@@ -22,6 +22,8 @@ namespace osu.Framework.Platform.Apple.Native
             Handle = handle;
         }
 
+        public static implicit operator NSData(NSMutableData data) => new NSData(data.Handle);
+
         internal byte[] ToBytes()
         {
             IntPtr pointer = Interop.SendIntPtr(Handle, sel_bytes);

--- a/osu.Framework/Platform/Apple/Native/NSMutableData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSMutableData.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Platform.MacOS.Native;
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal readonly struct NSMutableData : IDisposable
+    {
+        internal IntPtr Handle { get; }
+
+        private static readonly IntPtr class_pointer = Class.Get("NSMutableData");
+        private static readonly IntPtr sel_release = Selector.Get("release");
+        private static readonly IntPtr sel_data_with_length = Selector.Get("dataWithLength:");
+        private static readonly IntPtr sel_mutable_bytes = Selector.Get("mutableBytes");
+
+        internal NSMutableData(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal unsafe byte* MutableBytes => (byte*)Interop.SendIntPtr(Handle, sel_mutable_bytes);
+
+        internal void Release() => Interop.SendVoid(Handle, sel_release);
+
+        public void Dispose()
+        {
+            if (Handle != IntPtr.Zero)
+                Release();
+        }
+
+        internal static NSMutableData FromLength(int length)
+        {
+            IntPtr handle = Interop.SendIntPtr(class_pointer, sel_data_with_length, length);
+            return new NSMutableData(handle);
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -7,10 +7,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Platform.MacOS.Native;
 
@@ -43,6 +45,9 @@ namespace osu.Framework.Platform.MacOS
         protected override Clipboard CreateClipboard() => new MacOSClipboard();
 
         protected override ReadableKeyCombinationProvider CreateReadableKeyCombinationProvider() => new MacOSReadableKeyCombinationProvider();
+
+        public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
+            => new MacOSTextureLoaderStore(underlyingStore);
 
         protected override void Swap()
         {

--- a/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.IO;
+using osu.Framework.IO.Stores;
+using osu.Framework.Platform.Apple;
+using osu.Framework.Platform.Apple.Native;
+using osu.Framework.Platform.MacOS.Native;
+using SixLabors.ImageSharp;
+
+namespace osu.Framework.Platform.MacOS
+{
+    internal class MacOSTextureLoaderStore : AppleTextureLoaderStore
+    {
+        public MacOSTextureLoaderStore(IResourceStore<byte[]> store)
+            : base(store)
+        {
+        }
+
+        protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
+        {
+            int length = (int)(stream.Length - stream.Position);
+            using var nativeData = NSMutableData.FromLength(length);
+
+            var bytesSpan = new Span<byte>(nativeData.MutableBytes, length);
+            stream.ReadExactly(bytesSpan);
+
+            using var nsImage = NSImage.LoadFromData(nativeData);
+            if (nsImage.Handle == IntPtr.Zero)
+                throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+
+            var cgImage = nsImage.CGImage;
+            return ImageFromCGImage<TPixel>(cgImage);
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/NSImage.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSImage.cs
@@ -21,6 +21,9 @@ namespace osu.Framework.Platform.MacOS.Native
         private static readonly IntPtr sel_release = Selector.Get("release");
         private static readonly IntPtr sel_init_with_data = Selector.Get("initWithData:");
         private static readonly IntPtr sel_tiff_representation = Selector.Get("TIFFRepresentation");
+        private static readonly IntPtr sel_cg_image_for_proposed_rect = Selector.Get("CGImageForProposedRect:context:hints:");
+
+        internal CGImage CGImage => new CGImage(Interop.SendIntPtr(Handle, sel_cg_image_for_proposed_rect, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero));
 
         internal NSData TiffRepresentation => new NSData(Interop.SendIntPtr(Handle, sel_tiff_representation));
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/6474

Improves texture loading time by a magnitude. Shares most implementation with iOS.

![CleanShot 2024-12-28 at 15 47 53](https://github.com/user-attachments/assets/ed3ee1cb-1847-4816-ae23-ae08719b6cc9)
