### PR TITLE
FFmpeg build: Add linux-arm64 build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -172,26 +172,45 @@ jobs:
           path: win-arm64
 
   build-linux:
-    name: Build Linux (x64)
+    name: Build Linux
     # Use 20.04 to target glibc 2.31 like the other native libs
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+
     steps:
-      - name: Install dependencies
+      - name: Install dependencies (x64)
+        if: matrix.arch == 'x64'
         run: |
           sudo apt-get update
           sudo apt-get install nasm
+
+      - name: Install dependencies (arm64)
+        if: matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            make \
+            gcc-aarch64-linux-gnu \
+            libc-dev-arm64-cross \
+            binutils-aarch64-linux-gnu \
+            pkg-config-aarch64-linux-gnu
 
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Build
         run: osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
+        env:
+          arch: ${{ matrix.arch }}
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: linux-x64
-          path: linux-x64
+          name: linux-${{ matrix.arch }}
+          path: linux-${{ matrix.arch }}
 
   build-android:
     name: Build Android
@@ -245,6 +264,10 @@ jobs:
         with:
           name: linux-x64
           path: osu.Framework.NativeLibs/runtimes/linux-x64/native
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-arm64
+          path: osu.Framework.NativeLibs/runtimes/linux-arm64/native
       - uses: actions/download-artifact@v4
         with:
           name: win-arm64

--- a/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
+++ b/osu.Framework.NativeLibs/scripts/ffmpeg/build-linux.sh
@@ -6,18 +6,45 @@ SCRIPT_PATH=$(pwd)
 popd > /dev/null
 source "$SCRIPT_PATH/common.sh"
 
+if [ -z "${arch-}" ]; then
+    PS3='Build for which arch? '
+    select arch in "x64" "arm64"; do
+        if [ -z "$arch" ]; then
+            echo "invalid option"
+        else
+            break
+        fi
+    done
+fi
+
+case $arch in
+    x64)
+        FFMPEG_FLAGS+=(
+            --arch=x86_64
+        )
+        ;;
+
+    arm64)
+        FFMPEG_FLAGS+=(
+            --enable-cross-compile
+            --arch=aarch64
+            --cross-prefix=aarch64-linux-gnu-
+        )
+        ;;
+esac
+
 FFMPEG_FLAGS+=(
     --target-os=linux
 )
 
 pushd . > /dev/null
-prep_ffmpeg linux-x64
+prep_ffmpeg "linux-$arch"
 build_ffmpeg
 popd > /dev/null
 
 # gcc creates multiple symlinks per .so file for versioning.
 # We delete the symlinks and rename the real files to include the major library version
-rm linux-x64/*.so
-for f in linux-x64/*.so.*.*.*; do
+rm linux-$arch/*.so
+for f in linux-$arch/*.so.*.*.*; do
     mv -vf "$f" "${f%.*.*}"
 done


### PR DESCRIPTION
- Supersedes & closes #6288

Supersedes #6288 but does not include 32-bit targets. Supports Ubuntu and non-Ubuntu build hosts.

Cross-compiling from x86 to arm64/aarch64 is well-supported via official packages in many distros (e.g. this build script runs on Arch without any changes) and does not need emulation, so I think this is a better way of creating ARM binaries.

[Builds on my fork](https://github.com/FreezyLemon/osu-framework/actions/runs/12530103157)