### PR TITLE
Disable auto-capitalisation in textboxes

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -95,7 +95,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
                 textBoxes.Add(new CustomTextBox
                 {
-                    Text = @"Custom textbox",
+                    PlaceholderText = "Custom textbox",
+                    Size = new Vector2(500, 30),
+                    TabbableContentContainer = textBoxes
+                });
+
+                textBoxes.Add(new BasicTextBox
+                {
+                    InputProperties = new TextInputProperties(TextInputType.Text, AutoCapitalisation: true),
+                    Text = "Auto-capitalised textbox",
                     Size = new Vector2(500, 30),
                     TabbableContentContainer = textBoxes
                 });

--- a/osu.Framework/Input/TextInputProperties.cs
+++ b/osu.Framework/Input/TextInputProperties.cs
@@ -16,5 +16,6 @@ namespace osu.Framework.Input
     /// while others will ignore and always have the IME (dis)allowed.
     /// </para>
     /// </param>
-    public record struct TextInputProperties(TextInputType Type, bool AllowIme = true);
+    /// <param name="AutoCapitalisation">Whether text should be automatically capitalised.</param>
+    public record struct TextInputProperties(TextInputType Type, bool AllowIme = true, bool AutoCapitalisation = false);
 }

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -195,6 +195,12 @@ namespace osu.Framework.Platform.SDL3
 
             var props = currentTextInputProperties.Value;
             SDL_SetNumberProperty(props, SDL_PROP_TEXTINPUT_TYPE_NUMBER, (long)properties.Type.ToSDLTextInputType());
+
+            if (!properties.AutoCapitalisation)
+                SDL_SetNumberProperty(props, SDL_PROP_TEXTINPUT_CAPITALIZATION_NUMBER, (long)SDL_Capitalization.SDL_CAPITALIZE_NONE);
+            else
+                SDL_ClearProperty(props, SDL_PROP_TEXTINPUT_CAPITALIZATION_NUMBER);
+
             SDL_StartTextInputWithProperties(SDLWindowHandle, props);
         });
 


### PR DESCRIPTION
- [x] Depends on #6408 

Noticed while testing iOS. I cannot think of a single occurrence where we do want automatic capitalisation to be applied to user text input in osu!. One may say this should be disabled in `OsuTextBox` instead, I can move the default value there if that's preferred.