### PR TITLE
Fix touch input cancellation no longer being handled in latest SDL

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -567,6 +567,7 @@ namespace osu.Framework.Platform.SDL3
                 case SDL_EventType.SDL_EVENT_FINGER_DOWN:
                 case SDL_EventType.SDL_EVENT_FINGER_UP:
                 case SDL_EventType.SDL_EVENT_FINGER_MOTION:
+                case SDL_EventType.SDL_EVENT_FINGER_CANCELED:
                     HandleTouchFingerEvent(e.tfinger);
                     break;
 

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -281,6 +281,7 @@ namespace osu.Framework.Platform.SDL3
                     break;
 
                 case SDL_EventType.SDL_EVENT_FINGER_UP:
+                case SDL_EventType.SDL_EVENT_FINGER_CANCELED:
                     TouchUp?.Invoke(touch);
                     activeTouches[(int)existingSource] = null;
                     break;


### PR DESCRIPTION
- [ ] Update SDL

PR'ing this on the side as we bump SDL, turns out cancelled touches have been separated out from `SDL_EVENT_FINGER_UP` and to being their own event type, this is a silent failure so I'm explicitly opening a PR to keep track of it. See https://discourse.libsdl.org/t/sdl-added-sdl-event-finger-canceled/56427. 

I've added the "update SDL" task here as it is a good place to do it.