### PR TITLE
Fix incorrect release pattern in macOS/iOS texture loading code

### DIFF
--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -20,18 +20,21 @@ namespace osu.Framework.iOS.Graphics.Textures
 
         protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
-            int length = (int)(stream.Length - stream.Position);
-            using var nativeData = NSMutableData.FromLength(length);
+            using (new NSAutoreleasePool())
+            {
+                int length = (int)(stream.Length - stream.Position);
+                var nativeData = NSMutableData.FromLength(length);
 
-            var bytesSpan = new Span<byte>(nativeData.MutableBytes.ToPointer(), length);
-            stream.ReadExactly(bytesSpan);
+                var bytesSpan = new Span<byte>(nativeData.MutableBytes.ToPointer(), length);
+                stream.ReadExactly(bytesSpan);
 
-            using var uiImage = UIImage.LoadFromData(nativeData);
-            if (uiImage == null)
-                throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+                using var uiImage = UIImage.LoadFromData(nativeData);
+                if (uiImage == null)
+                    throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-            var cgImage = new Platform.Apple.Native.CGImage(uiImage.CGImage!.Handle);
-            return ImageFromCGImage<TPixel>(cgImage);
+                var cgImage = new Platform.Apple.Native.CGImage(uiImage.CGImage!.Handle);
+                return ImageFromCGImage<TPixel>(cgImage);
+            }
         }
     }
 }

--- a/osu.Framework/Platform/Apple/Native/Class.cs
+++ b/osu.Framework/Platform/Apple/Native/Class.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/NSArray.cs
+++ b/osu.Framework/Platform/Apple/Native/NSArray.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/NSAutoreleasePool.cs
+++ b/osu.Framework/Platform/Apple/Native/NSAutoreleasePool.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Platform.Apple.Native
+{
+    internal readonly struct NSAutoreleasePool : IDisposable
+    {
+        internal IntPtr Handle { get; }
+
+        internal NSAutoreleasePool(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        private static readonly IntPtr class_pointer = Class.Get("NSAutoreleasePool");
+        private static readonly IntPtr sel_alloc = Selector.Get("alloc");
+        private static readonly IntPtr sel_init = Selector.Get("init");
+        private static readonly IntPtr sel_drain = Selector.Get("drain");
+
+        public static NSAutoreleasePool Init()
+        {
+            var pool = alloc();
+            Interop.SendIntPtr(pool.Handle, sel_init);
+            return pool;
+        }
+
+        private static NSAutoreleasePool alloc() => new NSAutoreleasePool(Interop.SendIntPtr(class_pointer, sel_alloc));
+
+        public void Dispose()
+        {
+            if (Handle != IntPtr.Zero)
+                Interop.SendIntPtr(Handle, sel_drain);
+        }
+    }
+}

--- a/osu.Framework/Platform/Apple/Native/NSData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/NSData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSData.cs
@@ -6,12 +6,11 @@ using System.Runtime.InteropServices;
 
 namespace osu.Framework.Platform.Apple.Native
 {
-    internal readonly struct NSData : IDisposable
+    internal readonly struct NSData
     {
         internal IntPtr Handle { get; }
 
         private static readonly IntPtr class_pointer = Class.Get("NSData");
-        private static readonly IntPtr sel_release = Selector.Get("release");
         private static readonly IntPtr sel_data_with_bytes = Selector.Get("dataWithBytes:length:");
         private static readonly IntPtr sel_bytes = Selector.Get("bytes");
         private static readonly IntPtr sel_length = Selector.Get("length");
@@ -31,14 +30,6 @@ namespace osu.Framework.Platform.Apple.Native
             byte[] bytes = new byte[size];
             Marshal.Copy(pointer, bytes, 0, size);
             return bytes;
-        }
-
-        internal void Release() => Interop.SendVoid(Handle, sel_release);
-
-        public void Dispose()
-        {
-            if (Handle != IntPtr.Zero)
-                Release();
         }
 
         internal static unsafe NSData FromBytes(ReadOnlySpan<byte> bytes)

--- a/osu.Framework/Platform/Apple/Native/NSMutableData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSMutableData.cs
@@ -5,12 +5,11 @@ using System;
 
 namespace osu.Framework.Platform.Apple.Native
 {
-    internal readonly struct NSMutableData : IDisposable
+    internal readonly struct NSMutableData
     {
         internal IntPtr Handle { get; }
 
         private static readonly IntPtr class_pointer = Class.Get("NSMutableData");
-        private static readonly IntPtr sel_release = Selector.Get("release");
         private static readonly IntPtr sel_data_with_length = Selector.Get("dataWithLength:");
         private static readonly IntPtr sel_mutable_bytes = Selector.Get("mutableBytes");
 
@@ -20,14 +19,6 @@ namespace osu.Framework.Platform.Apple.Native
         }
 
         internal unsafe byte* MutableBytes => (byte*)Interop.SendIntPtr(Handle, sel_mutable_bytes);
-
-        internal void Release() => Interop.SendVoid(Handle, sel_release);
-
-        public void Dispose()
-        {
-            if (Handle != IntPtr.Zero)
-                Release();
-        }
 
         internal static NSMutableData FromLength(int length)
         {

--- a/osu.Framework/Platform/Apple/Native/NSMutableData.cs
+++ b/osu.Framework/Platform/Apple/Native/NSMutableData.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/NSNotificationCenter.cs
+++ b/osu.Framework/Platform/Apple/Native/NSNotificationCenter.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/NSString.cs
+++ b/osu.Framework/Platform/Apple/Native/NSString.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.Apple.Native
 {

--- a/osu.Framework/Platform/Apple/Native/Selector.cs
+++ b/osu.Framework/Platform/Apple/Native/Selector.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Runtime.InteropServices;
-using osu.Framework.Platform.Apple.Native;
 
-namespace osu.Framework.Platform.MacOS.Native
+namespace osu.Framework.Platform.Apple.Native
 {
     internal static partial class Selector
     {

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -35,9 +35,12 @@ namespace osu.Framework.Platform.MacOS
             using var stream = new MemoryStream();
             image.SaveAsTiff(stream);
 
-            using var nsData = NSData.FromBytes(stream.ToArray());
-            using var nsImage = NSImage.LoadFromData(nsData);
-            return setToPasteboard(nsImage.Handle);
+            using (NSAutoreleasePool.Init())
+            {
+                var nsData = NSData.FromBytes(stream.ToArray());
+                using var nsImage = NSImage.LoadFromData(nsData);
+                return setToPasteboard(nsImage.Handle);
+            }
         }
 
         private IntPtr getFromPasteboard(IntPtr @class)

--- a/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
@@ -20,18 +20,21 @@ namespace osu.Framework.Platform.MacOS
 
         protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
-            int length = (int)(stream.Length - stream.Position);
-            using var nativeData = NSMutableData.FromLength(length);
+            using (NSAutoreleasePool.Init())
+            {
+                int length = (int)(stream.Length - stream.Position);
+                var nativeData = NSMutableData.FromLength(length);
 
-            var bytesSpan = new Span<byte>(nativeData.MutableBytes, length);
-            stream.ReadExactly(bytesSpan);
+                var bytesSpan = new Span<byte>(nativeData.MutableBytes, length);
+                stream.ReadExactly(bytesSpan);
 
-            using var nsImage = NSImage.LoadFromData(nativeData);
-            if (nsImage.Handle == IntPtr.Zero)
-                throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
+                using var nsImage = NSImage.LoadFromData(nativeData);
+                if (nsImage.Handle == IntPtr.Zero)
+                    throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-            var cgImage = nsImage.CGImage;
-            return ImageFromCGImage<TPixel>(cgImage);
+                var cgImage = nsImage.CGImage;
+                return ImageFromCGImage<TPixel>(cgImage);
+            }
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/SDL2MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/SDL2MacOSWindow.cs
@@ -5,9 +5,9 @@
 
 using System;
 using osu.Framework.Platform.Apple.Native;
-using osu.Framework.Platform.MacOS.Native;
 using osu.Framework.Platform.SDL2;
 using osuTK;
+using Selector = osu.Framework.Platform.Apple.Native.Selector;
 
 namespace osu.Framework.Platform.MacOS
 {

--- a/osu.Framework/Platform/MacOS/SDL3MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/SDL3MacOSWindow.cs
@@ -5,9 +5,9 @@
 
 using System;
 using osu.Framework.Platform.Apple.Native;
-using osu.Framework.Platform.MacOS.Native;
 using osu.Framework.Platform.SDL3;
 using osuTK;
+using Selector = osu.Framework.Platform.Apple.Native.Selector;
 
 namespace osu.Framework.Platform.MacOS
 {


### PR DESCRIPTION
- Fixes recent segmentation fault on game exit since https://github.com/ppy/osu-framework/pull/6475

This is caused by the fact that the allocated `NSMutableData` object in the loading process is manually released whilst internally marked as auto-released (it is marked as auto-released because it is created using a convenience constructor, read https://stackoverflow.com/a/24807570 for more info (not owning the object essentially means the object itself is queued in the active auto-release pool).

To fix this in an obj-c friendly way, interop for `NSAutoreleasePool` is added and used in places where `NSData` is allocated, and the method to manually release `NSData` is removed as incorrect practice. I've also updated iOS code accordingly as it is generally better to have a local autorelease pool surrounding a code block which may allocate a large portion of memory.

I can confirm the segfault error is fixed by powering up `TestSceneTexturePerformance` and enable `unique textures` while the sprite count is set to 1000. On master, doing that then closing the game causes a segfault, whereas on this PR the game closes gracefully.

I have profiled between master and this PR so as to ensure no performance overhead is caused by initialising an auto-release pool. Reported times are almost identical.

I have also stressed out the code by a for-loop in `TestSceneTexturePerformance.load`. No sign of memory leak as far as I can tell. All I can see is the game accumulating up to 2 GB of memory usage, and that is due to how ImageSharp allocates space for the `Image` created in each time a texture was loaded.