### PR TITLE
Add input type for decimal numbers

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -103,17 +103,20 @@ namespace osu.Framework.Graphics.UserInterface
                 // discard control/special characters.
                 return false;
 
-            if (InputProperties.Type.IsNumerical())
+            var currentNumberFormat = CultureInfo.CurrentCulture.NumberFormat;
+
+            switch (InputProperties.Type)
             {
-                // if the input type is decimal and the character is a decimal separator, allow it.
-                if (InputProperties.Type == TextInputType.Decimal && CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator.Contains(character))
+                case TextInputType.Decimal:
+                    return char.IsAsciiDigit(character) || currentNumberFormat.NumberDecimalSeparator.Contains(character);
+
+                case TextInputType.Number:
+                case TextInputType.NumericalPassword:
+                    return char.IsAsciiDigit(character);
+
+                default:
                     return true;
-
-                // otherwise, only allow ascii digits for numerical input type.
-                return char.IsAsciiDigit(character);
             }
-
-            return true;
         }
 
         private bool readOnly;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -94,9 +95,25 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private bool canAddCharacter(char character)
         {
-            return !char.IsControl(character)
-                   && (!InputProperties.Type.IsNumerical() || char.IsAsciiDigit(character))
-                   && CanAddCharacter(character);
+            if (!CanAddCharacter(character))
+                // discard characters explicitly overriden by custom implementation.
+                return false;
+
+            if (char.IsControl(character))
+                // discard control/special characters.
+                return false;
+
+            if (InputProperties.Type.IsNumerical())
+            {
+                // if the input type is decimal and the character is a decimal separator, allow it.
+                if (InputProperties.Type == TextInputType.Decimal && CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator.Contains(character))
+                    return true;
+
+                // otherwise, only allow ascii digits for numerical input type.
+                return char.IsAsciiDigit(character);
+            }
+
+            return true;
         }
 
         private bool readOnly;

--- a/osu.Framework/Input/TextInputType.cs
+++ b/osu.Framework/Input/TextInputType.cs
@@ -26,9 +26,14 @@ namespace osu.Framework.Input
         Username,
 
         /// <summary>
-        /// The text input is numerical.
+        /// The text input is a whole number.
         /// </summary>
         Number,
+
+        /// <summary>
+        /// The text input is numerical with decimal point.
+        /// </summary>
+        Decimal,
 
         /// <summary>
         /// The text input is a password hidden from the user.
@@ -60,6 +65,7 @@ namespace osu.Framework.Input
         {
             switch (type)
             {
+                case TextInputType.Decimal:
                 case TextInputType.Number:
                 case TextInputType.NumericalPassword:
                     return true;

--- a/osu.Framework/Input/TextInputType.cs
+++ b/osu.Framework/Input/TextInputType.cs
@@ -61,20 +61,6 @@ namespace osu.Framework.Input
             }
         }
 
-        public static bool IsNumerical(this TextInputType type)
-        {
-            switch (type)
-            {
-                case TextInputType.Decimal:
-                case TextInputType.Number:
-                case TextInputType.NumericalPassword:
-                    return true;
-
-                default:
-                    return false;
-            }
-        }
-
         public static bool SupportsIme(this TextInputType type) => type == TextInputType.Name || type == TextInputType.Text;
     }
 }

--- a/osu.Framework/Platform/SDL3/SDL3Extensions.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Extensions.cs
@@ -1016,9 +1016,6 @@ namespace osu.Framework.Platform.SDL3
             switch (type)
             {
                 default:
-                // todo: SDL does not have a corresponding type for "number with decimal point", fall back to text for now.
-                // On iOS, using SDL_TEXTINPUT_TYPE_NUMBER does not offer a key for inserting a decimal.
-                case TextInputType.Decimal:
                 case TextInputType.Text:
                     return SDL_TextInputType.SDL_TEXTINPUT_TYPE_TEXT;
 
@@ -1032,6 +1029,7 @@ namespace osu.Framework.Platform.SDL3
                     return SDL_TextInputType.SDL_TEXTINPUT_TYPE_TEXT_USERNAME;
 
                 case TextInputType.Number:
+                case TextInputType.Decimal:
                     return SDL_TextInputType.SDL_TEXTINPUT_TYPE_NUMBER;
 
                 case TextInputType.Password:

--- a/osu.Framework/Platform/SDL3/SDL3Extensions.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Extensions.cs
@@ -1016,6 +1016,9 @@ namespace osu.Framework.Platform.SDL3
             switch (type)
             {
                 default:
+                // todo: SDL does not have a corresponding type for "number with decimal point", fall back to text for now.
+                // On iOS, using SDL_TEXTINPUT_TYPE_NUMBER does not offer a key for inserting a decimal.
+                case TextInputType.Decimal:
                 case TextInputType.Text:
                     return SDL_TextInputType.SDL_TEXTINPUT_TYPE_TEXT;
 


### PR DESCRIPTION
- [x] Depends on SDL bump (see https://github.com/ppy/osu-framework/pull/6498#discussion_r1922561417)

Required to (fix) https://github.com/ppy/osu/issues/31568.

Specifying a `Number` input type broke editor textboxes due to the type disallowing decimal characters from being entered. This disability is applied internally within `TextBox` and is not overridable with `CanAddCharacter` (rightly so).

As a proper fix for this, a specific input type for decimal numbers is added to support this. It has also came to my attention that displaying the software keyboard on iOS on a textbox that uses `TextInputType.Number` does not show a decimal button, which suggests that it is a good choice to add a different input type for decimal numbers. Unfortunately there's no corresponding SDL input type for decimal numbers, so this new input type is interpreted as "regular text" in SDL.

In other words, using the new `Decimal` input type will show the full alphanumeric software keyboard just for the sake of allowing the user to insert decimal points.