### PR TITLE
Add simple `InputProperties` / `TextInputType` test

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextInputProperties.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextInputProperties.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public partial class TestSceneTextInputProperties : FrameworkTestScene
+    {
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Create text boxes", () =>
+            {
+                FillFlowContainer flow;
+                Child = new BasicScrollContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = flow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Width = 0.9f,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Spacing = new Vector2(0, 13),
+                    }
+                };
+
+                foreach (var textInputType in Enum.GetValues<TextInputType>())
+                {
+                    flow.Add(new BasicTextBox
+                    {
+                        TabbableContentContainer = flow,
+                        RelativeSizeAxes = Axes.X,
+                        Height = 40,
+                        PlaceholderText = $"{textInputType} (allow IME)",
+                        InputProperties = new TextInputProperties
+                        {
+                            Type = textInputType,
+                            AllowIme = true
+                        },
+                    });
+                    flow.Add(new BasicTextBox
+                    {
+                        TabbableContentContainer = flow,
+                        RelativeSizeAxes = Axes.X,
+                        Height = 40,
+                        PlaceholderText = $"{textInputType} (no IME)",
+                        InputProperties = new TextInputProperties
+                        {
+                            Type = textInputType,
+                            AllowIme = false
+                        },
+                    });
+                }
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextInputProperties.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextInputProperties.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Width = 0.9f,
                         Anchor = Anchor.TopCentre,
                         Origin = Anchor.TopCentre,
-                        Spacing = new Vector2(0, 13),
+                        Spacing = new Vector2(20, 13),
                     }
                 };
 
@@ -40,6 +40,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         TabbableContentContainer = flow,
                         RelativeSizeAxes = Axes.X,
                         Height = 40,
+                        Width = 0.45f,
                         PlaceholderText = $"{textInputType} (allow IME)",
                         InputProperties = new TextInputProperties
                         {
@@ -52,6 +53,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         TabbableContentContainer = flow,
                         RelativeSizeAxes = Axes.X,
                         Height = 40,
+                        Width = 0.45f,
                         PlaceholderText = $"{textInputType} (no IME)",
                         InputProperties = new TextInputProperties
                         {


### PR DESCRIPTION
The added test scene is purely interactive, there are no automated tests.

Useful for checking how a OS platform shows the different text input types.

![image](https://github.com/user-attachments/assets/0464aad8-b57a-47ea-b0b6-37e18f34a095)
