### PR TITLE
Change IsRootedAt method from internal to public in DrawableExtensions

### DIFF
--- a/osu.Framework/Graphics/DrawableExtensions.cs
+++ b/osu.Framework/Graphics/DrawableExtensions.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics
         /// <param name="drawable">The <see cref="Drawable"/> to be checked.</param>
         /// <param name="root">The root to be checked against.</param>
         /// <returns>Whether the drawable was rooted.</returns>
-        internal static bool IsRootedAt(this Drawable? drawable, Drawable root)
+        public static bool IsRootedAt(this Drawable? drawable, Drawable root)
         {
             if (drawable == root) return true;
 


### PR DESCRIPTION
I think it can be useful to be able to use this method outside the framework. For example, I need it for this : 

```
bool sliderDraggedInItself = inputManager.DraggedDrawable.IsRootedAt(this);

if (Expanded.Value || IsHovered || sliderDraggedInItself)
{
    // Do things
}
```

Detailed example : https://github.com/ppy/osu/pull/31596