### PR TITLE
Prefer OpenGL by default on Windows systems

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -851,9 +851,10 @@ namespace osu.Framework.Platform
             switch (RuntimeInfo.OS)
             {
                 case RuntimeInfo.Platform.Windows:
+                    yield return RendererType.OpenGL;
+                    // The D3D implementation is very hacky and not well supported on all systems.
                     yield return RendererType.Direct3D11;
                     yield return RendererType.Deferred_Direct3D11;
-                    yield return RendererType.OpenGL;
                     yield return RendererType.Deferred_Vulkan;
 
                     break;


### PR DESCRIPTION
**Note that for users that haven't touched the automatic selection, this will now default them to OpenGL. I'm not sure if that's an issue or how to resolve it.**

I've been planning to do this for a while now... The D3D buffer management is inefficient and [`VeldridRenderer.CreateStagingBuffer<>()`](https://github.com/ppy/osu-framework/blob/6f7f43f074a5358ad31a3a1ad87b2bed8fbf5950/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs#L313-L343) is a hack to work around it. This breaks on some systems and sometimes creates problems like [this (likely)](https://github.com/ppy/osu/issues/31589). I personally use OpenGL because I notice microstutters and/or inconsistent frame timings on D3D @ 144hz.

I'll probably attempt this again soon, when I get around to implementing `SDL_gpu`.