### PR TITLE
Roll back windows build image to 2019 on android build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
   build-only-android:
     name: Build only (Android)
-    runs-on: windows-latest
+    runs-on: windows-2019
     timeout-minutes: 60
     steps:
       - name: Checkout


### PR DESCRIPTION
See https://github.com/ppy/osu/pull/31633 for reasoning.