### PR TITLE
SDL3: Handle keyboard input asynchronously when text input is disabled

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -308,6 +308,16 @@ namespace osu.Framework.Platform.SDL3
                     LowOnMemory?.Invoke();
                     break;
 
+                case SDL_EventType.SDL_EVENT_KEY_DOWN:
+                case SDL_EventType.SDL_EVENT_KEY_UP:
+                    if (!SDL_TextInputActive(SDLWindowHandle))
+                    {
+                        handleKeyboardEvent(e.key);
+                        return false;
+                    }
+
+                    break;
+
                 case SDL_EventType.SDL_EVENT_MOUSE_MOTION:
                     handleMouseMotionEvent(e.motion);
                     return false;


### PR DESCRIPTION
- Related: https://github.com/ppy/osu-framework/issues/6141
- Companion to https://github.com/ppy/osu-framework/pull/6235

This PR updates keyboard events to be handled asynchronously in the SDL event filter iff text input is disabled.

For now, keyboard input is handled synchronously when text input is enabled to prevent timing problems. If keyboard events are handled asynchronously, a keyboard event might come before a text input event. This is opposite to the current order and may break `TextBox` consuming key events that produce text. `TextBox` expects and is tested to first receive text, and then key input:

https://github.com/ppy/osu-framework/blob/54a23fb71d273d48d4936c84492e2a48ec1e6dce/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxKeyEvents.cs#L68-L78

## Threading concerns

There is a possibility for a key to get stuck in a pressed state if it's quickly tapped around the time text input is disabled.

Assume a key is quickly pressed and released, generating `SDL_EVENT_KEY_DOWN` and a `SDL_EVENT_KEY_UP`.

| Raw keyboard thread | Main thread | Update thread |
|--------|--------|--------|
| | | Text input enabled (initial state) |
| Receive `SDL_EVENT_KEY_DOWN`<br>Ignored as text input is enabled |  |  |
|  |  | Request text input disable |
|  | Run new frame<br>`commandScheduler.Update()`<br>`SDL_StopTextInput()` |  |
| Receive `SDL_EVENT_KEY_UP`<br>Handled, added to input queue |  |  |
|  | Receive the same `SDL_EVENT_KEY_DOWN`<br>Handled, added to input queue |  |
|  |  | Check input queue:<br>Handle key up event (no state change)<br>Handle key down event |

The key is now stuck. But the user can just press and release it to fix this.

The opposite is also possible: a key is pressed, but the game thinks it's released. Can happen if a held key is quickly released and pressed again.

This is only a concern if keyboard input is handled on a different thread, as things currently stand with SDL on Windows ([SDL_HINT_WINDOWS_RAW_KEYBOARD](https://wiki.libsdl.org/SDL3/SDL_HINT_WINDOWS_RAW_KEYBOARD) is disabled by default), keyboard events are added to the SDL event queue and handled by our filter on the main thread.