### PR TITLE
SDL3: Enabled raw keyboard on Windows

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -211,6 +211,7 @@ namespace osu.Framework.Platform.SDL3
             SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0"u8); // disable touch events generating synthetic mouse events on desktop platforms
             SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0"u8); // disable mouse events generating synthetic touch events on mobile platforms
             SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition"u8);
+            SDL_SetHint(SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8);
 
             SDLWindowHandle = SDL_CreateWindow(title, Size.Width, Size.Height, flags);
 


### PR DESCRIPTION
Related:
- https://github.com/ppy/osu-framework/issues/6141
- https://github.com/libsdl-org/SDL/issues/9409

With https://github.com/ppy/osu-framework/pull/6506, this will handle keyboard events on a dedicated thread to bypass the usual SDL event flow, leading to lower latency and immunity from main thread lag (we sometimes see `SDL_PumpEvents()` take a long time). Mouse input is already handled on this dedicated thread when relative mouse mode is enabled.

This PR is blocked as it breaks disabling the windows key during gameplay in osu!. Raw keyboard input will bypass [the hook that is supposed to disable the windows key](https://github.com/ppy/osu/blob/78cc28d75f49eb7f7b6007278169d39473e37272/osu.Desktop/Windows/WindowsKey.cs).

Enabling raw keyboard may lead to [timing issues](https://github.com/ppy/osu/issues/28261) wrt `TextBox` text input & related handling. This PR needs to be tested to check for IME regressions.