### PR TITLE
Fix pen input not being friendly with touch

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -296,7 +296,11 @@ namespace osu.Framework.Tests.Visual.Input
                 });
             });
 
-            AddStep("move pen to box", () => InputManager.MovePenTo(testInputManager));
+            AddStep("move pen to box", () => InputManager.Input(new MousePositionAbsoluteInputFromPen
+            {
+                DeviceType = TabletPenDeviceType.Unknown,
+                Position = testInputManager.ScreenSpaceDrawQuad.Centre
+            }));
 
             AddAssert("ensure parent manager produced mouse", () => InputManager.CurrentState.Mouse.Position == testInputManager.ScreenSpaceDrawQuad.Centre);
             AddAssert("ensure pass-through produced mouse", () => testInputManager.CurrentState.Mouse.Position == testInputManager.ScreenSpaceDrawQuad.Centre);
@@ -307,7 +311,10 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("inner box received 1 pen event", () => inner.PenEvents, () => Is.EqualTo(1));
             AddAssert("inner box received no mouse events", () => inner.MouseEvents, () => Is.EqualTo(0));
 
-            AddStep("press pen", () => InputManager.PressPen());
+            AddStep("press pen", () => InputManager.Input(new MouseButtonInputFromPen(true)
+            {
+                DeviceType = TabletPenDeviceType.Unknown,
+            }));
 
             AddAssert("ensure parent manager produced mouse", () => InputManager.CurrentState.Mouse.Buttons.Single() == MouseButton.Left);
             AddAssert("ensure pass-through produced mouse", () => testInputManager.CurrentState.Mouse.Buttons.Single() == MouseButton.Left);
@@ -318,7 +325,10 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("inner box received 2 pen events", () => inner.PenEvents, () => Is.EqualTo(2));
             AddAssert("inner box received no mouse events", () => inner.MouseEvents, () => Is.EqualTo(0));
 
-            AddStep("release pen", () => InputManager.ReleasePen());
+            AddStep("release pen", () => InputManager.Input(new MouseButtonInputFromPen(false)
+            {
+                DeviceType = TabletPenDeviceType.Unknown,
+            }));
 
             AddAssert("ensure parent manager produced mouse", () => InputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed, () => Is.False);
             AddAssert("ensure pass-through produced mouse", () => testInputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed, () => Is.False);

--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Tests.Visual.Input
 {
     public partial class TestSceneTouchInput : ManualInputManagerTestScene
     {
-        private static readonly TouchSource[] touch_sources = (TouchSource[])Enum.GetValues(typeof(TouchSource));
+        private static readonly TouchSource[] touch_sources = Enum.GetValues<TouchSource>().Take(10).ToArray();
 
         private Container<InputReceptor> receptors;
 

--- a/osu.Framework/Input/Handlers/Pen/PenHandler.cs
+++ b/osu.Framework/Input/Handlers/Pen/PenHandler.cs
@@ -31,13 +31,11 @@ namespace osu.Framework.Input.Handlers.Pen
                 if (enabled.NewValue)
                 {
                     window.PenMove += handlePenMove;
-                    window.PenTouch += handlePenTouch;
                     window.PenButton += handlePenButton;
                 }
                 else
                 {
                     window.PenMove -= handlePenMove;
-                    window.PenTouch -= handlePenTouch;
                     window.PenButton -= handlePenButton;
                 }
             }, true);
@@ -56,11 +54,6 @@ namespace osu.Framework.Input.Handlers.Pen
                 Position = position,
                 DeviceType = device_type
             });
-        }
-
-        private void handlePenTouch(bool pressed)
-        {
-            enqueueInput(new MouseButtonInputFromPen(pressed) { DeviceType = device_type });
         }
 
         private void handlePenButton(TabletPenButton button, bool pressed)

--- a/osu.Framework/Input/States/TouchState.cs
+++ b/osu.Framework/Input/States/TouchState.cs
@@ -9,9 +9,14 @@ namespace osu.Framework.Input.States
     public class TouchState
     {
         /// <summary>
-        /// The maximum amount of touches this can handle.
+        /// The maximum amount of touches this can handle (excluding <see cref="TouchSource.PenTouch"/>).
         /// </summary>
-        public static readonly int MAX_TOUCH_COUNT = Enum.GetValues<TouchSource>().Length;
+        public static readonly int MAX_TOUCH_COUNT = 10;
+
+        /// <summary>
+        /// The maximum number of <see cref="TouchSource"/>s.
+        /// </summary>
+        public static readonly int MAX_SOURCES_COUNT = Enum.GetValues<TouchSource>().Length;
 
         /// <summary>
         /// The list of currently active touch sources.
@@ -25,7 +30,7 @@ namespace osu.Framework.Input.States
         /// Using <see cref="GetTouchPosition"/> is recommended for retrieving
         /// logically correct values, as this may contain already stale values.
         /// </remarks>
-        public readonly Vector2[] TouchPositions = new Vector2[MAX_TOUCH_COUNT];
+        public readonly Vector2[] TouchPositions = new Vector2[MAX_SOURCES_COUNT];
 
         /// <summary>
         /// Retrieves the current touch position of a specified <paramref name="source"/>.

--- a/osu.Framework/Input/TouchSource.cs
+++ b/osu.Framework/Input/TouchSource.cs
@@ -57,5 +57,10 @@ namespace osu.Framework.Input
         /// The tenth and last available touch source.
         /// </summary>
         Touch10,
+
+        /// <summary>
+        /// A touch source that represents a pen/stylus.
+        /// </summary>
+        PenTouch,
     }
 }

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -128,12 +128,6 @@ namespace osu.Framework.Testing.Input
 
         public void MoveTouchTo(Touch touch) => Input(new TouchInput(touch, CurrentState.Touch.IsActive(touch.Source)));
 
-        public void MovePenTo(Drawable drawable, Vector2? offset = null, TabletPenDeviceType deviceType = TabletPenDeviceType.Unknown)
-            => MovePenTo(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre) + (offset ?? Vector2.Zero), deviceType);
-
-        public void MovePenTo(Vector2 position, TabletPenDeviceType deviceType = TabletPenDeviceType.Unknown)
-            => Input(new MousePositionAbsoluteInputFromPen { Position = position, DeviceType = deviceType });
-
         public new bool TriggerClick() =>
             throw new InvalidOperationException($"To trigger a click via a {nameof(ManualInputManager)} use {nameof(Click)} instead.");
 
@@ -170,9 +164,6 @@ namespace osu.Framework.Testing.Input
 
         public void PressMidiKey(MidiKey key, byte velocity) => Input(new MidiKeyInput(key, velocity, true));
         public void ReleaseMidiKey(MidiKey key, byte velocity) => Input(new MidiKeyInput(key, velocity, false));
-
-        public void PressPen(TabletPenDeviceType deviceType = TabletPenDeviceType.Unknown) => Input(new MouseButtonInputFromPen(true) { DeviceType = deviceType });
-        public void ReleasePen(TabletPenDeviceType deviceType = TabletPenDeviceType.Unknown) => Input(new MouseButtonInputFromPen(false) { DeviceType = deviceType });
 
         public void PressTabletPenButton(TabletPenButton penButton) => Input(new TabletPenButtonInput(penButton, true));
         public void ReleaseTabletPenButton(TabletPenButton penButton) => Input(new TabletPenButtonInput(penButton, false));


### PR DESCRIPTION
Fixes pen & touch osu! playstyle on mobile tablets no longer working in the past release.

---

- Closes https://github.com/ppy/osu/issues/31570

Back before SDL was bumped, SDL was propagating pen input on iOS in two forms:
 - mouse move input when the pen is within the screen's region but not touching it.
 - touch input when the pen is directly touching the screen.

This was working perfectly fine with our implementation of `OsuTouchInputMapper` in osu! for an elegant pen + touch playstyle. But since we bumped SDL and it became handling pen input natively on iOS and now became directly mapped to mouse input by our implementation in `SDL3Window` / https://github.com/ppy/osu-framework/pull/6488, everything fell apart.

I initially began on this by looking into updating the implementation of `OsuTouchInputMapper` to expect pen input by mouse events, but bailed out after finding multiple catastrophic input-level issues by the idea of sending pen input as mouse input (see https://github.com/ppy/osu-framework/issues/6508 / https://discord.com/channels/188630481301012481/589331078574112768/1332383057642000426).

I then attempted to dive right into the o!f input subsystem and try to get things in a right place, then I realised I'm essentially about to propose a top-down refactor of major input components, and I'm absolutely in no place, time, or even interest in doing any of that (nor do I think that anyone will be supporting this effort right at this very moment).

Finally, I decided to just remind myself of how osu! has always been working until now and mimicked that behaviour for now, calling it a day and allowing ourselves to focus on much better and prioritised tasks. In fact, I think the behaviour in this PR might even make more sense with regards to the idea that we want pen and touch input to work harmoniously.

I have tested this on my iPad and it's working perfectly fine everywhere.