### PR TITLE
Update SDL3, bringing in support for Windows Ink pen input, and enable it on desktop platforms once again

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -53,7 +53,7 @@ namespace osu.Framework
             if (DebugUtils.IsDebugBuild)
                 AllowInsecureRequests = parseBool(Environment.GetEnvironmentVariable("OSU_INSECURE_REQUESTS")) ?? false;
 
-            UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
+            UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? true);
         }
 
         private static bool? parseBool(string? value)

--- a/osu.Framework/Platform/SDL3/SDL3Extensions.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Extensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
@@ -1126,18 +1125,6 @@ namespace osu.Framework.Platform.SDL3
             string? error = SDL_GetError();
             SDL_ClearError();
             return error;
-        }
-
-        /// <summary>
-        /// Gets the <paramref name="name"/> of the touch device for this <see cref="SDL_TouchFingerEvent"/>.
-        /// </summary>
-        /// <remarks>
-        /// On Windows, this will return <c>"touch"</c> for touchscreen events or <c>"pen"</c> for pen/tablet events.
-        /// </remarks>
-        public static bool TryGetTouchName(this SDL_TouchFingerEvent e, [NotNullWhen(true)] out string? name)
-        {
-            name = SDL_GetTouchDeviceName(e.touchID);
-            return name != null;
         }
     }
 }

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -210,6 +210,8 @@ namespace osu.Framework.Platform.SDL3
             SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, "0"u8);
             SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0"u8); // disable touch events generating synthetic mouse events on desktop platforms
             SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0"u8); // disable mouse events generating synthetic touch events on mobile platforms
+            SDL_SetHint(SDL_HINT_PEN_TOUCH_EVENTS, "0"u8);
+            SDL_SetHint(SDL_HINT_PEN_MOUSE_EVENTS, "0"u8);
             SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition"u8);
 
             SDLWindowHandle = SDL_CreateWindow(title, Size.Width, Size.Height, flags);

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -570,6 +570,7 @@ namespace osu.Framework.Platform.SDL3
                 case SDL_EventType.SDL_EVENT_FINGER_DOWN:
                 case SDL_EventType.SDL_EVENT_FINGER_UP:
                 case SDL_EventType.SDL_EVENT_FINGER_MOTION:
+                case SDL_EventType.SDL_EVENT_FINGER_CANCELED:
                     HandleTouchFingerEvent(e.tfinger);
                     break;
 

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -571,7 +571,7 @@ namespace osu.Framework.Platform.SDL3
                 case SDL_EventType.SDL_EVENT_FINGER_UP:
                 case SDL_EventType.SDL_EVENT_FINGER_MOTION:
                 case SDL_EventType.SDL_EVENT_FINGER_CANCELED:
-                    HandleTouchFingerEvent(e.tfinger);
+                    handleTouchFingerEvent(e.tfinger);
                     break;
 
                 case SDL_EventType.SDL_EVENT_DROP_FILE:

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -269,7 +269,7 @@ namespace osu.Framework.Platform.SDL3
             return null;
         }
 
-        protected virtual void HandleTouchFingerEvent(SDL_TouchFingerEvent evtTfinger)
+        private void handleTouchFingerEvent(SDL_TouchFingerEvent evtTfinger)
         {
             var existingSource = getTouchSource(evtTfinger.fingerID);
 

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -300,6 +300,7 @@ namespace osu.Framework.Platform.SDL3
                     break;
 
                 case SDL_EventType.SDL_EVENT_FINGER_UP:
+                case SDL_EventType.SDL_EVENT_FINGER_CANCELED:
                     TouchUp?.Invoke(touch);
                     activeTouches[(int)existingSource] = null;
                     break;

--- a/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
@@ -10,7 +10,6 @@ using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Platform.SDL3;
 using osu.Framework.Platform.Windows.Native;
 using osuTK;
-using osuTK.Input;
 using SDL;
 using Icon = osu.Framework.Platform.Windows.Native.Icon;
 using static SDL.SDL3;
@@ -100,33 +99,6 @@ namespace osu.Framework.Platform.Windows
         }
 
         public override void ResetIme() => ScheduleCommand(() => Imm.CancelComposition(WindowHandle));
-
-        protected override void HandleTouchFingerEvent(SDL_TouchFingerEvent evtTfinger)
-        {
-            if (evtTfinger.TryGetTouchName(out string? name) && name == "pen")
-            {
-                // Windows Ink tablet/pen handling
-                // InputManager expects to receive this as mouse events, to have proper `mouseSource` input priority (see InputManager.GetPendingInputs)
-                // osu! expects to get tablet events as mouse events, and touch events as touch events for touch device (TD mod) handling (see https://github.com/ppy/osu/issues/25590)
-
-                TriggerMouseMove(evtTfinger.x * ClientSize.Width, evtTfinger.y * ClientSize.Height);
-
-                switch (evtTfinger.type)
-                {
-                    case SDL_EventType.SDL_EVENT_FINGER_DOWN:
-                        TriggerMouseDown(MouseButton.Left);
-                        break;
-
-                    case SDL_EventType.SDL_EVENT_FINGER_UP:
-                        TriggerMouseUp(MouseButton.Left);
-                        break;
-                }
-
-                return;
-            }
-
-            base.HandleTouchFingerEvent(evtTfinger);
-        }
 
         public override Size Size
         {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
-    <PackageReference Include="ppy.SDL3-CS" Version="2025.104.0" />
+    <PackageReference Include="ppy.SDL3-CS" Version="2025.127.0" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2024.1128.0" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
- Supersedes #6484
- Closes https://github.com/ppy/osu/issues/28254
- Closes #6291
- Closes https://github.com/ppy/osu/issues/28223
- Closes https://github.com/ppy/osu/issues/30641
- Resolves the soft dependency for https://github.com/ppy/osu-framework/pull/6498#discussion_r1923227642

---

Depends on:
- [x] https://github.com/ppy/SDL3-CS/pull/197
- [x] https://github.com/ppy/SDL3-CS/pull/200
- [x] SDL3-CS release

**This PR will make SDL3 the default option**, see https://github.com/ppy/osu/issues/30641#issuecomment-2581695099. `OSU_SDL3=0` can be set to use SDL2.

---

Issues to check after this SDL3 update propagates to osu!:
- https://github.com/ppy/osu/issues/28222
- https://github.com/ppy/osu/issues/28279
- https://github.com/ppy/osu/issues/28259