### PR TITLE
Revert changes to `OnScreenKeyboardOverlapsGameWindow` on iOS

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -30,6 +30,8 @@ namespace osu.Framework.iOS
 
         private IOSFilePresenter presenter = null!;
 
+        public override bool OnScreenKeyboardOverlapsGameWindow => true;
+
         public IOSGameHost()
             : base(string.Empty)
         {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -123,7 +123,6 @@ namespace osu.Framework.Platform
 
         /// <summary>
         /// Whether the on-screen keyboard covers a portion of the game window when presented to the user.
-        /// This is usually true on mobile platforms, but may change to false if a hardware keyboard is connected.
         /// </summary>
         public virtual bool OnScreenKeyboardOverlapsGameWindow => false;
 


### PR DESCRIPTION
- Reverts part of https://github.com/ppy/osu-framework/pull/6407
- Keeps the override in `SDLGameHost` as-is, as I think it's still good for any case of running the game on a 3-in-1 laptop with keyboard detached (assuming windows will slide up a software keyboard on any request of text input).

This introduced horrible UX in reality, contrary to what I thought and have seen when I added this. It seems I have not tested this enough back then.

While the on-sceren keyboard hides when a hardware keyboard is connected, it can be brought back, and once it's back, it does not hide again until the user explicitly hides it again. 

This introduces very weird / ugly behaviour when combined with a `FocusedTextBox` on osu!, e.g.:

https://github.com/user-attachments/assets/46dd8ea4-7abd-40ea-aae1-bf9839f16e5d

(after I brought back the on-screen keyboard, I began tapping on empty spots in the settings overlay, causing the keyboard to slide down, and then slide back up due to the logic of `FocusedTextBox`)