### PR TITLE
Add text input type for alphanumeric code

### DIFF
--- a/osu.Framework/Input/TextInputType.cs
+++ b/osu.Framework/Input/TextInputType.cs
@@ -16,14 +16,9 @@ namespace osu.Framework.Input
         Name,
 
         /// <summary>
-        /// The text input is an email address.
+        /// The text input is an alphanumeric code which can be visible to the user.
         /// </summary>
-        EmailAddress,
-
-        /// <summary>
-        /// The text input is a username.
-        /// </summary>
-        Username,
+        Code,
 
         /// <summary>
         /// The text input is numerical.
@@ -31,7 +26,17 @@ namespace osu.Framework.Input
         Number,
 
         /// <summary>
-        /// The text input is a password hidden from the user.
+        /// The text input is an email address.
+        /// </summary>
+        EmailAddress,
+
+        /// <summary>
+        /// The text input is a username. This may hint the operating system to provide a shortcut to a credentials manager for autofill.
+        /// </summary>
+        Username,
+
+        /// <summary>
+        /// The text input is a password hidden from the user. This may hint the operating system to provide a shortcut to a credentials manager for autofill.
         /// </summary>
         Password,
 

--- a/osu.Framework/Platform/SDL3/SDL3Extensions.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Extensions.cs
@@ -1017,6 +1017,7 @@ namespace osu.Framework.Platform.SDL3
             {
                 default:
                 case TextInputType.Text:
+                case TextInputType.Code:
                     return SDL_TextInputType.SDL_TEXTINPUT_TYPE_TEXT;
 
                 case TextInputType.Name:

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -201,6 +201,11 @@ namespace osu.Framework.Platform.SDL3
             else
                 SDL_ClearProperty(props, SDL_PROP_TEXTINPUT_CAPITALIZATION_NUMBER);
 
+            if (properties.Type == TextInputType.Code)
+                SDL_SetBooleanProperty(props, SDL_PROP_TEXTINPUT_AUTOCORRECT_BOOLEAN, false);
+            else
+                SDL_ClearProperty(props, SDL_PROP_TEXTINPUT_AUTOCORRECT_BOOLEAN);
+
             SDL_StartTextInputWithProperties(SDLWindowHandle, props);
         });
 


### PR DESCRIPTION
Very minor one, but also quite easy to implement so might as well. To be used for the two-factor authentication textbox in osu!, which I found quite weird to suddenly show a bar suggesting English words.

![IMG_0470](https://github.com/user-attachments/assets/84d78981-62dd-4f5d-bdc1-c9c14b77eef0)
