### PR TITLE
Don't force fs and vs shader file extension if shader load argument string already includes file extension

### DIFF
--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -83,14 +83,19 @@ namespace osu.Framework.Graphics.Shaders
             byte[]? rawData = GetRawData(name);
 
             if (rawData == null)
-                throw new FileNotFoundException($"{type} shader part could not be found.", name);
+                throw new FileNotFoundException($"{type} shader part could not be found. If using a different file extension than .fs or .vs, Be sure to include it in the argument.", name);
 
             return partCache[name] = renderer.CreateShaderPart(this, name, rawData, type);
         }
 
         private string ensureValidName(string name, ShaderPartType partType)
         {
-            string ending = getFileEnding(partType);
+            bool hasExistingExtension = !string.IsNullOrEmpty(Path.GetExtension(name));
+
+            string ending = string.Empty;
+
+            if (!hasExistingExtension)
+                ending = getFileEnding(partType);
 
             if (!name.StartsWith(shader_prefix, StringComparison.Ordinal))
                 name = shader_prefix + name;

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -90,11 +90,11 @@ namespace osu.Framework.Graphics.Shaders
 
         private string ensureValidName(string name, ShaderPartType partType)
         {
-            bool hasExistingExtension = !string.IsNullOrEmpty(Path.GetExtension(name));
+            bool noFileEnding = string.IsNullOrEmpty(Path.GetExtension(name));
 
             string ending = string.Empty;
 
-            if (!hasExistingExtension)
+            if (noFileEnding)
                 ending = getFileEnding(partType);
 
             if (!name.StartsWith(shader_prefix, StringComparison.Ordinal))

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -90,11 +90,8 @@ namespace osu.Framework.Graphics.Shaders
 
         private string ensureValidName(string name, ShaderPartType partType)
         {
-            bool noFileEnding = string.IsNullOrEmpty(Path.GetExtension(name));
-
             string ending = string.Empty;
-
-            if (noFileEnding)
+            if (string.IsNullOrEmpty(Path.GetExtension(name)))
                 ending = getFileEnding(partType);
 
             if (!name.StartsWith(shader_prefix, StringComparison.Ordinal))

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.Shaders
             byte[]? rawData = GetRawData(name);
 
             if (rawData == null)
-                throw new FileNotFoundException($"{type} shader part could not be found. If using a different file extension than .fs or .vs, Be sure to include it in the argument.", name);
+                throw new FileNotFoundException($"{type} shader part could not be found.", name);
 
             return partCache[name] = renderer.CreateShaderPart(this, name, rawData, type);
         }


### PR DESCRIPTION
This should allow shader files to be loaded, regardless of filename extension, as long as it's specified when using dependency injection. Otherwise, default to vs and fs for vertex and fragment shader respectively. ("sh_" prefix is still required)
The exception message is updated as well.

This might be a small change that might not matter to a lot of people since they can just follow as instructed and use the hardcoded filename extension, but it doesn't feel right to force people to accept on someone else's preference on something subjective IMO