### PR TITLE
Use decibel scaling for volume control (version 2)

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -32,9 +32,9 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
             SetDefault(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
             SetDefault(FrameworkSetting.AudioDevice, string.Empty);
-            SetDefault(FrameworkSetting.VolumeUniversal, 1.0, 0.0, 1.0, 0.01);
-            SetDefault(FrameworkSetting.VolumeMusic, 1.0, 0.0, 1.0, 0.01);
-            SetDefault(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
+            SetDefault(FrameworkSetting.VolumeUniversal, 1.0, 0.0, 1.0);
+            SetDefault(FrameworkSetting.VolumeMusic, 1.0, 0.0, 1.0);
+            SetDefault(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0);
             SetDefault(FrameworkSetting.HardwareVideoDecoder, HardwareVideoDecoder.Any);
             SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
             SetDefault(FrameworkSetting.MinimiseOnFocusLossInFullscreen, RuntimeInfo.IsDesktop);


### PR DESCRIPTION
An alternative approach to https://github.com/ppy/osu-framework/pull/6490

Meant to work alongside https://github.com/ppy/osu/pull/31717

As mentioned in https://github.com/ppy/osu/pull/31717, very few changes are needed on the framework end. All that's needed is an increase in volume level precision.