### PR TITLE
Fix iOS file presentation code not scheduled to main thread

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -56,9 +56,17 @@ namespace osu.Framework.iOS
 
         public override Storage GetStorage(string path) => new IOSStorage(path, this);
 
-        public override bool OpenFileExternally(string filename) => presenter.OpenFile(filename);
+        public override bool OpenFileExternally(string filename)
+        {
+            UIApplication.SharedApplication.InvokeOnMainThread(() => presenter.OpenFile(filename));
+            return true;
+        }
 
-        public override bool PresentFileExternally(string filename) => presenter.PresentFile(filename);
+        public override bool PresentFileExternally(string filename)
+        {
+            UIApplication.SharedApplication.InvokeOnMainThread(() => presenter.PresentFile(filename));
+            return true;
+        }
 
         public override void OpenUrlExternally(string url)
         {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/31727

Can be reproduced by changing threading mode to multi-threaded then export a file and click on it. Oversight from my end.