### PR TITLE
Update OpenTabletDriver to 0.6.5.1

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.5.0" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.5.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
## Tablet Support

### Added support

- Huion H1061P
- Huion Kamvas 13 (Gen 3)
- Wacom DTH-135
- XP-Pen Artist 10S
- XP-Pen Artist 24
- XP-Pen Deco mini7 V2
- XP-Pen Deco 01 V3
- XP-Pen Star 02

### Improved detection

- Add identifier and fix dimensions to Huion RTP-700
- Add support for new firmware of RTS-300
- Add support for 16k pressure variant of Gaomon M8
- Fix tilt for Huion H1061P
- add support of Huion 420 with null characters
- Add wireless support for Wacom CTC-6110WL
- Add linux support to Huion H610 Pro V3
- config/Huion Kamvas Pro 13: Add an additional device string
- Add identifier for Gaomon PD2200
- config/UGEE M708 V2: Fix dimensions and add new identifier
- Add support for variant of Huion Q630M
- Add string for kamvas pro 13
- Change H610 Pro V3 regex to support null character variants
- Add support for variant of XP-Pen Star G960S Plus

### Improved support
- Add eraser support for CTC-4110WL/6110WL
- Add Linux and MacOS support for the Genius i608x
- Add extra init to XP-Pen Innovator 16
- CTH-x61: Add auxiliary key support
- Parblo A610: Add interface

Support for the 10moons 1060N has been yanked due to parser problems and conflicts with other tablets, it will be readded in the future when we sort this out.

And more.