### PR TITLE
Reduce overhead of async disposal

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkAsyncDisposal.cs
+++ b/osu.Framework.Benchmarks/BenchmarkAsyncDisposal.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public partial class BenchmarkAsyncDisposal
+    {
+        private readonly List<Drawable> objects = new List<Drawable>();
+
+        [GlobalSetup]
+        [OneTimeSetUp]
+        public virtual void SetUp()
+        {
+            objects.Clear();
+            for (int i = 0; i < 10000; i++)
+                objects.Add(new Box());
+        }
+
+        [Test]
+        [Benchmark]
+        public void Run()
+        {
+            objects.ForEach(AsyncDisposalQueue.Enqueue);
+            AsyncDisposalQueue.WaitForEmpty();
+        }
+    }
+}

--- a/osu.Framework/Allocation/AsyncDisposalQueue.cs
+++ b/osu.Framework/Allocation/AsyncDisposalQueue.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Allocation
     /// </summary>
     internal static class AsyncDisposalQueue
     {
-        private static readonly GlobalStatistic<string> last_disposal = GlobalStatistics.Get<string>("Drawable", "Last disposal");
+        private static readonly GlobalStatistic<Type> last_disposal = GlobalStatistics.Get<Type>("Drawable", "Last disposal");
 
         private static Task runTask;
 
@@ -62,7 +62,7 @@ namespace osu.Framework.Allocation
                     {
                         ref var item = ref itemsToDispose[i];
 
-                        last_disposal.Value = item.ToString();
+                        last_disposal.Value = item.GetType();
 
                         item.Dispose();
                         item = null;

--- a/osu.Framework/Statistics/GlobalStatistic.cs
+++ b/osu.Framework/Statistics/GlobalStatistic.cs
@@ -3,6 +3,9 @@
 
 #nullable disable
 
+using System;
+using osu.Framework.Extensions.TypeExtensions;
+
 namespace osu.Framework.Statistics
 {
     public class GlobalStatistic<T> : IGlobalStatistic
@@ -23,6 +26,9 @@ namespace osu.Framework.Statistics
             {
                 switch (Value)
                 {
+                    case Type t:
+                        return t.ReadableName();
+
                     case double d:
                         return d.ToString("#,0.##");
 


### PR DESCRIPTION
I noticed that the majority of the time being spent in async disposal was actually on getting the readable type...

Before:
| Method |     Mean |     Error |    StdDev |     Gen0 |    Gen1 | Allocated |
|------- |---------:|----------:|----------:|---------:|--------:|----------:|
|    Run | 1.318 ms | 0.0263 ms | 0.0571 ms | 248.0469 | 11.7188 |   1.98 MB |

After:
| Method |     Mean |    Error |   StdDev |   Gen0 | Allocated |
|------- |---------:|---------:|---------:|-------:|----------:|
|    Run | 547.0 us | 10.87 us | 15.24 us | 8.7891 |   78.7 KB |
