### PR TITLE
Fix `[Solo]` attributes getting committed by blocking from NUnit runs

### DIFF
--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -7,7 +7,6 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -548,6 +549,10 @@ namespace osu.Framework.Testing
             {
                 if (test.Fixture is not TestScene testScene)
                     return;
+
+                bool hasSoloAttribute = test.Method?.MethodInfo.CustomAttributes.Any(a => a.AttributeType == typeof(SoloAttribute)) == true;
+                if (DebugUtils.IsNUnitRunning && hasSoloAttribute)
+                    throw new InvalidOperationException($"{typeof(SoloAttribute)} should not be specified on tests running under NUnit.");
 
                 // Since the host is created in OneTimeSetUp, all game threads will have the fixture's execution context
                 // This is undesirable since each test is run using those same threads, so we must make sure the execution context

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -551,7 +551,7 @@ namespace osu.Framework.Testing
 
                 bool hasSoloAttribute = test.Method?.MethodInfo.CustomAttributes.Any(a => a.AttributeType == typeof(SoloAttribute)) == true;
                 if (DebugUtils.IsNUnitRunning && hasSoloAttribute)
-                    throw new InvalidOperationException($"{typeof(SoloAttribute)} should not be specified on tests running under NUnit.");
+                    throw new InvalidOperationException($"{nameof(SoloAttribute)} should not be specified on tests running under NUnit.");
 
                 // Since the host is created in OneTimeSetUp, all game threads will have the fixture's execution context
                 // This is undesirable since each test is run using those same threads, so we must make sure the execution context


### PR DESCRIPTION
See https://github.com/peppy/osu/commit/aa329f397e684f41e5ca040d4d33a13026d464a5

Arguably this impairs the ability to leave them specified locally while running headless tests, but I don't think this is a blocker.