### PR TITLE
Fix iOS URL handling overriding deprecated method

### DIFF
--- a/osu.Framework.iOS/GameApplicationDelegate.cs
+++ b/osu.Framework.iOS/GameApplicationDelegate.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.iOS
             return true;
         }
 
-        public override bool OpenUrl(UIApplication application, NSUrl url, string sourceApplication, NSObject annotation)
+        public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
         {
             // copied verbatim from SDL: https://github.com/libsdl-org/SDL/blob/d252a8fe126b998bd1b0f4e4cf52312cd11de378/src/video/uikit/SDL_uikitappdelegate.m#L508-L535
             // the hope is that the SDL app delegate class does not have such handling exist there, but Apple does not provide a corresponding notification to make that possible.


### PR DESCRIPTION
- Probably closes https://github.com/ppy/osu/issues/31687

I'm surprised that .NET does not warn against this, but apparently I was overriding an older version of the method which was long deprecated since iOS 9. The functionality is still there and working except for that specific user, and I'm not sure why.

I'm not 100% sure that this would fix the issue above but it fulfills what the error message stated:
```
Application has LSSupportsOpeningDocumentsInPlace key, but doesn't implement application:openURL:options: on delegate <AppDelegate: 0x302991dc0>
```


Note that it's bizarre for the error message to include `LSSupportsOpeningDocumentsInPlace` since we actually have set that to false, but the error itself is surrounded in an exception typed `NSInternalInconsistencyException`, so maybe it's just an error in logging.