### PR TITLE
Fix Tablet Inputs

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -110,6 +110,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             if (device != null)
             {
+                outputMode = new AbsoluteTabletMode(this);
+
                 device.OutputMode = outputMode;
                 outputMode.Tablet = device.CreateReference();
 

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -110,9 +110,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
             if (device != null)
             {
-                outputMode = new AbsoluteTabletMode(this);
-
-                device.OutputMode = outputMode;
+                // Important to reinitialise outputMode here as the previous one is likely disposed.
+                device.OutputMode = outputMode = new AbsoluteTabletMode(this);
                 outputMode.Tablet = device.CreateReference();
 
                 updateTabletAndInputArea(device);


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/6525

For some reasons, the Input Device Tree's `Disconnected` event is being called, causing `Driver` to `Dispose()` of the Output Mode.

What comes with that is `entryElement` (The first element called in the tablet input pipeline), being nulled.
In this situation, `entryElement` is `AbsoluteOutputMode`'s `Consume()`.

So what happens if you null it but never set it back ?
Well, tablets inputs not going down the pipeline & position being set.
Normally, the a new output mode would be instanciated for each devices, but that's not the case in the integration.

Either you override `Dispose()` in `AbsoluteTabletMode` with nothing, OR you instanciate a new `AbsoluteTabletMode` object (as should be done), after the detection process.

1. Overriding `Dispose()`

```diff
diff --git a/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs b/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
index e7ca36726..5b68e17bc 100644
--- a/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
+++ b/osu.Framework/Input/Handlers/Tablet/AbsoluteTabletMode.cs
@@ -14,5 +14,7 @@ public AbsoluteTabletMode(IAbsolutePointer pointer)
         }
 
         public override IAbsolutePointer Pointer { get; set; }
+
+        public override void Dispose() {}
     }
 }
```

2. Instanciating a new `AbsoluteTabletMode`

```diff
diff --git a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
index faf28c953..66194ecff 100644
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -110,6 +110,8 @@ private void handleTabletsChanged(object? sender, IEnumerable<TabletReference> t

             if (device != null)
             {
+                outputMode = new AbsoluteTabletMode(this);
+
                 device.OutputMode = outputMode;
                 outputMode.Tablet = device.CreateReference();
```