### PR TITLE
Attempt to fix crashes when loading images on macOS

### DIFF
--- a/osu.Framework/Platform/Apple/Native/NSAutoreleasePool.cs
+++ b/osu.Framework/Platform/Apple/Native/NSAutoreleasePool.cs
@@ -20,13 +20,7 @@ namespace osu.Framework.Platform.Apple.Native
         private static readonly IntPtr sel_drain = Selector.Get("drain");
 
         public static NSAutoreleasePool Init()
-        {
-            var pool = alloc();
-            Interop.SendIntPtr(pool.Handle, sel_init);
-            return pool;
-        }
-
-        private static NSAutoreleasePool alloc() => new NSAutoreleasePool(Interop.SendIntPtr(class_pointer, sel_alloc));
+            => new NSAutoreleasePool(Interop.SendIntPtr(Interop.SendIntPtr(class_pointer, sel_alloc), sel_init));
 
         public void Dispose()
         {

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Platform.MacOS
             using (NSAutoreleasePool.Init())
             {
                 var nsData = NSData.FromBytes(stream.ToArray());
-                using var nsImage = NSImage.LoadFromData(nsData);
+                using var nsImage = NSImage.InitWithData(nsData);
                 return setToPasteboard(nsImage.Handle);
             }
         }

--- a/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextureLoaderStore.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Platform.MacOS
                 var bytesSpan = new Span<byte>(nativeData.MutableBytes, length);
                 stream.ReadExactly(bytesSpan);
 
-                using var nsImage = NSImage.LoadFromData(nativeData);
+                using var nsImage = NSImage.InitWithData(nativeData);
                 if (nsImage.Handle == IntPtr.Zero)
                     throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 

--- a/osu.Framework/Platform/MacOS/Native/NSImage.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSImage.cs
@@ -28,21 +28,13 @@ namespace osu.Framework.Platform.MacOS.Native
         internal NSData TiffRepresentation => new NSData(Interop.SendIntPtr(Handle, sel_tiff_representation));
 
         [MustDisposeResource]
-        internal static NSImage LoadFromData(NSData data)
-        {
-            var image = alloc();
-            Interop.SendIntPtr(image.Handle, sel_init_with_data, data);
-            return image;
-        }
-
-        internal void Release() => Interop.SendVoid(Handle, sel_release);
-
-        private static NSImage alloc() => new NSImage(Interop.SendIntPtr(class_pointer, sel_alloc));
+        internal static NSImage InitWithData(NSData data)
+            => new NSImage(Interop.SendIntPtr(Interop.SendIntPtr(class_pointer, sel_alloc), sel_init_with_data, data));
 
         public void Dispose()
         {
             if (Handle != IntPtr.Zero)
-                Release();
+                Interop.SendVoid(Handle, sel_release);
         }
     }
 }


### PR DESCRIPTION
I haven't been able to reproduce or induce this, so this is an _attempt_ at fixing https://github.com/ppy/osu/issues/31895 based solely on the documentation in https://developer.apple.com/documentation/objectivec/nsobject/1418641-init.

> In some cases, a custom implementation of the `init()` method might return a substitute object. You must therefore always use the object returned by `init()`, and not the one returned by `alloc` or `allocWithZone:`, in subsequent code.

I've looked into other possibilities - that perhaps `struct` vs `class` is causing the the `Dispose()` to be run early, or that perhaps the GC could be reordering disposals. I'm aware of special GC behaviour around native calls that could cause the GC to run early, but I couldn't induce any unexpected behaviours here, so I'm discounting this for now.  
Either of these possibilities would be more understandable if finalisers were involved (a common case where you'd use `GC.KeepAlive()`).