### PR TITLE
Remove Android SDL3 workaround code 

### DIFF
--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Bindables;
 using osu.Framework.Platform;
 using osu.Framework.Platform.SDL3;
 
@@ -22,10 +21,6 @@ namespace osu.Framework.Android
             base.Create();
 
             SafeAreaPadding.BindTo(AndroidGameActivity.Surface.SafeAreaPadding);
-
-            // Android SDL doesn't receive these events at start, so it never receives focus until it comes back from background
-            ((BindableBool)CursorInWindow).Value = true;
-            Focused = true;
         }
     }
 }


### PR DESCRIPTION
This was a workaround for https://github.com/libsdl-org/SDL/issues/9592, which was fixed by https://github.com/libsdl-org/SDL/pull/9926.

Spotted this no-longer-necessary code in https://github.com/ppy/osu-framework/pull/6462#discussion_r1957322742. With this removal, https://github.com/ppy/osu-framework/pull/6462/commits/03934bcd19f541ba8d410919e023031aab34fa1f is no longer necessary.

Tested to work as expected on my phone.