### PR TITLE
Only create `PenHandler` on SDL3

### DIFF
--- a/osu.Framework/Platform/SDLGameHost.cs
+++ b/osu.Framework/Platform/SDLGameHost.cs
@@ -41,17 +41,19 @@ namespace osu.Framework.Platform
                 ? new SDL3Clipboard(PngFormat.Instance) // PNG works well on linux
                 : new SDL2Clipboard();
 
-        protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() =>
-            new InputHandler[]
-            {
-                new KeyboardHandler(),
-                // tablet should get priority over mouse to correctly handle cases where tablet drivers report as mice as well.
-                new OpenTabletDriverHandler(),
-                new PenHandler(),
-                new MouseHandler(),
-                new TouchHandler(),
-                new JoystickHandler(),
-                new MidiHandler(),
-            };
+        protected override IEnumerable<InputHandler> CreateAvailableInputHandlers()
+        {
+            yield return new KeyboardHandler();
+            // tablet should get priority over mouse to correctly handle cases where tablet drivers report as mice as well.
+            yield return new OpenTabletDriverHandler();
+
+            if (FrameworkEnvironment.UseSDL3)
+                yield return new PenHandler();
+
+            yield return new MouseHandler();
+            yield return new TouchHandler();
+            yield return new JoystickHandler();
+            yield return new MidiHandler();
+        }
     }
 }


### PR DESCRIPTION
Creating it in SDL2 (when `OSU_SDL3=0`) would [disable the handler](https://github.com/ppy/osu-framework/blob/master/osu.Framework/Platform/GameHost.cs#L1159-L1163) since it fails to initialise on SDL2. We don't want the handler disabled as that is stored to config, and osu! doesn't show it in settings (no way for users to enable it in the GUI).

The handler only works with SDL3.

Spotted by @Joehuu [on discord](https://discord.com/channels/188630481301012481/589331078574112768/1341901014755967079).