### PR TITLE
Fix mouse handler moving OS pen cursor

### DIFF
--- a/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
+++ b/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
@@ -15,6 +15,7 @@ namespace osu.Framework.Input.Handlers
         /// </summary>
         /// <param name="position">The final mouse position.</param>
         /// <param name="isSelfFeedback">Whether the feedback was triggered from this handler.</param>
-        void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback);
+        /// <param name="isOsCursor">Whether the position represents OS cursor.</param>
+        void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback, bool isOsCursor);
     }
 }

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -32,6 +32,8 @@ namespace osu.Framework.Input.Handlers
 
         private bool isInitialized;
 
+        public virtual bool IsOsCursor => false;
+
         /// <summary>
         /// Used to initialize resources specific to this InputHandler. It gets called once.
         /// </summary>

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Input.Handlers.Mouse
             Precision = 0.01
         };
 
+        public override bool IsOsCursor => true;
+
         public override string Description => "Mouse";
 
         public override bool IsActive => true;
@@ -137,12 +139,12 @@ namespace osu.Framework.Input.Handlers.Mouse
             return true;
         }
 
-        public virtual void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback)
+        public virtual void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback, bool isOsCursor)
         {
             if (!Enabled.Value)
                 return;
 
-            if (!isSelfFeedback && isActive.Value)
+            if (!isSelfFeedback && !isOsCursor && isActive.Value)
                 // if another handler has updated the cursor position, handle updating the OS cursor so we can seamlessly revert
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);

--- a/osu.Framework/Input/Handlers/Pen/PenHandler.cs
+++ b/osu.Framework/Input/Handlers/Pen/PenHandler.cs
@@ -16,6 +16,8 @@ namespace osu.Framework.Input.Handlers.Pen
     {
         private static readonly GlobalStatistic<ulong> statistic_total_events = GlobalStatistics.Get<ulong>(StatisticGroupFor<PenHandler>(), "Total events");
 
+        public override bool IsOsCursor => true;
+
         public override bool IsActive => true;
 
         public override bool Initialize(GameHost host)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -964,7 +964,7 @@ namespace osu.Framework.Input
             foreach (var h in InputHandlers)
             {
                 if (h.Enabled.Value && h is INeedsMousePositionFeedback handler)
-                    handler.FeedbackMousePositionChange(mouse.Position, h == mouseSource);
+                    handler.FeedbackMousePositionChange(mouse.Position, h == mouseSource, mouseSource.IsOsCursor);
             }
 
             handleMouseMove(state, e.LastPosition);

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -31,10 +31,10 @@ namespace osu.Framework.Platform.Windows
             return base.Initialize(host);
         }
 
-        public override void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback)
+        public override void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback, bool isOsCursor)
         {
             window.LastMousePosition = position;
-            base.FeedbackMousePositionChange(position, isSelfFeedback);
+            base.FeedbackMousePositionChange(position, isSelfFeedback, isOsCursor);
         }
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/31948, not sure why the original author closed.

I've had this issue for a while, and just found out that the new `PenHandler` was the culprit.
Whenever `PenHandler` moves the cursor, `MouseHandler` tries to forcefully move the cursor to the reported position because it is not self-feedback, but SDL3 `PenHandler` also represents OS cursor.

I think the process here is like: Pen reports a position -> PenHandler becomes mouseSource -> MouseHandler moves the OS cursor -> Pen reports a position -> OS cursor gets repositioned -> Pen somehow reports the forcefully moved position? -> Cursor is now stuck

I don't have a tablet driver installed on my Windows installation, so it's only tested on Linux. This is somehow only reproducible on X11 for me. Honestly, I don't know how moving a cursor (`SDL_WarpMouseInWindow`) is affecting an absolute positioning device, but I don't really want to dig deeper.

I'm not sure if `isSelfFeedback` is needed anymore, but I just focused on fixing the issue. Please tell me if there's a better way to fix it!