### PR TITLE
Log SDL video driver

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Window.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Window.cs
@@ -197,7 +197,8 @@ namespace osu.Framework.Platform.SDL2
             SDL_GetVersion(out SDL_version version);
             Logger.Log($@"SDL2 Initialized
                           SDL2 Version: {version.major}.{version.minor}.{version.patch}
-                          SDL2 Revision: {SDL_GetRevision()}");
+                          SDL2 Revision: {SDL_GetRevision()}
+                          SDL2 Video driver: {SDL_GetCurrentVideoDriver()}");
 
             SDL_LogSetPriority((int)SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL_LogSetOutputFunction(logOutputDelegate = logOutput, IntPtr.Zero);

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -166,7 +166,8 @@ namespace osu.Framework.Platform.SDL3
             int version = SDL_GetVersion();
             Logger.Log($@"SDL3 Initialized
                           SDL3 Version: {SDL_VERSIONNUM_MAJOR(version)}.{SDL_VERSIONNUM_MINOR(version)}.{SDL_VERSIONNUM_MICRO(version)}
-                          SDL3 Revision: {SDL_GetRevision()}");
+                          SDL3 Revision: {SDL_GetRevision()}
+                          SDL3 Video driver: {SDL_GetCurrentVideoDriver()}");
 
             SDL_SetLogPriority(SDL_LogCategory.SDL_LOG_CATEGORY_ERROR, SDL_LogPriority.SDL_LOG_PRIORITY_DEBUG);
             SDL_SetLogOutputFunction(&logOutput, IntPtr.Zero);


### PR DESCRIPTION
Only really useful on Linux, to show if SDL is using `x11` or `wayland`.