### PR TITLE
Add tip pressure to click threshold to tablet handler configuration

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// <summary>
         /// The minimum pressure percentage required to click.
         /// </summary>
-        Bindable<float> PressureThreshold { get; }
+        BindableFloat PressureThreshold { get; }
 
         BindableBool Enabled { get; }
     }

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -32,6 +32,11 @@ namespace osu.Framework.Input.Handlers.Tablet
         /// </summary>
         Bindable<float> Rotation { get; }
 
+        /// <summary>
+        /// The minimum pressure percentage required to click.
+        /// </summary>
+        Bindable<float> PressureThreshold { get; }
+
         BindableBool Enabled { get; }
     }
 }

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -40,6 +40,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<float> Rotation { get; } = new Bindable<float>();
 
+        public Bindable<float> PressureThreshold { get; } = new Bindable<float>();
+
         public IBindable<TabletInfo?> Tablet => tablet;
 
         private readonly Bindable<TabletInfo?> tablet = new Bindable<TabletInfo?>();
@@ -102,7 +104,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             enqueueInput(new MousePositionRelativeInputFromPen { Delta = new Vector2(delta.X, delta.Y), DeviceType = lastTabletDeviceType });
         }
 
-        void IPressureHandler.SetPressure(float percentage) => enqueueInput(new MouseButtonInputFromPen(percentage > 0) { DeviceType = lastTabletDeviceType });
+        void IPressureHandler.SetPressure(float percentage) => enqueueInput(new MouseButtonInputFromPen(percentage > PressureThreshold.Value / 100) { DeviceType = lastTabletDeviceType });
 
         private void handleTabletsChanged(object? sender, IEnumerable<TabletReference> tablets)
         {

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -40,7 +40,12 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<float> Rotation { get; } = new Bindable<float>();
 
-        public Bindable<float> PressureThreshold { get; } = new Bindable<float>();
+        public BindableFloat PressureThreshold { get; } = new BindableFloat(0.0f)
+        {
+            MinValue = 0f,
+            MaxValue = 1f,
+            Precision = 0.005f,
+        };
 
         public IBindable<TabletInfo?> Tablet => tablet;
 
@@ -104,7 +109,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             enqueueInput(new MousePositionRelativeInputFromPen { Delta = new Vector2(delta.X, delta.Y), DeviceType = lastTabletDeviceType });
         }
 
-        void IPressureHandler.SetPressure(float percentage) => enqueueInput(new MouseButtonInputFromPen(percentage > PressureThreshold.Value / 100) { DeviceType = lastTabletDeviceType });
+        void IPressureHandler.SetPressure(float percentage) => enqueueInput(new MouseButtonInputFromPen(percentage > PressureThreshold.Value) { DeviceType = lastTabletDeviceType });
 
         private void handleTabletsChanged(object? sender, IEnumerable<TabletReference> tablets)
         {


### PR DESCRIPTION
Adds a bindable to set a threshold for the minimum tablet pen pressure required to click for opentabletdriver.

Worth noting that, on my setup, there is some interference from the systemwide tablet drivers. Specifically, tapping produces a click for one frame, regardless of pen pressure, and I can confirm this comes from the outside drivers since disabling clicking there removes the issue. Though, I wouldn't be surprised if this is an issue with my Linux setup specifically.

Untested on Windows, MacOS, iOS, or Android.