### PR TITLE
Allow multiple values for one key when adding web request parameters

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -109,12 +109,12 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Query string parameters.
         /// </summary>
-        private readonly Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+        private readonly List<(string key, string value)> queryParameters = new List<(string key, string value)>();
 
         /// <summary>
         /// Form parameters.
         /// </summary>
-        private readonly Dictionary<string, string> formParameters = new Dictionary<string, string>();
+        private readonly List<(string key, string value)> formParameters = new List<(string key, string value)>();
 
         /// <summary>
         /// FILE parameters.
@@ -304,7 +304,7 @@ namespace osu.Framework.IO.Network
 
                     StringBuilder requestParameters = new StringBuilder();
                     foreach (var p in queryParameters)
-                        requestParameters.Append($@"{p.Key}={Uri.EscapeDataString(p.Value)}&");
+                        requestParameters.Append($"{p.key}={Uri.EscapeDataString(p.value)}&");
                     string requestString = requestParameters.ToString().TrimEnd('&');
                     url = string.IsNullOrEmpty(requestString) ? url : $"{url}?{requestString}";
 
@@ -345,7 +345,7 @@ namespace osu.Framework.IO.Network
                             var formData = new MultipartFormDataContent(form_boundary);
 
                             foreach (var p in formParameters)
-                                formData.Add(new StringContent(p.Value), p.Key);
+                                formData.Add(new StringContent(p.value), p.key);
 
                             foreach (var p in files)
                             {
@@ -681,7 +681,7 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// <para>
-        /// Add a new parameter to this request. Replaces any existing parameter with the same name.
+        /// Add a new parameter to this request.
         /// </para>
         /// <para>
         /// If this request's <see cref="Method"/> supports a request body (<c>POST, PUT, DELETE, PATCH</c>), a <see cref="RequestParameterType.Form"/> parameter will be added;
@@ -701,7 +701,7 @@ namespace osu.Framework.IO.Network
             => AddParameter(name, value, supportsRequestBody(Method) ? RequestParameterType.Form : RequestParameterType.Query);
 
         /// <summary>
-        /// Add a new parameter to this request. Replaces any existing parameter with the same name.
+        /// Add a new parameter to this request.
         /// <see cref="RequestParameterType.Form"/> parameters may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
         /// </summary>
         /// <remarks>
@@ -718,14 +718,14 @@ namespace osu.Framework.IO.Network
             switch (type)
             {
                 case RequestParameterType.Query:
-                    queryParameters[name] = value;
+                    queryParameters.Add((name, value));
                     break;
 
                 case RequestParameterType.Form:
                     if (!supportsRequestBody(Method))
                         throw new ArgumentException("Cannot add form parameter to a request type which has no body.", nameof(type));
 
-                    formParameters[name] = value;
+                    formParameters.Add((name, value));
                     break;
             }
         }


### PR DESCRIPTION
Couldn't be me fixing this for FILE parameters (https://github.com/ppy/osu-framework/pull/6412) and then completely failing to notice that `AddParameter()` in fact *OVERWRITES* the previous value for a given key. :facepalm: 

This failure is the root cause for https://github.com/ppy/osu/issues/32059. The difference between the online version of the beatmap and the local version provided by the user is that two `.osu` files changed filename inadvertently, because of lazer escaping quote characters (which stable doesn't do).

In terms of patching, submission represents this as deleting the two files from the online version of the package and then adding another two. However, because `AddParameter()` would silently *ONLY KEEP THE LAST FILENAME SPECIFIED* to delete, one of the `.osu` files would remain in the patched package, and show up as a "tag mismatch" while it was supposed to be completely gone.

---

## Breaking changes

Calling `WebRequest.AddParameter()` multiple times with the same first parameter (`name`) will no longer overwrite previous calls, which is to say, a single parameter name is allowed to be associated with multiple values.