### PR TITLE
Add Windows precision touchpad (PTP) absolute position support (proof of concept)

### DIFF
--- a/osu.Framework/Input/Handlers/Touchpad/TouchpadHandler.cs
+++ b/osu.Framework/Input/Handlers/Touchpad/TouchpadHandler.cs
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.Handlers.Touchpad
+{
+    /// <summary>
+    /// For <see cref="IWindow"/> implementing <see cref="IHasTouchpadInput"/>. Translate the touchpad events to mouse events.
+    /// </summary>
+    public class TouchpadHandler : InputHandler, IHasCursorSensitivity
+    {
+        private static readonly GlobalStatistic<ulong> statistic_total_events = GlobalStatistics.Get<ulong>(StatisticGroupFor<TouchpadHandler>(), "Total events");
+
+        public override string Description => "Touchpad";
+
+        public override bool IsActive => true;
+
+        public BindableDouble Sensitivity { get; } = new BindableDouble(1)
+        {
+            MinValue = 1,
+            MaxValue = 10,
+            Precision = 0.01
+        };
+
+        private IHasTouchpadInput? window;
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            if (host.Window is not IHasTouchpadInput hasTouchpadInput)
+                return false;
+
+            window = hasTouchpadInput;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    window!.TouchpadDataUpdate += handleTouchpadUpdate;
+                }
+                else
+                {
+                    window!.TouchpadDataUpdate -= handleTouchpadUpdate;
+                }
+            }, true);
+
+            return true;
+        }
+
+        public override void Reset()
+        {
+            Sensitivity.SetDefault();
+            base.Reset();
+        }
+
+        private void handleTouchpadUpdate(TouchpadData data)
+        {
+            // We just use the first reported point (For PoC).
+            // This might not be the first finger touched.
+            foreach (var point in data.Points)
+            {
+                if (!point.Valid || !point.Confidence) continue;
+
+                var position = mapToWindow(data.Info, point);
+                enqueueInput(new MousePositionAbsoluteInput { Position = position });
+                break;
+            }
+
+            // TODO Real mouse button event should be suppressed (???) otherwise tapping can be converted to clicks by the OS
+            // TODO only enqueue when state changed
+            enqueueInput(new MouseButtonInput(MouseButton.Left, data.ButtonDown));
+        }
+
+        private Vector2 mapToWindow(TouchpadInfo info, TouchpadPoint point)
+        {
+            var center = window!.Size / 2;
+
+            // centered (-range/2 ~ range/2)
+            int x = point.X - info.XMin - info.XRange / 2;
+            int y = point.Y - info.YMin - info.YRange / 2;
+
+            // Minimum ratio to cover the whole window
+            float minimumRatio = Math.Max(
+                (float)window.Size.Width / info.XRange,
+                (float)window.Size.Height / info.YRange);
+            var toWindow = new Vector2(
+                center.Width + x * minimumRatio * (float)Sensitivity.Value,
+                center.Height + y * minimumRatio * (float)Sensitivity.Value);
+
+            return Vector2.Clamp(
+                toWindow,
+                Vector2.Zero,
+                new Vector2(window.Size.Width - 1, window.Size.Height - 1));
+        }
+
+        private void enqueueInput(IInput input)
+        {
+            PendingInputs.Enqueue(input);
+            FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
+            statistic_total_events.Value++;
+        }
+    }
+}

--- a/osu.Framework/Platform/IHasTouchpadInput.cs
+++ b/osu.Framework/Platform/IHasTouchpadInput.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Window has touchpad input reported
+    /// </summary>
+    internal interface IHasTouchpadInput : IWindow
+    {
+        /// <summary>
+        /// Publish the touchpad data. Read by <see cref="Input.Handlers.Touchpad.TouchpadHandler"/>.
+        /// </summary>
+        public event Action<TouchpadData>? TouchpadDataUpdate;
+    }
+
+    /// <summary>Information for the whole touchpad.</summary>
+    public struct TouchpadData
+    {
+        /// <summary>Static information.</summary>
+        public readonly TouchpadInfo Info;
+
+        /// <summary>Valid touch points.</summary>
+        public readonly List<TouchpadPoint> Points;
+
+        /// <summary>Is the touchpad pressed down?</summary>
+        public readonly bool ButtonDown;
+
+        public TouchpadData(TouchpadInfo info, List<TouchpadPoint> points, bool buttonDown)
+        {
+            Info = info;
+            Points = points;
+            ButtonDown = buttonDown;
+        }
+    }
+
+    /// <summary>Information for the whole touchpad.</summary>
+    public struct TouchpadInfo
+    {
+        /// <summary>Arbitrary numerical value to differentiate individual touchpads.</summary>
+        public IntPtr Handle;
+
+        /// <summary>The limit for the raw XY values.</summary>
+        /// <remarks>
+        /// <para>To map the values to 0~1, use `(value-min)/range`.</para>
+        /// <para>The YRange/XRange value is the aspect ratio of the touchpad.</para>
+        /// </remarks>
+        public int XMin, YMin, XRange, YRange;
+    }
+
+    /// <summary>Information for every touch point.</summary>
+    public struct TouchpadPoint
+    {
+        public int X, Y;
+
+        /// <summary>Unique ID for the contact.</summary>
+        /// <remarks>
+        /// The position of one contact in the array may and will change, if fingers are added or removed.
+        /// </remarks>
+        public int ContactId;
+
+        /// <summary>Is finger in contact with the touchpad?</summary>
+        /// <remarks>
+        /// If false, the XY coordinate may still be valid, but the finger can be in a hover state.
+        /// </remarks>
+        public bool Valid;
+
+        /// <summary>Is touch point too large to be considered invalid?</summary>
+        /// <remarks>
+        /// If false, this contact may be a palm-touchpad contact.
+        /// </remarks>
+        public bool Confidence;
+    }
+}

--- a/osu.Framework/Platform/SDLGameHost.cs
+++ b/osu.Framework/Platform/SDLGameHost.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers.Pen;
 using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Input.Handlers.Touch;
+using osu.Framework.Input.Handlers.Touchpad;
 using osu.Framework.Platform.SDL2;
 using osu.Framework.Platform.SDL3;
 using SixLabors.ImageSharp.Formats.Png;
@@ -50,6 +51,8 @@ namespace osu.Framework.Platform
             if (FrameworkEnvironment.UseSDL3)
                 yield return new PenHandler();
 
+            // Touchpad should get priority over mouse, same reason as tablets.
+            yield return new TouchpadHandler();
             yield return new MouseHandler();
             yield return new TouchHandler();
             yield return new JoystickHandler();

--- a/osu.Framework/Platform/Windows/Native/Hid.cs
+++ b/osu.Framework/Platform/Windows/Native/Hid.cs
@@ -1,0 +1,159 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+// (We are using the original names from the Windows API with type prefix removed.)
+
+namespace osu.Framework.Platform.Windows.Native
+{
+    internal class Hid
+    {
+        public const long HIDP_STATUS_SUCCESS = 0x00110000;
+
+        [DllImport("hid.dll")]
+        public static extern long HidP_GetCaps(IntPtr PreparsedData, out HIDP_CAPS Capabilities);
+
+        [DllImport("hid.dll")]
+        public static extern long HidP_GetValueCaps(HIDP_REPORT_TYPE ReportType, [Out] HIDP_VALUE_CAPS[] ValueCaps, ref ulong ValueCapsLength, IntPtr PreparsedData);
+
+        [DllImport("hid.dll")]
+        public static extern long HidP_GetLinkCollectionNodes([Out] HIDP_LINK_COLLECTION_NODE[] LinkCollectionNodes, ref ulong LinkCollectionNodesLength, IntPtr PreparsedData);
+
+        [DllImport("hid.dll")]
+        public static extern long HidP_GetUsageValue(
+            HIDP_REPORT_TYPE ReportType, ushort UsagePage, ushort LinkCollection, ushort Usage, out ulong UsageValue,
+            IntPtr PreparsedData, byte[] Report, ulong ReportLength);
+
+        [DllImport("hid.dll")]
+        public static extern long HidP_GetUsagesEx(
+            HIDP_REPORT_TYPE ReportType, ushort LinkCollection, [Out] USAGE_AND_PAGE[] ButtonList, ref ulong UsageLength,
+            IntPtr PreparsedData, byte[] Report, ulong ReportLength);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct HIDP_CAPS
+    {
+        public ushort Usage;
+        public ushort UsagePage;
+        public ushort InputReportByteLength;
+        public ushort OutputReportByteLength;
+        public ushort FeatureReportByteLength;
+        private unsafe fixed ushort Reserved[17];
+
+        public ushort NumberLinkCollectionNodes;
+
+        public ushort NumberInputButtonCaps;
+        public ushort NumberInputValueCaps;
+        public ushort NumberInputDataIndices;
+
+        public ushort NumberOutputButtonCaps;
+        public ushort NumberOutputValueCaps;
+        public ushort NumberOutputDataIndices;
+
+        public ushort NumberFeatureButtonCaps;
+        public ushort NumberFeatureValueCaps;
+        public ushort NumberFeatureDataIndices;
+    }
+
+    public enum HIDP_REPORT_TYPE
+    {
+        HidP_Input,
+        HidP_Output,
+        HidP_Feature
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct HIDP_VALUE_CAPS
+    {
+        public ushort UsagePage;
+        public byte ReportID;
+        public byte IsAlias;
+
+        public ushort BitField;
+        public ushort LinkCollection;
+
+        public ushort LinkUsage;
+        public ushort LinkUsagePage;
+
+        public byte IsRange;
+        public byte IsStringRange;
+        public byte IsDesignatorRange;
+        public byte IsAbsolute;
+
+        public byte HasNull;
+        private byte Reserved;
+        public ushort BitSize;
+
+        public ushort ReportCount;
+        private unsafe fixed ushort Reserved2[5];
+
+        public uint UnitsExp;
+        public uint Units;
+
+        public int LogicalMin, LogicalMax;
+        public int PhysicalMin, PhysicalMax;
+        public Union union;
+
+        [StructLayout(LayoutKind.Explicit, Pack = 4)]
+        public struct Union
+        {
+            [FieldOffset(0)]
+            public _Range Range;
+
+            [FieldOffset(0)]
+            public _NotRange NotRange;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct _Range
+        {
+            public ushort UsageMin, UsageMax;
+            public ushort StringMin, StringMax;
+            public ushort DesignatorMin, DesignatorMax;
+            public ushort DataIndexMin, DataIndexMax;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct _NotRange
+        {
+            public ushort Usage;
+            private ushort Reserved1;
+            public ushort StringIndex;
+            private ushort Reserved2;
+            public ushort DesignatorIndex;
+            private ushort Reserved3;
+            public ushort DataIndex;
+            private ushort Reserved4;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct HIDP_LINK_COLLECTION_NODE
+    {
+        public ushort LinkUsage;
+        public ushort LinkUsagePage;
+        public ushort Parent;
+        public ushort NumberOfChildren;
+        public ushort NextSibling;
+        public ushort FirstChild;
+
+        // The original definition is:
+        //     ULONG    CollectionType: 8;  // As defined in 6.2.2.6 of HID spec
+        //     ULONG    IsAlias : 1; // This link node is an allias of the next link node.
+        //     ULONG    Reserved: 23;
+        // Fortunately the value is not used here. Don't bother parsing the bitfield now.
+        public UInt32 _bitfield;
+
+        public IntPtr UserContext;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct USAGE_AND_PAGE
+    {
+        public ushort Usage;
+        public ushort UsagePage;
+    }
+}

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform.Windows.Native
             int cbSize);
 
         [DllImport("user32.dll")]
-        public static extern int GetRawInputData(IntPtr hRawInput, RawInputCommand uiCommand, out RawInputData pData, ref int pcbSize, int cbSizeHeader);
+        public static extern int GetRawInputData(IntPtr hRawInput, RawInputCommand uiCommand, IntPtr pData, ref int pcbSize, int cbSizeHeader);
 
         internal static Rectangle VirtualScreenRect => new Rectangle(
             GetSystemMetrics(SM_XVIRTUALSCREEN),

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -21,6 +21,12 @@ namespace osu.Framework.Platform.Windows.Native
         [DllImport("user32.dll")]
         public static extern int GetRawInputData(IntPtr hRawInput, RawInputCommand uiCommand, IntPtr pData, ref int pcbSize, int cbSizeHeader);
 
+        [DllImport("user32.dll")]
+        public static extern int GetRawInputDeviceInfo(IntPtr hDevice, RawInputDeviceInfoCommand uiCommand, ref RID_DEVICE_INFO info, ref int pcbSize);
+
+        [DllImport("user32.dll")]
+        public static extern int GetRawInputDeviceInfo(IntPtr hDevice, RawInputDeviceInfoCommand uiCommand, IntPtr pData, ref int pcbSize);
+
         internal static Rectangle VirtualScreenRect => new Rectangle(
             GetSystemMetrics(SM_XVIRTUALSCREEN),
             GetSystemMetrics(SM_YVIRTUALSCREEN),
@@ -144,6 +150,22 @@ namespace osu.Framework.Platform.Windows.Native
         /// The device-specific additional information for the event.
         /// </summary>
         public uint ExtraInformation;
+    }
+
+    /// <summary>Header of the raw input data if is a HID device.</summary>
+    /// <remarks>
+    /// This is just a header, because variable sized HID reports is following this.
+    /// </remarks>
+    public struct RawInputDataHidHeader
+    {
+        /// <summary>Header for the data.</summary>
+        public RawInputHeader Header;
+
+        /// <summary>Size of each HID report.</summary>
+        public int SizeHid;
+
+        /// <summary>Count of HID reports.</summary>
+        public int Count;
     }
 
     /// <summary>
@@ -317,17 +339,10 @@ namespace osu.Framework.Platform.Windows.Native
         AppKeys = 0x00000400
     }
 
-    public enum HIDUsage : ushort
-    {
-        Pointer = 0x01,
-        Mouse = 0x02,
-        Joystick = 0x04,
-        Gamepad = 0x05,
-        Keyboard = 0x06,
-        Keypad = 0x07,
-        SystemControl = 0x80,
-    }
-
+    /// <summary>HID usage page values.</summary>
+    /// <remarks>
+    /// See "HID Usage Tables" on the USB-IF website for a full list of UsagePages and the corresponding Usages.
+    /// </remarks>
     public enum HIDUsagePage : ushort
     {
         Undefined = 0x00,
@@ -360,6 +375,21 @@ namespace osu.Framework.Platform.Windows.Native
         MSR = 0x8E
     }
 
+    /// <summary>HID usage values.</summary>
+    /// <remarks>
+    /// The meaning of every numeral Usage value is dependent on the UsagePage.
+    /// </remarks>
+    public enum HIDUsage : ushort
+    {
+        Undefined = 0x00,
+
+        /// <summary>For <see cref="HIDUsagePage.Generic"/>.</summary>
+        Mouse = 0x02,
+
+        /// <summary>For <see cref="HIDUsagePage.Digitizer"/>.</summary>
+        TouchPad = 0x05,
+    }
+
     public enum FeedbackType
     {
         TouchContactVisualization = 1,
@@ -373,5 +403,75 @@ namespace osu.Framework.Platform.Windows.Native
         TouchPressAndHold = 9,
         TouchRightTap = 10,
         GesturePressAndTap = 11,
+    }
+
+    /// <summary>What information to retrieve for a raw input device.</summary>
+    public enum RawInputDeviceInfoCommand
+    {
+        /// <summary>Get preparsed data for <see cref="Hid"/> APIs.</summary>
+        PreparsedData = 0x20000005,
+
+        /// <summary>Get device path for opening directly (if possible).</summary>
+        DeviceName = 0x20000007,
+
+        /// <summary>Get <see cref="RID_DEVICE_INFO"/>.</summary>
+        DeviceInfo = 0x2000000B,
+    }
+
+    /// <summary>Raw input device info.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RID_DEVICE_INFO
+    {
+        /// <summary>Size of this structure, must be filled before calling GetRawInputDeviceInfo.</summary>
+        public int Size;
+
+        /// <summary>Type of this device.</summary>
+        public RawInputType Type;
+
+        /// <summary>Detailed information, depending on the device type.</summary>
+        public Union union;
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct Union
+        {
+            [FieldOffset(0)]
+            public RID_DEVICE_INFO_MOUSE mouse;
+
+            [FieldOffset(0)]
+            public RID_DEVICE_INFO_KEYBOARD keyboard;
+
+            [FieldOffset(0)]
+            public RID_DEVICE_INFO_HID hid;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RID_DEVICE_INFO_MOUSE
+        {
+            public uint Id;
+            public uint NumberOfButtons;
+            public uint SampleRate;
+            public uint HasHorizontalWheel;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RID_DEVICE_INFO_KEYBOARD
+        {
+            public uint Type;
+            public uint SubType;
+            public uint KeyboardMode;
+            public uint NumberOfFunctionKeys;
+            public uint NumberOfIndicators;
+            public uint NumberOfKeysTotal;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RID_DEVICE_INFO_HID
+        {
+            public uint VendorId;
+            public uint ProductId;
+            public uint VersionNumber;
+            public ushort UsagePage;
+            public ushort Usage;
+        }
     }
 }

--- a/osu.Framework/Platform/Windows/SDL2WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/SDL2WindowsWindow.cs
@@ -18,7 +18,7 @@ using static SDL2.SDL;
 namespace osu.Framework.Platform.Windows
 {
     [SupportedOSPlatform("windows")]
-    internal class SDL2WindowsWindow : SDL2DesktopWindow, IWindowsWindow
+    internal class SDL2WindowsWindow : SDL2DesktopWindow, IWindowsWindow, IHasTouchpadInput
     {
         private const int seticon_message = 0x0080;
         private const int icon_big = 1;
@@ -41,6 +41,8 @@ namespace osu.Framework.Platform.Windows
         private readonly SDL_WindowsMessageHook sdl2Callback;
 
         public readonly WindowsRawInputManager RawInputManager;
+        private readonly WindowsTouchpadReader touchpadReader;
+        public event Action<TouchpadData>? TouchpadDataUpdate;
 
         public SDL2WindowsWindow(GraphicsSurfaceType surfaceType, string appName)
             : base(surfaceType, appName)
@@ -61,6 +63,8 @@ namespace osu.Framework.Platform.Windows
                 declareDpiAware();
 
             RawInputManager = new WindowsRawInputManager(WindowHandle);
+            touchpadReader = new WindowsTouchpadReader(RawInputManager);
+            touchpadReader.TouchpadDataUpdate += data => TouchpadDataUpdate?.Invoke(data);
 
             // ReSharper disable once ConvertClosureToMethodGroup
             sdl2Callback = (ptr, wnd, u, param, l) => windowsMessageHookSDL2(ptr, wnd, u, param, l);

--- a/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/SDL3WindowsWindow.cs
@@ -19,7 +19,7 @@ using static SDL.SDL3;
 namespace osu.Framework.Platform.Windows
 {
     [SupportedOSPlatform("windows")]
-    internal class SDL3WindowsWindow : SDL3DesktopWindow, IWindowsWindow
+    internal class SDL3WindowsWindow : SDL3DesktopWindow, IWindowsWindow, IHasTouchpadInput
     {
         private const int seticon_message = 0x0080;
         private const int icon_big = 1;
@@ -37,6 +37,8 @@ namespace osu.Framework.Platform.Windows
         private readonly bool applyBorderlessWindowHack;
 
         private readonly WindowsRawInputManager rawInputManager;
+        private readonly WindowsTouchpadReader? touchpadReader;
+        public event Action<TouchpadData>? TouchpadDataUpdate;
 
         public SDL3WindowsWindow(GraphicsSurfaceType surfaceType, string appName)
             : base(surfaceType, appName)
@@ -54,6 +56,8 @@ namespace osu.Framework.Platform.Windows
             }
 
             rawInputManager = new WindowsRawInputManager(WindowHandle);
+            touchpadReader = new WindowsTouchpadReader(rawInputManager);
+            touchpadReader.TouchpadDataUpdate += TouchpadDataUpdate;
 
             unsafe
             {

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -25,8 +25,8 @@ namespace osu.Framework.Platform.Windows
 
             window = windowsWindow;
 
-            if (window is SDL2WindowsWindow)
-                initialiseSDL2(host);
+            if (window is SDL2WindowsWindow sdl2WindowsWindow)
+                initialiseSDL2(sdl2WindowsWindow);
 
             return base.Initialize(host);
         }

--- a/osu.Framework/Platform/Windows/WindowsRawInputManager.cs
+++ b/osu.Framework/Platform/Windows/WindowsRawInputManager.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using osu.Framework.Logging;
+using osu.Framework.Platform.Windows.Native;
+
+namespace osu.Framework.Platform.Windows
+{
+    public class WindowsRawInputManager
+    {
+        /// <summary>Fired when raw mouse input is detected in <see cref="ProcessWmInput"/>.</summary>
+        public event Action<RawInputData>? RawMouse
+        {
+            add
+            {
+                if (rawMouse == null)
+                    register(HIDUsagePage.Generic, HIDUsage.Mouse, true);
+                rawMouse += value;
+            }
+            remove
+            {
+                rawMouse -= value;
+                if (rawMouse == null)
+                    register(HIDUsagePage.Generic, HIDUsage.Mouse, false);
+            }
+        }
+
+        private event Action<RawInputData>? rawMouse;
+
+        /// <summary>The HWND associated with the manager. Used on registering.</summary>
+        public readonly IntPtr WindowHandle;
+
+        public WindowsRawInputManager(IntPtr windowHandle)
+        {
+            WindowHandle = windowHandle;
+        }
+
+        /// <summary>
+        /// Register a HID device to use with raw input.
+        /// </summary>
+        /// <param name="usagePage">Usage page of the HID device.</param>
+        /// <param name="usage">Usage of the HID device (meaning of the value depend on the page).</param>
+        /// <param name="enable">Register (true) or unregister (false).</param>
+        private unsafe void register(HIDUsagePage usagePage, HIDUsage usage, bool enable)
+        {
+            var registration = new RawInputDevice
+            {
+                UsagePage = usagePage,
+                Usage = usage,
+                Flags = enable ? RawInputDeviceFlags.None : RawInputDeviceFlags.Remove,
+                WindowHandle = WindowHandle
+            };
+
+            bool r = Native.Input.RegisterRawInputDevices([registration], 1, sizeof(RawInputDevice));
+
+            if (!r)
+            {
+                Logger.Log($"RegisterRawInputDevices failed ({Marshal.GetLastWin32Error()}): touchpad reading not possible",
+                    LoggingTarget.Input, LogLevel.Error);
+            }
+        }
+
+        /// <summary>
+        /// Process the WM_INPUT message. Only lParam is needed.
+        /// </summary>
+        /// <param name="lParam">A HRAWINPUT handle to the RAWINPUT structure that contains the raw input from the device.</param>
+        public unsafe void ProcessWmInput(IntPtr lParam)
+        {
+            int size = 0;
+            Native.Input.GetRawInputData(lParam, RawInputCommand.Input, IntPtr.Zero, ref size, sizeof(RawInputHeader));
+            IntPtr buffer = Marshal.AllocHGlobal(size);
+
+            try
+            {
+                if (Native.Input.GetRawInputData(lParam, RawInputCommand.Input, buffer, ref size, sizeof(RawInputHeader)) < 0)
+                {
+                    Logger.Log($"GetRawInputData failed ({Marshal.GetLastWin32Error()})", LoggingTarget.Input, LogLevel.Error);
+                    return;
+                }
+
+                RawInputType rawInputType = Marshal.PtrToStructure<RawInputHeader>(buffer).Type;
+
+                switch (rawInputType)
+                {
+                    case RawInputType.Mouse:
+                    {
+                        if (size < sizeof(RawInputData))
+                        {
+                            Logger.Log($"Raw mouse buffer too small ({size} < {sizeof(RawInputData)})", LoggingTarget.Input, LogLevel.Error);
+                            return;
+                        }
+
+                        rawMouse?.Invoke(Marshal.PtrToStructure<RawInputData>(buffer));
+                        break;
+                    }
+
+                    case RawInputType.Keyboard:
+                    case RawInputType.HID:
+                    default:
+                        break;
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsTouchpadReader.cs
+++ b/osu.Framework/Platform/Windows/WindowsTouchpadReader.cs
@@ -1,0 +1,274 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using osu.Framework.Logging;
+using osu.Framework.Platform.Windows.Native;
+
+namespace osu.Framework.Platform.Windows
+{
+    internal class WindowsTouchpadReader
+    {
+        public event Action<TouchpadData>? TouchpadDataUpdate;
+
+        public WindowsTouchpadReader(WindowsRawInputManager rawInputManager)
+        {
+            rawInputManager.RawTouchpad += readTouchpad;
+        }
+
+        /// <summary>The actual report reader for one single device, contains parsed information.</summary>
+        private TouchpadInstanceReader? reader;
+
+        private void readTouchpad(RawInputDataHidHeader header, List<byte[]> reports)
+        {
+            if (reader?.Info.Handle != header.Header.Device)
+            {
+                // TODO: If we enable more raw input devices later, it can be possible to run this code every time when reports for another device is received.
+                //  For the best result, extract the device manager code into a new class (and cache all connected devices)
+                if (!prepareDevice(header.Header.Device))
+                    return;
+            }
+
+            TouchpadData? data = null;
+
+            foreach (byte[] report in reports)
+            {
+                data = reader!.ReadRawInput(report);
+            }
+
+            if (data.HasValue)
+                TouchpadDataUpdate?.Invoke(data.Value);
+        }
+
+        private unsafe bool prepareDevice(IntPtr hDevice)
+        {
+            RID_DEVICE_INFO deviceInfo = new RID_DEVICE_INFO();
+            int size = deviceInfo.Size = sizeof(RID_DEVICE_INFO);
+
+            if (Native.Input.GetRawInputDeviceInfo(hDevice, RawInputDeviceInfoCommand.DeviceInfo, ref deviceInfo, ref size) == -1)
+            {
+                Logger.Log($"GetRawInputDeviceInfo failed ({Marshal.GetLastWin32Error()})", LoggingTarget.Input, LogLevel.Error);
+                return false;
+            }
+
+            if (deviceInfo.Type != RawInputType.HID
+                || deviceInfo.union.hid.UsagePage != (int)HIDUsagePage.Digitizer
+                || deviceInfo.union.hid.Usage != (int)HIDUsage.TouchPad)
+                return false;
+
+            try
+            {
+                reader = new TouchpadInstanceReader(hDevice);
+            }
+            catch (TouchpadInstanceReader.ParseException e)
+            {
+                Logger.Error(e, "TouchpadReader creation failed: cannot parse device info", LoggingTarget.Input);
+                return false;
+            }
+
+            return true;
+        }
+
+        private class TouchpadInstanceReader
+        {
+            public class ParseException : Exception
+            {
+                public ParseException(string? message)
+                    : base(message)
+                {
+                }
+            }
+
+            public class ReadException : Exception
+            {
+                public ReadException(string? message)
+                    : base(message)
+                {
+                }
+            }
+
+            /// <summary>Information read from the touchpad.</summary>
+            public readonly TouchpadInfo Info;
+
+            private readonly IntPtr preparsedData;
+
+            /// <summary>Which LCs are corresponding to the fingers</summary>
+            private readonly List<ushort> fingerLinkCollections;
+
+            private readonly USAGE_AND_PAGE[] usageAndPageBuffer;
+
+            public TouchpadInstanceReader(IntPtr hDevice)
+            {
+                Info.Handle = hDevice;
+
+                // Read preparsed_data
+                int size = 0;
+                if (Native.Input.GetRawInputDeviceInfo(hDevice, RawInputDeviceInfoCommand.PreparsedData, IntPtr.Zero, ref size) != 0)
+                    throw new ParseException($"GetRawInputDeviceInfo(RIDI_PREPARSEDDATA): {Marshal.GetLastWin32Error()}");
+
+                preparsedData = Marshal.AllocHGlobal(size);
+                if (Native.Input.GetRawInputDeviceInfo(hDevice, RawInputDeviceInfoCommand.PreparsedData, preparsedData, ref size) == -1)
+                    throw new ParseException($"GetRawInputDeviceInfo(RIDI_PREPARSEDDATA)2: {Marshal.GetLastWin32Error()}");
+
+                // Read caps (i.e. summary information of the device)
+                HIDP_CAPS caps;
+                if (Hid.HidP_GetCaps(preparsedData, out caps) != Hid.HIDP_STATUS_SUCCESS)
+                    throw new ParseException($"HidP_GetCaps: {Marshal.GetLastWin32Error()}");
+
+                // Read valueCaps (i.e. information about every reported numeral value)
+                ulong valueCapsLength = caps.NumberInputValueCaps;
+                var valueCaps = new HIDP_VALUE_CAPS[valueCapsLength];
+                if (Hid.HidP_GetValueCaps(HIDP_REPORT_TYPE.HidP_Input, valueCaps, ref valueCapsLength, preparsedData) != Hid.HIDP_STATUS_SUCCESS)
+                    throw new ParseException($"HidP_GetValueCaps: {Marshal.GetLastWin32Error()}");
+                if (valueCapsLength != caps.NumberInputValueCaps)
+                    throw new ParseException($"NumberInputValueCaps mismatch, before: {caps.NumberInputValueCaps} after: {valueCapsLength}");
+
+                // Read linkCollections to find out which LC corresponds to fingers.
+                // (LC: a collection of UsagePage and Usages, one for each finger contact, and one for the touchpad global info)
+                ulong linkCollectionLength = caps.NumberLinkCollectionNodes;
+                var lcList = new HIDP_LINK_COLLECTION_NODE[linkCollectionLength];
+                if (Hid.HidP_GetLinkCollectionNodes(lcList, ref linkCollectionLength, preparsedData) != Hid.HIDP_STATUS_SUCCESS)
+                    throw new ParseException($"HidP_GetLinkCollectionNodes: {Marshal.GetLastWin32Error()}");
+                if (linkCollectionLength != caps.NumberLinkCollectionNodes)
+                    throw new ParseException($"NumberLinkCollectionNodes mismatch, before: {caps.NumberLinkCollectionNodes} after: {linkCollectionLength}");
+
+                fingerLinkCollections = new List<ushort>();
+                ushort index = lcList[0].FirstChild;
+
+                while (index != 0)
+                {
+                    var lc = lcList[index];
+
+                    // 0x0D, 0x22: Finger
+                    if (lc.LinkUsagePage == 0x0D && lc.LinkUsage == 0x22)
+                        fingerLinkCollections.Add(index);
+
+                    index = lc.NextSibling;
+                }
+
+                fingerLinkCollections.Sort();
+
+                usageAndPageBuffer = new USAGE_AND_PAGE[caps.NumberInputButtonCaps];
+
+                int maxFingerCount = fingerLinkCollections.Count;
+                if (maxFingerCount <= 0)
+                    throw new ParseException($"Invalid finger count: {maxFingerCount}");
+
+                foreach (var valueCap in valueCaps)
+                {
+                    // Just read the XY ranges for the first finger.
+                    // Never seen a device with different ranges for fingers.
+                    if (valueCap.LinkCollection != fingerLinkCollections[0]) continue;
+
+                    // 0x01, 0x30: X
+                    if (checkUsageMatch(valueCap, 0x01, 0x30))
+                    {
+                        Info.XMin = valueCap.LogicalMin;
+                        Info.XRange = valueCap.LogicalMax - valueCap.LogicalMin;
+                    }
+
+                    // 0x01, 0x31: Y
+                    if (checkUsageMatch(valueCap, 0x01, 0x31))
+                    {
+                        Info.YMin = valueCap.LogicalMin;
+                        Info.YRange = valueCap.LogicalMax - valueCap.LogicalMin;
+                    }
+                }
+            }
+
+            private static bool checkUsageMatch(HIDP_VALUE_CAPS valueCap, ushort usagePage, ushort usage)
+            {
+                if (valueCap.UsagePage != usagePage)
+                    return false;
+
+                return valueCap.IsRange != 0
+                    ? valueCap.union.Range.UsageMin <= usage && usage <= valueCap.union.Range.UsageMax
+                    : valueCap.union.NotRange.Usage == usage;
+            }
+
+            ~TouchpadInstanceReader()
+            {
+                Marshal.FreeHGlobal(preparsedData);
+            }
+
+            public TouchpadData ReadRawInput(byte[] report)
+            {
+                uint reportLen = (uint)report.Length;
+
+                // TODO: comment on the usage values
+                ulong fingerCount;
+                if (Hid.HidP_GetUsageValue(HIDP_REPORT_TYPE.HidP_Input, 0x0D, 0, 0x54, out fingerCount, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                    throw new ReadException($"HidP_GetUsageValue (lc=0,0D:54): {Marshal.GetLastWin32Error()}");
+
+                int validPointCount = Math.Min((int)fingerCount, fingerLinkCollections.Count);
+
+                // TODO do we care about scan_time?
+                // 0D:56 scan time in 100us units, can be unavailable
+
+                ulong caplen = (ulong)usageAndPageBuffer.Length;
+
+                if (Hid.HidP_GetUsagesEx(HIDP_REPORT_TYPE.HidP_Input, 0, usageAndPageBuffer, ref caplen, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                    throw new ReadException($"HidP_GetUsagesEx (lc=0): {Marshal.GetLastWin32Error()}");
+
+                bool buttonDown = false;
+
+                for (ulong i = 0; i < caplen; i++)
+                {
+                    ushort usagePage = usageAndPageBuffer[i].UsagePage;
+                    ushort usage = usageAndPageBuffer[i].Usage;
+
+                    if (usagePage == 0x09 && usage == 0x01)
+                        buttonDown = true;
+                }
+
+                List<TouchpadPoint> points = new List<TouchpadPoint>();
+
+                for (int i = 0; i < validPointCount; i++)
+                {
+                    TouchpadPoint point = new TouchpadPoint();
+                    ushort lc = fingerLinkCollections[i];
+                    ulong temp;
+
+                    if (Hid.HidP_GetUsageValue(HIDP_REPORT_TYPE.HidP_Input, 0x01, lc, 0x30, out temp, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                        throw new ReadException($"HidP_GetUsageValue (lc={lc},01:30): {Marshal.GetLastWin32Error()}");
+
+                    point.X = (int)temp;
+
+                    if (Hid.HidP_GetUsageValue(HIDP_REPORT_TYPE.HidP_Input, 0x01, lc, 0x31, out temp, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                        throw new ReadException($"HidP_GetUsageValue (lc={lc},01:31): {Marshal.GetLastWin32Error()}");
+
+                    point.Y = (int)temp;
+
+                    if (Hid.HidP_GetUsageValue(HIDP_REPORT_TYPE.HidP_Input, 0x0D, lc, 0x51, out temp, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                        throw new ReadException($"HidP_GetUsageValue (lc={lc},0D:51): {Marshal.GetLastWin32Error()}");
+
+                    point.ContactId = (int)temp;
+
+                    caplen = (ulong)usageAndPageBuffer.Length;
+
+                    if (Hid.HidP_GetUsagesEx(HIDP_REPORT_TYPE.HidP_Input, lc, usageAndPageBuffer, ref caplen, preparsedData, report, reportLen) != Hid.HIDP_STATUS_SUCCESS)
+                        throw new ReadException($"HidP_GetUsagesEx (lc={lc}): {Marshal.GetLastWin32Error()}");
+
+                    point.Valid = point.Confidence = false;
+
+                    for (int j = 0; j < (int)caplen; j++)
+                    {
+                        ushort usagePage = usageAndPageBuffer[j].UsagePage;
+                        ushort usage = usageAndPageBuffer[j].Usage;
+
+                        if (usagePage == 0x0D && usage == 0x42)
+                            point.Valid = true;
+                        if (usagePage == 0x0D && usage == 0x47)
+                            point.Confidence = true;
+                    }
+
+                    points.Add(point);
+                }
+
+                return new TouchpadData(Info, points, buttonDown);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add absolute position support for Windows precision touchpads, make them behave like a drawing tablet.

## Details

* Add `interface IHasTouchpadInput : IWindow` for windows supporting PTP data reporting.
  * Currently only `SDL2WindowsWindow` and `SDL3WindowsWindow`, should also be possible on macOS once libsdl-org/SDL#12391 is fixed.
  * This interface may be removed, or the methods merged into the base class if implemented by most windows.
* Refactor Windows raw input related functions into `WindowsRawInputManager`.
  * On SDL2, Windows raw input is used for raw mouse. After this refactor, raw mouse register to `WindowsRawInputManager.RawMouse` event when enabled.
* Implemented HID touchpad reading according to [Microsoft specs](https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/touchpad-required-hid-top-level-collections) in `WindowsTouchpadReader`, using `HidP_` Windows API functions.
  * Windows open touchpads in exclusive mode, so you are unable to "open the device" and read/write HID reports directly (like with normal drawing tablets). The only option is to subscribe to raw input events.
  * `HidSharpCore` is not used, because to extract data with it we need a HID descriptor in bytes, but raw input only provides "preparsed data". It's possible to reconstruct the descriptor from ppd (and this is what `HidSharpCore` is doing, hiding in an [internal class](https://github.com/InfinityGhost/HIDSharpCore/blob/master/HidSharp/Platform/Windows/WinHidDevice.ReportDescriptorReconstructor.cs)), but the logic is complicated and I don't feel like duplicating it.
  * This is translated from another C++ code (written by myself).
* Add `TouchpadHandler` to post-process the data from `IHasTouchpadInput` windows, emits `MousePositionAbsoluteInput`.
  * The first touch point is used as the mouse pointer. (not ideal)
  * Sensitivity is supported (reused with raw mouse, not ideal). Lowest sensitivity (1) maps the whole touchpad to the whole window while respecting aspect ratio, higher ones (n) maps from a fraction (1/n) of the touchpad.

## TODOs

- [ ] Possibly remove `IHasTouchpadInput`.
- [ ] Raw input device management.
  > TODO: If we enable more raw input devices later, it can be possible to run this code every time when reports for another device is received.
  > For the best result, extract the device manager code into a new class (and cache all connected devices)
- [ ] Implement for macOS. (See the SDL issue above)
- [ ] Suppress mouse click after touchpad actions. (Tapping the touchpad can generate a mouse click, based on Windows settings)
- [ ] Editable touchpad origin. (i.e. which point maps to the center of the window)
- [ ] Only enable `TouchpadHandler` in the actual game, not in menus. (Possibly in the main osu repo)