### PR TITLE
Fix tablet buttons being handled when window is not active

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -53,6 +53,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private Task? lastInitTask;
 
+        private IBindable<bool> isActive;
+
         public override bool Initialize(GameHost host)
         {
             this.host = host;
@@ -60,6 +62,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             outputMode = new AbsoluteTabletMode(this);
 
             host.Window.Resized += () => updateOutputArea(host.Window);
+            isActive = host.Window.IsActive.GetBoundCopy();
 
             AreaOffset.BindValueChanged(_ => updateTabletAndInputArea(device));
             AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device));
@@ -203,6 +206,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleTabletReport(ITabletReport tabletReport)
         {
+            if (!isActive.Value)
+                return;
+
             int buttonCount = tabletReport.PenButtons.Length;
             var buttons = new ButtonInputEntry<TabletPenButton>[buttonCount];
             for (int i = 0; i < buttonCount; i++)
@@ -213,6 +219,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleAuxiliaryReport(IAuxReport auxiliaryReport)
         {
+            if (!isActive.Value)
+                return;
+
             int buttonCount = auxiliaryReport.AuxButtons.Length;
             var buttons = new ButtonInputEntry<TabletAuxiliaryButton>[buttonCount];
             for (int i = 0; i < buttonCount; i++)

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -216,9 +216,6 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleAuxiliaryReport(IAuxReport auxiliaryReport)
         {
-            if (!windowActive.Value)
-                return;
-
             int buttonCount = auxiliaryReport.AuxButtons.Length;
             var buttons = new ButtonInputEntry<TabletAuxiliaryButton>[buttonCount];
             for (int i = 0; i < buttonCount; i++)

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private Task? lastInitTask;
 
-        private IBindable<bool> isActive = null!;
+        private IBindable<bool> windowActive = null!;
 
         public override bool Initialize(GameHost host)
         {
@@ -62,7 +62,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             outputMode = new AbsoluteTabletMode(this);
 
             host.Window.Resized += () => updateOutputArea(host.Window);
-            isActive = host.Window.IsActive.GetBoundCopy();
+            windowActive = host.Window.IsActive.GetBoundCopy();
 
             AreaOffset.BindValueChanged(_ => updateTabletAndInputArea(device));
             AreaSize.BindValueChanged(_ => updateTabletAndInputArea(device));
@@ -206,9 +206,6 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleTabletReport(ITabletReport tabletReport)
         {
-            if (!isActive.Value)
-                return;
-
             int buttonCount = tabletReport.PenButtons.Length;
             var buttons = new ButtonInputEntry<TabletPenButton>[buttonCount];
             for (int i = 0; i < buttonCount; i++)
@@ -219,7 +216,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void handleAuxiliaryReport(IAuxReport auxiliaryReport)
         {
-            if (!isActive.Value)
+            if (!windowActive.Value)
                 return;
 
             int buttonCount = auxiliaryReport.AuxButtons.Length;
@@ -232,6 +229,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private void enqueueInput(IInput input)
         {
+            if (!windowActive.Value)
+                return;
+
             PendingInputs.Enqueue(input);
             FrameStatistics.Increment(StatisticsCounterType.TabletEvents);
             statistic_total_events.Value++;

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private Task? lastInitTask;
 
-        private IBindable<bool> isActive;
+        private IBindable<bool> isActive = null!;
 
         public override bool Initialize(GameHost host)
         {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32132.

Arguably we don't want to handle movement events as well in this scenario. Need someone to test with a tablet and see which feels more correct.