### PR TITLE
Fix `TextFlowContainer` not laying text out properly on some `TextAnchor` settings

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTextFlowContainer.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTextFlowContainer.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Benchmarks
+{
+    public partial class BenchmarkTextFlowContainer : GameBenchmark
+    {
+        private TestGame game = null!;
+
+        [Test]
+        [Benchmark]
+        public void SetText()
+        {
+            game.Schedule(() => game.TextFlow.Text =
+                @"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer in urna faucibus, consectetur lorem at, maximus lectus. Vivamus mattis faucibus ante et volutpat. Quisque ligula velit, tristique condimentum placerat sit amet, varius a nisi. Curabitur sit amet sodales ex. Cras in risus sed ipsum auctor laoreet. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam sed ligula cursus neque gravida pretium non vel lacus. Aliquam tincidunt congue est nec malesuada.
+
+Sed viverra neque sed orci ultrices varius. Suspendisse malesuada vitae ligula ornare laoreet. Nunc gravida, orci tempus placerat tempor, sem metus hendrerit nisl, in posuere erat turpis at felis. Pellentesque tempor velit odio, eu scelerisque odio sodales non. Cras sagittis, lorem ut tristique euismod, lacus lacus consequat lorem, vel placerat diam est luctus dolor. Duis ac erat tortor. Ut massa massa, iaculis porttitor sem vitae, sodales rhoncus risus. Aliquam erat volutpat. Ut sed est leo. Curabitur congue, dolor non suscipit molestie, neque nisi convallis erat, nec interdum nibh lacus nec dolor. Donec pellentesque commodo erat. Fusce sed ligula at elit mollis congue in sit amet quam. Maecenas venenatis cursus erat vitae ultrices. Etiam lobortis pellentesque accumsan. Curabitur blandit purus hendrerit arcu tempor venenatis.
+
+Nunc ac commodo magna, et blandit lectus. Mauris sagittis urna vulputate massa blandit consectetur. Cras eget volutpat quam. Suspendisse a pharetra urna. Nunc sit amet ultricies ligula, eget blandit risus. Nunc mollis, nisl ut hendrerit consequat, eros ligula iaculis neque, sed viverra dolor felis vel purus. Vivamus eu sollicitudin nunc. Aliquam varius, nulla vitae efficitur placerat, tortor est eleifend justo, vitae venenatis urna diam nec velit. Integer in aliquet sapien, mollis tincidunt dui. Curabitur vestibulum pretium lorem. Morbi tincidunt semper aliquet. Curabitur semper est ac dapibus scelerisque. Morbi aliquam pulvinar bibendum. Curabitur blandit consequat sapien non faucibus. ");
+            RunSingleFrame();
+        }
+
+        protected override Game CreateGame() => game = new TestGame();
+
+        private partial class TestGame : Game
+        {
+            public TextFlowContainer TextFlow { get; private set; } = null!;
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Add(TextFlow = new TextFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both
+                });
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -61,7 +61,6 @@ namespace osu.Framework.Tests.Visual.Containers
         public void TestChangeTextAnchor(Anchor anchor)
         {
             AddStep("change text anchor", () => textContainer.TextAnchor = anchor);
-            AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == anchor && c.Origin == anchor));
             AddAssert("children are positioned correctly", () =>
             {
                 string result = string.Concat(textContainer.Children
@@ -70,14 +69,6 @@ namespace osu.Framework.Tests.Visual.Containers
                                                            .Select(c => (c as SpriteText)?.Text.ToString() ?? "\n"));
                 return result == default_text;
             });
-        }
-
-        [Test]
-        public void TestAddTextWithTextAnchor()
-        {
-            AddStep("change text anchor", () => textContainer.TextAnchor = Anchor.TopCentre);
-            AddStep("add text", () => textContainer.AddText("added text"));
-            AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == Anchor.TopCentre && c.Origin == Anchor.TopCentre));
         }
 
         [Test]
@@ -136,6 +127,6 @@ namespace osu.Framework.Tests.Visual.Containers
             => AddAssert($"text flow has {count} sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == count);
 
         private void assertTotalChildCount(int count)
-            => AddAssert($"text flow has {count} children", () => textContainer.Count == count);
+            => AddAssert($"text flow has {count} children", () => textContainer.Children.Count() == count);
     }
 }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Tests.Visual.Containers
 {
     public partial class TestSceneTextFlowContainer : FrameworkTestScene
     {
-        private const string default_text = "Default text\n\nnewline";
+        private const string default_text = "Default text which is long enough such that it will break a line\n\nnewline";
 
         private TextFlowContainer textContainer;
 
@@ -52,6 +52,9 @@ namespace osu.Framework.Tests.Visual.Containers
         [TestCase(Anchor.TopLeft)]
         [TestCase(Anchor.TopCentre)]
         [TestCase(Anchor.TopRight)]
+        [TestCase(Anchor.CentreLeft)]
+        [TestCase(Anchor.Centre)]
+        [TestCase(Anchor.CentreRight)]
         [TestCase(Anchor.BottomLeft)]
         [TestCase(Anchor.BottomCentre)]
         [TestCase(Anchor.BottomRight)]

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Graphics.Containers
             // placeholders via AddPlaceholder() are similar to manual text parts
             // in that they were added/registered externally and cannot be recreated.
             // remove them before proceeding with part recreation to avoid accidentally disposing them in the process.
-            RemoveRange(Placeholders, false);
+            Flow.RemoveRange(Placeholders, false);
 
             base.RecreateAllParts();
         }

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -68,10 +68,16 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || !layout.IsValid;
 
+        internal event Action OnLayoutInvalidated;
+
         /// <summary>
         /// Invoked when layout should be invalidated.
         /// </summary>
-        protected virtual void InvalidateLayout() => layout.Invalidate();
+        protected virtual void InvalidateLayout()
+        {
+            layout.Invalidate();
+            OnLayoutInvalidated?.Invoke();
+        }
 
         private readonly Dictionary<Drawable, float> layoutChildren = new Dictionary<Drawable, float>();
 

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// </summary>
     public partial class MarkdownTextFlowContainer : CustomizableTextContainer, IMarkdownTextComponent
     {
-        public float TotalTextWidth => Padding.TotalHorizontal + FlowingChildren.Sum(x => x.BoundingBox.Size.X);
+        public float TotalTextWidth => Padding.TotalHorizontal + Flow.FlowingChildren.Sum(x => x.BoundingBox.Size.X);
 
         [Resolved]
         private IMarkdownTextComponent parentTextComponent { get; set; }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/5084
- Closes https://github.com/ppy/osu-framework/issues/5499
- Closes https://github.com/ppy/osu-framework/issues/2073
- Closes https://github.com/ppy/osu/issues/8580
- Supersedes / closes https://github.com/ppy/osu-framework/pull/5507

You might ask why I'm bothering to try this now. Well, this came up when I wanted to use text flow for BSS purposes (and forced me to hack around it), and came up again in https://github.com/ppy/osu/pull/31970, and I'm sick of it.

The actual fix is taken verbatim from https://github.com/ppy/osu-framework/pull/5507, it's just restructured using the idea of a single nested flow taken from https://github.com/ppy/osu-framework/pull/5507#discussion_r1023426911.

Game side changes available for preview at https://github.com/ppy/osu/compare/master...bdach:osu:text-flow-game-side-adjustments?expand=1

## Benchmarks

### Before

|  Method |     Mean |     Error |    StdDev |   Median |    Gen0 |    Gen1 | Allocated |
|-------- |---------:|----------:|----------:|---------:|--------:|--------:|----------:|
| SetText | 1.157 ms | 0.0565 ms | 0.1666 ms | 1.094 ms | 99.6094 | 85.9375 |    1.2 MB |

### After

|  Method |     Mean |     Error |    StdDev |    Gen0 |    Gen1 | Allocated |
|-------- |---------:|----------:|----------:|--------:|--------:|----------:|
| SetText | 1.169 ms | 0.0536 ms | 0.1580 ms | 89.8438 | 74.2188 |   1.09 MB |

## Breaking changes

### `TextFlowContainer` no longer inherits from `FillFlowContainer` and instead is a `CompositeDrawable`

All methods and properties that consumers should be using (and additionally some that they arguably shouldn't) remain accessible.