### PR TITLE
Remove `TrackBass` frequency clamping

### DIFF
--- a/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
+++ b/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
@@ -67,6 +67,8 @@ namespace osu.Framework.Audio
             if (channel == 0)
                 throw new InvalidOperationException("Attempted to set the channel frequency without calling SetChannel() first.");
 
+            // In the past, allowing frequency to go too low (like 1 Hz) caused audible artifacts.
+            // For this reason, the lower range is clamped to 100Hz, a value which is usually low enough to naturally be silent.
             int channelFrequency = (int)Math.Max(100, Math.Abs(initialFrequency * relativeFrequency));
             Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, channelFrequency);
 

--- a/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
+++ b/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
@@ -67,12 +67,7 @@ namespace osu.Framework.Audio
             if (channel == 0)
                 throw new InvalidOperationException("Attempted to set the channel frequency without calling SetChannel() first.");
 
-            // http://bass.radio42.com/help/html/ff7623f0-6e9f-6be8-c8a7-17d3a6dc6d51.htm (BASS_ATTRIB_FREQ's description)
-            // Above documentation shows the frequency limits which the constants (min_bass_freq, max_bass_freq) came from.
-            const int min_bass_freq = 100;
-            const int max_bass_freq = 100000;
-
-            int channelFrequency = (int)Math.Clamp(Math.Abs(initialFrequency * relativeFrequency), min_bass_freq, max_bass_freq);
+            int channelFrequency = (int)Math.Max(1, Math.Abs(initialFrequency * relativeFrequency));
             Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, channelFrequency);
 
             // Maintain internal pause on zero frequency due to BASS not supporting them (0 is took for original rate in BASS API)

--- a/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
+++ b/osu.Framework/Audio/BassRelativeFrequencyHandler.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Audio
             if (channel == 0)
                 throw new InvalidOperationException("Attempted to set the channel frequency without calling SetChannel() first.");
 
-            int channelFrequency = (int)Math.Max(1, Math.Abs(initialFrequency * relativeFrequency));
+            int channelFrequency = (int)Math.Max(100, Math.Abs(initialFrequency * relativeFrequency));
             Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, channelFrequency);
 
             // Maintain internal pause on zero frequency due to BASS not supporting them (0 is took for original rate in BASS API)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/32321

Well... It's not every day we encounter a bug with about 9 years of history. This goes all the way back to osu!framework's initial commit, but going further than that it was added in the transitional period here: https://github.com/peppy/osu-lazer-transitional/pull/168

It's a non-descript change that is probably hoping the inline documentation is enough. In this case it's not enough because we don't use (and have never used, even in the above commit) BASS.NET which is the alternative C# wrapper to ManagedBass.   
The official documentation (https://www.un4seen.com/doc/#bass/BASS_ATTRIB_FREQ.html) makes no mention of such limitation. [`osu-stable`](https://github.com/peppy/osu-stable-reference/blob/996648fba06baf4e7d2e0b248959399444017895/osu!/Audio/AudioTrackBass.cs#L290-L302) likewise makes no effort to place such a limitation itself either.

The beatmap in the issue thread has a 96kHz track, which basically immediately hits the clamp when adjusted. This appears to work correctly at all values in the 48Hz-9600kHz frequency range tested, so I assume the only natural limit is `1` after which `0` indicates the track's original frequency as documented.