### PR TITLE
Only consider flowing children when performing layout of text flow

### DIFF
--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -404,7 +404,7 @@ namespace osu.Framework.Graphics.Containers
             var childrenByLine = new List<List<Drawable>>();
             var curLine = new List<Drawable>();
 
-            foreach (var c in Flow.Children)
+            foreach (var c in Flow.FlowingChildren)
             {
                 if (c is NewLineContainer nlc)
                 {


### PR DESCRIPTION
Fixes one part of https://github.com/ppy/osu/issues/32348.

The reason this is required is due to the game-side abuse done by `DrawableLinkCompiler` & co. See [this game-side crime](https://github.com/ppy/osu/blob/4633f635a4137d6af902187e12d6fc360bc3a50d/osu.Game/Graphics/Containers/LinkFlowContainer.cs#L141-L144).

`FillFlowContainer` performs layout computations on `FlowingChildren` specifically:

https://github.com/ppy/osu-framework/blob/1ccf0376c4306cb4077d0e3230f60efb92ea7803/osu.Framework/Graphics/Containers/FillFlowContainer.cs#L113

Because of this, if using `Flow.Children` in `TextFlowContainer`, the `DrawableLinkCompiler` - which was skipped by the inner fill flow - is now being considered for layout at the text flow level. Text flow sees that the X position of the compiler is 0 (because it wasn't touched by the inner fill flow), and thus thinks it must be a line break, which it's not.

So we use `FlowingChildren` to restore parity.