### PR TITLE
SDL3: Add hack to make resizing store windowed size to config

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -335,7 +335,10 @@ namespace osu.Framework.Platform.SDL3
                 case SDL_EventType.SDL_EVENT_WINDOW_RESIZED:
                     // polling via SDL_PollEvent blocks on resizes (https://stackoverflow.com/a/50858339)
                     if (!updatingWindowStateAndSize)
-                        fetchWindowSize(storeToConfig: false);
+                    {
+                        bool isUserResizing = SDL_GetGlobalMouseState(null, null).HasFlagFast(SDL_MouseButtonFlags.SDL_BUTTON_LMASK);
+                        fetchWindowSize(storeToConfig: isUserResizing);
+                    }
 
                     break;
             }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/6489#issuecomment-2716480865

This PR changes the buggy workaround introduced in ff2ee9db1de3c44aa5b185477bd12e9a847bc5e0 to only apply when the user is not holding left click. I.e. if the user is holding left click (when resizing the window), windowed size will be stored to config.

https://github.com/ppy/osu-framework/pull/6264#issuecomment-2070857205 should not regress with this change. The user is unlikely to be holding left click when changing the window mode to borderless:
- <kbd>F11</kbd> and <kbd>Alt</kbd>+<kbd>Enter</kbd> don't work when holding left click
- if using the dropdown, the selected window mode is only applied after releasing left click.

Please test it with of! Tests → Platform → Borderless. If you hold left click, the test should fail (macOS and Linux).