### PR TITLE
Allow usage of "frame statistics via touch" envvar on release builds

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -9,7 +9,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
-using osu.Framework.Development;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -285,7 +285,7 @@ namespace osu.Framework
 
             FrameStatistics.BindValueChanged(e => performanceOverlay.State = e.NewValue, true);
 
-            if (FrameworkEnvironment.FrameStatisticsViaTouch && DebugUtils.IsDebugBuild)
+            if (FrameworkEnvironment.FrameStatisticsViaTouch)
             {
                 base.AddInternal(new FrameStatisticsTouchReceptor(this)
                 {
@@ -293,7 +293,7 @@ namespace osu.Framework
                     Anchor = Anchor.BottomRight,
                     Origin = Anchor.BottomRight,
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(0.5f),
+                    Size = new Vector2(0.2f),
                 });
             }
         }


### PR DESCRIPTION
It's disabled by default so it won't affect anyone, and I've just learned of a method where I can launch a release build of an iOS app with specific envvars:
```
mlaunch --devname "<device name>" --killdev sh.ppy.osulazer --launchdev ./osu.iOS.app --wait-for-unlock --argument=-connection-mode --argument=usb -sdk 13.4 --setenv:OSU_ENVVAR_GOES_HERE=1 --sdkroot /Applications/Xcode.app/Contents/Developer
```

It's dodgy but it works so I'll use it while I can.