### PR TITLE
Avoid fill flow layout flipping between floating point precisions

### DIFF
--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Layout;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Framework.Graphics.Containers
@@ -206,7 +207,7 @@ namespace osu.Framework.Graphics.Containers
                     var existingTransform = drawable.TransformsForTargetMember(FlowTransform.TARGET_MEMBER).FirstOrDefault(x => x is FlowTransform) as FlowTransform;
                     Vector2 currentTargetPos = existingTransform?.EndValue ?? drawable.Position;
 
-                    if (currentTargetPos == pos) continue;
+                    if (Precision.AlmostEquals(currentTargetPos, pos)) continue;
 
                     if (LayoutDuration > 0)
                         drawable.TransformTo(drawable.PopulateTransform(new FlowTransform { Rewindable = false }, pos, LayoutDuration, LayoutEasing));


### PR DESCRIPTION
This is one of two safeties to alleviate performance issues described in https://github.com/ppy/osu/issues/32474.

Hoping this can be considered acceptable to fix cases like this:

https://github.com/user-attachments/assets/005c53ce-4134-4fe6-bd61-457b6435c05f

I've done ~2 hours of due diligence investigation and don't see there being a better fix for this.

I will note that:

- It's not `ScrollContainer` related – in this case the `Current` and `Target` are in a stable state
- This cyclic case only happens when `Padding` [is non-zero](https://github.com/ppy/osu/blob/cca63b599eb3b0f57ef23abf582884003ae7d3af/osu.Game/Rulesets/Edit/ExpandingToolboxContainer.cs#L34). This is likely due to [this line](https://github.com/ppy/osu-framework/blob/024fd0b437c7c846d10eedd03db3f6122b49f0a1/osu.Framework/Graphics/Containers/CompositeDrawable.cs#L1902) causing invalidation and triggering fill flow layout, which then invalidates autosize to complete the loop. I have doubts about that padding reset logic causing an invalidation (this means that even if the resultant autosize doesn't change, all children will still be invalidated). But I'm not personally investigating this further.
