### PR TITLE
Update to .NET 9.0 to support LoongArch

### DIFF
--- a/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/Benchmarks.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/Benchmarks.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Benchmarks" type="DotNetProject" factoryName=".NET Project">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Framework.Benchmarks/bin/Debug/net8.0/osu.Framework.Benchmarks.dll" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Framework.Benchmarks/bin/Debug/net9.0/osu.Framework.Benchmarks.dll" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/osu.Framework.Benchmarks/bin/Debug/net8.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/osu.Framework.Benchmarks/bin/Debug/net9.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net8.0" />
+    <option name="PROJECT_TFM" value="net9.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/SampleGame.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/SampleGame.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="SampleGame" type="DotNetProject" factoryName=".NET Project" activateToolWindowBeforeRun="false">
-    <option name="EXE_PATH" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/net8.0/SampleGame.Desktop.dll" />
+    <option name="EXE_PATH" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/net9.0/SampleGame.Desktop.dll" />
     <option name="PROGRAM_PARAMETERS" value="" />
-    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/net8.0" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/net9.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <option name="USE_MONO" value="0" />
@@ -12,7 +12,7 @@
     <option name="PROJECT_ARGUMENTS_TRACKING" value="1" />
     <option name="PROJECT_WORKING_DIRECTORY_TRACKING" value="1" />
     <option name="PROJECT_KIND" value="DotNetCore" />
-    <option name="PROJECT_TFM" value="net8.0" />
+    <option name="PROJECT_TFM" value="net9.0" />
     <method v="2">
       <option name="Build" />
     </method>

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This framework is intended to take steps beyond what you would normally expect f
 
 ## Requirements
 
-- A desktop platform with the [.NET 8.0 SDK](https://dotnet.microsoft.com/download).
+- A desktop platform with the [.NET 9.0 SDK](https://dotnet.microsoft.com/download).
 - When running on linux, please have a system-wide ffmpeg installation available to support video decoding.
-- When running on Windows 7 or 8.1, *[additional prerequisites](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=net60&pivots=os-windows#dependencies)** may be required to correctly run .NET 8 applications if your operating system is not up-to-date with the latest service packs.
+- When running on Windows 7 or 8.1, *[additional prerequisites](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=net60&pivots=os-windows#dependencies)** may be required to correctly run .NET 9 applications if your operating system is not up-to-date with the latest service packs.
 - When working with the codebase, we recommend using an IDE with intellisense and syntax highlighting, such as [Visual Studio 2019+](https://visualstudio.microsoft.com/vs/), [Jetbrains Rider](https://www.jetbrains.com/rider/), or [Visual Studio Code](https://code.visualstudio.com/) with the [EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) and [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) plugin installed.
 
 ### Building

--- a/SampleGame.Android/SampleGame.Android.csproj
+++ b/SampleGame.Android/SampleGame.Android.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.Framework.Android.props" />
   <PropertyGroup>
-    <TargetFramework>net8.0-android</TargetFramework>
+    <TargetFramework>net9.0-android</TargetFramework>
     <OutputType>Exe</OutputType>
     <RootNamespace>SampleGame.Android</RootNamespace>
     <AssemblyName>SampleGame.Android</AssemblyName>

--- a/SampleGame.Desktop/SampleGame.Desktop.csproj
+++ b/SampleGame.Desktop/SampleGame.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>WinExe</OutputType>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/SampleGame.iOS/SampleGame.iOS.csproj
+++ b/SampleGame.iOS/SampleGame.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-ios</TargetFramework>
+    <TargetFramework>net9.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
   </PropertyGroup>
   <Import Project="..\osu.Framework.iOS.props" />

--- a/SampleGame/SampleGame.csproj
+++ b/SampleGame/SampleGame.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.104",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0-android</TargetFramework>
+    <TargetFramework>net9.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21.0</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
+++ b/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/osu.Framework.NativeLibs/osu.Framework.NativeLibs.csproj
+++ b/osu.Framework.NativeLibs/osu.Framework.NativeLibs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyTitle>osu!framework Libraries</AssemblyTitle>
     <AssemblyName>osu.Framework.NativeLibs</AssemblyName>

--- a/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
+++ b/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />

--- a/osu.Framework.Templates/osu.Framework.Templates.csproj
+++ b/osu.Framework.Templates/osu.Framework.Templates.csproj
@@ -5,7 +5,7 @@
     <Title>osu! framework templates</Title>
     <Description>Templates that can be used as starting points for new games, built with of osu! framework.</Description>
     <PackageTags>dotnet-new;templates;osu;framework</PackageTags>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <ContentTargetFolders>content</ContentTargetFolders>

--- a/osu.Framework.Templates/templates/template-empty/.vscode/launch.json
+++ b/osu.Framework.Templates/templates/template-empty/.vscode/launch.json
@@ -9,13 +9,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/TemplateGame.Game.Tests/bin/Debug/net8.0/TemplateGame.Game.Tests.dll",
+                "${workspaceRoot}/TemplateGame.Game.Tests/bin/Debug/net9.0/TemplateGame.Game.Tests.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Tests, Debug)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Game.Tests/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Game.Tests/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -26,13 +26,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/TemplateGame.Game.Tests/bin/Release/net8.0/TemplateGame.Game.Tests.dll",
+                "${workspaceRoot}/TemplateGame.Game.Tests/bin/Release/net9.0/TemplateGame.Game.Tests.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Tests, Release)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Game.Tests/bin/Release/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Game.Tests/bin/Release/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -43,13 +43,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net8.0/TemplateGame.dll",
+                "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net9.0/TemplateGame.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Desktop, Debug)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -60,13 +60,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net8.0/TemplateGame.dll",
+                "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net9.0/TemplateGame.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Desktop, Release)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/TemplateGame.Desktop/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Desktop/TemplateGame.Desktop.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Desktop/TemplateGame.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>TemplateGame</AssemblyName>
     <ApplicationIcon>game.ico</ApplicationIcon>

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game/TemplateGame.Game.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game/TemplateGame.Game.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\TemplateGame.Resources\TemplateGame.Resources.csproj" />

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Resources/TemplateGame.Resources.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Resources/TemplateGame.Resources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Fonts\**\*" />

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-ios</TargetFramework>
+    <TargetFramework>net9.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <CodesignKey>iPhone Developer</CodesignKey>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>

--- a/osu.Framework.Templates/templates/template-flappy/.vscode/launch.json
+++ b/osu.Framework.Templates/templates/template-flappy/.vscode/launch.json
@@ -9,13 +9,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/FlappyDon.Game.Tests/bin/Debug/net8.0/FlappyDon.Game.Tests.dll",
+                "${workspaceRoot}/FlappyDon.Game.Tests/bin/Debug/net9.0/FlappyDon.Game.Tests.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Tests, Debug)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Game.Tests/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Game.Tests/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -26,13 +26,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/FlappyDon.Game.Tests/bin/Release/net8.0/FlappyDon.Game.Tests.dll",
+                "${workspaceRoot}/FlappyDon.Game.Tests/bin/Release/net9.0/FlappyDon.Game.Tests.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Tests, Release)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Game.Tests/bin/Release/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Game.Tests/bin/Release/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -43,13 +43,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net8.0/FlappyDon.dll",
+                "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net9.0/FlappyDon.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Desktop, Debug)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"
@@ -60,13 +60,13 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net8.0/FlappyDon.dll",
+                "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net9.0/FlappyDon.dll",
             ],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "Build (Desktop, Release)",
             "linux": {
                 "env": {
-                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net8.0:${env:LD_LIBRARY_PATH}"
+                    "LD_LIBRARY_PATH": "${workspaceRoot}/FlappyDon.Desktop/bin/Debug/net9.0:${env:LD_LIBRARY_PATH}"
                 }
             },
             "console": "internalConsole"

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Desktop/FlappyDon.Desktop.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Desktop/FlappyDon.Desktop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>FlappyDon</AssemblyName>
     <ApplicationIcon>game.ico</ApplicationIcon>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup Label="Project References">

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/FlappyDon.Game.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/FlappyDon.Game.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlappyDon.Resources\FlappyDon.Resources.csproj" />

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Resources/FlappyDon.Resources.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Resources/FlappyDon.Resources.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="Fonts\**\*" />

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.iOS/FlappyDon.iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-ios</TargetFramework>
+    <TargetFramework>net9.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <CodesignKey>iPhone Developer</CodesignKey>
     <NullabilityInfoContextSupport>true</NullabilityInfoContextSupport>

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0-ios</TargetFramework>
+    <TargetFramework>net9.0-ios</TargetFramework>
     <SupportedOSPlatformVersion>13.4</SupportedOSPlatformVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>osu!framework</AssemblyTitle>


### PR DESCRIPTION
.NET 9.0 is the first version thar support LoongArch New World, that can be seen in [areweloongyet](https://areweloongyet.com/en/project/dotnet) .[xen0n](https://github.com/xen0n) built the .NET SDK for LoongArch in https://github.com/loongson-community/dotnet-unofficial-build ,and [Catty2014](https://github.com/Catty2014) built the [osu-lazer-loongarch](https://github.com/Catty2014/osu-lazer-loongarch) using .NET 9.
Can be seen in https://github.com/Catty2014/osu-framework-loongarch/commit/f81c92a398fc6563f3ff9f37f8d642a4cce43724