### PR TITLE
Add ability to skip initial autosize transform in `CompositeDrawable`

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -87,6 +88,29 @@ namespace osu.Framework.Tests.Visual.Containers
 
             AddAssert("transforms cleared", () => clearedTransforms);
             AddUntilStep("container still autosized", () => container.Size == new Vector2(100));
+        }
+
+        [Test]
+        public void TestSkipInitialAutoSizeTransform()
+        {
+            Container container = null;
+            Drawable child = null;
+
+            AddStep("create hierarchy", () =>
+            {
+                Child = container = new Container
+                {
+                    Masking = true,
+                    AutoSizeAxes = Axes.Both,
+                    AutoSizeDuration = 1000,
+                    SkipInitialAutoSizeTransform = true,
+                    Child = child = new Box { Size = new Vector2(100) },
+                };
+            });
+
+            AddAssert("no AutoSize transform present", () => container.Transforms.All(it => it.TargetMember != "baseSize"));
+            AddStep("update child size", () => child.Size = new Vector2(200));
+            AddAssert("autoSize transform present", () => container.Transforms.Any(it => it.TargetMember == "baseSize"));
         }
 
         private partial class SortableComposite : CompositeDrawable

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -945,6 +945,13 @@ namespace osu.Framework.Graphics.Containers
             UpdateAfterChildren();
 
             updateChildrenSizeDependencies();
+
+            if (SkipInitialAutoSizeTransform && !didInitialAutosize)
+            {
+                FinishTransforms(false, nameof(baseSize));
+                didInitialAutosize = true;
+            }
+
             UpdateAfterAutoSize();
             return true;
         }
@@ -954,6 +961,8 @@ namespace osu.Framework.Graphics.Containers
             Debug.Assert(c.LoadState >= LoadState.Ready);
             c.UpdateSubTree();
         }
+
+        private bool didInitialAutosize;
 
         /// <summary>
         /// Updates all masking calculations for this <see cref="CompositeDrawable"/> and its <see cref="AliveInternalChildren"/>.
@@ -1823,6 +1832,12 @@ namespace osu.Framework.Graphics.Containers
         /// is non-zero.
         /// </summary>
         public Easing AutoSizeEasing { get; protected set; }
+
+        /// <summary>
+        /// Whether the first resize should be instantaneously when autosize gets applied for the first time and <see cref="AutoSizeDuration"/>
+        /// is non-zero.
+        /// </summary>
+        public bool SkipInitialAutoSizeTransform { get; protected set; }
 
         /// <summary>
         /// Fired after this <see cref="CompositeDrawable"/>'s <see cref="Size"/> is updated through autosize.

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -511,6 +511,16 @@ namespace osu.Framework.Graphics.Containers
             set => base.AutoSizeEasing = value;
         }
 
+        /// <summary>
+        /// Whether the first resize should be instantaneously when autosize gets applied for the first time and <see cref="AutoSizeDuration"/>
+        /// is non-zero.
+        /// </summary>
+        public new bool SkipInitialAutoSizeTransform
+        {
+            get => base.SkipInitialAutoSizeTransform;
+            set => base.SkipInitialAutoSizeTransform = value;
+        }
+
         public struct Enumerator : IEnumerator<T>
         {
             private Container<T> container;


### PR DESCRIPTION
Prior discussion on [discord](https://discord.com/channels/188630481301012481/589331078574112768/1356329205167820840).

Adds a `SkipInitialAutoSizeTransform` property to `CompositeDrawable` and `Container` to allow automatically skipping the autoSize transform when it is applied for the first time. Loosely based on how `VisibilityContainer` skips it's initial hide animation using `didInitialHide`.