### PR TITLE
Feature/continuous autosize

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
@@ -168,11 +168,11 @@ namespace osu.Framework.Tests.Visual.Containers
                     }
                 };
             });
-            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
+            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.LayoutSize));
             AddStep("resize child", () => child.Size = new Vector2(200));
-            AddAssert("size doesn't match child", () => !Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
+            AddAssert("size doesn't match child", () => !Precision.AlmostEquals(parent.ChildSize, child.LayoutSize));
             AddStep("finish autosize transform", () => parent.FinishAutoSizeTransforms());
-            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
+            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.LayoutSize));
         }
 
         private partial class SortableComposite : CompositeDrawable

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
@@ -89,6 +89,54 @@ namespace osu.Framework.Tests.Visual.Containers
             AddUntilStep("container still autosized", () => container.Size == new Vector2(100));
         }
 
+        [Test]
+        public void TestAutoSizeDuration()
+        {
+            Container parent = null;
+            Drawable child = null;
+
+            AddStep("create hierarchy", () =>
+            {
+                Child = parent = new Container
+                {
+                    Masking = true,
+                    AutoSizeAxes = Axes.Both,
+                    AutoSizeDuration = 500,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Yellow,
+                        },
+                        new Container
+                        {
+                            Padding = new MarginPadding(50),
+                            AutoSizeAxes = Axes.Both,
+                            Child = child = new Box
+                            {
+                                Size = new Vector2(100),
+                                Colour = Color4.Red,
+                            }
+                        }
+                    }
+                };
+            });
+
+            AddSliderStep("AutoSizeDuration", 0f, 1500f, 500f, value =>
+            {
+                if (parent != null) parent.AutoSizeDuration = value;
+            });
+            AddSliderStep("Width", 0f, 300f, 100f, value =>
+            {
+                if (child != null) child.Width = value;
+            });
+            AddSliderStep("Height", 0f, 300f, 100f, value =>
+            {
+                if (child != null) child.Height = value;
+            });
+        }
+
         private partial class SortableComposite : CompositeDrawable
         {
             public SortableComposite()

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -135,6 +136,43 @@ namespace osu.Framework.Tests.Visual.Containers
             {
                 if (child != null) child.Height = value;
             });
+        }
+
+        [Test]
+        public void TestFinishAutoSizeTransforms()
+        {
+            Container parent = null;
+            Drawable child = null;
+
+            AddStep("create hierarchy", () =>
+            {
+                Child = parent = new Container
+                {
+                    Masking = true,
+                    AutoSizeAxes = Axes.Both,
+                    AutoSizeDuration = 1000,
+                    Name = "Parent",
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Yellow,
+                        },
+                        child = new Box
+                        {
+                            Size = new Vector2(100),
+                            Colour = Color4.Red,
+                            Alpha = 0.5f,
+                        }
+                    }
+                };
+            });
+            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
+            AddStep("resize child", () => child.Size = new Vector2(200));
+            AddAssert("size doesn't match child", () => !Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
+            AddStep("finish autosize transform", () => parent.FinishAutoSizeTransforms());
+            AddAssert("size matches child", () => Precision.AlmostEquals(parent.ChildSize, child.DrawSize));
         }
 
         private partial class SortableComposite : CompositeDrawable

--- a/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
@@ -18,10 +18,9 @@ namespace osu.Framework.Tests.Visual.Layout
     public partial class TestSceneLayoutDurations : FrameworkTestScene
     {
         private ManualClock manualClock;
-        private Container autoSizeContainer;
         private FillFlowContainer fillFlowContainer;
 
-        private Box box1, box2;
+        private Box box;
 
         private const float duration = 1000;
 
@@ -34,23 +33,6 @@ namespace osu.Framework.Tests.Visual.Layout
 
             Children = new Drawable[]
             {
-                autoSizeContainer = new Container
-                {
-                    Clock = new FramedClock(manualClock),
-                    Children = new[]
-                    {
-                        new Box
-                        {
-                            Colour = Color4.Red,
-                            RelativeSizeAxes = Axes.Both
-                        },
-                        box1 = new Box
-                        {
-                            Colour = Color4.Transparent,
-                            Size = Vector2.Zero,
-                        },
-                    }
-                },
                 fillFlowContainer = new FillFlowContainer
                 {
                     Clock = new FramedClock(manualClock),
@@ -59,27 +41,20 @@ namespace osu.Framework.Tests.Visual.Layout
                     Children = new Drawable[]
                     {
                         new Box { Colour = Color4.Red, Size = new Vector2(100) },
-                        box2 = new Box { Colour = Color4.Blue, Size = new Vector2(100) },
+                        box = new Box { Colour = Color4.Blue, Size = new Vector2(100) },
                     }
                 }
             };
 
             paused = false;
-            autoSizeContainer.FinishTransforms();
             fillFlowContainer.FinishTransforms();
-
-            autoSizeContainer.AutoSizeAxes = Axes.None;
-            autoSizeContainer.AutoSizeDuration = 0;
-            autoSizeContainer.Size = Vector2.Zero;
-            box1.Size = Vector2.Zero;
 
             fillFlowContainer.LayoutDuration = 0;
             fillFlowContainer.Size = new Vector2(200, 200);
         });
 
         private void check(float ratio) =>
-            AddAssert($"Check @{ratio}", () => Precision.AlmostEquals(autoSizeContainer.Size, new Vector2(changed_value * ratio)) &&
-                                               Precision.AlmostEquals(box2.Position, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
+            AddAssert($"Check @{ratio}", () => Precision.AlmostEquals(box.Position, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
 
         private void skipTo(float ratio) => AddStep($"skip to {ratio}", () => { manualClock.CurrentTime = duration * ratio; });
 
@@ -90,12 +65,7 @@ namespace osu.Framework.Tests.Visual.Layout
             {
                 paused = true;
                 manualClock.CurrentTime = 0;
-                autoSizeContainer.FinishTransforms();
                 fillFlowContainer.FinishTransforms();
-
-                autoSizeContainer.AutoSizeAxes = Axes.Both;
-                autoSizeContainer.AutoSizeDuration = duration;
-                box1.Size = new Vector2(100);
 
                 fillFlowContainer.LayoutDuration = duration;
                 fillFlowContainer.Width = 100;
@@ -115,14 +85,11 @@ namespace osu.Framework.Tests.Visual.Layout
             {
                 paused = true;
                 manualClock.CurrentTime = 0;
-                autoSizeContainer.FinishTransforms();
                 fillFlowContainer.FinishTransforms();
 
-                autoSizeContainer.AutoSizeAxes = Axes.Both;
-                autoSizeContainer.AutoSizeDuration = duration;
                 fillFlowContainer.LayoutDuration = duration;
 
-                box1.Size = new Vector2(changed_value);
+                box.Size = new Vector2(changed_value);
                 fillFlowContainer.Width = changed_value;
             });
 
@@ -131,7 +98,6 @@ namespace osu.Framework.Tests.Visual.Layout
 
             AddStep("set duration 0", () =>
             {
-                autoSizeContainer.AutoSizeDuration = 0;
                 fillFlowContainer.LayoutDuration = 0;
             });
 
@@ -145,7 +111,6 @@ namespace osu.Framework.Tests.Visual.Layout
 
             AddStep("alter values", () =>
             {
-                box1.Size = new Vector2(0);
                 fillFlowContainer.Width = 200;
             });
 
@@ -161,11 +126,10 @@ namespace osu.Framework.Tests.Visual.Layout
 
         protected override void Update()
         {
-            if (autoSizeContainer != null)
+            if (fillFlowContainer != null)
             {
                 if (!paused) manualClock.CurrentTime = Clock.CurrentTime;
 
-                autoSizeContainer.Children[0].Invalidate();
                 fillFlowContainer.Invalidate();
             }
 

--- a/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
@@ -37,7 +37,6 @@ namespace osu.Framework.Tests.Visual.Layout
                 autoSizeContainer = new Container
                 {
                     Clock = new FramedClock(manualClock),
-                    AutoSizeEasing = Easing.None,
                     Children = new[]
                     {
                         new Box

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1937,6 +1937,9 @@ namespace osu.Framework.Graphics.Containers
 
             targetAutoSize.Value = computeAutoSize() + Padding.Total;
 
+            if (AutoSizeDuration <= 0)
+                applyAutoSize(targetAutoSize.Value);
+
             //note that this is called before autoSize becomes valid. may be something to consider down the line.
             //might work better to add an OnRefresh event in Cached<> and invoke there.
             OnAutoSize?.Invoke();

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -2003,6 +2003,14 @@ namespace osu.Framework.Graphics.Containers
             baseSize = newSize;
         }
 
+        protected void FinishAutoSizeTransforms()
+        {
+            updateChildrenSizeDependencies();
+
+            if (targetAutoSize.IsValid)
+                autoSizeResizeTo(targetAutoSize.Value, 0);
+        }
+
         /// <summary>
         /// When valid, holds the current target size computed for automatic sizing.
         /// </summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1969,9 +1969,6 @@ namespace osu.Framework.Graphics.Containers
 
         private void applyAutoSize()
         {
-            if (AutoSizeAxes == Axes.None)
-                return;
-
             if (targetAutoSize.IsValid)
                 autoSizeResizeTo(targetAutoSize.Value, AutoSizeDuration);
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -2000,6 +2000,9 @@ namespace osu.Framework.Graphics.Containers
             baseSize = newSize;
         }
 
+        /// <summary>
+        /// Immediately resizes to the current target size if <see cref="AutoSizeDuration"/> is non-zero.
+        /// </summary>
         protected void FinishAutoSizeTransforms()
         {
             updateChildrenSizeDependencies();

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -2012,7 +2012,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// When valid, holds the current target size computed for automatic sizing.
+        /// When valid, holds the current target size that should be approached when using automatic sizing and <see cref="AutoSizeDuration"/> is non-zero.
         /// </summary>
         private readonly Cached<Vector2> targetAutoSize = new Cached<Vector2>();
 

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -501,6 +501,9 @@ namespace osu.Framework.Graphics.Containers
             set => base.AutoSizeDuration = value;
         }
 
+        /// <summary>
+        /// Immediately resizes to the current target size if <see cref="AutoSizeDuration"/> is non-zero.
+        /// </summary>
         public new void FinishAutoSizeTransforms() => base.FinishAutoSizeTransforms();
 
         public struct Enumerator : IEnumerator<T>

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -501,6 +501,8 @@ namespace osu.Framework.Graphics.Containers
             set => base.AutoSizeDuration = value;
         }
 
+        public new void FinishAutoSizeTransforms() => base.FinishAutoSizeTransforms();
+
         public struct Enumerator : IEnumerator<T>
         {
             private Container<T> container;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -492,23 +492,13 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// The duration which automatic sizing should take. If zero, then it is instantaneous.
-        /// Otherwise, this is equivalent to applying an automatic size via a resize transform.
+        /// The duration which automatic sizing should approximately take. If zero, then it is instantaneous.
+        /// AutoSize is being applied continuously so the actual amount of time taken depends on the overall change in value.
         /// </summary>
         public new float AutoSizeDuration
         {
             get => base.AutoSizeDuration;
             set => base.AutoSizeDuration = value;
-        }
-
-        /// <summary>
-        /// The type of easing which should be used for smooth automatic sizing when <see cref="AutoSizeDuration"/>
-        /// is non-zero.
-        /// </summary>
-        public new Easing AutoSizeEasing
-        {
-            get => base.AutoSizeEasing;
-            set => base.AutoSizeEasing = value;
         }
 
         public struct Enumerator : IEnumerator<T>

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -31,11 +31,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The easing that should be used when children are moved to their position in the layout.
         /// </summary>
-        public Easing LayoutEasing
-        {
-            get => AutoSizeEasing;
-            set => AutoSizeEasing = value;
-        }
+        public Easing LayoutEasing { get; set; }
 
         /// <summary>
         /// The time it should take to move a child from its current position to its new layout position.

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -33,6 +33,21 @@ namespace osu.Framework.Utils
         }
 
         /// <summary>
+        /// Interpolates between 2 vectors (start and final) using a given base and exponent.
+        /// </summary>
+        /// <param name="start">The start value.</param>
+        /// <param name="final">The end value.</param>
+        /// <param name="base">The base of the exponential. The valid range is [0, 1], where smaller values mean that the final value is achieved more quickly, and values closer to 1 results in slow convergence to the final value.</param>
+        /// <param name="exponent">The exponent of the exponential. An exponent of 0 results in the start values, whereas larger exponents make the result converge to the final value.</param>
+        public static Vector2 Damp(Vector2 start, Vector2 final, double @base, double exponent)
+        {
+            if (@base < 0 || @base > 1)
+                throw new ArgumentOutOfRangeException(nameof(@base), $"{nameof(@base)} has to lie in [0,1], but is {@base}.");
+
+            return Vector2.Lerp(start, final, (float)(1 - Math.Pow(@base, exponent)));
+        }
+
+        /// <summary>
         /// Interpolate the current value towards the target value based on the elapsed time.
         /// If the current value is updated every frame using this function, the result is approximately frame-rate independent.
         /// </summary>
@@ -45,6 +60,24 @@ namespace osu.Framework.Utils
         /// <param name="halfTime">The time it takes to reach the middle value of the current and the target value.</param>
         /// <param name="elapsedTime">The elapsed time of the current frame.</param>
         public static double DampContinuously(double current, double target, double halfTime, double elapsedTime)
+        {
+            double exponent = elapsedTime / halfTime;
+            return Damp(current, target, 0.5, exponent);
+        }
+
+        /// <summary>
+        /// Interpolate the current value towards the target value based on the elapsed time.
+        /// If the current value is updated every frame using this function, the result is approximately frame-rate independent.
+        /// </summary>
+        /// <remarks>
+        /// Because floating-point errors can accumulate over a long time, this function shouldn't be
+        /// used for things requiring accurate values.
+        /// </remarks>
+        /// <param name="current">The current value.</param>
+        /// <param name="target">The target value.</param>
+        /// <param name="halfTime">The time it takes to reach the middle value of the current and the target value.</param>
+        /// <param name="elapsedTime">The elapsed time of the current frame.</param>
+        public static Vector2 DampContinuously(Vector2 current, Vector2 target, double halfTime, double elapsedTime)
         {
             double exponent = elapsedTime / halfTime;
             return Damp(current, target, 0.5, exponent);


### PR DESCRIPTION
Follow-up/alternative to #6560 to explore another approach which applies the AutoSize animation continuously instead of relying on transforms.

I tried keeping the AutoSizeDuration property (partially because `FlowContainer.LayoutDirection` uses it) but the actual duration will only roughly match the specified amount now given that the actual time taken depends on how big the change was.
Perhaps exposing this as a parameter with a more explicit name (i.e. `AutoSizeDamping/Decay`) would be a better choice here.