### PR TITLE
Fix incorrect text flow layout with non-left anchors when line breaks at last word of paragraph

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -165,6 +165,21 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("cancel", () => repeat.Cancel());
         }
 
+        [TestCase(Anchor.TopLeft)]
+        [TestCase(Anchor.Centre)]
+        [TestCase(Anchor.BottomRight)]
+        public void TestAlignmentIsCorrectWhenLineBreaksAtLastWordOfParagraph(Anchor textAnchor)
+        {
+            AddStep("set text to break at last word of paragraph", () =>
+            {
+                textContainer.Clear();
+                textContainer.AddParagraph("first paragraph lorem ipsum dolor sit amet");
+                textContainer.AddParagraph(string.Empty);
+                textContainer.AddParagraph("second paragraph lorem ipsum dolor sit ametttttttttttttttttt");
+                textContainer.TextAnchor = textAnchor;
+            });
+        }
+
         private void assertSpriteTextCount(int count)
             => AddAssert($"text flow has {count} sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == count);
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -567,7 +567,8 @@ namespace osu.Framework.Graphics.Containers
 
                             layoutPositions[i] = current;
 
-                            rowWidths.Add(0);
+                            // DIFFERENCE: `FillFlowContainer` does 0 here, because it's tracking offsets *to middle*, not total row widths.
+                            rowWidths.Add(current.X + size.X);
                             // DIFFERENCE: `IHasLineBaseHeight` tracking.
                             lineBaseHeights.Add((c as IHasLineBaseHeight)?.LineBaseHeight ?? 0);
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/32861.