### PR TITLE
Differentiate direct and indirect pens/tablets on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Android
 
         protected abstract Game CreateGame();
 
-        protected override string[] GetLibraries() => new string[] { "SDL3" };
+        protected override string[] GetLibraries() => new[] { "SDL3" };
 
         protected override SDLSurface CreateSDLSurface(Context? context) => new AndroidGameSurface(this, context);
 

--- a/osu.Framework.Android/AndroidGameSurface.cs
+++ b/osu.Framework.Android/AndroidGameSurface.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using Android.Content;
 using Android.Runtime;
 using Org.Libsdl.App;
@@ -124,6 +125,7 @@ namespace osu.Framework.Android
             };
         }
 
+        [SupportedOSPlatform("android29.0")]
         private TabletPenDeviceType getPenDeviceType(MotionEvent e)
         {
             var device = e.Device;
@@ -139,6 +141,9 @@ namespace osu.Framework.Android
         /// </summary>
         public override bool DispatchGenericMotionEvent(MotionEvent? e)
         {
+            if (!OperatingSystem.IsAndroidVersionAtLeast(29))
+                return base.DispatchGenericMotionEvent(e);
+
             Debug.Assert(e != null);
 
             switch (e.ActionMasked)
@@ -165,6 +170,9 @@ namespace osu.Framework.Android
         /// </summary>
         public override bool OnTouch(View? view, MotionEvent? e)
         {
+            if (!OperatingSystem.IsAndroidVersionAtLeast(29))
+                return base.OnTouch(view, e);
+
             Debug.Assert(e != null);
 
             // SDLSurface does some weird checks here for event action index, but it doesn't really matter as we only expect one pen at a time

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Platform.SDL3;
+using SDL;
 
 namespace osu.Framework.Android
 {
@@ -15,6 +17,8 @@ namespace osu.Framework.Android
             : base(surfaceType, appName)
         {
         }
+
+        protected override TabletPenDeviceType GetPenDeviceType(SDL_PenID id) => AndroidGameActivity.Surface.LastPenDeviceType;
 
         public override void Create()
         {

--- a/osu.Framework.iOS/IOSWindow.cs
+++ b/osu.Framework.iOS/IOSWindow.cs
@@ -8,8 +8,10 @@ using System.Runtime.InteropServices;
 using ObjCRuntime;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Platform.SDL3;
+using SDL;
 using static SDL.SDL3;
 using UIKit;
 
@@ -35,6 +37,9 @@ namespace osu.Framework.iOS
             : base(surfaceType, appName)
         {
         }
+
+        // On iPadOS, the only supported pen device is the Apple Pencil, and it's always used with the internal screen.
+        protected override TabletPenDeviceType GetPenDeviceType(SDL_PenID id) => TabletPenDeviceType.Direct;
 
         public override void Create()
         {

--- a/osu.Framework/Input/Handlers/Pen/PenHandler.cs
+++ b/osu.Framework/Input/Handlers/Pen/PenHandler.cs
@@ -45,24 +45,20 @@ namespace osu.Framework.Input.Handlers.Pen
             return true;
         }
 
-        // Pen input is not necessarily direct on mobile platforms (specifically Android, where external tablets are supported),
-        // but until users experience issues with this, consider it "direct" for now.
-        private static readonly TabletPenDeviceType device_type = RuntimeInfo.IsMobile ? TabletPenDeviceType.Direct : TabletPenDeviceType.Unknown;
-
-        private void handlePenMove(Vector2 position, bool pressed)
+        private void handlePenMove(TabletPenDeviceType deviceType, Vector2 position, bool pressed)
         {
-            if (pressed && device_type == TabletPenDeviceType.Direct)
+            if (pressed && deviceType == TabletPenDeviceType.Direct)
                 enqueueInput(new TouchInput(new Input.Touch(TouchSource.PenTouch, position), true));
             else
-                enqueueInput(new MousePositionAbsoluteInputFromPen { DeviceType = device_type, Position = position });
+                enqueueInput(new MousePositionAbsoluteInputFromPen { DeviceType = deviceType, Position = position });
         }
 
-        private void handlePenTouch(bool pressed, Vector2 position)
+        private void handlePenTouch(TabletPenDeviceType deviceType, bool pressed, Vector2 position)
         {
-            if (device_type == TabletPenDeviceType.Direct)
+            if (deviceType == TabletPenDeviceType.Direct)
                 enqueueInput(new TouchInput(new Input.Touch(TouchSource.PenTouch, position), pressed));
             else
-                enqueueInput(new MouseButtonInputFromPen(pressed) { DeviceType = device_type });
+                enqueueInput(new MouseButtonInputFromPen(pressed) { DeviceType = deviceType });
         }
 
         private void handlePenButton(TabletPenButton button, bool pressed)

--- a/osu.Framework/Platform/SDL3/SDL3DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL3/SDL3DesktopWindow.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Input.StateChanges;
+using SDL;
 using static SDL.SDL3;
 
 namespace osu.Framework.Platform.SDL3
@@ -11,6 +13,8 @@ namespace osu.Framework.Platform.SDL3
             : base(surfaceType, appName)
         {
         }
+
+        protected override TabletPenDeviceType GetPenDeviceType(SDL_PenID id) => TabletPenDeviceType.Unknown;
 
         protected override unsafe void UpdateWindowStateAndSize(WindowState state, Display display, DisplayMode displayMode)
         {

--- a/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
+++ b/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
@@ -1,22 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Input.StateChanges;
-using SDL;
 using static SDL.SDL3;
 
 namespace osu.Framework.Platform.SDL3
 {
-    internal class SDL3MobileWindow : SDL3Window
+    internal abstract class SDL3MobileWindow : SDL3Window
     {
-        public SDL3MobileWindow(GraphicsSurfaceType surfaceType, string appName)
+        protected SDL3MobileWindow(GraphicsSurfaceType surfaceType, string appName)
             : base(surfaceType, appName)
         {
         }
-
-        // Pen input is not necessarily direct on mobile platforms (specifically Android, where external tablets are supported),
-        // but until users experience issues with this, consider it "direct" for now.
-        protected override TabletPenDeviceType GetPenDeviceType(SDL_PenID id) => TabletPenDeviceType.Direct;
 
         protected override unsafe void UpdateWindowStateAndSize(WindowState state, Display display, DisplayMode displayMode)
         {

--- a/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
+++ b/osu.Framework/Platform/SDL3/SDL3MobileWindow.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Input.StateChanges;
+using SDL;
 using static SDL.SDL3;
 
 namespace osu.Framework.Platform.SDL3
@@ -11,6 +13,10 @@ namespace osu.Framework.Platform.SDL3
             : base(surfaceType, appName)
         {
         }
+
+        // Pen input is not necessarily direct on mobile platforms (specifically Android, where external tablets are supported),
+        // but until users experience issues with this, consider it "direct" for now.
+        protected override TabletPenDeviceType GetPenDeviceType(SDL_PenID id) => TabletPenDeviceType.Direct;
 
         protected override unsafe void UpdateWindowStateAndSize(WindowState state, Display display, DisplayMode displayMode)
         {

--- a/osu.Framework/Platform/SDL3/SDL3Window.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.cs
@@ -587,6 +587,11 @@ namespace osu.Framework.Platform.SDL3
                     handleDropEvent(e.drop);
                     break;
 
+                case SDL_EventType.SDL_EVENT_PEN_PROXIMITY_IN:
+                case SDL_EventType.SDL_EVENT_PEN_PROXIMITY_OUT:
+                    handlePenProximityEvent(e.pproximity);
+                    break;
+
                 case SDL_EventType.SDL_EVENT_PEN_DOWN:
                 case SDL_EventType.SDL_EVENT_PEN_UP:
                     handlePenTouchEvent(e.ptouch);

--- a/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window_Input.cs
@@ -11,6 +11,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
+using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
 using osu.Framework.Logging;
 using osuTK;
@@ -530,14 +531,40 @@ namespace osu.Framework.Platform.SDL3
 
         private void handleKeymapChangedEvent() => KeymapChanged?.Invoke();
 
+        protected abstract TabletPenDeviceType GetPenDeviceType(SDL_PenID id);
+
+        private readonly Dictionary<SDL_PenID, TabletPenDeviceType> penDeviceTypes = new Dictionary<SDL_PenID, TabletPenDeviceType>();
+
+        private void handlePenProximityEvent(SDL_PenProximityEvent evtPenProximity)
+        {
+            var id = evtPenProximity.which;
+
+            if (evtPenProximity.type == SDL_EventType.SDL_EVENT_PEN_PROXIMITY_IN)
+            {
+                Debug.Assert(!penDeviceTypes.ContainsKey(id));
+                penDeviceTypes[id] = GetPenDeviceType(id);
+            }
+            else
+            {
+                Debug.Assert(penDeviceTypes.ContainsKey(id));
+                penDeviceTypes.Remove(id);
+            }
+        }
+
         private void handlePenMotionEvent(SDL_PenMotionEvent evtPenMotion)
         {
-            PenMove?.Invoke(new Vector2(evtPenMotion.x, evtPenMotion.y) * Scale, evtPenMotion.pen_state.HasFlagFast(SDL_PenInputFlags.SDL_PEN_INPUT_DOWN));
+            Debug.Assert(penDeviceTypes.ContainsKey(evtPenMotion.which));
+
+            if (penDeviceTypes.TryGetValue(evtPenMotion.which, out var deviceType))
+                PenMove?.Invoke(deviceType, new Vector2(evtPenMotion.x, evtPenMotion.y) * Scale, evtPenMotion.pen_state.HasFlagFast(SDL_PenInputFlags.SDL_PEN_INPUT_DOWN));
         }
 
         private void handlePenTouchEvent(SDL_PenTouchEvent evtPenTouch)
         {
-            PenTouch?.Invoke(evtPenTouch.down, new Vector2(evtPenTouch.x, evtPenTouch.y) * Scale);
+            Debug.Assert(penDeviceTypes.ContainsKey(evtPenTouch.which));
+
+            if (penDeviceTypes.TryGetValue(evtPenTouch.which, out var deviceType))
+                PenTouch?.Invoke(deviceType, evtPenTouch.down, new Vector2(evtPenTouch.x, evtPenTouch.y) * Scale);
         }
 
         /// <summary>
@@ -745,13 +772,13 @@ namespace osu.Framework.Platform.SDL3
         /// <summary>
         /// Invoked when a pen moves. Passes pen position and whether the pen is touching the tablet surface.
         /// </summary>
-        public event Action<Vector2, bool>? PenMove;
+        public event Action<TabletPenDeviceType, Vector2, bool>? PenMove;
 
         /// <summary>
         /// Invoked when a pen touches (<c>true</c>) or lifts (<c>false</c>) from the tablet surface.
         /// Also passes the current position of the pen.
         /// </summary>
-        public event Action<bool, Vector2>? PenTouch;
+        public event Action<TabletPenDeviceType, bool, Vector2>? PenTouch;
 
         /// <summary>
         /// Invoked when a <see cref="TabletPenButton">pen button</see> is pressed (<c>true</c>) or released (<c>false</c>).


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/32868

This PR uses the Android API 29+ (Android 10+) function [`InputDevice.isExternal()`](https://developer.android.com/reference/android/view/InputDevice#isExternal()) to check if the tablet device is external or internal, mapping to indirect and direct respectively. The code path that propagate this value to the [`PenHandler`](https://github.com/ppy/osu-framework/blob/a846a033884619cb2f2c35d4fc284966d9c644b3/osu.Framework/Input/Handlers/Pen/PenHandler.cs) is as follows:

1. Android sends a pen event to `AndroidGameSurface`
2. Query `event.getDevice().isExternal()` and store to a "global" variable: `LastPenDeviceType` (on the Android UI thread)
3. SDL handles the event and adds it to the queue
4. Handle [SDL_EVENT_PEN_PROXIMITY_IN](https://wiki.libsdl.org/SDL3/SDL_PenProximityEvent), querying `LastPenDeviceType` (on the main thread)
5. Invoke `PenHandler`

## Testing

[Tested to work as expected](https://discord.com/channels/188630481301012481/1097318920991559880/1366135531242520687) on ASUS Z012D with a Gaomon S620 tablet (thanks @Danielbzac!). I would like to see testing on a Samsung Galaxy Note device to check that internal pen digitizers are actually reported as internal by this API.