### PR TITLE
Add volume slider in test browser

### DIFF
--- a/osu.Framework/Testing/Drawables/Sections/ToolbarVolumeSection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarVolumeSection.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Framework.Testing.Drawables.Sections
+{
+    public partial class ToolbarVolumeSection : ToolbarSection
+    {
+        [BackgroundDependencyLoader]
+        private void load(FrameworkConfigManager config)
+        {
+            Padding = new MarginPadding { Right = 10 };
+
+            BasicSliderBar<double> volumeSlider;
+            SpriteText volumeText;
+            ClickableContainer clickableReset;
+
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                ColumnDimensions = new[]
+                {
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension(),
+                },
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Padding = new MarginPadding(5) { Right = 0 },
+                            Text = "Volume:",
+                            Font = FrameworkFont.Condensed
+                        },
+                        clickableReset = new ClickableContainer
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            AutoSizeAxes = Axes.Both,
+                            Child = volumeText = new SpriteText
+                            {
+                                Padding = new MarginPadding(5),
+                                Width = 45,
+                                Colour = FrameworkColour.Yellow,
+                                Font = FrameworkFont.Condensed
+                            },
+                        },
+                        volumeSlider = new BasicSliderBar<double>
+                        {
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            RelativeSizeAxes = Axes.Both,
+                            Current = config.GetBindable<double>(FrameworkSetting.VolumeUniversal),
+                        }
+                    }
+                }
+            };
+
+            volumeSlider.Current.BindValueChanged(e => volumeText.Text = e.NewValue.ToString("0%"), true);
+            clickableReset.Action = () => volumeSlider.Current.Value = 0.25f;
+        }
+    }
+}

--- a/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
+++ b/osu.Framework/Testing/Drawables/TestBrowserToolbar.cs
@@ -41,6 +41,7 @@ namespace osu.Framework.Testing.Drawables
                     {
                         new Dimension(GridSizeMode.AutoSize),
                         new Dimension(),
+                        new Dimension(maxSize: 300),
                         new Dimension(GridSizeMode.AutoSize),
                         new Dimension(GridSizeMode.AutoSize),
                     },
@@ -50,6 +51,7 @@ namespace osu.Framework.Testing.Drawables
                         {
                             new ToolbarRunAllStepsSection { RelativeSizeAxes = Axes.Y },
                             new ToolbarRateSection { RelativeSizeAxes = Axes.Both },
+                            new ToolbarVolumeSection { RelativeSizeAxes = Axes.Both },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Y,


### PR DESCRIPTION
Has been proposed in [discord](https://discord.com/channels/188630481301012481/1359431017680863302/1366614892655677462) beforehand. Helps quickly testing audible components without going through a hassle. Clicking on volume resets to 25% as a practical default (unlike 100%, which might be ear-raping instead).