### PR TITLE
Show GC pause duration in frame statistics graphs

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -426,7 +426,7 @@ namespace osu.Framework.Graphics.Performance
                     return Color4.YellowGreen;
 
                 case PerformanceCollectionType.GC:
-                    return Color4.HotPink;
+                    return Color4.Orange;
 
                 case PerformanceCollectionType.SwapBuffer:
                     return Color4.Red;

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -425,6 +425,9 @@ namespace osu.Framework.Graphics.Performance
                 default:
                     return Color4.YellowGreen;
 
+                case PerformanceCollectionType.GC:
+                    return Color4.HotPink;
+
                 case PerformanceCollectionType.SwapBuffer:
                     return Color4.Red;
 #if DEBUG

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -11,6 +11,7 @@ namespace osu.Framework.Statistics
         internal readonly Dictionary<PerformanceCollectionType, double> CollectedTimes = new Dictionary<PerformanceCollectionType, double>(NUM_STATISTICS_COUNTER_TYPES);
         internal readonly Dictionary<StatisticsCounterType, long> Counts = new Dictionary<StatisticsCounterType, long>(NUM_STATISTICS_COUNTER_TYPES);
         internal readonly List<int> GarbageCollections = new List<int>();
+
         public double FramesPerSecond { get; set; }
 
         internal static readonly int NUM_STATISTICS_COUNTER_TYPES = Enum.GetValues<StatisticsCounterType>().Length;
@@ -43,6 +44,7 @@ namespace osu.Framework.Statistics
     internal enum PerformanceCollectionType
     {
         Work = 0,
+        GC,
         SwapBuffer,
         WndProc,
         Debug,


### PR DESCRIPTION
Could provide some insight into GC performance? Not sure about the colour (conflicts with `Scheduler`) - tried to make it visually distinct from `Work`...

https://github.com/user-attachments/assets/ce86c810-fd20-4705-81ff-4b3b453ffe2b

Satori GC for comparison:

https://github.com/user-attachments/assets/23078de2-e6d3-4d12-8ba4-2e74f37c1978