### PR TITLE
Fix passthrough input manager mouse position being desynced from parent on first frame

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
@@ -101,7 +101,6 @@ namespace osu.Framework.Tests.Visual.Input
                 };
             });
 
-            // InitialMousePosition cannot be used here because the event counters should be reset after the initial mouse move.
             AddStep("move mouse to center", () => InputManager.MoveMouseTo(actionContainer));
             AddStep("reset event counters", () =>
             {

--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -330,6 +330,22 @@ namespace osu.Framework.Tests.Visual.Input
             AddAssert("inner box received no mouse events", () => inner.MouseEvents, () => Is.EqualTo(0));
         }
 
+        [Test]
+        public void TestInitialMousePositionSynced()
+        {
+            Vector2 immediateMousePosition = Vector2.Zero;
+
+            AddStep("move mouse to centre", () => InputManager.MoveMouseTo(InputManager.ScreenSpaceDrawQuad.Centre));
+            AddStep("load test input manager and immediately read mouse position", () =>
+            {
+                var testManager = new TestInputManager();
+                Add(testManager);
+                testManager.UpdateSubTree();
+                immediateMousePosition = testManager.CurrentState.Mouse.Position;
+            });
+            AddAssert("mouse position synced", () => immediateMousePosition, () => Is.EqualTo(InputManager.CurrentState.Mouse.Position));
+        }
+
         public partial class TestInputManager : ManualInputManager
         {
             public readonly TestSceneInputManager.ContainingInputManagerStatusText Status;

--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -259,13 +259,11 @@ namespace osu.Framework.Tests.Visual.Input
             });
 
             AddStep("begin touch", () => InputManager.BeginTouch(new Touch(TouchSource.Touch1, testInputManager.ScreenSpaceDrawQuad.Centre)));
-            AddAssert("ensure parent manager produced mouse", () =>
-                InputManager.CurrentState.Mouse.Buttons.Single() == MouseButton.Left &&
-                InputManager.CurrentState.Mouse.Position == testInputManager.ScreenSpaceDrawQuad.Centre);
+            AddAssert("ensure parent manager produced press", () =>
+                InputManager.CurrentState.Mouse.Buttons.Single() == MouseButton.Left);
 
-            AddAssert("pass-through did not produce mouse", () =>
-                !testInputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed &&
-                testInputManager.CurrentState.Mouse.Position != testInputManager.ScreenSpaceDrawQuad.Centre);
+            AddAssert("pass-through did not produce press", () =>
+                !testInputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed);
 
             AddStep("end touch", () => InputManager.EndTouch(new Touch(TouchSource.Touch1, testInputManager.ScreenSpaceDrawQuad.Centre)));
 

--- a/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -17,8 +15,6 @@ namespace osu.Framework.Tests.Visual.Testing
 {
     public partial class TestSceneManualInputManagerTestScene : ManualInputManagerTestScene
     {
-        protected override Vector2 InitialMousePosition => new Vector2(10f);
-
         [Test]
         public void TestResetInput()
         {
@@ -29,7 +25,7 @@ namespace osu.Framework.Tests.Visual.Testing
 
             AddStep("reset input", ResetInput);
 
-            AddAssert("mouse position reset", () => InputManager.CurrentState.Mouse.Position == InitialMousePosition);
+            AddAssert("mouse position is zero", () => InputManager.CurrentState.Mouse.Position, () => Is.EqualTo(Vector2.Zero));
             AddAssert("all input states released", () =>
                 !InputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed &&
                 !InputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed &&
@@ -39,7 +35,7 @@ namespace osu.Framework.Tests.Visual.Testing
         [Test]
         public void TestPlatformAction()
         {
-            BasicTextBox textbox = null;
+            BasicTextBox textbox = null!;
 
             AddStep("add textbox", () => Child = textbox = new BasicTextBox
             {
@@ -65,7 +61,7 @@ namespace osu.Framework.Tests.Visual.Testing
         [Test]
         public void TestHoldLeftFromMaskedPosition()
         {
-            TestCursor cursor = null;
+            TestCursor cursor = null!;
 
             AddStep("retrieve cursor", () => cursor = (TestCursor)InputManager.ChildrenOfType<TestCursorContainer>().Single().ActiveCursor);
 
@@ -78,8 +74,5 @@ namespace osu.Framework.Tests.Visual.Testing
             AddStep("move mouse to content", () => InputManager.MoveMouseTo(Content));
             AddAssert("cursor still holding", () => cursor.Left.IsPresent);
         }
-
-        [Test]
-        public void TestMousePositionSetToInitial() => AddAssert("mouse position set to initial", () => InputManager.CurrentState.Mouse.Position == InitialMousePosition);
     }
 }

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -23,11 +23,6 @@ namespace osu.Framework.Testing
         protected override Container<Drawable> Content { get; } = new Container { RelativeSizeAxes = Axes.Both };
 
         /// <summary>
-        /// The position which is used to initialize the mouse position before at setup.
-        /// </summary>
-        protected virtual Vector2 InitialMousePosition => Vector2.Zero;
-
-        /// <summary>
         /// The <see cref="ManualInputManager"/>.
         /// </summary>
         protected ManualInputManager InputManager { get; }
@@ -127,7 +122,7 @@ namespace osu.Framework.Testing
             var currentState = InputManager.CurrentState;
 
             var mouse = currentState.Mouse;
-            InputManager.MoveMouseTo(InitialMousePosition);
+            InputManager.MoveMouseTo(Vector2.Zero);
             mouse.Buttons.ForEach(InputManager.ReleaseButton);
 
             var keyboard = currentState.Keyboard;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/28384

Assume a parenting `InputManager` A and a child `PassThroughInputManager` B.

On the first frame where B is a child of A, the following sequence of events occurs:

1. `InputManager` is a `CompositeDrawable`. `CompositeDrawable`s update themselves before updating children. As such, A updates itself first.
2. As part of its update logic, A grabs all pending inputs to be processed.
3. The collected pending inputs are "applied to current state". The process of "applying to current state" is equivalent to passing the input to the appropriate input queue in order, until a drawable handles the input.
4. While B at this point is a child of A, it is not yet `LoadState.Loaded`, because `LoadComplete()` runs as part of the first `UpdateSubTree()` call on B, which is yet to occur. Therefore, B is omitted from any potentially relevant input queues.
5. Having completed updating itself, A updates its children.
6. As part of that children update, B's `UpdateSubTree()` is called, and with it, its `LoadComplete()`.
7. `InputManager.LoadComplete()` has this:

    https://github.com/ppy/osu-framework/blob/576c99b7369432af8d4e6860ac59478e78b5bb48/osu.Framework/Input/InputManager.cs#L184-L186

   which means that not only did it not sync its mouse position with the parent even if it has `UseParentInput == true` because of (4), it can *actively* use a completely different non-zero position due to the aforementioned operation.

While all this corrects in the next frame, the entire aforementioned sequence still means that for the first frame of operation, B will have a mouse position completely desynced from A, even if it specifies `UseParentInput == true`.

Because of the aforementioned fact that `CompositeDrawable`s update themselves before updating children, this allows the *children* to read the bogus mouse position, too. One such child may be a *replay recorder*, for instance, thus causing https://github.com/ppy/osu/issues/28384.

The proposed fix here is a forced synchronisation of mouse position with the parent on every frame via `Update()`. As, again, `CompositeDrawable`s update themselves before children, this is sufficient to avoid exposing the invalid position anywhere lower down.