### PR TITLE
Improve reliability of waveform disposal

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -81,6 +81,8 @@ namespace osu.Framework.Audio.Track
         {
             this.data = data;
 
+            var token = cancelSource.Token;
+
             readTask = Task.Run(() =>
             {
                 if (data == null)
@@ -155,6 +157,8 @@ namespace osu.Framework.Audio.Track
                         // Each point is composed of multiple samples
                         for (int i = 0; i < samplesRead && pointIndex < pointCount; i += samplesPerPoint)
                         {
+                            token.ThrowIfCancellationRequested();
+
                             // We assume one or more channels.
                             // For non-stereo tracks, we'll use the single track for both amplitudes.
                             // For anything above two tracks we'll use the first and second track.
@@ -220,6 +224,8 @@ namespace osu.Framework.Audio.Track
                         // We know that each data point required sampleDataPerPoint amount of data
                         for (; currentPoint < points.Length && currentPoint * bytesPerPoint < currentByte; currentPoint++)
                         {
+                            token.ThrowIfCancellationRequested();
+
                             var point = points[currentPoint];
                             point.LowIntensity = lowIntensity;
                             point.MidIntensity = midIntensity;
@@ -243,7 +249,7 @@ namespace osu.Framework.Audio.Track
                     if (sampleBuffer != null)
                         ArrayPool<float>.Shared.Return(sampleBuffer);
                 }
-            }, cancelSource.Token);
+            }, token);
 
             void logBassError(string reason) => Logger.Log($"BASS failure while reading waveform: {reason} ({Bass.LastError})");
         }

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -410,7 +410,6 @@ namespace osu.Framework.Audio.Track
 
             cancelSource.Cancel();
             cancelSource.Dispose();
-            points = Array.Empty<Point>();
 
             // Try disposing the stream again in case the task was not started.
             data?.Dispose();


### PR DESCRIPTION
Today I found some weird test failures on my machine to the tune of:

	Failed TestMultipleAudioFiles [433 ms]
	Error Message:
	System.AggregateException : One or more errors occurred. (Index was outside the bounds of the array.)
	----> System.IndexOutOfRangeException : Index was outside the bounds of the array.
	Stack Trace:
	at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
	at System.Threading.Tasks.Task.Wait()
	at osu.Framework.Extensions.TaskExtensions.WaitSafely(Task task) in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Extensions/TaskExtensions.cs:line 22
	at osu.Framework.Testing.TestScene.checkForErrors() in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Testing/TestScene.cs:line 519
	at osu.Framework.Testing.TestScene.UseTestSceneRunnerAttribute.AfterTest(ITest test) in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Testing/TestScene.cs:line 589
	at ++(TestExecutionContext context)
	at +[2]+()
	at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)
	--IndexOutOfRangeException
	at +[3]+() in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Audio/Track/Waveform.cs:line 86
	at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
	--- End of stack trace from previous location ---
	at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
	at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
	--- End of stack trace from previous location ---
	at osu.Framework.Audio.Track.Waveform.GetPointsAsync() in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Audio/Track/Waveform.cs:line 374
	at +[4]+() in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Graphics/Audio/WaveformGraph.cs:line 205
	at +[5]+() in /Users/bdach/Documents/Work/open-source/osu-framework/osu.Framework/Graphics/Audio/WaveformGraph.cs:line 203

The stack trace here is very useless, but the gist of it is that the disposal of `Waveform` is playing some very dangerous games. Imagine the following scenario:

	Thread A					Thread B

	Waveform() ctor runs
	Waveform() ctor starts readTask
							readTask starts executing
							readTask accesses some elements from points array
	Waveform.Dispose() called
	Dispose() cancels internal token source
	Dispose() overwrites points with empty array
							readTask attempts to access more elements in points array,
							ignoring the fact that it's been cancelled,
							and dies

Now there are two possible ways out here:

- Don't touch `points` in `Waveform.Dispose()`, which would more or less be a direct revert of ce7c38d75c6f5f80fdc76d296b1554842aab2e49, or

- Use the passed cancellation token to exit out of the `readTask` when it is known that `points` will no longer be valid for reading, by strategically placing `ThrowIfCancellationRequested()` calls in the innermost loops of the `readTask`, which is what this PR does.