### PR TITLE
Populate sample length in `SampleBass`

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassInitTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassInitTest.cs
@@ -37,8 +37,10 @@ namespace osu.Framework.Tests.Audio
                 Assert.Ignore("Test may be intermittent on linux (see AudioThread.FreeDevice()).");
 
             Assert.That(sample.IsLoaded, Is.False);
+            Assert.That(sample.Length, Is.EqualTo(0));
             bass.RunOnAudioThread(() => bass.SampleStore.UpdateDevice(0));
             Assert.That(sample.IsLoaded, Is.True);
+            Assert.That(sample.Length, Is.GreaterThan(0));
         }
     }
 }

--- a/osu.Framework/Audio/Sample/ISample.cs
+++ b/osu.Framework/Audio/Sample/ISample.cs
@@ -17,8 +17,10 @@ namespace osu.Framework.Audio.Sample
 
         /// <summary>
         /// The length in milliseconds of this <see cref="ISample"/>.
-        /// <remarks>The value may not be available yet if <see cref="ISample.IsLoaded"/> is false.</remarks>
         /// </summary>
+        /// <remarks>
+        /// The value may not be available yet if <see cref="ISample.IsLoaded"/> is false.
+        /// </remarks>
         double Length { get; }
 
         /// <summary>

--- a/osu.Framework/Audio/Sample/ISample.cs
+++ b/osu.Framework/Audio/Sample/ISample.cs
@@ -17,8 +17,14 @@ namespace osu.Framework.Audio.Sample
 
         /// <summary>
         /// The length in milliseconds of this <see cref="ISample"/>.
+        /// <remarks>The value may not be available yet if <see cref="ISample.IsLoaded"/> is false.</remarks>
         /// </summary>
         double Length { get; }
+
+        /// <summary>
+        /// Whether this <see cref="ISample"/> is fully loaded.
+        /// </summary>
+        public bool IsLoaded { get; }
 
         /// <summary>
         /// The number of times this sample (as identified by name) can be played back concurrently.

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -19,7 +19,12 @@ namespace osu.Framework.Audio.Sample
             Name = name;
         }
 
-        public double Length { get; protected set; }
+        /// <summary>
+        /// The length of the sample in milliseconds.
+        /// <remarks>The value may not be available yet if <see cref="AudioComponent.IsLoaded"/> is false.</remarks>
+        /// </summary>
+        public abstract double Length { get; }
+
         public Bindable<int> PlaybackConcurrency { get; } = new Bindable<int>(DEFAULT_CONCURRENCY);
 
         internal Action<Sample> OnPlay;

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -19,10 +19,6 @@ namespace osu.Framework.Audio.Sample
             Name = name;
         }
 
-        /// <summary>
-        /// The length of the sample in milliseconds.
-        /// <remarks>The value may not be available yet if <see cref="AudioComponent.IsLoaded"/> is false.</remarks>
-        /// </summary>
         public abstract double Length { get; }
 
         public Bindable<int> PlaybackConcurrency { get; } = new Bindable<int>(DEFAULT_CONCURRENCY);

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -14,6 +14,8 @@ namespace osu.Framework.Audio.Sample
         private readonly SampleBassFactory factory;
         private readonly BassAudioMixer mixer;
 
+        public override double Length => factory.Length;
+
         internal SampleBass(SampleBassFactory factory, BassAudioMixer mixer)
             : base(factory.Name)
         {

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -11,10 +11,10 @@ namespace osu.Framework.Audio.Sample
 
         public override bool IsLoaded => factory.IsLoaded;
 
+        public override double Length => factory.Length;
+
         private readonly SampleBassFactory factory;
         private readonly BassAudioMixer mixer;
-
-        public override double Length => factory.Length;
 
         internal SampleBass(SampleBassFactory factory, BassAudioMixer mixer)
             : base(factory.Name)

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Audio.Sample
             if (!IsLoaded)
                 return;
 
-            Length = Bass.ChannelBytes2Seconds(SampleId, dataLength) * 1000;
+            Length = Bass.ChannelBytes2Seconds(SampleId, Bass.ChannelGetLength(SampleId)) * 1000;
             memoryLease = NativeMemoryTracker.AddMemory(this, dataLength);
         }
 

--- a/osu.Framework/Audio/Sample/SampleVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleVirtual.cs
@@ -11,12 +11,11 @@ namespace osu.Framework.Audio.Sample
     {
         protected override SampleChannel CreateChannel() => new SampleChannelVirtual(Name);
 
-        public override double Length { get; }
+        public override double Length => 0;
 
-        public SampleVirtual(string name = "virtual", double length = 0)
+        public SampleVirtual(string name = "virtual")
             : base(name)
         {
-            Length = length;
         }
     }
 }

--- a/osu.Framework/Audio/Sample/SampleVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleVirtual.cs
@@ -11,9 +11,12 @@ namespace osu.Framework.Audio.Sample
     {
         protected override SampleChannel CreateChannel() => new SampleChannelVirtual(Name);
 
-        public SampleVirtual(string name = "virtual")
+        public override double Length { get; }
+
+        public SampleVirtual(string name = "virtual", double length = 0)
             : base(name)
         {
+            Length = length;
         }
     }
 }


### PR DESCRIPTION
Closes #6399 

Exposes the length of the underlying `SampleBaseFactory` on `SampleBass`. 
The length may not be immediately available since initialization happens on the audio thread (brief discussion about that about that on [discord](https://discord.com/channels/188630481301012481/589331078574112768/1375503628126781642)).