### PR TITLE
Fix passthrough input manager so that it works again with game-side usages

### DIFF
--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -53,6 +53,7 @@ namespace osu.Framework.Input
         {
             base.LoadComplete();
             parentInputManager = GetContainingInputManager();
+            syncWithParent();
         }
 
         public override bool HandleHoverEvents => parentInputManager != null && UseParentInput ? parentInputManager.HandleHoverEvents : base.HandleHoverEvents;
@@ -205,8 +206,13 @@ namespace osu.Framework.Input
             base.Update();
 
             // There are scenarios wherein we cannot receive the release events of pressed inputs. For simplicity, sync every frame.
+            // This intentionally omits mouse position syncing because they don't apply to the above logic of "being unable to receive" such events
+            // (and also because there are game-side usages that stop working correctly if that is done, e.g. osu! touch input handling)
             if (UseParentInput)
-                syncWithParent();
+            {
+                syncReleasedInputs();
+                syncJoystickAxes();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
You'll probably wisely ask "what is this title? isn't that the tail wagging the dog?" It is. `PassThroughInputManager` usage in `RulesetInputManager` sucks. It should not exist. https://github.com/ppy/osu-framework/pull/6579 broke game-side osu! touch input mapping (see [test failures](https://github.com/ppy/osu/actions/runs/15438536705/job/43453184186)) because the touch input mapping wants to do its bespoke mouse position logic on top of `PassThroughInputManager`.

It is my firm belief that `RulesetInputManager` should stop using `PassThroughInputManager` and instead roll its own bespoke logic. But I am not going to do that here, because I want to put a framework release out now rather than in a week, so this attempts to roll out the fix in https://github.com/ppy/osu-framework/pull/6579 in a slightly different (read: uglier) way so that it does not break the delicate game-side usages. If that is not an acceptable outcome, the only other thing I can offer is a revert.

The last time we had this sort of situation is `DecoupleableInterpolatingFramedClock` which was also a situation where the tail wagged the dog for so long and in such inscrutable manner that eventually it got deleted and rewritten using other classes. Which took weeks.