### PR TITLE
Fix issues with proxying PoolableDrawables

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -311,6 +311,20 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddAssert("child prepared", () => drawable.PreparedCount == 1);
         }
 
+        [Test]
+        public void TestUsePoolableDrawableWithProxy()
+        {
+            const int pool_size = 1;
+
+            resetWithNewPool(() => new TestPool(TimePerAction, pool_size));
+
+            AddRepeatStep("get new pooled drawable with proxy", () =>
+            {
+                var drawable = consumeDrawable();
+                Add(drawable.CreateProxy());
+            }, 50);
+        }
+
         protected override void Update()
         {
             base.Update();

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -61,6 +61,12 @@ namespace osu.Framework.Graphics
 
             public override bool UpdateSubTreeMasking() => true;
 
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+                Original.proxy = null;
+            }
+
             private class ProxyDrawNode : DrawNode
             {
                 /// <summary>


### PR DESCRIPTION
Currently, if you attempt to create a proxy for a PoolableDrawable, you run into issues when the Drawable is reused. The proxy is disposed when the original is returned to the pool, but the reference in the original is never cleared so HasProxy will still be true despite proxy pointing to a disposed object that no longer renders.

To fix this, I've overridden OnDisposed in PoolableDrawable to clear the reference to the original when it is disposed.

I've also added a test case to TestSceneDrawablePool that fails on origin/master and passes with the changes from this PR.