### PR TITLE
Fix `CircularProgress` not working properly with texture-atlas backed textures

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -32,9 +32,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private Texture gradientTextureHorizontal;
         private Texture gradientTextureVertical;
         private Texture gradientTextureBoth;
+        private Texture textureAtlasTexture;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(TextureStore textures)
         {
             const int width = 128;
 
@@ -82,6 +83,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             gradientTextureBoth.SetData(new TextureUpload(image));
 
+            textureAtlasTexture = textures.Get("sample-texture");
+
             Box background;
             Container maskingContainer;
 
@@ -116,7 +119,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("Horizontal Gradient Texture", delegate { setTexture(1); });
             AddStep("Vertical Gradient Texture", delegate { setTexture(2); });
-            AddStep("2D Graident Texture", delegate { setTexture(3); });
+            AddStep("2D Gradient Texture", delegate { setTexture(3); });
+            AddStep("Texture Atlas Texture", delegate { setTexture(4); });
             AddStep("White Texture", delegate { setTexture(0); });
 
             AddStep("Red Colour", delegate { setColour(1); });
@@ -190,6 +194,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
                 case 3:
                     clock.Texture = gradientTextureBoth;
+                    break;
+
+                case 4:
+                    clock.Texture = textureAtlasTexture;
                     break;
             }
         }

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -32,7 +32,7 @@ void main(void)
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);
 
-    o_Colour = vec4(textureColour.rgb, textureColour.a * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize));
+    o_Colour = textureColour * progressAlphaAt(pixelPos, progress, innerRadius, roundedCaps, texelSize);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
+++ b/osu.Framework/Resources/Shaders/sh_CircularProgress.fs
@@ -27,7 +27,7 @@ layout(location = 0) out vec4 o_Colour;
 void main(void)
 {
     highp vec2 resolution = v_TexRect.zw - v_TexRect.xy;
-    highp vec2 pixelPos = v_TexCoord / resolution;
+    highp vec2 pixelPos = (v_TexCoord - v_TexRect.xy) / resolution;
     
     highp vec2 wrappedCoord = wrap(v_TexCoord, v_TexRect);
     lowp vec4 textureColour = getRoundedColor(wrappedSampler(wrappedCoord, v_TexRect, m_Texture, m_Sampler, -0.9), wrappedCoord);


### PR DESCRIPTION
The `pixelPos` will be incorrect when `v_TexRect.xy` is non-zero, leading to an incorrect center for the arc when using the drawable with texture-atlas backed textures (i.e. from TextureStore).

Also noticed that the alpha wasn't premultiplied in the shader output so I added a fix for that too while I was at it.

### Before:

https://github.com/user-attachments/assets/769a0d6d-1499-4ad7-8513-5011a67cf71a

### After:

https://github.com/user-attachments/assets/531a9a2e-888c-4cf6-aa82-d248f70c22b6

