### PR TITLE
Add button to take screenshot of target drawable to DrawVisualiser

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -375,6 +375,22 @@ namespace osu.Framework.Graphics.OpenGL
             return image;
         }
 
+        protected internal override Image<Rgba32>? ExtractFrameBufferData(IFrameBuffer frameBuffer)
+        {
+            int width = frameBuffer.Texture.Width;
+            int height = frameBuffer.Texture.Height;
+
+            var data = MemoryAllocator.Default.Allocate<Rgba32>(width * height);
+
+            frameBuffer.Bind();
+            GL.ReadPixels(0, 0, width, height, PixelFormat.Rgba, PixelType.UnsignedByte, ref MemoryMarshal.GetReference(data.Memory.Span));
+            frameBuffer.Unbind();
+
+            var image = Image.LoadPixelData<Rgba32>(data.Memory.Span, width, height);
+
+            return image;
+        }
+
         protected override IShaderPart CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType)
         {
             ShaderType glType;

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -351,6 +351,11 @@ namespace osu.Framework.Graphics.Rendering
         protected internal Image<Rgba32> TakeScreenshot();
 
         /// <summary>
+        /// Returns an image containing the content of a framebuffer.
+        /// </summary>
+        public Image<Rgba32>? ExtractFrameBufferData(IFrameBuffer frameBuffer);
+
+        /// <summary>
         /// Creates a new <see cref="IShaderPart"/>.
         /// </summary>
         /// <param name="store">The shader store to load headers with.</param>

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -328,6 +328,11 @@ namespace osu.Framework.Graphics.Rendering
         protected internal abstract Image<Rgba32> TakeScreenshot();
 
         /// <summary>
+        /// Returns an image containing the content of a framebuffer.
+        /// </summary>
+        protected internal virtual Image<Rgba32>? ExtractFrameBufferData(IFrameBuffer frameBuffer) => null;
+
+        /// <summary>
         /// Performs a once-off initialisation of this <see cref="Renderer"/>.
         /// </summary>
         protected abstract void Initialise(IGraphicsSurface graphicsSurface);
@@ -1219,6 +1224,7 @@ namespace osu.Framework.Graphics.Rendering
         void IRenderer.PushQuadBatch(IVertexBatch<TexturedVertex2D> quadBatch) => PushQuadBatch(quadBatch);
         void IRenderer.PopQuadBatch() => PopQuadBatch();
         Image<Rgba32> IRenderer.TakeScreenshot() => TakeScreenshot();
+        Image<Rgba32>? IRenderer.ExtractFrameBufferData(IFrameBuffer frameBuffer) => ExtractFrameBufferData(frameBuffer);
         IShaderPart IRenderer.CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType) => CreateShaderPart(store, name, rawData, partType);
         IShader IRenderer.CreateShader(string name, IShaderPart[] parts) => CreateShader(name, parts, shaderCompilationStore);
 

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -329,7 +329,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             if (!waitForFence(fence, 5000))
             {
-                Logger.Log("Failed to capture swapchain framebuffer content within reasonable time.", level: LogLevel.Important);
+                Logger.Log("Failed to capture framebuffer content within reasonable time.", level: LogLevel.Important);
                 return new Image<Rgba32>((int)width, (int)height);
             }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -308,45 +308,49 @@ namespace osu.Framework.Graphics.Veldrid
                 }
 
                 default:
-                {
-                    uint width = texture.Width;
-                    uint height = texture.Height;
-
-                    using var staging = Factory.CreateTexture(TextureDescription.Texture2D(width, height, 1, 1, texture.Format, TextureUsage.Staging));
-                    using var commands = Factory.CreateCommandList();
-                    using var fence = Factory.CreateFence(false);
-
-                    commands.Begin();
-                    commands.CopyTexture(texture, staging);
-                    commands.End();
-                    Device.SubmitCommands(commands, fence);
-
-                    if (!waitForFence(fence, 5000))
-                    {
-                        Logger.Log("Failed to capture swapchain framebuffer content within reasonable time.", level: LogLevel.Important);
-                        return new Image<Rgba32>((int)width, (int)height);
-                    }
-
-                    var resource = Device.Map(staging, MapMode.Read);
-                    var span = new Span<Bgra32>(resource.Data.ToPointer(), (int)(resource.SizeInBytes / Marshal.SizeOf<Bgra32>()));
-
-                    // on some backends (Direct3D11, in particular), the staging resource data may contain padding at the end of each row for alignment,
-                    // which means that for the image width, we cannot use the framebuffer's width raw.
-                    using var image = Image.LoadPixelData<Bgra32>(span, (int)(resource.RowPitch / Marshal.SizeOf<Bgra32>()), (int)height);
-
-                    if (!Device.IsUvOriginTopLeft)
-                        image.Mutate(i => i.Flip(FlipMode.Vertical));
-
-                    // if the image width doesn't match the framebuffer, it means that we still have padding at the end of each row mentioned above to get rid of.
-                    // snip it to get a clean image.
-                    if (image.Width != width)
-                        image.Mutate(i => i.Crop((int)width, (int)height));
-
-                    Device.Unmap(staging);
-
-                    return image.CloneAs<Rgba32>();
-                }
+                    return ExtractTexture<Bgra32>(texture, flipVertical: !Device.IsUvOriginTopLeft);
             }
+        }
+
+        public unsafe Image<Rgba32> ExtractTexture<TPixel>(Texture texture, bool flipVertical = false)
+            where TPixel : unmanaged, IPixel<TPixel>
+        {
+            uint width = texture.Width;
+            uint height = texture.Height;
+
+            using var staging = Factory.CreateTexture(TextureDescription.Texture2D(width, height, texture.MipLevels, texture.ArrayLayers, texture.Format, TextureUsage.Staging));
+            using var commands = Factory.CreateCommandList();
+            using var fence = Factory.CreateFence(false);
+
+            commands.Begin();
+            commands.CopyTexture(texture, staging);
+            commands.End();
+            Device.SubmitCommands(commands, fence);
+
+            if (!waitForFence(fence, 5000))
+            {
+                Logger.Log("Failed to capture swapchain framebuffer content within reasonable time.", level: LogLevel.Important);
+                return new Image<Rgba32>((int)width, (int)height);
+            }
+
+            var resource = Device.Map(staging, MapMode.Read);
+            var span = new Span<TPixel>(resource.Data.ToPointer(), (int)(resource.SizeInBytes / Marshal.SizeOf<TPixel>()));
+
+            // on some backends (Direct3D11, in particular), the staging resource data may contain padding at the end of each row for alignment,
+            // which means that for the image width, we cannot use the framebuffer's width raw.
+            using var image = Image.LoadPixelData<TPixel>(span, (int)(resource.RowPitch / Marshal.SizeOf<TPixel>()), (int)height);
+
+            if (flipVertical)
+                image.Mutate(i => i.Flip(FlipMode.Vertical));
+
+            // if the image width doesn't match the framebuffer, it means that we still have padding at the end of each row mentioned above to get rid of.
+            // snip it to get a clean image.
+            if (image.Width != width)
+                image.Mutate(i => i.Crop((int)texture.Width, (int)texture.Height));
+
+            Device.Unmap(staging);
+
+            return image.CloneAs<Rgba32>();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -223,6 +223,18 @@ namespace osu.Framework.Graphics.Veldrid
         protected internal override Image<Rgba32> TakeScreenshot()
             => veldridDevice.TakeScreenshot();
 
+        protected internal override Image<Rgba32>? ExtractFrameBufferData(IFrameBuffer frameBuffer)
+            => ExtractTexture((VeldridTexture)frameBuffer.Texture.NativeTexture);
+
+        protected internal Image<Rgba32>? ExtractTexture(VeldridTexture texture)
+        {
+            var resource = texture.GetResourceList().FirstOrDefault();
+            if (resource == null)
+                return null;
+
+            return veldridDevice.ExtractTexture<Rgba32>(resource.Texture);
+        }
+
         /// <summary>
         /// Updates a <see cref="global::Veldrid.Texture"/> with a <paramref name="data"/> at the specified coordinates.
         /// </summary>

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -59,13 +59,7 @@ namespace osu.Framework.Graphics.Visualisation
                     },
                     GoUpOneParent = goUpOneParent,
                     ToggleInspector = toggleInspector,
-                    TakeScreenshot = () =>
-                    {
-                        if (Target == null)
-                            return;
-
-                        takeScreenshot(Target);
-                    },
+                    TakeScreenshot = takeScreenshot,
                 },
                 new CursorContainer()
             };
@@ -124,18 +118,25 @@ namespace osu.Framework.Graphics.Visualisation
                 setHighlight(targetVisualiser);
         }
 
-        private void takeScreenshot(Drawable target)
+        private void takeScreenshot()
         {
-            Add(new DrawableScreenshotter(target, image =>
+            var currentTarget = Target;
+            if (currentTarget == null)
+                return;
+
+            Add(new DrawableScreenshotter(currentTarget, image =>
             {
                 if (image == null)
                     return;
 
                 clipboard.SetImage(image);
 
+                if (currentTarget.IsDisposed)
+                    return;
+
                 var flash = new FlashyBox(static d => d.ScreenSpaceDrawQuad)
                 {
-                    Target = target,
+                    Target = currentTarget,
                     Depth = 1
                 };
                 Add(flash);

--- a/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
@@ -1,0 +1,120 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Platform;
+using osuTK;
+using osuTK.Graphics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    /// <summary>
+    /// Takes an image of a drawable.
+    /// </summary>
+    internal partial class DrawableScreenshotter : Drawable, IBufferedDrawable
+    {
+        public readonly Drawable Target;
+
+        private readonly Action<Image<Rgba32>?> onImageReceived;
+        private bool didRender;
+
+        public DrawableScreenshotter(Drawable target, Action<Image<Rgba32>?> onImageReceived)
+        {
+            this.onImageReceived = onImageReceived;
+
+            Target = target;
+        }
+
+        public override Quad ScreenSpaceDrawQuad => Target.ScreenSpaceDrawQuad;
+
+        private IShader textureShader = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            textureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        public override bool IsPresent => true;
+
+        public IShader? TextureShader => textureShader;
+        public Color4 BackgroundColour => new Color4(0, 0, 0, 0);
+        public DrawColourInfo? FrameBufferDrawColour => new DrawColourInfo(Color4.White);
+        public Vector2 FrameBufferScale => Vector2.One;
+
+        public override DrawColourInfo DrawColourInfo => new DrawColourInfo(Color4.White);
+
+        public override DrawInfo DrawInfo => Target.DrawInfo;
+
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderBufferFormat.D16 }, pixelSnapping: true, clipToRootNode: true);
+
+        [Resolved]
+        private GameHost host { get; set; } = null!;
+
+        [Resolved]
+        private IRenderer renderer { get; set; } = null!;
+
+        private void onRendered(IFrameBuffer frameBuffer)
+        {
+            if (didRender)
+                return;
+
+            didRender = true;
+
+            host.DrawThread.Scheduler.Add(() =>
+            {
+                var image = renderer.ExtractFrameBufferData(frameBuffer);
+
+                Schedule(() =>
+                {
+                    onImageReceived(image);
+
+                    Expire();
+                });
+            });
+        }
+
+        internal override DrawNode? GenerateDrawNodeSubtree(ulong frame, int treeIndex, bool forceNewDrawNode)
+        {
+            if (didRender)
+                return null;
+
+            var targetDrawNode = Target.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
+
+            if (targetDrawNode == null)
+                return null;
+
+            var drawNode = new DrawableScreenshotterDrawNode(this, targetDrawNode, sharedData, onRendered);
+
+            drawNode.ApplyState();
+
+            return drawNode;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            sharedData.Dispose();
+        }
+
+        private class DrawableScreenshotterDrawNode : BufferedDrawNode
+        {
+            private readonly Action<IFrameBuffer> onRendered;
+
+            public DrawableScreenshotterDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData, Action<IFrameBuffer> onRendered)
+                : base(source, child, sharedData)
+            {
+                this.onRendered = onRendered;
+            }
+
+            protected override void DrawContents(IRenderer renderer) => onRendered(SharedData.MainBuffer);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/ToolWindow.cs
+++ b/osu.Framework/Graphics/Visualisation/ToolWindow.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osuTK;
 
@@ -158,8 +159,35 @@ namespace osu.Framework.Graphics.Visualisation
             });
         }
 
+        protected void AddButton(IconUsage icon, Action action)
+        {
+            ToolbarContent.Add(new IconButton(icon)
+            {
+                Action = action
+            });
+        }
+
         protected override void PopIn() => this.FadeIn(100);
 
         protected override void PopOut() => this.FadeOut(100);
+
+        private partial class IconButton : BasicButton
+        {
+            public IconButton(IconUsage icon)
+            {
+                AutoSizeAxes = Axes.X;
+                Height = button_height;
+
+                Add(new SpriteIcon
+                {
+                    Size = new Vector2(16),
+                    Margin = new MarginPadding { Horizontal = 10 },
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Icon = icon,
+                    Colour = FrameworkColour.Yellow,
+                });
+            }
+        }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -17,6 +17,7 @@ namespace osu.Framework.Graphics.Visualisation
         public Action ChooseTarget;
         public Action GoUpOneParent;
         public Action ToggleInspector;
+        public Action TakeScreenshot;
 
         internal DrawableInspector DrawableInspector { get; private set; }
 
@@ -48,6 +49,7 @@ namespace osu.Framework.Graphics.Visualisation
             AddButton(@"choose target", () => ChooseTarget?.Invoke());
             AddButton(@"up one parent", () => GoUpOneParent?.Invoke());
             AddButton(@"toggle inspector", () => ToggleInspector?.Invoke());
+            AddButton(FontAwesome.Solid.Camera, () => TakeScreenshot?.Invoke());
 
             MainHorizontalContent.Add(DrawableInspector = new DrawableInspector());
         }


### PR DESCRIPTION
RFC
I have a bunch of drawables that I want to take before/after screenshots of to do pixels diffs with, and there's no good way to get a screenshot cropped to the exact drawable bounds currently so I tried to make one. 
The button basically renders the DrawVisualier's current `Target` drawable and draws it to a texture, which it then extracts & puts into the system clipboard.

The way I went about getting an arbitrary drawable drawn to a texture is kinda cursed, but abusing a BufferedDrawNode like this seemed like the simplest way of doing this.

https://github.com/user-attachments/assets/77b06cf7-4001-466d-b512-ac2302260122

