### PR TITLE
Fix disposal logic in `DrawableScreenshotterDrawNode`

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
@@ -85,10 +85,7 @@ namespace osu.Framework.Graphics.Visualisation
             if (didRender)
                 return null;
 
-            // This looks a bit weird, but we essentially want a DrawNode that we can safely dispose once we've rendered it.
-            // The second call to GenerateDrawNodeSubtree is there to make sure the drawable is no longer referencing this DrawNode
             var targetDrawNode = Target.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
-            Target.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode: true);
 
             if (targetDrawNode == null)
             {
@@ -97,6 +94,10 @@ namespace osu.Framework.Graphics.Visualisation
                 Expire();
                 return null;
             }
+
+            // This looks a bit odd, but we essentially want a drawNode that we can safely dispose once we've rendered it.
+            // This call will force the target drawable to recreate its drawNode subtree so the one we got should be completely detached.
+            Target.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode: true);
 
             var drawNode = new DrawableScreenshotterDrawNode(this, targetDrawNode, sharedData, onRendered);
 


### PR DESCRIPTION
The `DrawableScreenshotterDrawNode` will propagate it's disposal to the child DrawNode which should be avoided since that drawNode is essentially just "borrowed" from the original drawable and still very much needed.
I find it a bit odd that I didn't run into any cases where this actually caused issues when testing this but I think it should be fixed regardless.

There's 2 ways of fixing this from what I can tell, either preventing the disposal of the child drawNode or making sure we have a drawNode that can be safely disposed. Ended up going with the latter since re-using draw nodes like this kinda breaks the expectations the whole system is built around.