### PR TITLE
Add MoltenVK support on macOS

### DIFF
--- a/.github/workflows/build-mvk.yml
+++ b/.github/workflows/build-mvk.yml
@@ -1,0 +1,43 @@
+name: Build MoltenVK
+on: workflow_dispatch
+
+jobs:
+  build-macos:
+    name: Build macOS
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: osu.Framework.NativeLibs/scripts/moltenvk/build-macOS.sh
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: macOS-universal
+          path: macOS-universal
+
+  make-pr:
+    name: Create pull request
+    runs-on: ubuntu-22.04
+    needs:
+      - build-macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: macOS-universal
+          path: osu.Framework.NativeLibs/runtimes/osx/native
+
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update MoltenVK binary
+          title: Update MoltenVK binary
+          body: This PR has been auto-generated to update the MoltenVK binary.
+          branch: update-mvk-binary
+          delete-branch: true
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -346,4 +346,6 @@ inspectcode
 # NativeLibs build folders and tarballs
 osu.Framework.NativeLibs/scripts/ffmpeg/*/
 osu.Framework.NativeLibs/scripts/ffmpeg/*.tar.gz
+osu.Framework.NativeLibs/scripts/moltenvk/*/
+osu.Framework.NativeLibs/scripts/moltenvk/*.dylib
 

--- a/osu.Framework.NativeLibs/scripts/moltenvk/BUILDING.md
+++ b/osu.Framework.NativeLibs/scripts/moltenvk/BUILDING.md
@@ -1,0 +1,24 @@
+# Build Instructions
+
+NOTE: MoltenVK is supported only on Apple devices.
+
+1. Install the dependencies
+2. Run the build script `build-macOS.sh`
+
+### Dependencies
+
+Check [this page](https://github.com/KhronosGroup/MoltenVK) for instructions on how to install dependencies.
+It is enough to install these packages in addition to Xcode:
+
+```zsh
+brew install git cmake python3 ninja make
+```
+
+## Output files
+
+The shared library will be located in the `macOS-universal` directory,
+and the directory called `mvk-build` will contain the respective build files.
+
+## Cleanup
+
+Files are left around for debugging purposes, manually delete the directories to clean up.

--- a/osu.Framework.NativeLibs/scripts/moltenvk/build-macOS.sh
+++ b/osu.Framework.NativeLibs/scripts/moltenvk/build-macOS.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+
+set -eu
+
+pushd . > /dev/null
+
+git clone "https://github.com/KhronosGroup/MoltenVK.git" "mvk-build"
+cd "mvk-build"
+
+./fetchDependencies --macos -v
+
+make macos \
+    MVK_CONFIG_LOG_LEVEL=1 \
+    MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS=1 \
+    MVK_CONFIG_SHOULD_MAXIMIZE_CONCURRENT_COMPILATION=1 \
+    MVK_CONFIG_API_VERSION_TO_ADVERTISE=13
+
+mkdir -p ../macOS-universal
+cp "Package/Release/MoltenVK/dylib/macOS/libMoltenVK.dylib" "../macOS-universal/libMoltenVK.dylib"
+
+popd > /dev/null

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -134,9 +134,9 @@ namespace osu.Framework.Graphics.Veldrid
 
                 case RuntimeInfo.Platform.macOS:
                 {
-                    // OpenGL doesn't use a swapchain, so it's only needed on Metal.
+                    // OpenGL doesn't use a swapchain, so it's only needed on Metal/MoltenVK.
                     // Creating a Metal surface in general would otherwise destroy the GL context.
-                    if (this.graphicsSurface.Type == GraphicsSurfaceType.Metal)
+                    if (this.graphicsSurface.Type != GraphicsSurfaceType.OpenGL)
                     {
                         var metalGraphics = (IMetalGraphicsSurface)this.graphicsSurface;
                         swapchain.Source = SwapchainSource.CreateNSView(metalGraphics.CreateMetalView());

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -843,6 +843,17 @@ namespace osu.Framework.Platform
         {
             yield return RendererType.Automatic;
 
+            bool isVulkanSupported;
+
+            try
+            {
+                isVulkanSupported = Veldrid.GraphicsDevice.IsBackendSupported(Veldrid.GraphicsBackend.Vulkan);
+            }
+            catch
+            {
+                isVulkanSupported = false;
+            }
+
             // Preferred per-platform renderers
             switch (RuntimeInfo.OS)
             {
@@ -850,14 +861,18 @@ namespace osu.Framework.Platform
                     yield return RendererType.Direct3D11;
                     yield return RendererType.Deferred_Direct3D11;
                     yield return RendererType.OpenGL;
-                    yield return RendererType.Deferred_Vulkan;
+
+                    if (isVulkanSupported)
+                        yield return RendererType.Deferred_Vulkan;
 
                     break;
 
                 case RuntimeInfo.Platform.Linux:
                     yield return RendererType.OpenGL;
                     yield return RendererType.Deferred_OpenGL;
-                    yield return RendererType.Deferred_Vulkan;
+
+                    if (isVulkanSupported)
+                        yield return RendererType.Deferred_Vulkan;
 
                     break;
 
@@ -865,6 +880,9 @@ namespace osu.Framework.Platform
                     yield return RendererType.Metal;
                     yield return RendererType.Deferred_Metal;
                     yield return RendererType.OpenGL;
+
+                    if (isVulkanSupported)
+                        yield return RendererType.Deferred_Vulkan;
 
                     break;
 


### PR DESCRIPTION
Sometimes MoltenVK performs better than Metal while trying to play Windows games on Mac through DirectX translation layers. Therefore I've thought of trying to use Vulkan in osu!, cause Metal is capped at 60FPS and produces visible tearing if you try to turn FPS up to get at least higher updates rate. OpenGL works awfully on M1, thanks to Apple for very basic support of it.

I've found that some code in Vk, Veldrid and even osu-framework shows that there were some movements in this direction, but all of them are incomplete (at least nowadays). My chain of PRs introduces critical fixes for MoltenVK to work.

Performance is almost like Metal, but without the FPS cap and sometimes even more stable.

Also, the default 2x frame rate graphics option finally works on macOS with MoltenVK. With OpenGL it was laggy enough to make FPS drop below 120, with Metal it was capped at 60.

To sum up, I think that adding MoltenVK support is reasonable. At least for some period for testing on more devices (I've not compared performance on Mac with AMD GPU).

This PR also provides script and workflow to bundle MoltenVK with osu.

My device is MacBook Air M1 (7-core GPU).

Required PRs:
* https://github.com/ppy/veldrid/pull/64
* https://github.com/ppy/vk/pull/2

Frame time graphs mid-game:
![IMAGE 2025-06-10 3:24:09 AM](https://github.com/user-attachments/assets/6d9a5a17-20ef-4bfc-992b-6dbaf78db53e)

