### PR TITLE
Refactor render events

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkEventList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkEventList.cs
@@ -34,11 +34,11 @@ namespace osu.Framework.Benchmarks
 
             for (int i = 0; i < 10000; i++)
             {
-                staticItems[0].list.Add(RenderEvent.Init(new FlushEvent(new ResourceReference(1), 10)));
-                staticItems[1].list.Add(RenderEvent.Init(new AddPrimitiveToBatchEvent(new ResourceReference(0), staticItems[1].allocator.AllocateRegion(1024))));
+                staticItems[0].list.Add(RenderEvent.Create(new FlushEvent(new ResourceReference(1), 10)));
+                staticItems[1].list.Add(RenderEvent.Create(new AddPrimitiveToBatchEvent(new ResourceReference(0), staticItems[1].allocator.AllocateRegion(1024))));
                 staticItems[2].list.Add(i % 2 == 0
-                    ? RenderEvent.Init(new FlushEvent(new ResourceReference(1), 10))
-                    : RenderEvent.Init(new AddPrimitiveToBatchEvent(new ResourceReference(0), staticItems[2].allocator.AllocateRegion(1024))));
+                    ? RenderEvent.Create(new FlushEvent(new ResourceReference(1), 10))
+                    : RenderEvent.Create(new AddPrimitiveToBatchEvent(new ResourceReference(0), staticItems[2].allocator.AllocateRegion(1024))));
             }
         }
 
@@ -48,7 +48,7 @@ namespace osu.Framework.Benchmarks
             localAllocator.NewFrame();
 
             for (int i = 0; i < 10000; i++)
-                localEventList.Add(RenderEvent.Init(new FlushEvent()));
+                localEventList.Add(RenderEvent.Create(new FlushEvent()));
         }
 
         [Benchmark]
@@ -57,7 +57,7 @@ namespace osu.Framework.Benchmarks
             localAllocator.NewFrame();
 
             for (int i = 0; i < 10000; i++)
-                localEventList.Add(RenderEvent.Init(new AddPrimitiveToBatchEvent(new ResourceReference(0), localAllocator.AllocateRegion(1024))));
+                localEventList.Add(RenderEvent.Create(new AddPrimitiveToBatchEvent(new ResourceReference(0), localAllocator.AllocateRegion(1024))));
         }
 
         [Benchmark]

--- a/osu.Framework.Benchmarks/BenchmarkRenderEvent.cs
+++ b/osu.Framework.Benchmarks/BenchmarkRenderEvent.cs
@@ -1,0 +1,147 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using osu.Framework.Graphics.Rendering.Deferred.Events;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkRenderEvent
+    {
+        private readonly Consumer consumer = new Consumer();
+
+        [Benchmark]
+        public void AddPrimitiveToBatch()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(AddPrimitiveToBatchEvent)));
+        }
+
+        [Benchmark]
+        public void Clear()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(ClearEvent)));
+        }
+
+        [Benchmark]
+        public void DrawNodeAction()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(DrawNodeActionEvent)));
+        }
+
+        [Benchmark]
+        public void Flush()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(FlushEvent)));
+        }
+
+        [Benchmark]
+        public void ResizeFrameBuffer()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(ResizeFrameBufferEvent)));
+        }
+
+        [Benchmark]
+        public void SetBlend()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetBlendEvent)));
+        }
+
+        [Benchmark]
+        public void SetBlendMask()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetBlendMaskEvent)));
+        }
+
+        [Benchmark]
+        public void SetDepthInfo()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetDepthInfoEvent)));
+        }
+
+        [Benchmark]
+        public void SetFrameBuffer()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetFrameBufferEvent)));
+        }
+
+        [Benchmark]
+        public void SetScissor()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetScissorEvent)));
+        }
+
+        [Benchmark]
+        public void SetShader()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetShaderEvent)));
+        }
+
+        [Benchmark]
+        public void SetScissorState()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetScissorStateEvent)));
+        }
+
+        [Benchmark]
+        public void SetShaderStorageBufferObjectData()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetShaderStorageBufferObjectDataEvent)));
+        }
+
+        [Benchmark]
+        public void SetStencilInfo()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetStencilInfoEvent)));
+        }
+
+        [Benchmark]
+        public void SetTexture()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetTextureEvent)));
+        }
+
+        [Benchmark]
+        public void SetUniformBufferData()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetUniformBufferDataEvent)));
+        }
+
+        [Benchmark]
+        public void SetUniformBufferDataRange()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetUniformBufferDataRangeEvent)));
+        }
+
+        [Benchmark]
+        public void SetUniformBuffer()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetUniformBufferEvent)));
+        }
+
+        [Benchmark]
+        public void SetViewport()
+        {
+            for (int i = 0; i < 10000; i++)
+                consumer.Consume(RenderEvent.Init(default(SetViewportEvent)));
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkRenderEvent.cs
+++ b/osu.Framework.Benchmarks/BenchmarkRenderEvent.cs
@@ -15,133 +15,133 @@ namespace osu.Framework.Benchmarks
         public void AddPrimitiveToBatch()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(AddPrimitiveToBatchEvent)));
+                consumer.Consume(RenderEvent.Create(default(AddPrimitiveToBatchEvent)));
         }
 
         [Benchmark]
         public void Clear()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(ClearEvent)));
+                consumer.Consume(RenderEvent.Create(default(ClearEvent)));
         }
 
         [Benchmark]
         public void DrawNodeAction()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(DrawNodeActionEvent)));
+                consumer.Consume(RenderEvent.Create(default(DrawNodeActionEvent)));
         }
 
         [Benchmark]
         public void Flush()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(FlushEvent)));
+                consumer.Consume(RenderEvent.Create(default(FlushEvent)));
         }
 
         [Benchmark]
         public void ResizeFrameBuffer()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(ResizeFrameBufferEvent)));
+                consumer.Consume(RenderEvent.Create(default(ResizeFrameBufferEvent)));
         }
 
         [Benchmark]
         public void SetBlend()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetBlendEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetBlendEvent)));
         }
 
         [Benchmark]
         public void SetBlendMask()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetBlendMaskEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetBlendMaskEvent)));
         }
 
         [Benchmark]
         public void SetDepthInfo()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetDepthInfoEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetDepthInfoEvent)));
         }
 
         [Benchmark]
         public void SetFrameBuffer()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetFrameBufferEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetFrameBufferEvent)));
         }
 
         [Benchmark]
         public void SetScissor()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetScissorEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetScissorEvent)));
         }
 
         [Benchmark]
         public void SetShader()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetShaderEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetShaderEvent)));
         }
 
         [Benchmark]
         public void SetScissorState()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetScissorStateEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetScissorStateEvent)));
         }
 
         [Benchmark]
         public void SetShaderStorageBufferObjectData()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetShaderStorageBufferObjectDataEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetShaderStorageBufferObjectDataEvent)));
         }
 
         [Benchmark]
         public void SetStencilInfo()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetStencilInfoEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetStencilInfoEvent)));
         }
 
         [Benchmark]
         public void SetTexture()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetTextureEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetTextureEvent)));
         }
 
         [Benchmark]
         public void SetUniformBufferData()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetUniformBufferDataEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetUniformBufferDataEvent)));
         }
 
         [Benchmark]
         public void SetUniformBufferDataRange()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetUniformBufferDataRangeEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetUniformBufferDataRangeEvent)));
         }
 
         [Benchmark]
         public void SetUniformBuffer()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetUniformBufferEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetUniformBufferEvent)));
         }
 
         [Benchmark]
         public void SetViewport()
         {
             for (int i = 0; i < 10000; i++)
-                consumer.Consume(RenderEvent.Init(default(SetViewportEvent)));
+                consumer.Consume(RenderEvent.Create(default(SetViewportEvent)));
         }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/EventProcessor.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/EventProcessor.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
                         SetUniformBufferDataEvent e = (SetUniformBufferDataEvent)renderEvent;
                         IDeferredUniformBuffer buffer = context.Dereference<IDeferredUniformBuffer>(e.Buffer);
                         UniformBufferReference range = buffer.Write(e.Data);
-                        context.RenderEvents[i] = RenderEvent.Init(new SetUniformBufferDataRangeEvent(e.Buffer, range));
+                        context.RenderEvents[i] = RenderEvent.Create(new SetUniformBufferDataRangeEvent(e.Buffer, range));
                         break;
                     }
 

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/AddPrimitiveToBatchEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/AddPrimitiveToBatchEvent.cs
@@ -11,6 +11,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     {
         public static RenderEvent Create<T>(DeferredRenderer renderer, DeferredVertexBatch<T> batch, ReadOnlySpan<T> vertices)
             where T : unmanaged, IVertex, IEquatable<T>
-            => RenderEvent.Init(new AddPrimitiveToBatchEvent(renderer.Context.Reference(batch), renderer.Context.AllocateRegion(vertices)));
+            => RenderEvent.Create(new AddPrimitiveToBatchEvent(renderer.Context.Reference(batch), renderer.Context.AllocateRegion(vertices)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/ClearEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/ClearEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct ClearEvent(ClearInfo Info)
     {
         public static RenderEvent Create(ClearInfo info)
-            => RenderEvent.Init(new ClearEvent(info));
+            => RenderEvent.Create(new ClearEvent(info));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/DrawNodeActionEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/DrawNodeActionEvent.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct DrawNodeActionEvent(ResourceReference DrawNode, DrawNodeActionType Action)
     {
         public static RenderEvent Create(DeferredRenderer renderer, DrawNode drawNode, DrawNodeActionType action)
-            => RenderEvent.Init(new DrawNodeActionEvent(renderer.Context.Reference(drawNode), action));
+            => RenderEvent.Create(new DrawNodeActionEvent(renderer.Context.Reference(drawNode), action));
     }
 
     internal enum DrawNodeActionType : byte

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/FlushEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/FlushEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct FlushEvent(ResourceReference VertexBatch, int VertexCount)
     {
         public static RenderEvent Create(DeferredRenderer renderer, IDeferredVertexBatch vertexBatch, int vertexCount)
-            => RenderEvent.Init(new FlushEvent(renderer.Context.Reference(vertexBatch), vertexCount));
+            => RenderEvent.Create(new FlushEvent(renderer.Context.Reference(vertexBatch), vertexCount));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
@@ -2,12 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace osu.Framework.Graphics.Rendering.Deferred.Events
 {
-    [SkipLocalsInit]
     [StructLayout(LayoutKind.Explicit)]
     internal struct RenderEvent
     {

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
@@ -74,115 +74,115 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
         [FieldOffset(8)]
         private SetViewportEvent setViewport;
 
-        public static RenderEvent Init(in AddPrimitiveToBatchEvent @event) => new RenderEvent
+        public static RenderEvent Create(in AddPrimitiveToBatchEvent @event) => new RenderEvent
         {
             Type = RenderEventType.AddPrimitiveToBatch,
             addPrimitiveToBatch = @event
         };
 
-        public static RenderEvent Init(in ClearEvent @event) => new RenderEvent
+        public static RenderEvent Create(in ClearEvent @event) => new RenderEvent
         {
             Type = RenderEventType.Clear,
             clear = @event
         };
 
-        public static RenderEvent Init(in DrawNodeActionEvent @event) => new RenderEvent
+        public static RenderEvent Create(in DrawNodeActionEvent @event) => new RenderEvent
         {
             Type = RenderEventType.DrawNodeAction,
             drawNodeAction = @event
         };
 
-        public static RenderEvent Init(in FlushEvent @event) => new RenderEvent
+        public static RenderEvent Create(in FlushEvent @event) => new RenderEvent
         {
             Type = RenderEventType.Flush,
             flush = @event
         };
 
-        public static RenderEvent Init(in ResizeFrameBufferEvent @event) => new RenderEvent
+        public static RenderEvent Create(in ResizeFrameBufferEvent @event) => new RenderEvent
         {
             Type = RenderEventType.ResizeFrameBuffer,
             resizeFrameBuffer = @event
         };
 
-        public static RenderEvent Init(in SetBlendEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetBlendEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetBlend,
             setBlend = @event
         };
 
-        public static RenderEvent Init(in SetBlendMaskEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetBlendMaskEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetBlendMask,
             setBlendMask = @event
         };
 
-        public static RenderEvent Init(in SetDepthInfoEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetDepthInfoEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetDepthInfo,
             setDepthInfo = @event
         };
 
-        public static RenderEvent Init(in SetFrameBufferEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetFrameBufferEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetFrameBuffer,
             setFrameBuffer = @event
         };
 
-        public static RenderEvent Init(in SetScissorEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetScissorEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetScissor,
             setScissor = @event
         };
 
-        public static RenderEvent Init(in SetShaderEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetShaderEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetShader,
             setShader = @event
         };
 
-        public static RenderEvent Init(in SetScissorStateEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetScissorStateEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetScissorState,
             setScissorState = @event
         };
 
-        public static RenderEvent Init(in SetShaderStorageBufferObjectDataEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetShaderStorageBufferObjectDataEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetShaderStorageBufferObjectData,
             setShaderStorageBufferObjectData = @event
         };
 
-        public static RenderEvent Init(in SetStencilInfoEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetStencilInfoEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetStencilInfo,
             setStencilInfo = @event
         };
 
-        public static RenderEvent Init(in SetTextureEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetTextureEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetTexture,
             setTexture = @event
         };
 
-        public static RenderEvent Init(in SetUniformBufferDataEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetUniformBufferDataEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetUniformBufferData,
             setUniformBufferData = @event
         };
 
-        public static RenderEvent Init(in SetUniformBufferDataRangeEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetUniformBufferDataRangeEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetUniformBufferDataRange,
             setUniformBufferDataRange = @event
         };
 
-        public static RenderEvent Init(in SetUniformBufferEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetUniformBufferEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetUniformBuffer,
             setUniformBuffer = @event
         };
 
-        public static RenderEvent Init(in SetViewportEvent @event) => new RenderEvent
+        public static RenderEvent Create(in SetViewportEvent @event) => new RenderEvent
         {
             Type = RenderEventType.SetViewport,
             setViewport = @event

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/RenderEvent.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -75,162 +74,119 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
         [FieldOffset(8)]
         private SetViewportEvent setViewport;
 
-        [Obsolete("RenderEvent must be initialised via Init().", true)]
-        public RenderEvent()
+        public static RenderEvent Init(in AddPrimitiveToBatchEvent @event) => new RenderEvent
         {
-        }
+            Type = RenderEventType.AddPrimitiveToBatch,
+            addPrimitiveToBatch = @event
+        };
 
-        public static RenderEvent Init(in AddPrimitiveToBatchEvent @event)
+        public static RenderEvent Init(in ClearEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.AddPrimitiveToBatch;
-            e.addPrimitiveToBatch = @event;
-            return e;
-        }
+            Type = RenderEventType.Clear,
+            clear = @event
+        };
 
-        public static RenderEvent Init(in ClearEvent @event)
+        public static RenderEvent Init(in DrawNodeActionEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.Clear;
-            e.clear = @event;
-            return e;
-        }
+            Type = RenderEventType.DrawNodeAction,
+            drawNodeAction = @event
+        };
 
-        public static RenderEvent Init(in DrawNodeActionEvent @event)
+        public static RenderEvent Init(in FlushEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.DrawNodeAction;
-            e.drawNodeAction = @event;
-            return e;
-        }
+            Type = RenderEventType.Flush,
+            flush = @event
+        };
 
-        public static RenderEvent Init(in FlushEvent @event)
+        public static RenderEvent Init(in ResizeFrameBufferEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.Flush;
-            e.flush = @event;
-            return e;
-        }
+            Type = RenderEventType.ResizeFrameBuffer,
+            resizeFrameBuffer = @event
+        };
 
-        public static RenderEvent Init(in ResizeFrameBufferEvent @event)
+        public static RenderEvent Init(in SetBlendEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.ResizeFrameBuffer;
-            e.resizeFrameBuffer = @event;
-            return e;
-        }
+            Type = RenderEventType.SetBlend,
+            setBlend = @event
+        };
 
-        public static RenderEvent Init(in SetBlendEvent @event)
+        public static RenderEvent Init(in SetBlendMaskEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetBlend;
-            e.setBlend = @event;
-            return e;
-        }
+            Type = RenderEventType.SetBlendMask,
+            setBlendMask = @event
+        };
 
-        public static RenderEvent Init(in SetBlendMaskEvent @event)
+        public static RenderEvent Init(in SetDepthInfoEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetBlendMask;
-            e.setBlendMask = @event;
-            return e;
-        }
+            Type = RenderEventType.SetDepthInfo,
+            setDepthInfo = @event
+        };
 
-        public static RenderEvent Init(in SetDepthInfoEvent @event)
+        public static RenderEvent Init(in SetFrameBufferEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetDepthInfo;
-            e.setDepthInfo = @event;
-            return e;
-        }
+            Type = RenderEventType.SetFrameBuffer,
+            setFrameBuffer = @event
+        };
 
-        public static RenderEvent Init(in SetFrameBufferEvent @event)
+        public static RenderEvent Init(in SetScissorEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetFrameBuffer;
-            e.setFrameBuffer = @event;
-            return e;
-        }
+            Type = RenderEventType.SetScissor,
+            setScissor = @event
+        };
 
-        public static RenderEvent Init(in SetScissorEvent @event)
+        public static RenderEvent Init(in SetShaderEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetScissor;
-            e.setScissor = @event;
-            return e;
-        }
+            Type = RenderEventType.SetShader,
+            setShader = @event
+        };
 
-        public static RenderEvent Init(in SetShaderEvent @event)
+        public static RenderEvent Init(in SetScissorStateEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetShader;
-            e.setShader = @event;
-            return e;
-        }
+            Type = RenderEventType.SetScissorState,
+            setScissorState = @event
+        };
 
-        public static RenderEvent Init(in SetScissorStateEvent @event)
+        public static RenderEvent Init(in SetShaderStorageBufferObjectDataEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetScissorState;
-            e.setScissorState = @event;
-            return e;
-        }
+            Type = RenderEventType.SetShaderStorageBufferObjectData,
+            setShaderStorageBufferObjectData = @event
+        };
 
-        public static RenderEvent Init(in SetShaderStorageBufferObjectDataEvent @event)
+        public static RenderEvent Init(in SetStencilInfoEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetShaderStorageBufferObjectData;
-            e.setShaderStorageBufferObjectData = @event;
-            return e;
-        }
+            Type = RenderEventType.SetStencilInfo,
+            setStencilInfo = @event
+        };
 
-        public static RenderEvent Init(in SetStencilInfoEvent @event)
+        public static RenderEvent Init(in SetTextureEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetStencilInfo;
-            e.setStencilInfo = @event;
-            return e;
-        }
+            Type = RenderEventType.SetTexture,
+            setTexture = @event
+        };
 
-        public static RenderEvent Init(in SetTextureEvent @event)
+        public static RenderEvent Init(in SetUniformBufferDataEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetTexture;
-            e.setTexture = @event;
-            return e;
-        }
+            Type = RenderEventType.SetUniformBufferData,
+            setUniformBufferData = @event
+        };
 
-        public static RenderEvent Init(in SetUniformBufferDataEvent @event)
+        public static RenderEvent Init(in SetUniformBufferDataRangeEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetUniformBufferData;
-            e.setUniformBufferData = @event;
-            return e;
-        }
+            Type = RenderEventType.SetUniformBufferDataRange,
+            setUniformBufferDataRange = @event
+        };
 
-        public static RenderEvent Init(in SetUniformBufferDataRangeEvent @event)
+        public static RenderEvent Init(in SetUniformBufferEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetUniformBufferDataRange;
-            e.setUniformBufferDataRange = @event;
-            return e;
-        }
+            Type = RenderEventType.SetUniformBuffer,
+            setUniformBuffer = @event
+        };
 
-        public static RenderEvent Init(in SetUniformBufferEvent @event)
+        public static RenderEvent Init(in SetViewportEvent @event) => new RenderEvent
         {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetUniformBuffer;
-            e.setUniformBuffer = @event;
-            return e;
-        }
-
-        public static RenderEvent Init(in SetViewportEvent @event)
-        {
-            Unsafe.SkipInit(out RenderEvent e);
-            e.Type = RenderEventType.SetViewport;
-            e.setViewport = @event;
-            return e;
-        }
+            Type = RenderEventType.SetViewport,
+            setViewport = @event
+        };
 
         public static explicit operator AddPrimitiveToBatchEvent(RenderEvent @event)
         {

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/ResizeFrameBufferEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/ResizeFrameBufferEvent.cs
@@ -9,6 +9,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct ResizeFrameBufferEvent(ResourceReference FrameBuffer, Vector2I Size)
     {
         public static RenderEvent Create(DeferredRenderer renderer, DeferredFrameBuffer frameBuffer, Vector2I size)
-            => RenderEvent.Init(new ResizeFrameBufferEvent(renderer.Context.Reference(frameBuffer), size));
+            => RenderEvent.Create(new ResizeFrameBufferEvent(renderer.Context.Reference(frameBuffer), size));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetBlendEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetBlendEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetBlendEvent(BlendingParameters Parameters)
     {
         public static RenderEvent Create(BlendingParameters parameters)
-            => RenderEvent.Init(new SetBlendEvent(parameters));
+            => RenderEvent.Create(new SetBlendEvent(parameters));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetBlendMaskEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetBlendMaskEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetBlendMaskEvent(BlendingMask Mask)
     {
         public static RenderEvent Create(BlendingMask mask)
-            => RenderEvent.Init(new SetBlendMaskEvent(mask));
+            => RenderEvent.Create(new SetBlendMaskEvent(mask));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetDepthInfoEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetDepthInfoEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetDepthInfoEvent(DepthInfo Info)
     {
         public static RenderEvent Create(DepthInfo info)
-            => RenderEvent.Init(new SetDepthInfoEvent(info));
+            => RenderEvent.Create(new SetDepthInfoEvent(info));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetFrameBufferEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetFrameBufferEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetFrameBufferEvent(ResourceReference FrameBuffer)
     {
         public static RenderEvent Create(DeferredRenderer renderer, IFrameBuffer? frameBuffer)
-            => RenderEvent.Init(new SetFrameBufferEvent(renderer.Context.Reference(frameBuffer)));
+            => RenderEvent.Create(new SetFrameBufferEvent(renderer.Context.Reference(frameBuffer)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetScissorEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetScissorEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetScissorEvent(RectangleI Scissor)
     {
         public static RenderEvent Create(RectangleI scissor)
-            => RenderEvent.Init(new SetScissorEvent(scissor));
+            => RenderEvent.Create(new SetScissorEvent(scissor));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetScissorStateEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetScissorStateEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetScissorStateEvent(bool Enabled)
     {
         public static RenderEvent Create(bool enabled)
-            => RenderEvent.Init(new SetScissorStateEvent(enabled));
+            => RenderEvent.Create(new SetScissorStateEvent(enabled));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetShaderEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetShaderEvent.cs
@@ -9,6 +9,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetShaderEvent(ResourceReference Shader)
     {
         public static RenderEvent Create(DeferredRenderer renderer, IShader shader)
-            => RenderEvent.Init(new SetShaderEvent(renderer.Context.Reference(shader)));
+            => RenderEvent.Create(new SetShaderEvent(renderer.Context.Reference(shader)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetShaderStorageBufferObjectDataEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetShaderStorageBufferObjectDataEvent.cs
@@ -10,6 +10,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     {
         public static RenderEvent Create<T>(DeferredRenderer renderer, IDeferredShaderStorageBufferObject buffer, int index, T data)
             where T : unmanaged, IEquatable<T>
-            => RenderEvent.Init(new SetShaderStorageBufferObjectDataEvent(renderer.Context.Reference(buffer), index, renderer.Context.AllocateObject(data)));
+            => RenderEvent.Create(new SetShaderStorageBufferObjectDataEvent(renderer.Context.Reference(buffer), index, renderer.Context.AllocateObject(data)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetStencilInfoEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetStencilInfoEvent.cs
@@ -6,6 +6,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetStencilInfoEvent(StencilInfo Info)
     {
         public static RenderEvent Create(StencilInfo info)
-            => RenderEvent.Init(new SetStencilInfoEvent(info));
+            => RenderEvent.Create(new SetStencilInfoEvent(info));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetTextureEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetTextureEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetTextureEvent(ResourceReference Texture, int Unit)
     {
         public static RenderEvent Create(DeferredRenderer renderer, INativeTexture? texture, int unit)
-            => RenderEvent.Init(new SetTextureEvent(renderer.Context.Reference(texture), unit));
+            => RenderEvent.Create(new SetTextureEvent(renderer.Context.Reference(texture), unit));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferDataEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferDataEvent.cs
@@ -10,6 +10,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     {
         public static RenderEvent Create<T>(DeferredRenderer renderer, IDeferredUniformBuffer uniformBuffer, T data)
             where T : unmanaged, IEquatable<T>
-            => RenderEvent.Init(new SetUniformBufferDataEvent(renderer.Context.Reference(uniformBuffer), renderer.Context.AllocateObject(data)));
+            => RenderEvent.Create(new SetUniformBufferDataEvent(renderer.Context.Reference(uniformBuffer), renderer.Context.AllocateObject(data)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferDataRangeEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferDataRangeEvent.cs
@@ -10,6 +10,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     {
         public static RenderEvent Create<T>(DeferredRenderer renderer, IDeferredUniformBuffer uniformBuffer, UniformBufferReference range)
             where T : unmanaged, IEquatable<T>
-            => RenderEvent.Init(new SetUniformBufferDataRangeEvent(renderer.Context.Reference(uniformBuffer), range));
+            => RenderEvent.Create(new SetUniformBufferDataRangeEvent(renderer.Context.Reference(uniformBuffer), range));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetUniformBufferEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetUniformBufferEvent(ResourceReference Name, ResourceReference Buffer)
     {
         public static RenderEvent Create(DeferredRenderer renderer, string name, IUniformBuffer buffer)
-            => RenderEvent.Init(new SetUniformBufferEvent(renderer.Context.Reference(name), renderer.Context.Reference(buffer)));
+            => RenderEvent.Create(new SetUniformBufferEvent(renderer.Context.Reference(name), renderer.Context.Reference(buffer)));
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/Events/SetViewportEvent.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/Events/SetViewportEvent.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Graphics.Rendering.Deferred.Events
     internal readonly record struct SetViewportEvent(RectangleI Viewport)
     {
         public static RenderEvent Create(RectangleI viewport)
-            => RenderEvent.Init(new SetViewportEvent(viewport));
+            => RenderEvent.Create(new SetViewportEvent(viewport));
     }
 }


### PR DESCRIPTION
See [this sharplab](https://sharplab.io/#v2:C4LghgzgtgPgAgBgARwIwDoBKBXAdsASygFN0BhAeygAcCAbYgJwGUmA3AgY2IgG4BYAFCIUGHPiKkAkviYVqrRh258hQgNrNgjbJ2AAZMAE8K2YAApDJswGkCuACboAogA9qdLgWABKALpCSEHBQXAAzEgQ2rrASAAqPMBaOnqBIcEA3mnp6eoAYgTEdA4A8gBmZRDEFgj+2TnB4UgARkbAxEgAggKC9Q1I+YXF5ZXV5rUBgv0hTfaxAEI9fQ2DRaUVVTV1U9OhEXQUuADmSGRLO7urwxtjABzbu3stbR0AIuePAwVrI5vm95NPrN8EhnB9Hld1qMLADljkmgdjkg8uDLt9rtDzKgAGwPR5NVrtJAAcVR00hvzGOLxu2BsQAEmT+hSbhZqYD8ftDicpEyGk0ElFkjFzISOmAfHD0lkLp8ukgALxIACsPU+AF81LL+k00Nj4olhXokDJvK8CIxiHpRS8kBLFQA+JC4YgAdwNQuiqW1DRlcuCnUVKqlIXVfPhET1HqSXtipuAAHVvAALACquAgYDKxGYAGsCNR4zaiRKQ5kyzl05ns+g8wWi6ZYoKYylYhAfGr/ZF0IGlaqK+k4AB2SKd3aa3o+nKafPUfQUThgOgQeMc2mRnHRo1x3DeJPAZN1wu74CdYDaAjNMzEYvinyO51urexgd+ru94NT9JhqXqoA==) for a showcase. Of note:
1. Explicitly implemented ctor will zero-initialise each individual field. `RenderEvent` is a pretty big struct (by number of fields, not by bytes), so we don't want this.
2. There appears to be no difference with `[SkipLocalsInit]` attached to the initialiser implementation used in this PR.
3. `Unsafe.SkipInit()` (the previous implementation) is slower due to code size. The benchmarks below show differences surfacing likely as a result of lack of inlining. This is why I consider this a minor performance-related PR.

Before:

|                           Method |     Mean |    Error |   StdDev |
|--------------------------------- |---------:|---------:|---------:|
|              AddPrimitiveToBatch | 67.99 us | 0.020 us | 0.017 us |
|                            Clear | 87.04 us | 0.032 us | 0.027 us |
|                   DrawNodeAction | 27.20 us | 0.007 us | 0.007 us |
|                            Flush | 27.24 us | 0.036 us | 0.030 us |
|                ResizeFrameBuffer | 87.10 us | 0.063 us | 0.059 us |
|                         SetBlend | 87.07 us | 0.027 us | 0.022 us |
|                     SetBlendMask | 24.50 us | 0.018 us | 0.017 us |
|                     SetDepthInfo | 68.02 us | 0.050 us | 0.047 us |
|                   SetFrameBuffer | 24.49 us | 0.024 us | 0.020 us |
|                       SetScissor | 67.99 us | 0.026 us | 0.022 us |
|                        SetShader | 24.51 us | 0.014 us | 0.013 us |
|                  SetScissorState | 24.51 us | 0.024 us | 0.022 us |
| SetShaderStorageBufferObjectData | 95.20 us | 0.025 us | 0.022 us |
|                   SetStencilInfo | 87.05 us | 0.039 us | 0.035 us |
|                       SetTexture | 27.22 us | 0.016 us | 0.014 us |
|             SetUniformBufferData | 87.07 us | 0.081 us | 0.076 us |
|        SetUniformBufferDataRange | 87.06 us | 0.041 us | 0.038 us |
|                 SetUniformBuffer | 27.22 us | 0.027 us | 0.024 us |
|                      SetViewport | 71.11 us | 0.225 us | 0.211 us |

After:

|                           Method |     Mean |    Error |   StdDev |
|--------------------------------- |---------:|---------:|---------:|
|              AddPrimitiveToBatch | 21.77 us | 0.014 us | 0.013 us |
|                            Clear | 21.78 us | 0.019 us | 0.016 us |
|                   DrawNodeAction | 27.22 us | 0.012 us | 0.010 us |
|                            Flush | 27.30 us | 0.043 us | 0.039 us |
|                ResizeFrameBuffer | 21.85 us | 0.035 us | 0.033 us |
|                         SetBlend | 21.84 us | 0.041 us | 0.037 us |
|                     SetBlendMask | 24.55 us | 0.037 us | 0.035 us |
|                     SetDepthInfo | 21.79 us | 0.026 us | 0.023 us |
|                   SetFrameBuffer | 24.60 us | 0.059 us | 0.055 us |
|                       SetScissor | 21.86 us | 0.040 us | 0.037 us |
|                        SetShader | 24.59 us | 0.047 us | 0.040 us |
|                  SetScissorState | 24.56 us | 0.036 us | 0.032 us |
| SetShaderStorageBufferObjectData | 21.78 us | 0.015 us | 0.013 us |
|                   SetStencilInfo | 21.79 us | 0.024 us | 0.022 us |
|                       SetTexture | 27.22 us | 0.026 us | 0.023 us |
|             SetUniformBufferData | 21.80 us | 0.041 us | 0.036 us |
|        SetUniformBufferDataRange | 21.80 us | 0.038 us | 0.034 us |
|                 SetUniformBuffer | 27.24 us | 0.025 us | 0.023 us |
|                      SetViewport | 21.78 us | 0.016 us | 0.014 us |

