### PR TITLE
Rewrite `TestCaseSource` attribute implementation to fix edge cases

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
@@ -31,6 +31,8 @@ namespace osu.Framework.Tests.Visual.Testing
 
         protected static object[] SingleParameterSource = { 1, 2, 3, 4 };
 
+        protected static string[] SingleParameterStringsSource = { "1", "2", "3", "4" };
+
         protected static object[][] DifferentTypesSource =
         {
             new object[] { Visibility.Visible, FillDirection.Horizontal, false },
@@ -74,6 +76,11 @@ namespace osu.Framework.Tests.Visual.Testing
 
         [TestCaseSource(nameof(SingleParameterSource))]
         public void TestSingleParameterSource(int x)
+        {
+        }
+
+        [TestCaseSource(nameof(SingleParameterStringsSource))]
+        public void TestSingleParameterStringsSource(string x)
         {
         }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -479,30 +479,14 @@ namespace osu.Framework.Testing
 
                     foreach (var tcs in m.GetCustomAttributes(typeof(TestCaseSourceAttribute), false).OfType<TestCaseSourceAttribute>())
                     {
-                        IEnumerable sourceValue = getTestCaseSourceValue(m, tcs);
+                        var tcsTests = tcs.BuildFrom(methodWrapper, null);
 
-                        if (sourceValue == null)
-                        {
-                            Debug.Assert(tcs.SourceName != null);
-                            throw new InvalidOperationException($"The value of the source member {tcs.SourceName} must be non-null.");
-                        }
-
-                        foreach (object argument in sourceValue)
+                        foreach (var tcsTest in tcsTests)
                         {
                             hadTestAttributeTest = true;
+                            CurrentTest.AddLabel($"{name}({string.Join(", ", tcsTest.Arguments)}){repeatSuffix}");
 
-                            if (argument is IEnumerable argumentsEnumerable)
-                            {
-                                object[] arguments = argumentsEnumerable.Cast<object>().ToArray();
-
-                                CurrentTest.AddLabel($"{name}({string.Join(", ", arguments)}){repeatSuffix}");
-                                handleTestMethod(m, arguments);
-                            }
-                            else
-                            {
-                                CurrentTest.AddLabel($"{name}({argument}){repeatSuffix}");
-                                handleTestMethod(m, argument);
-                            }
+                            handleTestMethod(m, tcsTest.Arguments);
                         }
                     }
                 }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -430,7 +430,7 @@ namespace osu.Framework.Testing
                 {
                     string repeatSuffix = i > 0 ? $" ({i + 1})" : string.Empty;
 
-                    var methodWrapper = new MethodWrapper(m.GetType(), m);
+                    var methodWrapper = new MethodWrapper(m.DeclaringType, m);
 
                     if (methodWrapper.GetCustomAttributes<TestAttribute>(false).SingleOrDefault() != null)
                     {


### PR DESCRIPTION
Breakage noticed in `TestSceneOsuTooltip` on test browser, specifically a test backed by a `TestCaseSource` attribute which points to an array of `string`s. Included similar test in `TestSceneTestWithSource`.

To explain briefly why that breaks with the current code: `string` implements `IEnumerable<char>`, and the logic we have treats types with `IEnumerable` specially and assumes it's an enumerable of multiple parameters per test case, meanwhile in this case the test only intends to accept a single `string` parameter.

Regardless, I've rewritten the entire logic to just rely completely on NUnit and not reinvent the wheel with parsing the attribute.