### PR TITLE
Fix flickering when the tooltip changes

### DIFF
--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -208,14 +208,7 @@ namespace osu.Framework.Graphics.Cursor
 
                 if (hasValidTooltip(target))
                     CurrentTooltip.Show();
-
-                RefreshTooltip(CurrentTooltip, target);
             }
-        }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
 
             RefreshTooltip(CurrentTooltip, currentlyDisplayed);
 


### PR DESCRIPTION
fix https://github.com/ppy/osu/issues/33749


before:

https://github.com/user-attachments/assets/912128f4-6260-455c-b0ca-85a82029e186

after:

https://github.com/user-attachments/assets/1795af23-5686-4ff7-8186-da081e8b7c6b

The `TooltipContainer` was refreshing the tooltip's content in `UpdateAfterChildren()`, this caused the tooltip to not render properly during that specific frame. Moving the content refresh to `Update()` fixed the issue