### PR TITLE
Add helper functions for keeping bindables of different types in sync

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableExtensionTest
+    {
+        [Test]
+        public void TestMappedBindable()
+        {
+            var source = new Bindable<int>();
+
+            var mapped1 = source.Map(v => v.ToString());
+            var mapped2 = source.Map(v => v * 2);
+
+            int changed1 = 0;
+            int changed2 = 0;
+
+            mapped1.ValueChanged += _ => changed1++;
+            mapped2.ValueChanged += _ => changed2++;
+
+            Assert.AreEqual(mapped1.Value, "0");
+
+            source.Value = 3;
+
+            Assert.AreEqual(mapped1.Value, "3");
+            Assert.AreEqual(changed1, 1);
+
+            Assert.AreEqual(mapped2.Value, 6);
+            Assert.AreEqual(changed2, 1);
+
+            source.Value = -10;
+
+            Assert.AreEqual(mapped1.Value, "-10");
+            Assert.AreEqual(changed1, 2);
+
+            Assert.AreEqual(mapped2.Value, -20);
+            Assert.AreEqual(changed2, 2);
+
+            source.Disabled = true;
+            Assert.IsTrue(mapped1.Disabled);
+            Assert.IsTrue(mapped2.Disabled);
+
+            source.Disabled = false;
+            Assert.IsFalse(mapped1.Disabled);
+            Assert.IsFalse(mapped2.Disabled);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
@@ -137,5 +137,101 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(sourceDisabledChanged, 4);
             Assert.AreEqual(destDisabledChanged, 4);
         }
+
+        [Test]
+        public void TestSafeSyncedBindable()
+        {
+            var source = new Bindable<int>();
+            var dest = new Bindable<string>();
+
+            int sourceChanged = 0;
+            int destChanged = 0;
+
+            source.ValueChanged += _ => sourceChanged++;
+            dest.ValueChanged += _ => destChanged++;
+
+            dest.SyncWith(source, value => value.ToString(), int.TryParse);
+
+            Assert.AreEqual(0, source.Value);
+            Assert.AreEqual("0", dest.Value);
+            Assert.AreEqual(0, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            source.Value = 5;
+
+            Assert.AreEqual(5, source.Value);
+            Assert.AreEqual("5", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "-10";
+
+            Assert.AreEqual(-10, source.Value);
+            Assert.AreEqual("-10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "invalid value";
+
+            Assert.AreEqual(-10, source.Value);
+            Assert.AreEqual("-10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            void resetCount()
+            {
+                sourceChanged = 0;
+                destChanged = 0;
+            }
+        }
+
+        [Test]
+        public void TestSafeSyncedDisabledState()
+        {
+            var source = new Bindable<int>();
+            var dest = new Bindable<string>();
+
+            dest.SyncWith(source, value => value.ToString(), int.TryParse);
+
+            int sourceDisabledChanged = 0;
+            int destDisabledChanged = 0;
+
+            source.DisabledChanged += _ => sourceDisabledChanged++;
+            dest.DisabledChanged += _ => destDisabledChanged++;
+
+            source.Disabled = true;
+
+            Assert.IsTrue(source.Disabled);
+            Assert.IsTrue(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 1);
+            Assert.AreEqual(destDisabledChanged, 1);
+
+            source.Disabled = false;
+
+            Assert.IsFalse(source.Disabled);
+            Assert.IsFalse(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 2);
+            Assert.AreEqual(destDisabledChanged, 2);
+
+            dest.Disabled = true;
+
+            Assert.IsTrue(source.Disabled);
+            Assert.IsTrue(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 3);
+            Assert.AreEqual(destDisabledChanged, 3);
+
+            dest.Disabled = false;
+
+            Assert.IsFalse(source.Disabled);
+            Assert.IsFalse(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 4);
+            Assert.AreEqual(destDisabledChanged, 4);
+        }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
@@ -50,5 +50,92 @@ namespace osu.Framework.Tests.Bindables
             Assert.IsFalse(mapped1.Disabled);
             Assert.IsFalse(mapped2.Disabled);
         }
+
+        [Test]
+        public void TestSyncedBindable()
+        {
+            var source = new Bindable<int>();
+            var dest = new Bindable<string>();
+
+            int sourceChanged = 0;
+            int destChanged = 0;
+
+            source.ValueChanged += _ => sourceChanged++;
+            dest.ValueChanged += _ => destChanged++;
+
+            dest.SyncWith(source, value => value.ToString(), int.Parse);
+
+            Assert.AreEqual(0, source.Value);
+            Assert.AreEqual("0", dest.Value);
+            Assert.AreEqual(0, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            source.Value = 5;
+
+            Assert.AreEqual(5, source.Value);
+            Assert.AreEqual("5", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "-10";
+
+            Assert.AreEqual(-10, source.Value);
+            Assert.AreEqual("-10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            void resetCount()
+            {
+                sourceChanged = 0;
+                destChanged = 0;
+            }
+        }
+
+        [Test]
+        public void TestSyncedDisabledState()
+        {
+            var source = new Bindable<int>();
+            var dest = new Bindable<string>();
+
+            dest.SyncWith(source, value => value.ToString(), int.Parse);
+
+            int sourceDisabledChanged = 0;
+            int destDisabledChanged = 0;
+
+            source.DisabledChanged += _ => sourceDisabledChanged++;
+            dest.DisabledChanged += _ => destDisabledChanged++;
+
+            source.Disabled = true;
+
+            Assert.IsTrue(source.Disabled);
+            Assert.IsTrue(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 1);
+            Assert.AreEqual(destDisabledChanged, 1);
+
+            source.Disabled = false;
+
+            Assert.IsFalse(source.Disabled);
+            Assert.IsFalse(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 2);
+            Assert.AreEqual(destDisabledChanged, 2);
+
+            dest.Disabled = true;
+
+            Assert.IsTrue(source.Disabled);
+            Assert.IsTrue(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 3);
+            Assert.AreEqual(destDisabledChanged, 3);
+
+            dest.Disabled = false;
+
+            Assert.IsFalse(source.Disabled);
+            Assert.IsFalse(dest.Disabled);
+            Assert.AreEqual(sourceDisabledChanged, 4);
+            Assert.AreEqual(destDisabledChanged, 4);
+        }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
@@ -192,6 +192,25 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestAsymmetricSync()
+        {
+            var source = new BindableInt();
+            var dest = new BindableInt();
+
+            dest.SyncWith(source, toDest: v => v * 2, toSource: v => v / 4);
+
+            source.Value = 10;
+
+            Assert.AreEqual(10, source.Value);
+            Assert.AreEqual(20, dest.Value);
+
+            // When the toSource mapping function returns a value that isn't the exact inverse of the toDest mapping, the dest value's final state should be based on the new source value
+            dest.Value = 80;
+            Assert.AreEqual(20, source.Value);
+            Assert.AreEqual(40, dest.Value);
+        }
+
+        [Test]
         public void TestSafeSyncedDisabledState()
         {
             var source = new Bindable<int>();

--- a/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableExtensionTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Globalization;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
@@ -251,6 +253,254 @@ namespace osu.Framework.Tests.Bindables
             Assert.IsFalse(dest.Disabled);
             Assert.AreEqual(sourceDisabledChanged, 4);
             Assert.AreEqual(destDisabledChanged, 4);
+        }
+
+        [Test]
+        public void TestSyncWithInt()
+        {
+            var source = new BindableInt();
+            var dest = new Bindable<string>();
+
+            int sourceChanged = 0;
+            int destChanged = 0;
+
+            source.ValueChanged += _ => sourceChanged++;
+            dest.ValueChanged += _ => destChanged++;
+
+            dest.SyncWith(source);
+
+            Assert.AreEqual(0, source.Value);
+            Assert.AreEqual("0", dest.Value);
+            Assert.AreEqual(0, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            source.Value = 5;
+
+            Assert.AreEqual(5, source.Value);
+            Assert.AreEqual("5", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "-10";
+
+            Assert.AreEqual(-10, source.Value);
+            Assert.AreEqual("-10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "invalid value";
+
+            Assert.AreEqual(-10, source.Value);
+            Assert.AreEqual("-10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            resetCount();
+
+            source.MaxValue = 10;
+            dest.Value = "20";
+
+            Assert.AreEqual(10, source.Value);
+            Assert.AreEqual("10", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            void resetCount()
+            {
+                sourceChanged = 0;
+                destChanged = 0;
+            }
+        }
+
+        [Test]
+        public void TestSyncWithFloat()
+        {
+            var source = new BindableFloat();
+            var dest = new Bindable<string>();
+
+            int sourceChanged = 0;
+            int destChanged = 0;
+
+            source.ValueChanged += _ => sourceChanged++;
+            dest.ValueChanged += _ => destChanged++;
+
+            dest.SyncWith(source);
+
+            Assert.AreEqual(0, source.Value);
+            Assert.AreEqual("0", dest.Value);
+            Assert.AreEqual(0, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            source.Value = 5.3f;
+
+            Assert.AreEqual(5.3f, source.Value);
+            Assert.AreEqual("5.3", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "-10.9";
+
+            Assert.AreEqual(-10.9f, source.Value);
+            Assert.AreEqual("-10.9", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "invalid value";
+            Assert.AreEqual(-10.9f, source.Value);
+            Assert.AreEqual("-10.9", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            resetCount();
+
+            source.MaxValue = 10.2f;
+            dest.Value = "20";
+
+            Assert.AreEqual(10.2f, source.Value);
+            Assert.AreEqual("10.2", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            resetCount();
+
+            source.Precision = 0.01f;
+            dest.Value = Math.PI.ToString(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(3.14f, source.Value);
+            Assert.AreEqual("3.14", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            void resetCount()
+            {
+                sourceChanged = 0;
+                destChanged = 0;
+            }
+        }
+
+        [Test]
+        public void TestSyncWithDouble()
+        {
+            var source = new BindableDouble();
+            var dest = new Bindable<string>();
+
+            int sourceChanged = 0;
+            int destChanged = 0;
+
+            source.ValueChanged += _ => sourceChanged++;
+            dest.ValueChanged += _ => destChanged++;
+
+            dest.SyncWith(source);
+
+            Assert.AreEqual(0, source.Value);
+            Assert.AreEqual("0", dest.Value);
+            Assert.AreEqual(0, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            source.Value = 5.3;
+
+            Assert.AreEqual(5.3, source.Value);
+            Assert.AreEqual("5.3", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "-10.9";
+
+            Assert.AreEqual(-10.9, source.Value);
+            Assert.AreEqual("-10.9", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(1, destChanged);
+
+            resetCount();
+
+            dest.Value = "invalid value";
+            Assert.AreEqual(-10.9, source.Value);
+            Assert.AreEqual("-10.9", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            resetCount();
+
+            source.MaxValue = 10.2;
+            dest.Value = "20";
+
+            Assert.AreEqual(10.2, source.Value);
+            Assert.AreEqual("10.2", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            resetCount();
+
+            source.Precision = 0.01;
+            dest.Value = Math.PI.ToString(CultureInfo.InvariantCulture);
+
+            Assert.AreEqual(3.14, source.Value);
+            Assert.AreEqual("3.14", dest.Value);
+            Assert.AreEqual(1, sourceChanged);
+            Assert.AreEqual(2, destChanged);
+
+            void resetCount()
+            {
+                sourceChanged = 0;
+                destChanged = 0;
+            }
+        }
+
+        [Test]
+        public void TestIntFormatting()
+        {
+            var source = new BindableInt();
+            var dest = new Bindable<string>();
+
+            dest.SyncWith(source, format: "N0", style: NumberStyles.Integer | NumberStyles.AllowThousands);
+
+            Assert.AreEqual(dest.Value, "0");
+
+            source.Value = 1234;
+            Assert.AreEqual(dest.Value, "1,234");
+
+            dest.Value = "1234567";
+            Assert.AreEqual(1234567, source.Value);
+            Assert.AreEqual("1,234,567", dest.Value);
+
+            dest.Value = "981,412";
+            Assert.AreEqual(981412, source.Value);
+        }
+
+        [Test]
+        public void TestFloatFormatting()
+        {
+            var source = new BindableFloat();
+            var dest = new Bindable<string>();
+
+            dest.SyncWith(source, format: "F2", style: NumberStyles.Float, CultureInfo.InvariantCulture);
+
+            Assert.AreEqual("0.00", dest.Value);
+
+            source.Value = MathF.PI;
+
+            Assert.AreEqual("3.14", dest.Value);
+
+            dest.Value = "1.23456";
+
+            Assert.AreEqual(1.23456f, source.Value);
+            Assert.AreEqual("1.23", dest.Value);
         }
     }
 }

--- a/osu.Framework/Extensions/BindableExtensions.cs
+++ b/osu.Framework/Extensions/BindableExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Extensions
+{
+    public static class BindableExtensions
+    {
+        /// <summary>
+        /// Creates a readonly <see cref="IBindable{T}"/> with it's value automatically assigned from the source <see cref="IBindable{T}"/> and converted using the given transform function.
+        /// </summary>
+        public static IBindable<TDest> Map<TSource, TDest>(this IBindable<TSource> source, Func<TSource, TDest> transform)
+        {
+            var dest = new Bindable<TDest>();
+
+            dest.ComputeFrom(source, transform);
+
+            return dest;
+        }
+
+        /// <summary>
+        /// Binds a <see cref="Bindable{T}"/> to another <see cref="IBindable{T}"/> with the value automatically converted using the given transform function.
+        /// </summary>
+        public static void ComputeFrom<TSource, TDest>(this Bindable<TDest> dest, IBindable<TSource> source, Func<TSource, TDest> transform)
+        {
+            source.BindValueChanged(e =>
+            {
+                dest.Value = transform(e.NewValue);
+            }, true);
+
+            source.BindDisabledChanged(disabled =>
+            {
+                dest.Disabled = disabled;
+            }, true);
+        }
+    }
+}

--- a/osu.Framework/Extensions/BindableExtensions.cs
+++ b/osu.Framework/Extensions/BindableExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Extensions
@@ -125,6 +126,45 @@ namespace osu.Framework.Extensions
             {
                 source.Disabled = disabled;
             });
+        }
+
+        /// <summary>
+        /// Bidirectionally syncs the value of a <see cref="Bindable{String}"/> with a <see cref="Bindable{Int}"/>.
+        /// </summary>
+        public static void SyncWith(
+            this Bindable<string> dest, Bindable<int> source,
+            [StringSyntax("NumericFormat")] string? format = null,
+            NumberStyles style = NumberStyles.Integer,
+            IFormatProvider? formatProvider = null
+        )
+        {
+            dest.SyncWith(source, value => value.ToString(format, formatProvider), (string str, out int result) => int.TryParse(str, style, formatProvider, out result));
+        }
+
+        /// <summary>
+        /// Bidirectionally syncs the value of a <see cref="Bindable{String}"/> with a <see cref="Bindable{Float}"/>.
+        /// </summary>
+        public static void SyncWith(
+            this Bindable<string> dest, Bindable<float> source,
+            [StringSyntax("NumericFormat")] string? format = null,
+            NumberStyles style = NumberStyles.Float,
+            IFormatProvider? formatProvider = null
+        )
+        {
+            dest.SyncWith(source, value => value.ToString(format, formatProvider), (string str, out float result) => float.TryParse(str, style, formatProvider, out result));
+        }
+
+        /// <summary>
+        /// Bidirectionally syncs the value of a <see cref="Bindable{String}"/> with a <see cref="Bindable{Double}"/>.
+        /// </summary>
+        public static void SyncWith(
+            this Bindable<string> dest, Bindable<double> source,
+            [StringSyntax("NumericFormat")] string? format = null,
+            NumberStyles style = NumberStyles.Float,
+            IFormatProvider? formatProvider = null
+        )
+        {
+            dest.SyncWith(source, value => value.ToString(format, formatProvider), (string str, out double result) => double.TryParse(str, style, formatProvider, out result));
         }
     }
 }

--- a/osu.Framework/Extensions/BindableExtensions.cs
+++ b/osu.Framework/Extensions/BindableExtensions.cs
@@ -35,5 +35,23 @@ namespace osu.Framework.Extensions
                 dest.Disabled = disabled;
             }, true);
         }
+
+        /// <summary>
+        /// Bidirectionally syncs the value of two <see cref="Bindable{T}"/>s with the two given transform functions.
+        /// </summary>
+        public static void SyncWith<TSource, TDest>(this Bindable<TDest> dest, Bindable<TSource> source, Func<TSource, TDest> toDest, Func<TDest, TSource> toSource)
+        {
+            dest.ComputeFrom(source, toDest);
+
+            dest.BindValueChanged(e =>
+            {
+                source.Value = toSource(e.NewValue);
+            });
+
+            dest.BindDisabledChanged(disabled =>
+            {
+                source.Disabled = disabled;
+            });
+        }
     }
 }


### PR DESCRIPTION
Adds a couple extension functions to deal with a bunch of scenarios of having to keep 2 bindables of different types in sync that I encounter quite often.

### Bindable.Map
Creates an `IBindable` which automatically gets it's value updated from the source bindable with the value converted using the given mapping function.

*Example usage*
```cs
var floatValue = new BindableFloat();
var percentage = floatValue.Map(static v => v.ToString("P0"));

floatValue.Value = 0.3f;
Logger.Log(percentage.Value); // prints "30%"
```

### Bindable.ComputeFrom
Same as `Bindable.Map` but used when the destination bindable already exists

### Bindable.SyncWith
Bidirectionally syncs 2 Bindables of different types with each other, with mapping functions in each direction.

*Example usage*
```cs
var sourceValue = new BindableInt();
var displayValue = new Bindable<string>();

displayValue.SyncWith(displayValue, value => value.ToString(), displayString => int.Parse(displayString));
```

It also comes with a second variant that allows to reset to the source value if the destination value is invalid, expecting a mapping function with the same type as the `TryParse` methods commonly found in .net.
```cs
var sourceValue = new BindableInt(10);
var displayValue = new Bindable<string>();

displayValue.SyncWith(displayValue, value => value.ToString(), int.TryParse);

displayValue.Value = "invalid value";
Logger.Log(displayValue.Value); // prints 10, value has been reset to source bindable
```

### String <-> Number synchronization methods
Specialized verions of the `SyncWith` method for keeping two bindables of string & number types in sync, with additional parameters to customize number formatting & parsing options.
Common usage scenario here would be having text boxes that hold number values.

*Example usage*
```cs
var sourceValue = new BindableInt();
var displayValue = new Bindable<string>();

sourceValue.SyncWith(displayValue, format: "N0", style: NumberStyle.Integer | NumberStyles.AllowThousands);

sourceValue.Value = 1234;
Logger.Log(displayValue.Value); // prints 1,234

displayValue.Value = "7,325";
Logger.Log($"{sourceValue.Value}"); // prints 7325
```