### PR TITLE
Use test clock as reference for decoupling clock

### DIFF
--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Platform;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Development
@@ -20,8 +21,15 @@ namespace osu.Framework.Development
         /// be used to track a realtime reference.
         /// </summary>
         /// <remarks>
-        /// Components such as <see cref="DecouplingFramedClock"/> use this to advance time at a faster
-        /// pace in order to not induce artificial delays from having to way on wall clock time to elapse.
+        /// <list type="bullet">
+        ///   <item>
+        ///     Components such as <see cref="DecouplingFramedClock"/> use this to advance time at a faster
+        ///     pace in order to not induce artificial delays from having to way on wall clock time to elapse.
+        ///   </item>
+        ///   <item>
+        ///     Note that this property is only populated after the <see cref="GameHost"/> is run.
+        ///   </item>
+        /// </list>
         /// </remarks>
         public static IClock? RealtimeClock { get; internal set; }
 

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Development
         ///   </item>
         /// </list>
         /// </remarks>
-        public static IClock? RealtimeClock { get; internal set; }
+        internal static IClock? RealtimeClock { get; set; }
 
         public static bool IsNUnitRunning => is_nunit_running.Value;
 

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -8,11 +8,23 @@ using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Development
 {
     public static class DebugUtils
     {
+        /// <summary>
+        /// This represents a clock that runs at a faster-than-realtime pace during unit testing,
+        /// and is intended to substitute for a <see cref="StopwatchClock"/> that would normally
+        /// be used to track a realtime reference.
+        /// </summary>
+        /// <remarks>
+        /// Components such as <see cref="DecouplingFramedClock"/> use this to advance time at a faster
+        /// pace in order to not induce artificial delays from having to way on wall clock time to elapse.
+        /// </remarks>
+        public static IClock? RealtimeClock { get; internal set; }
+
         public static bool IsNUnitRunning => is_nunit_running.Value;
 
         private static readonly Lazy<bool> is_nunit_running = new Lazy<bool>(() =>

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -82,6 +82,9 @@ namespace osu.Framework.Platform
                 FastClock fastRealtimeClock = new FastClock(CLOCK_RATE, Threads.ToArray());
 
                 customClock = new FramedClock(fastRealtimeClock);
+
+                // Decoupling clock sometimes uses a realtime stopwatch which can make tests run slow when
+                // in a decoupled state. Replace it during fast-run-testing to make sure it doesn't waste time.
                 DecouplingFramedClock.RealtimeReferenceClock = fastRealtimeClock;
 
                 // time is incremented per frame, rather than based on the real-world time.

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Platform
             {
                 get
                 {
-                    lock (gameThreads)
+                    lock (stopwatch)
                     {
                         double realElapsedTime = stopwatch.Elapsed.TotalMilliseconds;
                         stopwatch.Restart();

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Configuration;
+using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering.Dummy;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Logging;
@@ -79,13 +80,8 @@ namespace osu.Framework.Platform
 
             if (!realtime)
             {
-                FastClock fastRealtimeClock = new FastClock(CLOCK_RATE, Threads.ToArray());
-
-                customClock = new FramedClock(fastRealtimeClock);
-
-                // Decoupling clock sometimes uses a realtime stopwatch which can make tests run slow when
-                // in a decoupled state. Replace it during fast-run-testing to make sure it doesn't waste time.
-                DecouplingFramedClock.RealtimeReferenceClock = fastRealtimeClock;
+                DebugUtils.RealtimeClock = new FastClock(CLOCK_RATE, Threads.ToArray());
+                customClock = new FramedClock(DebugUtils.RealtimeClock);
 
                 // time is incremented per frame, rather than based on the real-world time.
                 // therefore our goal is to run frames as fast as possible.
@@ -111,6 +107,12 @@ namespace osu.Framework.Platform
         }
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() => Array.Empty<InputHandler>();
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            DebugUtils.RealtimeClock = null;
+        }
 
         private class FastClock : IClock
         {

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -142,20 +142,23 @@ namespace osu.Framework.Platform
             {
                 get
                 {
-                    double realElapsedTime = stopwatch.Elapsed.TotalMilliseconds;
-                    stopwatch.Restart();
-
-                    if (allThreadsHaveProgressed)
+                    lock (gameThreads)
                     {
-                        for (int i = 0; i < gameThreads.Length; i++)
-                            gameThreadLastFrames[i] = gameThreads[i].FrameIndex;
+                        double realElapsedTime = stopwatch.Elapsed.TotalMilliseconds;
+                        stopwatch.Restart();
 
-                        // Increment time at the expedited rate.
-                        return time += increment;
+                        if (allThreadsHaveProgressed)
+                        {
+                            for (int i = 0; i < gameThreads.Length; i++)
+                                gameThreadLastFrames[i] = gameThreads[i].FrameIndex;
+
+                            // Increment time at the expedited rate.
+                            return time += increment;
+                        }
+
+                        // Fall back to real time to ensure we don't break random tests that expect threads to be running.
+                        return time += realElapsedTime;
                     }
-
-                    // Fall back to real time to ensure we don't break random tests that expect threads to be running.
-                    return time += realElapsedTime;
                 }
             }
 

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -79,7 +79,10 @@ namespace osu.Framework.Platform
 
             if (!realtime)
             {
-                customClock = new FramedClock(new FastClock(CLOCK_RATE, Threads.ToArray()));
+                FastClock fastRealtimeClock = new FastClock(CLOCK_RATE, Threads.ToArray());
+
+                customClock = new FramedClock(fastRealtimeClock);
+                DecouplingFramedClock.RealtimeReferenceClock = fastRealtimeClock;
 
                 // time is incremented per frame, rather than based on the real-world time.
                 // therefore our goal is to run frames as fast as possible.

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework.Development;
 
 namespace osu.Framework.Timing
 {
@@ -57,7 +58,7 @@ namespace osu.Framework.Timing
         private double currentTime;
 
         /// <summary>
-        /// Tracks the current time of <see cref="RealtimeReferenceClock"/> one <see cref="ProcessFrame"/> ago.
+        /// Tracks the current time of <see cref="realtimeReferenceClock"/> one <see cref="ProcessFrame"/> ago.
         /// </summary>
         private double? lastReferenceTime;
 
@@ -70,7 +71,7 @@ namespace osu.Framework.Timing
         /// <summary>
         /// This clock is used when we are decoupling from the source.
         /// </summary>
-        internal static IClock RealtimeReferenceClock = new StopwatchClock(true);
+        private readonly IClock realtimeReferenceClock = DebugUtils.RealtimeClock ?? new StopwatchClock(true);
 
         private IAdjustableClock adjustableSourceClock;
 
@@ -113,7 +114,7 @@ namespace osu.Framework.Timing
                 if (lastReferenceTime == null)
                     return;
 
-                double elapsedReferenceTime = (RealtimeReferenceClock.CurrentTime - lastReferenceTime.Value) * Rate;
+                double elapsedReferenceTime = (realtimeReferenceClock.CurrentTime - lastReferenceTime.Value) * Rate;
 
                 currentTime += elapsedReferenceTime;
 
@@ -135,7 +136,7 @@ namespace osu.Framework.Timing
             finally
             {
                 IsRunning = shouldBeRunning;
-                lastReferenceTime = RealtimeReferenceClock.CurrentTime;
+                lastReferenceTime = realtimeReferenceClock.CurrentTime;
                 CurrentTime = currentTime;
                 ElapsedFrameTime = CurrentTime - lastTime;
             }

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Timing
         private double currentTime;
 
         /// <summary>
-        /// Tracks the current time of <see cref="realtimeReferenceClock"/> one <see cref="ProcessFrame"/> ago.
+        /// Tracks the current time of <see cref="RealtimeReferenceClock"/> one <see cref="ProcessFrame"/> ago.
         /// </summary>
         private double? lastReferenceTime;
 
@@ -70,7 +70,7 @@ namespace osu.Framework.Timing
         /// <summary>
         /// This clock is used when we are decoupling from the source.
         /// </summary>
-        private readonly StopwatchClock realtimeReferenceClock = new StopwatchClock(true);
+        internal static IClock RealtimeReferenceClock = new StopwatchClock(true);
 
         private IAdjustableClock adjustableSourceClock;
 
@@ -113,7 +113,7 @@ namespace osu.Framework.Timing
                 if (lastReferenceTime == null)
                     return;
 
-                double elapsedReferenceTime = (realtimeReferenceClock.CurrentTime - lastReferenceTime.Value) * Rate;
+                double elapsedReferenceTime = (RealtimeReferenceClock.CurrentTime - lastReferenceTime.Value) * Rate;
 
                 currentTime += elapsedReferenceTime;
 
@@ -135,7 +135,7 @@ namespace osu.Framework.Timing
             finally
             {
                 IsRunning = shouldBeRunning;
-                lastReferenceTime = realtimeReferenceClock.CurrentTime;
+                lastReferenceTime = RealtimeReferenceClock.CurrentTime;
                 CurrentTime = currentTime;
                 ElapsedFrameTime = CurrentTime - lastTime;
             }


### PR DESCRIPTION
I don't know how to push this change in any reasonable fashion (please suggest alternatives), and I'm aware of concerns:
- Introduction of a static.
  - I don't know how to get around this.
- Introduction of a reference (which potentially holds inner references to GameThread and the rest of everything)
  - I figure this is fine because it's cleared on every `TestScene` init.
- Using a single reference clock or non-zeroed clock across all instances.
  - I figure this to be fine because code is only relying on the elapsed time rather than using the reference clock's current time as-is.

Practically all current gameplay tests have a lead-in time of up to/usually ~2s, see: https://github.com/ppy/osu/blob/321707590ab51333ce86a0b1198592705603cdb4/osu.Game/Rulesets/UI/DrawableRuleset.cs#L64

During this time, the decoupling clock is seeked to a negative current time and is made to use the reference clock. The source clock (`OsuTestScene.TrackVirtualManual -> FastClock`) is only started after the decoupling clock transitions to a positive current time:

https://github.com/ppy/osu-framework/blob/eb079409dc760e1c734dc90e0e5c5346d9ea5722/osu.Framework/Timing/DecouplingFramedClock.cs#L124-L133

For this reason, our tests are basically needlessly waiting for ~2 real-time seconds.

As a reference point, my change runtime of `osu.Game.Rulesets.Osu.Tests`:
```
Before: 9m 3s
After: 5m 3s
```