### PR TITLE
Fix `DecouplingFramedClock` not starting source in edge case scenario

### DIFF
--- a/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
@@ -57,6 +57,36 @@ namespace osu.Framework.Tests.Clocks
             Assert.That(decouplingClock.IsRunning, Is.True);
         }
 
+        [Test]
+        public void TestSeekFromDecouplingWithoutProcessFrame()
+        {
+            decouplingClock.AllowDecoupling = true;
+
+            Assert.That(source.CurrentTime, Is.EqualTo(0));
+            Assert.That(decouplingClock.CurrentTime, Is.EqualTo(0));
+
+            decouplingClock.Start();
+
+            decouplingClock.Seek(1000);
+            decouplingClock.ProcessFrame();
+            Assert.That(source.IsRunning, Is.True);
+
+            decouplingClock.Seek(-1000);
+            // Intentionally no process frame.
+            Assert.That(source.IsRunning, Is.False);
+
+            decouplingClock.Seek(-1);
+
+            // intentionally make sure that reference time has increased to push time into positive before a process frame.
+            Thread.Sleep(500);
+            decouplingClock.ProcessFrame();
+
+            while (decouplingClock.CurrentTime < 0)
+                decouplingClock.ProcessFrame();
+
+            Assert.That(source.IsRunning, Is.True);
+        }
+
         [TestCase(true)]
         [TestCase(false)]
         public void TestSeekFromDecoupling(bool allowDecoupling)

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -128,6 +128,8 @@ namespace osu.Framework.Timing
                 // Note that this carries the common assumption that the source clock *should* be able to run from zero.
                 if (pendingSourceRestartAfterNegativeSeek && currentTime >= 0)
                 {
+                    pendingSourceRestartAfterNegativeSeek = false;
+
                     // We still need to check the seek was successful, else we might have already exceeded valid length of the source.
                     lastSeekFailed = !adjustableSourceClock.Seek(currentTime);
                     if (!lastSeekFailed)
@@ -170,6 +172,7 @@ namespace osu.Framework.Timing
         public void Reset()
         {
             adjustableSourceClock.Reset();
+            pendingSourceRestartAfterNegativeSeek = false;
             shouldBeRunning = false;
             lastSeekFailed = false;
             currentTime = 0;

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -75,6 +75,12 @@ namespace osu.Framework.Timing
 
         private IAdjustableClock adjustableSourceClock;
 
+        /// <summary>
+        /// Denotes a state where a negative seek stopped the source clock and entered decoupled mode, meaning that
+        /// after crossing into positive time again we should attempt to start and use the source clock.
+        /// </summary>
+        private bool pendingSourceRestartAfterNegativeSeek;
+
         public DecouplingFramedClock(IClock? source = null)
         {
             ChangeSource(source);
@@ -118,11 +124,9 @@ namespace osu.Framework.Timing
 
                 currentTime += elapsedReferenceTime;
 
-                // When crossing the zero time boundary forwards, we should start and use the source clock.
-                // Note that this implicitly assumes the source starts at zero,
-                // and additionally the right-side boundary is not handled as we don't know where the source's max time is.
-                // This could be potentially handled if need be, if we had a notion of what the source's max allowable time is.
-                if (lastTime < 0 && currentTime >= 0)
+                // When crossing into positive time, we should attempt to start and use the source clock.
+                // Note that this carries the common assumption that the source clock *should* be able to run from zero.
+                if (pendingSourceRestartAfterNegativeSeek && currentTime >= 0)
                 {
                     // We still need to check the seek was successful, else we might have already exceeded valid length of the source.
                     lastSeekFailed = !adjustableSourceClock.Seek(currentTime);
@@ -212,6 +216,7 @@ namespace osu.Framework.Timing
 
                 // Ensure the underlying clock is stopped as we enter decoupled mode.
                 adjustableSourceClock.Stop();
+                pendingSourceRestartAfterNegativeSeek = position < 0;
             }
 
             currentTime = position;


### PR DESCRIPTION
Handles a scenario discovered with recent changes to make reference time run faster during headless testing. Here's two scenarios and how they handled with previous code (before this PR).

✅ working:

```
decoupled.CurrentTime = 1000

decoupled.seek(-15)
 "can source run?" no
 "okay we'll enter decoupled mode"

decoupled.processFrame();
 "okay our exposed currenttime is now -15"

sleep(17);

decoupled.processFrame();
 "moving from -15 to 2"
 "time crossed 0, let's try starting the source"
```

❌ fail case:

```
decoupled.CurrentTime = 1000

decoupled.seek(-15)
 "can source run?" no
 "okay we'll enter decoupled mode"

// decoupled.processFrame(); <-- not called
 "our exposed currenttime is still 1000"

sleep(17);

decoupled.processFrame();
 "moving from 1000 to 2"
 "no need to attempt starting the source track because time didn't cross 0"
```

The failure hinged on `CurrentTime` not being updated from the private instantaneous `currentTime` until the next `ProcessFrame`. This is actually something we want, but the "crossing zero" code would fall over due to using the non-instantaneous value.

To make things as clear as I can, I added a new boolean specifically tracking what we intend to do here. Another standalone fix which may help with understanding the issue is this:

```diff
diff --git a/osu.Framework/Timing/DecouplingFramedClock.cs b/osu.Framework/Timing/DecouplingFramedClock.cs
index 790d34561..bc1ca1a4a 100644
--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -85,6 +85,7 @@ public DecouplingFramedClock(IClock? source = null)
         public void ProcessFrame()
         {
             double lastTime = CurrentTime;
+            double lastNonStaleTime = currentTime;
 
             (Source as IFrameBasedClock)?.ProcessFrame();
 
@@ -122,7 +123,7 @@ public void ProcessFrame()
                 // Note that this implicitly assumes the source starts at zero,
                 // and additionally the right-side boundary is not handled as we don't know where the source's max time is.
                 // This could be potentially handled if need be, if we had a notion of what the source's max allowable time is.
-                if (lastTime < 0 && currentTime >= 0)
+                if (lastNonStaleTime < 0 && currentTime >= 0)
                 {
                     // We still need to check the seek was successful, else we might have already exceeded valid length of the source.
                     lastSeekFailed = !adjustableSourceClock.Seek(currentTime);
```