### PR TITLE
Gracefully handle errors when retrieving track position

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -335,7 +335,8 @@ namespace osu.Framework.Audio.Track
             Debug.Assert(CanPerformInline);
 
             long bytePosition = bassMixer.ChannelGetPosition(this);
-            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
+            if (bytePosition != -1)
+                Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
         }
 
         private double currentTime;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/34307
Fixes https://github.com/ppy/osu/issues/34294
Should also fix https://github.com/ppy/osu/issues/34307#issuecomment-3094666882 (I spied this one happening to me out the corner of my eye)

Follow-up investigation to the issue above, the user claims this happens on any OGG output by this tool: https://github.com/Tyrrrz/YoutubeDownloader. I haven't verified that claim, though it should be a good repro for those wanting one, without me having to upload copyrighted content here.

I tested with the user's original track.

It looks like this is a mixer issue. I didn't manage to make a repro for it other than empirically testing in the editor. My test was:
1. Seek to 0.
2. Play and pause the track immediately.
3. Seek +30s.
4. Play ---> error should occur here. repeat if it doesn't.

Repros on Windows, but not Linux. Have not tested macOS.

Rather than going even further into the weeds, I noticed that the return value is `-1`, which BASSmix [documents](https://www.un4seen.com/doc/#bassmix/BASS_Mixer_ChannelGetPositionEx.html) (in this case `Bass.LastError` returns `BASS_ERROR_UNKNOWN` :open_mouth:). `BassAudioMixer` also [documents](https://github.com/ppy/osu-framework/blob/63f5cebd4190c144942246117871fdac59d645d6/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs#L173-L176) this also but `TrackBass` does not handle it.

Seems sane enough to discard the value, which will be picked up again in the next audio frame. I expect this to remain regardless of whether we end up reverting the BASS libs or not (e.g. to fix [some latency issues?](https://discord.com/channels/188630481301012481/589331078574112768/1396290261369491589)).