### PR TITLE
Fix dropdown menu keyboard navigation traversal order potentially not matching display order

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -313,6 +313,42 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestKeyboardSelectionOrder()
+        {
+            TestDropdown testDropdown = null!;
+            BindableList<TestModel?> bindableList = null!;
+
+            AddStep("setup dropdown", () => testDropdown = createDropdown());
+
+            AddStep("bind source", () => testDropdown.ItemSource = bindableList = new BindableList<TestModel?>());
+
+            AddStep("add items to bindable", () => bindableList.AddRange(new[] { "one", "two", "three" }.Select(s => new TestModel(s))));
+
+            AddStep("hover dropdown", () => InputManager.MoveMouseTo(testDropdown.Header));
+
+            AddStep("select first item", () => InputManager.Keys(PlatformAction.MoveToListStart));
+            AddAssert("'one' is selected", () => testDropdown.Current.Value?.Identifier == "one");
+
+            AddStep("select next item", () =>
+            {
+                InputManager.Key(Key.Down);
+            });
+            AddAssert("'two' is selected", () => testDropdown.Current.Value?.Identifier == "two");
+
+            AddStep("add 'three-halves'", () => bindableList.Add("three-halves"));
+            AddStep("move 'three-halves'", () => bindableList.Move(3, 1));
+
+            AddStep("select previous item", () =>
+            {
+                InputManager.Key(Key.Up);
+            });
+            AddAssert("'three-halves' is selected", () => testDropdown.Current.Value?.Identifier == "three-halves");
+
+            AddStep("select last item", () => InputManager.Keys(PlatformAction.MoveToListEnd));
+            AddAssert("'three' is selected", () => testDropdown.Current.Value?.Identifier == "three");
+        }
+
+        [Test]
         public void TestExternalManagement()
         {
             TestDropdown dropdown = null!;

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -289,7 +289,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!MenuItems.Any())
                 return;
 
-            var dropdownMenuItems = MenuItems.ToList();
+            var dropdownMenuItems = Menu.VisibleMenuItems.Select(item => (DropdownMenuItem<T>)item.Item).ToList();
 
             switch (action)
             {
@@ -505,7 +505,7 @@ namespace osu.Framework.Graphics.UserInterface
                     PreselectItem(null);
             }
 
-            protected internal IEnumerable<DrawableDropdownMenuItem> VisibleMenuItems => Children.OfType<DrawableDropdownMenuItem>().Where(i => i.MatchingFilter);
+            protected internal IEnumerable<DrawableDropdownMenuItem> VisibleMenuItems => Children.OrderBy(itemsFlow.GetLayoutPosition).OfType<DrawableDropdownMenuItem>().Where(i => i.MatchingFilter);
             protected internal IEnumerable<DrawableDropdownMenuItem> MenuItemsInView => VisibleMenuItems.Where(item => !item.IsMaskedAway);
 
             public DrawableDropdownMenuItem PreselectedItem => VisibleMenuItems.FirstOrDefault(c => c.IsPreSelected)


### PR DESCRIPTION
I noticed the following inconsistency: When items are inserted or moved within a `Dropdown` using a `BindableList`, the visible order of the items in the `DropdownMenu` correctly reflects this. However, changing the Dropdown's selection using the keyboard appears to jump around rather than follow that correct order, instead seemingly being based on the order the underlying items were added.

I added an (initially) failing test to illustrate the problem.

I think this happens because `MenuItems` -- [used](https://github.com/Seercat3160/osu-framework/blob/da681b8d42fe44bd4ec836451d0c0beff15a2d6e/osu.Framework/Graphics/UserInterface/Dropdown.cs#L292) in `selectionKeyPressed` to interact with the menu items when doing keyboard navigation -- is [defined](https://github.com/Seercat3160/osu-framework/blob/da681b8d42fe44bd4ec836451d0c0beff15a2d6e/osu.Framework/Graphics/UserInterface/Dropdown.cs#L63) in terms of `itemMap`, which is a Dictionary (unordered).

~~As a possible fix, I've changed that code to use VisibleMenuItems from the DropdownMenu (which is probably desirable anyway), which I've made to be ordered based on the items' layout positions. I don't think that has any unintended effects, and tests are passing.~~
That approach is too shallow and doesn't address the actual problem here.