### PR TITLE
Add display range to SliderBar

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -104,6 +104,21 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         KeyboardStep = 1,
                         Current = sliderBarValue
                     },
+                    new SpriteText
+                    {
+                        Text = "w/ WithDisplayRange:",
+                    },
+                    new BasicSliderBar<double>
+                    {
+                        Size = new Vector2(200, 10),
+                        BackgroundColour = Color4.White,
+                        SelectionColour = Color4.Pink,
+                        FocusColour = Color4.OrangeRed,
+                        KeyboardStep = 1,
+                        Current = sliderBarValue,
+                        MaxDisplayRange = 20,
+                        MinDisplayRange = 0
+                    }
                 }
             });
         }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -22,6 +22,44 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         public float RangePadding;
 
+        private T maxDisplayRange = T.MaxValue;
+
+        private T minDisplayRange = T.MinValue;
+
+        /// <summary>
+        /// The maximum value to display on the slider bar.
+        /// By default, the slider bar will display values between <see cref="BindableNumber{T}.MinValue"/> and <see cref="BindableNumber{T}.MaxValue"/> of <see cref="Current"/>.
+        /// To display a different range, you can set <see cref="MaxDisplayRange"/> and <see cref="MinDisplayRange"/>.
+        /// </summary>
+        public T MaxDisplayRange
+        {
+            get
+            {
+                if (maxDisplayRange == T.MaxValue)
+                    return currentNumberInstantaneous.MaxValue;
+
+                return maxDisplayRange;
+            }
+            set => maxDisplayRange = value;
+        }
+
+        /// <summary>
+        /// The minimum value to display on the slider bar.
+        /// By default, the slider bar will display values between <see cref="BindableNumber{T}.MinValue"/> and <see cref="BindableNumber{T}.MaxValue"/> of <see cref="Current"/>.
+        /// To display a different range, you can set <see cref="MaxDisplayRange"/> and <see cref="MinDisplayRange"/>.
+        /// </summary>
+        public T MinDisplayRange
+        {
+            get
+            {
+                if (minDisplayRange == T.MinValue)
+                    return currentNumberInstantaneous.MinValue;
+
+                return minDisplayRange;
+            }
+            set => minDisplayRange = value;
+        }
+
         public float UsableWidth => DrawWidth - 2 * RangePadding;
 
         /// <summary>
@@ -96,9 +134,29 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
+        /// The normalized value representing the position between <see cref="MinDisplayRange"/> and <see cref="MaxDisplayRange"/>.
+        /// </summary>
+        protected float NormalizedPosition
+        {
+            get
+            {
+                float min = float.CreateTruncating(MinDisplayRange);
+                float max = float.CreateTruncating(MaxDisplayRange);
+
+                if (max - min == 0)
+                    return 1;
+
+                float val = float.CreateTruncating(currentNumberInstantaneous.Value);
+                return (val - min) / (max - min);
+            }
+        }
+
+        /// <summary>
         /// Triggered when the <see cref="Current"/> value has changed. Used to update the displayed value.
         /// </summary>
-        /// <param name="value">The normalized <see cref="Current"/> value.</param>
+        /// <param name="value">
+        /// The normalized value representing the position between <see cref="MinDisplayRange"/> and <see cref="MaxDisplayRange"/>.
+        /// </param>
         protected abstract void UpdateValue(float value);
 
         protected override void LoadComplete()
@@ -112,10 +170,10 @@ namespace osu.Framework.Graphics.UserInterface
             Scheduler.AddOnce(updateValue);
         }
 
-        private void updateValue() => UpdateValue(NormalizedValue);
+        private void updateValue() => UpdateValue(NormalizedPosition);
 
         private bool handleClick;
-        private float? relativeValueAtMouseDown;
+        private float? normalizedPositionAtMouseDown;
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
@@ -125,11 +183,14 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (ShouldHandleAsRelativeDrag(e))
             {
-                float min = float.CreateTruncating(currentNumberInstantaneous.MinValue);
-                float max = float.CreateTruncating(currentNumberInstantaneous.MaxValue);
+                float min = float.CreateTruncating(MinDisplayRange);
+                float max = float.CreateTruncating(MaxDisplayRange);
                 float val = float.CreateTruncating(currentNumberInstantaneous.Value);
 
-                relativeValueAtMouseDown = (val - min) / (max - min);
+                if (max - min == 0)
+                    normalizedPositionAtMouseDown = 1;
+
+                normalizedPositionAtMouseDown = (val - min) / (max - min);
 
                 // Click shouldn't be handled if relative dragging is happening (i.e. while holding a nub).
                 // This is generally an expectation by most OSes and UIs.
@@ -138,7 +199,7 @@ namespace osu.Framework.Graphics.UserInterface
             else
             {
                 handleClick = true;
-                relativeValueAtMouseDown = null;
+                normalizedPositionAtMouseDown = null;
             }
 
             return base.OnMouseDown(e);
@@ -246,18 +307,24 @@ namespace osu.Framework.Graphics.UserInterface
 
             float localX = ToLocalSpace(e.ScreenSpaceMousePosition).X;
 
-            float newValue;
+            float normalizedPosition;
 
-            if (relativeValueAtMouseDown != null && e is DragEvent drag)
+            if (normalizedPositionAtMouseDown != null && e is DragEvent drag)
             {
-                newValue = relativeValueAtMouseDown.Value + (localX - ToLocalSpace(drag.ScreenSpaceMouseDownPosition).X) / UsableWidth;
+                normalizedPosition = normalizedPositionAtMouseDown.Value + (localX - ToLocalSpace(drag.ScreenSpaceMouseDownPosition).X) / UsableWidth;
             }
             else
             {
-                newValue = (localX - RangePadding) / UsableWidth;
+                normalizedPosition = (localX - RangePadding) / UsableWidth;
             }
 
-            currentNumberInstantaneous.SetProportional(newValue, e.ShiftPressed ? KeyboardStep : 0);
+            double min = double.CreateTruncating(MinDisplayRange);
+            double max = double.CreateTruncating(MaxDisplayRange);
+            double value = min + (max - min) * normalizedPosition;
+            if (e.ShiftPressed) // if shift is pressed, snap the final value to the closest multiple of KeyboardStep
+                value = Math.Round(value / KeyboardStep) * KeyboardStep;
+
+            currentNumberInstantaneous.Set(value);
             onUserChange(currentNumberInstantaneous.Value);
         }
 


### PR DESCRIPTION


This PR adds `MinDisplayRange` and `MaxDisplayRange` properties to `SliderBar`, allowing the display range to be adjusted instead of being fixed to `BindableNumber.MinValue` and `BindableNumber.MaxValue`.

Context: https://github.com/ppy/osu/pull/34362#issuecomment-3131504660
I spent some time considering variable naming and changed some original variable names, which may require discussion.

This change will not break the original behavior of `SliderBar`, and osu should be able to upgrade safely.

https://github.com/user-attachments/assets/5ec0bc48-5a53-4d61-a1d1-621b24f0c3c5

After this PR is merged, it will be possible to adjust the `LowerBound` and `UpperBound` ranges independently in osu `ShearedSliderBar`

https://github.com/user-attachments/assets/28d397d4-edf8-4ea6-a170-97314611ddc6



