### PR TITLE
Fix audio not working on iOS

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -70,7 +70,13 @@ namespace osu.Framework.Audio
         /// The names of all available audio devices.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property does not contain the names of disabled audio devices.
+        /// </para>
+        /// <para>
+        /// This property may also not necessarily contain the name of the default audio device provided by the OS.
+        /// Consumers should provide a "Default" audio device entry which sets <see cref="AudioDevice"/> to an empty string.
+        /// </para>
         /// </remarks>
         public IEnumerable<string> AudioDeviceNames => audioDeviceNames;
 
@@ -334,7 +340,9 @@ namespace osu.Framework.Audio
                 return true;
 
             // try using the system default if there is any device present.
-            if (audioDeviceNames.Count > 0 && setAudioDevice(bass_default_device))
+            // mobiles are an exception as the built-in speakers may not be provided as an audio device name,
+            // but they are still provided by BASS under the internal device name "Default".
+            if ((audioDeviceNames.Count > 0 || RuntimeInfo.IsMobile) && setAudioDevice(bass_default_device))
                 return true;
 
             // no audio devices can be used, so try using Bass-provided "No sound" device as last resort.


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34564

Indirectly regressed with the new libraries in https://github.com/ppy/osu-framework/pull/6620 due to BASS no longer providing the "Voice" audio device, which is the only audio device present in `AudioDeviceNames`. Without it present, `AudioManager` assumes there are no audio devices and does not attempt to initialise BASS with default audio device.

I was initially going to approach this by including "Default" in `AudioDeviceNames`, but there's no simple method to determine when does that make sense in platforms other than iOS. In desktop platforms, "Default" is present even when there are no real audio devices connected (see [assertion](https://github.com/ppy/osu-framework/blob/632e572e2f4a2d1946f26f6db0d856c34da3f370/osu.Framework/Audio/AudioManager.cs#L442)).

Instead, I've went a cheaper route and bypassed the condition for mobile platforms, under the justification that BASS doesn't really give us a reliable way to determine if having only "No sound" and "Default" available means there is a built-in speaker device (the case in iOS) or there are no audio devices at all (the case in any other platform).