### PR TITLE
Fix tooltip position abruptly changing when content reaches edge of the screen

### DIFF
--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -131,13 +131,7 @@ namespace osu.Framework.Graphics.Cursor
 
             // Clamp position to tooltip container
             tooltipPos.X = Math.Min(tooltipPos.X, DrawWidth - CurrentTooltip.DrawSize.X - 5);
-            float dX = Math.Max(0, tooltipPos.X - cursorCentre.X);
-            float dY = MathF.Sqrt(boundingRadius * boundingRadius - dX * dX);
-
-            if (tooltipPos.Y > DrawHeight - CurrentTooltip.DrawSize.Y - 5)
-                tooltipPos.Y = cursorCentre.Y - dY - CurrentTooltip.DrawSize.Y;
-            else
-                tooltipPos.Y = cursorCentre.Y + dY;
+            tooltipPos.Y = Math.Min(tooltipPos.Y, DrawHeight - CurrentTooltip.DrawSize.Y - 5);
 
             return tooltipPos;
         }


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/34515
- Mostly (fixes) https://github.com/ppy/osu/issues/33975
	- this doesn't address if the tooltip content is actually too big for the screen (i.e. easily done with >1.0 scale / mobile), would need some scaling logic or automatic scrolling of the content
		- but at that point, should the problematic custom tooltip be redesigned? can probably close the issue then if so

Just matches the x position logic. As indicated by the second issue, the previous logic didn't work to keep the tooltip content on screen when it gets moved to the top right of the cursor.

And as said in https://github.com/ppy/osu/issues/34515, this will match stable FWIW.

| Before | After |
| --- | --- |
| ![Kapture 2025-08-10 at 18 43 06](https://github.com/user-attachments/assets/f6371078-7299-4cd6-9f61-2abde5e9bab9) | ![Kapture 2025-08-10 at 18 33 41](https://github.com/user-attachments/assets/3af3055b-8eae-4d7d-b024-1b8a048dd1dd) |
| ![Kapture 2025-08-10 at 18 44 47](https://github.com/user-attachments/assets/219a2dd3-2e80-4e02-880e-1dfb27b68bb5) | ![Kapture 2025-08-10 at 18 38 38](https://github.com/user-attachments/assets/717491e2-fc19-4a0b-9947-b633f7fb7a46) |