### PR TITLE
Fix decoupling clock drifting during decoupled mode execution

### DIFF
--- a/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecouplingFramedClockTest.cs
@@ -432,6 +432,29 @@ namespace osu.Framework.Tests.Clocks
             }
         }
 
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(50)]
+        public void TestNoDecoupledDrift(int updateRate)
+        {
+            var stopwatch = new StopwatchClock();
+
+            decouplingClock.Start();
+            stopwatch.Start();
+
+            decouplingClock.Seek(-100);
+            stopwatch.Seek(-100);
+
+            while (decouplingClock.CurrentTime <= 0)
+            {
+                decouplingClock.ProcessFrame();
+                Assert.That(decouplingClock.CurrentTime, Is.EqualTo(stopwatch.CurrentTime).Within(1));
+
+                Thread.Sleep(updateRate);
+            }
+        }
+
         [Test]
         public void TestForwardPlaybackOverZeroBoundary()
         {

--- a/osu.Framework.Tests/Clocks/InterpolatingFramedClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingFramedClockTest.cs
@@ -250,6 +250,28 @@ namespace osu.Framework.Tests.Clocks
             Assert.That(interpolating.ElapsedFrameTime, Is.EqualTo(0).Within(100));
         }
 
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(10)]
+        [TestCase(50)]
+        public void TestNoInterpolationDrift(int updateRate)
+        {
+            var stopwatch = new StopwatchClock();
+
+            interpolating.ChangeSource(stopwatch);
+
+            source.Start();
+            stopwatch.Start();
+
+            while (interpolating.CurrentTime <= 1000)
+            {
+                interpolating.ProcessFrame();
+                Assert.That(interpolating.CurrentTime, Is.EqualTo(stopwatch.CurrentTime).Within(1));
+
+                Thread.Sleep(updateRate);
+            }
+        }
+
         [Test]
         public void InterpolationStaysWithinBounds()
         {

--- a/osu.Framework/Timing/DecouplingFramedClock.cs
+++ b/osu.Framework/Timing/DecouplingFramedClock.cs
@@ -94,6 +94,8 @@ namespace osu.Framework.Timing
 
             (Source as IFrameBasedClock)?.ProcessFrame();
 
+            double referenceTime = realtimeReferenceClock.CurrentTime;
+
             try
             {
                 // If the source is running, there is never a need for any decoupling logic.
@@ -120,7 +122,7 @@ namespace osu.Framework.Timing
                 if (lastReferenceTime == null)
                     return;
 
-                double elapsedReferenceTime = (realtimeReferenceClock.CurrentTime - lastReferenceTime.Value) * Rate;
+                double elapsedReferenceTime = (referenceTime - lastReferenceTime.Value) * Rate;
 
                 currentTime += elapsedReferenceTime;
 
@@ -142,7 +144,7 @@ namespace osu.Framework.Timing
             finally
             {
                 IsRunning = shouldBeRunning;
-                lastReferenceTime = realtimeReferenceClock.CurrentTime;
+                lastReferenceTime = referenceTime;
                 CurrentTime = currentTime;
                 ElapsedFrameTime = CurrentTime - lastTime;
             }


### PR DESCRIPTION
Likely not the main cause of clock drift that some users are reporting, but noticed this logic fallacy during testing.

When frames are run often enough, there is a compounding error caused by querying the source clock's time twice in the decoupled update method, losing a small amount of time each iteration. The test scene added shows a worst case scenario when `Thread.Sleep` is zero, resulting in 10%+ drift.

Luckily, the more important interpolating clock does not suffer from a similar issue.