### PR TITLE
Fix interpolating clocks' drift recovery being frame rate dependent

### DIFF
--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Timing
 {
@@ -100,11 +101,15 @@ namespace osu.Framework.Timing
 
                 if (IsInterpolating)
                 {
-                    // apply time increase from interpolation.
+                    // Apply time increase from interpolation.
                     currentTime += realtimeClock.ElapsedFrameTime * Rate;
-                    // if we differ from the elapsed time of the source, let's adjust for the difference.
-                    // TODO: this is frame rate depending, and can result in unexpected results.
-                    currentTime += (framedSourceClock.CurrentTime - currentTime) / 8;
+
+                    // Then check the post-interpolated time.
+                    // If we differ from the current time of the source, gradually approach the ground truth.
+                    //
+                    // The remaining error halves every halfTime ms.
+                    // This may need further tweaking to be less discernible by users (upwards, likely?).
+                    currentTime = Interpolation.DampContinuously(currentTime, framedSourceClock.CurrentTime, 50, realtimeClock.ElapsedFrameTime);
 
                     bool withinAllowableError = Math.Abs(framedSourceClock.CurrentTime - currentTime) <= AllowableErrorMilliseconds * Rate;
 


### PR DESCRIPTION
This should largely alleviate any remaining concerns of stutters due to https://github.com/ppy/osu/issues/22488. It's not an absolute fix, but it's a no-brainer improvement which requires much less thought.

In testing, on both windows and macOS the delay for bass to start playback is around 10 ms. If there is no interpolation, this would cause a 10 ms stutter.

I've confirmed that interpolation *does* alleviate this already. The problem is that depending on the update frame rate, it doesn't do a great job.

With this change, the drift is spread out over multiple frames, which should make the issue much less visible to an end user (gameplay will run slightly slower for a brief period rather than outright stopping).

Spreadsheet which can be used to play with half time values: https://docs.google.com/spreadsheets/d/1MoByZbgzYpmfSD2A3UeB7PWfJPtuBXF1/edit?usp=sharing&ouid=108555233068064484888&rtpof=true&sd=true
Branch used for testing delay and effects of changes: https://github.com/ppy/osu-framework/compare/master...peppy:osu-framework:audio-startup-delay-fix?expand=1 (it's a bit raw, based off frenzi's test scene but adjusted to also have interpolation).