### PR TITLE
Add ability to adjust drift recovery as a property

### DIFF
--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -22,6 +22,30 @@ namespace osu.Framework.Timing
         public double AllowableErrorMilliseconds { get; set; } = 1000.0 / 60 * 2;
 
         /// <summary>
+        /// Drift recovery half-life in milliseconds. Defaults to 80 ms.
+        /// </summary>
+        /// <remarks>
+        /// The time error decays exponentially toward the source.
+        /// Every <see cref="DriftRecoveryHalfLife"/> ms, the remaining error halves.
+        ///
+        /// An example, starting at 10 ms error with an 80 ms half-life:
+        ///
+        /// - at 0 ms, error is 10 ms.
+        /// - at 80 ms, error is 5 ms.
+        /// - at 160 ms, error is 2.5 ms.
+        /// - at 240 ms, error is 1.25 ms.
+        /// ...
+        ///
+        /// To an observer, it will look like time has a temporary ramp applied to it:
+        ///
+        /// - If source is ahead, time will speed up and gradually approach original speed.
+        /// - If source is behind, time will slow down and gradually approach original speed.
+        ///
+        /// Only applies when the error is within <see cref="AllowableErrorMilliseconds"/>.
+        /// </remarks>
+        public double DriftRecoveryHalfLife { get; set; } = 80;
+
+        /// <summary>
         /// Whether interpolation was applied at the last processed frame.
         /// </summary>
         /// <remarks>
@@ -107,9 +131,8 @@ namespace osu.Framework.Timing
                     // Then check the post-interpolated time.
                     // If we differ from the current time of the source, gradually approach the ground truth.
                     //
-                    // The remaining error halves every halfTime ms.
-                    // This may need further tweaking to be less discernible by users (upwards, likely?).
-                    currentTime = Interpolation.DampContinuously(currentTime, framedSourceClock.CurrentTime, 50, realtimeClock.ElapsedFrameTime);
+                    // The remaining error halves every half-life ms.
+                    currentTime = Interpolation.DampContinuously(currentTime, framedSourceClock.CurrentTime, DriftRecoveryHalfLife, realtimeClock.ElapsedFrameTime);
 
                     bool withinAllowableError = Math.Abs(framedSourceClock.CurrentTime - currentTime) <= AllowableErrorMilliseconds * Rate;
 


### PR DESCRIPTION
Also adjusts the default upwards from 50 ms to 80 ms (based on initial user feedback). Another path would be to set this to closer to what is use to be and leave it up to the consumer to decide if they want to adjust.