### PR TITLE
Add operator * overload for Triangle * Matrix3

### DIFF
--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -24,6 +24,12 @@ namespace osu.Framework.Graphics.Primitives
             P2 = p2;
         }
 
+        public static Triangle operator *(Triangle t, Matrix3 m) =>
+            new Triangle(
+                Vector2Extensions.Transform(t.P0, m),
+                Vector2Extensions.Transform(t.P1, m),
+                Vector2Extensions.Transform(t.P2, m));
+
         public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
         public ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in P0), 3);


### PR DESCRIPTION
As I mentioned in https://discord.com/channels/188630481301012481/589331078574112768/1412423491889791038
Currently, you can do Quad * Matrix3 but not Triangle * Matrix3.
This change has been tested just in case.