### PR TITLE
Fix disabled dropdowns absorbing input

### DIFF
--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             if (!Enabled.Value)
-                return true;
+                return false;
 
             switch (e.Key)
             {
@@ -173,7 +173,7 @@ namespace osu.Framework.Graphics.UserInterface
         public bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
         {
             if (!Enabled.Value)
-                return true;
+                return false;
 
             switch (e.Action)
             {


### PR DESCRIPTION
In osu! song select, when you are hovering the disabled sort dropdown on non-local leaderboards, it will absorb the left and right keys that are used to navigate the carousel.