### PR TITLE
Truncate drawable class names so that position and size are always visible in draw visualiser

### DIFF
--- a/osu.Framework/Graphics/Visualisation/ToolWindow.cs
+++ b/osu.Framework/Graphics/Visualisation/ToolWindow.cs
@@ -129,6 +129,7 @@ namespace osu.Framework.Graphics.Visualisation
                                                 ScrollContent = new BasicScrollContainer<Drawable>
                                                 {
                                                     RelativeSizeAxes = Axes.Both,
+                                                    ScrollbarOverlapsContent = false,
                                                     Child = SearchContainer = new SearchContainer
                                                     {
                                                         AutoSizeAxes = Axes.Y,


### PR DESCRIPTION
Also adds a tooltip of the full class name when truncated.

| Before | After |
| --- | --- |
| <img width="560" height="661" alt="Screenshot 2025-09-07 at 11 28 37 AM" src="https://github.com/user-attachments/assets/12d1591c-ac4f-4867-a34b-058e1a038b51" /> | <img width="1203" height="664" alt="Screenshot 2025-09-07 at 11 26 10 AM" src="https://github.com/user-attachments/assets/a0b9bb42-9311-4969-8421-6697ff1c50f6" /> |
