### PR TITLE
Fix web requests not using a dual-stack network client

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -846,12 +846,14 @@ namespace osu.Framework.IO.Network
 
         private static async ValueTask<Stream> attemptConnection(AddressFamily addressFamily, SocketsHttpConnectionContext context, CancellationToken cancellationToken)
         {
-            // The following socket constructor will create a dual-mode socket on systems where IPV6 is available.
             var socket = new Socket(addressFamily, SocketType.Stream, ProtocolType.Tcp)
             {
                 // Turn off Nagle's algorithm since it degrades performance in most HttpClient scenarios.
-                NoDelay = true
+                NoDelay = true,
             };
+
+            if (addressFamily == AddressFamily.InterNetworkV6)
+                socket.DualMode = true;
 
             try
             {


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34654

With web content filtering enabled, IPv6 is completely blocked on macOS (see [discord](https://discord.com/channels/90072389919997952/1327149041511043134/1415510876605120553)). I don't know the reason why, and there's not a single page available on Google referencing any part of this.

That being said, based on what I can understand, this never affects any other app in the system because they're all expectedly using a dual-stack network client, and the web content filtering is causing said apps to be limited to IPv4 only. Meanwhile on osu!, dual-stack mode has always been silently disabled for `$year` years, and so requests could not fall back to IPv4 and end up failing outright with "Connection reset by peer" instead.

I'm not 101% sure how this goes with the entire IPv4 fallback logic that is manually implemented due to lack of "Happy Eyeballs", to me it looks like it renders it completely redundant, but I'm totally no expert on this.