### PR TITLE
Fix `Path` may have missing pixels during rasterization

### DIFF
--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -291,13 +291,13 @@ namespace osu.Framework.Graphics.Lines
                             if (progress < 0)
                             {
                                 // expand segment backwards
-                                segmentToDraw = new Line(closest, segmentToDraw.Value.EndPoint);
+                                segmentToDraw = new Line(segments[i].EndPoint, segmentToDraw.Value.EndPoint);
                                 modifiedLocation = SegmentStartLocation.Outside;
                             }
                             else if (progress > 1)
                             {
                                 // or forward
-                                segmentToDraw = new Line(segmentToDraw.Value.StartPoint, closest);
+                                segmentToDraw = new Line(segmentToDraw.Value.StartPoint, segments[i].EndPoint);
                             }
                         }
                         else // Otherwise draw the expanded segment


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/34991

Regressed with https://github.com/ppy/osu-framework/pull/6603.
By decreasing allowed "optimisation precision" we can clearly see that on master the path shape is completely butchered, which is caused by mismatch between segment end point and next segment start point which may cause missing pixels with high precision.
|master (low precision) |pr (low precision)|pr (normal precision)|
|---|---|---|
|<img width="1920" height="1080" alt="osu_2025-09-13_02-26-35" src="https://github.com/user-attachments/assets/9030e432-ee46-4928-8d8c-eb85b00f2962" />|<img width="1920" height="1080" alt="osu_2025-09-13_02-25-34" src="https://github.com/user-attachments/assets/cf73c728-c65c-4af5-8110-f5676a0716b4" />|<img width="1920" height="1080" alt="osu_2025-09-13_02-47-31" src="https://github.com/user-attachments/assets/37b9e74c-565e-4be5-999f-851e3b897d31" />|

Why only editor? Different scaling/pixel allignment. Most likely.