### PR TITLE
Work around web request failures on macOS when on networks with no IPv6 support and content filters enabled

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -501,13 +501,46 @@ namespace osu.Framework.IO.Network
             if (Aborted)
                 return Task.CompletedTask;
 
-            var we = e as WebException;
-
-            bool allowRetry = AllowRetryOnTimeout;
             bool wasTimeout = false;
+            bool wasMacOSNetworkBlock = false;
 
             if (e != null)
-                wasTimeout = we?.Status == WebExceptionStatus.Timeout;
+            {
+                switch (e)
+                {
+                    case WebException we:
+                        wasTimeout = we?.Status == WebExceptionStatus.Timeout;
+                        break;
+
+                    case HttpRequestException hre:
+                    {
+                        // this is an extremely specific code path covering an obfuscated, but common enough failure mode on macOS.
+                        // the prerequisites for the failure mode in question appear to be:
+                        // - user is on macOS
+                        // - user is on a network that does not support IPv6
+                        // - user has a Screen Time filter enabled
+                        // in these circumstances, all outgoing IPv6 requests will be dropped with socket error 56 ("Connection reset by peer") near instantly.
+                        // it is nigh impossible to understand *why* this behaviour takes place, but it is reproducible across many domains and many HTTP clients
+                        // (for one instance, this same behaviour was observed when attempting to access google.com through its IPv6 address via curl).
+                        // the specificity of this failure mode is not that high, this could very well trigger in other circumstances, too -
+                        // but there is no more signal to use to distinguish this failure mode any further.
+                        // the hopes are that when IPv6 fallback gets implemented upstream in dotnet itself much of this can hopefully go away.
+                        if (useIPv6
+                            && RuntimeInfo.OS == RuntimeInfo.Platform.macOS
+                            && hre.HttpRequestError == HttpRequestError.SecureConnectionError
+                            && hre.InnerException is IOException ioe
+                            && ioe.InnerException is SocketException se
+                            && se.SocketErrorCode == SocketError.ConnectionReset)
+                        {
+                            logger.Add("Disabling IPv6 support due to suspicion of active Screen Time network filter dropping all IPv6 requests.");
+                            useIPv6 = false;
+                            wasMacOSNetworkBlock = true;
+                        }
+
+                        break;
+                    }
+                }
+            }
             else if (!response.IsSuccessStatusCode)
             {
                 e = new WebException(response.StatusCode.ToString());
@@ -521,7 +554,7 @@ namespace osu.Framework.IO.Network
                 }
             }
 
-            allowRetry &= wasTimeout;
+            bool allowRetry = (wasTimeout && AllowRetryOnTimeout) || wasMacOSNetworkBlock;
 
             if (e != null)
             {

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -509,7 +509,7 @@ namespace osu.Framework.IO.Network
                 switch (e)
                 {
                     case WebException we:
-                        wasTimeout = we?.Status == WebExceptionStatus.Timeout;
+                        wasTimeout = we.Status == WebExceptionStatus.Timeout;
                         break;
 
                     case HttpRequestException hre:


### PR DESCRIPTION
By disabling IPv6 support and retrying the request.

Very targeted, but given the conversation in https://github.com/ppy/osu-framework/pull/6637 should be much safer and better to understand. Given what I've seen of this issue I'm betting this is 99% some apple weirdness.

- Supersedes / closes https://github.com/ppy/osu-framework/pull/6637
- Closes https://github.com/ppy/osu/issues/34654