### PR TITLE
Update OpenTabletDriver to 0.6.6.0

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.5.1" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.6.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
## Tablet Support
### Added support:
- Gaomon M5
- Huion GT-191 V2
- Huion HC16 16k variant
- Huion Kamvas 16 (Gen 3)
- Huion Kamvas 24 (GS2401)
- Huion Kamvas Pro 27
- Huion L310
- Huion L610
- UGEE UE16
- Wacom Cintiq Pro 22 (DTH-227)
- Wacom DTH-2200
- Wacom DTK-2100
- Wacom PTK-470
- Wacom PTK-670
- Wacom PTK-870
- XP-Pen Artist 15.6 Pro V2
- XP-Pen Artist Pro 14 (Gen2)
- XP-Pen Artist Pro 19 (Gen2)
- XP-Pen Artist Pro 24 (Gen2)
- XP-Pen Deco 01 V3 (Variant 2)
- XP-Pen Deco 640 (IT640)
- XP-Pen Deco Pro MW Gen2

### Improved detection
- Artisul AP604
- FlooGoo FMA100
- Gaomon S630
- Huion H690
- Huion HS610
- Huion Kamvas 20
- Huion Kamvas Pro 20
- Huion New 1060 Plus (2048)
- Monoprice 10594
- Monoprice MP1060-HA60
- Parblo A610
- Turcom TS-6580
- UGEE M708
- XP-Pen Artist 10S
- XP-Pen Artist 22HD
- XP-Pen Deco 01 v2 variant 2
- XP-Pen Deco mini7 V2

### Improved support:
- Genius G-Pen 560
- Huion H1161
- Wacom CTE-430
- Wacom CTE-440
- Wacom CTE-630
- Wacom DTK-1200
- Wacom DTK-2200
- Wacom ET-0405A-U
- Wacom ET-0405-U
- XP-Pen Artist 12
- XP-Pen Deco 01
- XP-Pen Deco L