### PR TITLE
Update OpenTabletDriver to 0.6.6.2

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.6.1" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.6.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />


### PR DESCRIPTION
This release mostly contains fixes for standalone OTD but there's a few things that are worth bumping for osu framework.

## Tablet Support
### Added Support
- XP-Pen Deco Pro MW
### Improved Support
- Viewsonic Woodpad PF0730
- Monoprice 10594
- Fixed broken pressure handling (this causes issues with the pen tip binding) in some XP-Pen tablets due to differences in data sent on certain variants. Potentially affected tablets:
  - XP-Pen Artist 10 (2nd Gen)
  - XP-Pen Artist 12 (2nd Gen)
  - XP-Pen Artist 13 (2nd Gen)
  - XP-Pen Artist 16 (2nd Gen)
  - XP-Pen Deco L
  - XP-Pen Deco M
