### PR TITLE
BASSWASAPI init tweaks

### DIFF
--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -238,7 +238,7 @@ namespace osu.Framework.Threading
                 }
             });
 
-            bool initialised = BassWasapi.Init(wasapiDevice, Procedure: wasapiProcedure, Buffer: 0.02f, Period: 0.01f);
+            bool initialised = BassWasapi.Init(wasapiDevice, Procedure: wasapiProcedure, Flags: WasapiInitFlags.EventDriven | WasapiInitFlags.AutoFormat, Buffer: 0f, Period: float.Epsilon);
 
             if (!initialised)
                 return;


### PR DESCRIPTION
This PR attempts to improve the BASSWASAPI backend, which was introduced in #6088 and disabled in #6093, by tweaking the initialization parameters. The change itself is as tiny as the research behind it is massive, see https://github.com/ppy/osu-framework/issues/705#issuecomment-3367110862 for details. I'm omitting the issue closing macro, as supporting exclusive mode(s) is still up for debate.

## Tweaks explained

* `Flags: WasapiInitFlags.EventDriven` - causes the callback to be scheduled by WASAPI instead of a timer in BASSWASAPI, solving cycle misalignment issues that made underruns more likely

* `Flags: WasapiInitFlags.AutoFormat` - BASSWASAPI uses WASAPI's built-in resampler, which isn't always available. By searching for a driver-compatible format (using `ppClosestMatch` from [`IAudioClient::IsFormatSupported()`](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-isformatsupported)) we reduce the chances of failing the initialization, and increase the chances of not having to resample at all

* `Period: float.Epsilon` - The requested value is clamped to the supported range (except for zero, which falls back to default), so we can use epsilon to always get the smallest supported value without having to look it up ourselves

* `Buffer: 0f` - This tells BASSWASAPI to use [`IAudioClient3::InitializeSharedAudioStream()`](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient3-initializesharedaudiostream) instead of [`IAudioClient::Initialize()`](https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-initialize), which gives us access to periodicities below 10ms when the driver supports it, and behaves the same as the latter when it doesn't. This behaviour [is by design](https://www.un4seen.com/doc/#basswasapi/BASS_WASAPI_Init.html)