### PR TITLE
Allow enabling wasapi experimental initialisation via environment variable

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -21,6 +21,7 @@ namespace osu.Framework
         public static bool NoStructuredBuffers { get; }
         public static string? DeferredRendererEventsOutputPath { get; }
         public static bool UseSDL3 { get; }
+        public static bool UseWasapi { get; }
 
         /// <summary>
         /// Whether non-SSL requests should be allowed. Debug only. Defaults to disabled.
@@ -55,6 +56,8 @@ namespace osu.Framework
 
             // Desktop has many issues, see https://github.com/ppy/osu-framework/issues/6540.
             UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
+
+            UseWasapi = parseBool(Environment.GetEnvironmentVariable("OSU_AUDIO_WASAPI_EXPERIMENTAL")) ?? false;
         }
 
         private static bool? parseBool(string? value)

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -140,8 +140,7 @@ namespace osu.Framework.Threading
 
             // That this has not been mass-tested since https://github.com/ppy/osu-framework/pull/6651 and probably needs to be.
             // Currently envvar gated for users to test at their own discretion.
-            bool useWasapiInit = Environment.GetEnvironmentVariable("OSU_AUDIO_WASAPI_EXPERIMENTAL") == "1";
-            if (useWasapiInit)
+            if (FrameworkEnvironment.UseWasapi)
                 attemptWasapiInitialisation();
 
             initialised_devices.Add(deviceId);


### PR DESCRIPTION
`OSU_AUDIO_WASAPI_EXPERIMENTAL` can now be set to `1` to test experimental WASAPI initialisationsupport. Hopefully reduces latency and doesn't cause adverse issues this time around.

If preferred, we can just drop the envvar flag and push this out to tachyon for testing.