### PR TITLE
Move TabbableContainer focus movement logic into helper function

### DIFF
--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -3,9 +3,6 @@
 
 #nullable disable
 
-using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Input.Events;
 using osuTK.Input;
 
@@ -44,54 +41,8 @@ namespace osu.Framework.Graphics.Containers
             if (TabbableContentContainer == null || e.Key != Key.Tab)
                 return false;
 
-            moveToNextTabStop(TabbableContentContainer, e.ShiftPressed);
+            TabbableContentContainer.MoveFocusToNextTabStop(e.ShiftPressed);
             return true;
-        }
-
-        private void moveToNextTabStop(CompositeDrawable target, bool reverse)
-        {
-            var focusManager = GetContainingFocusManager().AsNonNull();
-
-            Stack<Drawable> stack = new Stack<Drawable>();
-            stack.Push(target); // Extra push for circular tabbing
-            stack.Push(target);
-
-            bool started = false;
-
-            while (stack.Count > 0)
-            {
-                var drawable = stack.Pop();
-
-                if (!started)
-                    started = ReferenceEquals(drawable, this);
-                else if (drawable is ITabbableContainer tabbable && tabbable.CanBeTabbedTo && focusManager.ChangeFocus(drawable))
-                    return;
-
-                if (drawable is CompositeDrawable composite)
-                {
-                    var newChildren = composite.InternalChildren.ToList();
-                    int bound = reverse ? newChildren.Count : 0;
-
-                    if (!started)
-                    {
-                        // Find self, to know starting point
-                        int index = newChildren.IndexOf(this);
-                        if (index != -1)
-                            bound = reverse ? index + 1 : index;
-                    }
-
-                    if (reverse)
-                    {
-                        for (int i = 0; i < bound; i++)
-                            stack.Push(newChildren[i]);
-                    }
-                    else
-                    {
-                        for (int i = newChildren.Count - 1; i >= bound; i--)
-                            stack.Push(newChildren[i]);
-                    }
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Companion to ppy/osu#35439

Moves the focus movement logic into as an extension function to cover 2 use-cases:
- implementing `ITabbableContainer` without inheriting from `TabbableContainer `
- being able to control focus movement from the parent

Also adds the option to navigate to the first valid focus target if no child is currently focused through the `requireFocusedChild` parameter (naming kinda bad I know, but I couldn't think of anything better).