### PR TITLE
Increase `Path` "approximation resolution" during draw process

### DIFF
--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -267,6 +267,7 @@ namespace osu.Framework.Graphics.Lines
                 Line? segmentToDraw = null;
                 SegmentStartLocation location = SegmentStartLocation.Outside;
                 SegmentStartLocation modifiedLocation = SegmentStartLocation.Outside;
+                SegmentStartLocation nextLocation = SegmentStartLocation.End;
                 SegmentWithThickness? lastDrawnSegment = null;
 
                 for (int i = 0; i < segments.Count; i++)
@@ -293,11 +294,17 @@ namespace osu.Framework.Graphics.Lines
                                 // expand segment backwards
                                 segmentToDraw = new Line(segments[i].EndPoint, segmentToDraw.Value.EndPoint);
                                 modifiedLocation = SegmentStartLocation.Outside;
+                                nextLocation = SegmentStartLocation.Start;
                             }
                             else if (progress > 1)
                             {
                                 // or forward
                                 segmentToDraw = new Line(segmentToDraw.Value.StartPoint, segments[i].EndPoint);
+                                nextLocation = SegmentStartLocation.End;
+                            }
+                            else
+                            {
+                                nextLocation = SegmentStartLocation.Middle;
                             }
                         }
                         else // Otherwise draw the expanded segment
@@ -307,11 +314,9 @@ namespace osu.Framework.Graphics.Lines
                             connect(s, lastDrawnSegment, texRect);
 
                             lastDrawnSegment = s;
-
-                            // Figure out at which point within currently drawn segment the new one starts
-                            float p = progressFor(segmentToDraw.Value, segmentToDrawLength, segments[i].StartPoint);
                             segmentToDraw = segments[i];
-                            location = modifiedLocation = Precision.AlmostEquals(p, 1f) ? SegmentStartLocation.End : Precision.AlmostEquals(p, 0f) ? SegmentStartLocation.Start : SegmentStartLocation.Middle;
+                            location = modifiedLocation = nextLocation;
+                            nextLocation = SegmentStartLocation.End;
                         }
                     }
                     else


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35522
Very unusual slider here.
<img width="1920" height="1080" alt="osu_2025-10-29_23-07-44" src="https://github.com/user-attachments/assets/3c5ae567-2fd4-40b5-87b0-c80d7ebbe39b" />
At this point I was thinking about dropping this whole "approximation" part after https://github.com/ppy/osu-framework/pull/6658, since vertex count will be much smaller overall, but no, not happening, draw performance will be back to abysmal for aspire maps.
Also just in case replaced some clanky precision stuff.