### PR TITLE
Remove useless menus from iPadOS's new app menu bar

### DIFF
--- a/osu.Framework.iOS/GameApplicationDelegate.cs
+++ b/osu.Framework.iOS/GameApplicationDelegate.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.iOS
     /// <summary>
     /// Base <see cref="UIApplicationDelegate"/> implementation for osu!framework applications.
     /// </summary>
-    public abstract class GameApplicationDelegate : UIApplicationDelegate
+    public abstract class GameApplicationDelegate : UIResponder, IUIApplicationDelegate
     {
         internal event Action<string>? DragDrop;
 
@@ -27,7 +27,7 @@ namespace osu.Framework.iOS
 
         public IOSGameHost Host { get; private set; } = null!;
 
-        public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+        public virtual bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
         {
             mapLibraryNames();
 
@@ -46,13 +46,24 @@ namespace osu.Framework.iOS
             return true;
         }
 
-        public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
+        public virtual bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
         {
             // copied verbatim from SDL: https://github.com/libsdl-org/SDL/blob/d252a8fe126b998bd1b0f4e4cf52312cd11de378/src/video/uikit/SDL_uikitappdelegate.m#L508-L535
             // the hope is that the SDL app delegate class does not have such handling exist there, but Apple does not provide a corresponding notification to make that possible.
             NSUrl? fileUrl = url.FilePathUrl;
             DragDrop?.Invoke(fileUrl != null ? fileUrl.Path! : url.AbsoluteString!);
             return true;
+        }
+
+        public override void BuildMenu(IUIMenuBuilder builder)
+        {
+            base.BuildMenu(builder);
+
+            // Remove useless menus on iPadOS. This makes it almost match macOS, displaying only "Window" and "Help".
+            builder.RemoveMenu(UIMenuIdentifier.File.GetConstant());
+            builder.RemoveMenu(UIMenuIdentifier.Edit.GetConstant());
+            builder.RemoveMenu(UIMenuIdentifier.Format.GetConstant());
+            builder.RemoveMenu(UIMenuIdentifier.View.GetConstant());
         }
 
         /// <summary>


### PR DESCRIPTION
Noticed while testing the new iPadOS 26 window system. I'm not 101% sure if this is the natural way to do it but it works correctly. 

This change involved changing `GameApplicationDelegate` to inherit `UIResponder` (and `IUIApplicationDelegate` instead), in order to access and override the `BuildMenu` function. This is apparently how it was meant to be the whole time, based off of creating a sample iOS project on Xcode. Tested the game to launch as normal so nothing is off with this change.

| before | after |
|--------|-------|
| <img width="1194" height="834" src="https://github.com/user-attachments/assets/5aa684b3-2977-47fc-acb0-494e9650cb1c" /> | <img width="1194" height="834" src="https://github.com/user-attachments/assets/4027cbd6-0f58-4bee-baa1-2ea86b1b12b1" /> |

Note that this should be accompanied with the following osu!-side change:

```diff
diff --git a/osu.iOS/AppDelegate.cs b/osu.iOS/AppDelegate.cs
index 5d309f2fc1..65c1951e80 100644
--- a/osu.iOS/AppDelegate.cs
+++ b/osu.iOS/AppDelegate.cs
@@ -9,7 +9,7 @@
 namespace osu.iOS
 {
     [Register("AppDelegate")]
-    public class AppDelegate : GameApplicationDelegate
+    public class AppDelegate : GameApplicationDelegate, IUIApplicationDelegate
     {
         private UIInterfaceOrientationMask? defaultOrientationsMask;
         private UIInterfaceOrientationMask? orientations;
@@ -41,7 +41,7 @@ public UIInterfaceOrientationMask? Orientations
 
         protected override Framework.Game CreateGame() => new OsuGameIOS(this);
 
-        public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, UIWindow forWindow)
+        public UIInterfaceOrientationMask GetSupportedInterfaceOrientations(UIApplication application, UIWindow forWindow)
         {
             if (orientations != null)
                 return orientations.Value;

```