### PR TITLE
Switch to upstream ManagedBass

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -21,11 +21,12 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="managed-midi" Version="1.10.1" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
+    <PackageReference Include="ManagedBass" Version="4.0.2" />
+    <PackageReference Include="ManagedBass.Fx" Version="4.0.2" />
+    <PackageReference Include="ManagedBass.Loud" Version="4.0.2" />
+    <PackageReference Include="ManagedBass.Mix" Version="4.0.2" />
+    <PackageReference Include="ManagedBass.Wasapi" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
-    <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
-    <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
-    <PackageReference Include="ppy.ManagedBass.Mix" Version="2022.1216.0" />
-    <PackageReference Include="ppy.ManagedBass.Wasapi" Version="2022.1216.0" />
     <PackageReference Include="ppy.Veldrid" Version="4.9.69-ga405fe8484" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g5911265ec3" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />


### PR DESCRIPTION
- Supersedes https://github.com/peppy/ManagedBass/pull/1
- Prerequisite for https://github.com/ppy/osu/pull/27793
- Original discussion on [discord](https://discord.com/channels/188630481301012481/188630652340404224/1425609257323331635)

This PR removes the dependency on `ppy.ManagedBass` and switches to using [upstream](https://github.com/ManagedBass/ManagedBass) `ManagedBass`. Also adds bindings for Volume FX and Bassloud, and a rather substantial [refactoring](https://github.com/ManagedBass/ManagedBass/commit/b6ced792f0deca280a1eff615e449cad5db3b474) of `ManagedBass`.

Roughly pulls in the following changes: https://github.com/ManagedBass/ManagedBass/compare/43f9d4b...4.0.2

Builds on this branch succeed, and so does building `osu` using this framework branch. No IDE warnings or errors are emitted on this branch, and all framework tests pass. I have rigorously tested audio manually using this branch on MacOS and iOS without any issues.