### PR TITLE
Explicitly set GL swap interval on android

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
@@ -182,11 +182,8 @@ namespace osu.Framework.Platform.SDL3
             }
             set
             {
-                if (RuntimeInfo.IsDesktop)
-                {
-                    SDL_GL_SetSwapInterval(value ? 1 : 0);
-                    verticalSync = value;
-                }
+                SDL_GL_SetSwapInterval(value ? 1 : 0);
+                verticalSync = value;
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/35914.

The latest release on android specifically has brought many complaints about crippled frame rate. After spending the whole of today bisecting, the bisect turned up

	There are only 'skip'ped commits left to test.
	The first bad commit could be any of:
	5f4585f6fbaae277965ba3e7fdc297d0bffb013d
	352dff602b61d35e1deee14aa996f73644fce78e

in framework, and

	137b0b2bee2bb9dd76e2c260970ccf7ff0621692 is the first bad commit
	commit 137b0b2bee2bb9dd76e2c260970ccf7ff0621692 (HEAD)
	Author: Sam Lantinga <slouken@libsdl.org>
	Date:   Mon Sep 22 10:22:41 2025 -0700

	    The default swap interval on EGL is 1, according to the spec

	    Fixes https://github.com/libsdl-org/SDL/issues/14014

	 src/video/SDL_egl.c | 3 ++-
	 1 file changed, 2 insertions(+), 1 deletion(-)

in SDL. (See also: https://github.com/libsdl-org/SDL/issues/14014.)

Now I am honestly not really super sure who's at fault here, but it *seems* that we were relying on SDL setting this to 0 by default in conjunction with our default frame limiter not being vsync, which worked until it didn't, and we can fix it on our side.

iOS is not relevant for this because OpenGL is not a supported renderer there anymore:

https://github.com/ppy/osu-framework/blob/eb6d97d62d0dc5504e183026c28ff376ea64d1a1/osu.Framework/Platform/GameHost.cs#L871-L874