### PR TITLE
Fix racing condition in TestSceneAudioMixer.cs (reopened)

### DIFF
--- a/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
+++ b/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
@@ -4,10 +4,12 @@
 #nullable disable
 
 using System;
+using System.Reflection;
 using System.Threading;
 using ManagedBass;
 using ManagedBass.Mix;
 using NUnit.Framework;
+using osu.Framework.Audio;
 using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
@@ -264,6 +266,60 @@ namespace osu.Framework.Tests.Audio
             bass.Update();
 
             Assert.That(secondMixer.ChannelIsActive(track), Is.Not.EqualTo(PlaybackState.Playing));
+        }
+
+        /// Tests a race condition where mixer.Add(track) is called before createMixer.
+        /// Artificially forces the wrong order by manually modifying AudioComponent.pendingActions.
+        /// This actually happens quite frequently when initializing TestSceneAudioMixer.cs.
+        [Test]
+        public void TestRaceConditionAddBeforeCreateMixer()
+        {
+            int trackHandle = getHandle();
+            Assert.That(trackHandle, Is.Not.Zero, "Track should have a BASS handle");
+
+            // Create a mixer but don't register it with the component manager yet
+            var newMixer = new BassAudioMixer(null, bass.Mixer, "Race test mixer");
+            bass.Add(newMixer);
+
+            var enqueueActionMethod = typeof(AudioComponent).GetMethod("EnqueueAction",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var pendingActionsField = typeof(AudioComponent).GetField("PendingActions",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var createMixerMethod = typeof(BassAudioMixer).GetMethod("createMixer",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.That(enqueueActionMethod, Is.Not.Null, "Should be able to find EnqueueAction method");
+            Assert.That(pendingActionsField, Is.Not.Null, "Should be able to find PendingActions field");
+            Assert.That(createMixerMethod, Is.Not.Null, "Should be able to find createMixer method");
+
+            // Clear the pending action queue to remove the auto-queued createMixer from constructor
+            object pendingActions = pendingActionsField!.GetValue(newMixer);
+            Assert.That(pendingActions, Is.Not.Null, "PendingActions should not be null");
+            object newQueue = Activator.CreateInstance(pendingActions.GetType());
+            pendingActionsField.SetValue(newMixer, newQueue);
+
+            // Reconstruct the pending action queue to simulate what happens when mixer.Add(track) is called before the mixer is initialized
+            // 1. track channel added to the BassAudioMixer.pendingChannels, since mixer handle is still null
+            enqueueActionMethod.Invoke(newMixer,
+            [
+                new Action(() =>
+                {
+                    newMixer.Add(track);
+                })
+            ]);
+            // 2. create mixer is called, after which mixer handle will be valid
+            enqueueActionMethod.Invoke(newMixer,
+            [
+                new Action(() => createMixerMethod!.Invoke(newMixer, null))
+            ]);
+            // 3. track channel salvaged from pending channels and added to the mixer by BassAudioMixer.UpdateState
+            bass.Update();
+
+            Assert.That(newMixer.Handle, Is.Not.Zero, "Mixer should be initialized");
+
+            // Now the track should be in the new mixer
+            Assert.That(BassMix.ChannelGetMixer(trackHandle), Is.EqualTo(newMixer.Handle),
+                "Track should be successfully added to the mixer even when Add was called before createMixer");
         }
 
         private int getHandle() => ((IBassAudioChannel)track).Handle;

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using ManagedBass;
 using ManagedBass.Mix;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Logging;
 using osu.Framework.Statistics;
 
 namespace osu.Framework.Audio.Mixing.Bass
@@ -28,6 +29,12 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// The list of channels which are currently active in the BASS mix.
         /// </summary>
         private readonly List<IBassAudioChannel> activeChannels = new List<IBassAudioChannel>();
+
+        /// <summary>
+        /// The list of channels which are pending addition to the BASS mix.
+        /// These channels are waiting for either the mixer or the channel to be initialized.
+        /// </summary>
+        private readonly List<IBassAudioChannel> pendingChannels = new List<IBassAudioChannel>();
 
         private readonly Dictionary<IEffectParameter, int> activeEffects = new Dictionary<IEffectParameter, int>();
 
@@ -82,15 +89,14 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             if (Handle == 0 || bassChannel.Handle == 0)
             {
-                // Channel will be added to the BASS mix when the mixer is created.
-                // See createMixer() which processes all channels in activeChannels.
-                if (!activeChannels.Contains(bassChannel))
-                    activeChannels.Add(bassChannel);
+                // Channel will be added to the BASS mix when both the mixer and channel are ready.
+                if (!pendingChannels.Contains(bassChannel))
+                    pendingChannels.Add(bassChannel);
                 return;
             }
 
             if (!bassChannel.MixerChannelPaused)
-                ChannelPlay(bassChannel);
+                AddToBassMixAndPlay(bassChannel);
         }
 
         protected override void RemoveInternal(IAudioChannel channel)
@@ -100,24 +106,24 @@ namespace osu.Framework.Audio.Mixing.Bass
             if (channel is not IBassAudioChannel bassChannel)
                 return;
 
-            if (Handle == 0 || bassChannel.Handle == 0)
-                return;
+            // Remove from pending channels if it's there
+            pendingChannels.Remove(bassChannel);
 
-            if (activeChannels.Remove(bassChannel))
+            // Remove from active channels and BASS mix if mixer is valid
+            if (Handle != 0 && bassChannel.Handle != 0 && activeChannels.Remove(bassChannel))
                 removeChannelFromBassMix(bassChannel);
         }
 
         /// <summary>
-        /// Plays a channel.
+        /// Adds a channel to the BASS mix and plays it.
         /// </summary>
         /// <remarks>See: <see cref="ManagedBass.Bass.ChannelPlay"/>.</remarks>
-        /// <param name="channel">The channel to play.</param>
-        /// <param name="restart">Restart playback from the beginning?</param>
+        /// <param name="channel">The channel to add and play.</param>
         /// <returns>
         /// If successful, <see langword="true"/> is returned, else <see langword="false"/> is returned.
         /// Use <see cref="ManagedBass.Bass.LastError"/> to get the error code.
         /// </returns>
-        public bool ChannelPlay(IBassAudioChannel channel, bool restart = false)
+        public bool AddToBassMixAndPlay(IBassAudioChannel channel)
         {
             if (Handle == 0 || channel.Handle == 0)
                 return false;
@@ -274,6 +280,27 @@ namespace osu.Framework.Audio.Mixing.Bass
 
         protected override void UpdateState()
         {
+            // Process pending channels if mixer is ready
+            if (Handle != 0 && pendingChannels.Count > 0)
+            {
+                var toProcess = pendingChannels.ToArray();
+                pendingChannels.Clear();
+
+                foreach (var channel in toProcess)
+                {
+                    if (channel.Handle == 0)
+                    {
+                        // Channel still not ready, keep pending
+                        pendingChannels.Add(channel);
+                    }
+                    else
+                    {
+                        // Channel is ready, add to BASS mix and play
+                        AddToBassMixAndPlay(channel);
+                    }
+                }
+            }
+
             for (int i = 0; i < activeChannels.Count; i++)
             {
                 var channel = activeChannels[i];
@@ -310,11 +337,25 @@ namespace osu.Framework.Audio.Mixing.Bass
             ManagedBass.Bass.ChannelSetAttribute(Handle, ChannelAttribute.Buffer, 0);
 
             // Register all channels that were previously added prior to the mixer being loaded.
-            // These channels were queued in activeChannels but not yet added to the BASS mix.
-            var toAdd = activeChannels.ToArray();
-            activeChannels.Clear();
+            // These channels were queued in pendingChannels but not yet added to the BASS mix.
+            var toAdd = pendingChannels.ToArray();
+            pendingChannels.Clear();
+
             foreach (var channel in toAdd)
-                AddChannelToBassMix(channel);
+            {
+                if (channel.Handle == 0)
+                {
+                    // Channel is not yet initialized, keep it pending for later processing
+                    pendingChannels.Add(channel);
+                }
+                else
+                {
+                    AddToBassMixAndPlay(channel);
+                }
+            }
+
+            if (pendingChannels.Count > 0)
+                Logger.Log($"BassAudioMixer '{Identifier}' has {pendingChannels.Count} pending channels after mixer creation", LoggingTarget.Runtime, LogLevel.Important);
 
             if (manager?.GlobalMixerHandle.Value != null)
                 BassMix.MixerAddChannel(manager.GlobalMixerHandle.Value.Value, Handle, BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin);

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -77,11 +77,17 @@ namespace osu.Framework.Audio.Mixing.Bass
         {
             Debug.Assert(CanPerformInline);
 
-            if (!(channel is IBassAudioChannel bassChannel))
+            if (channel is not IBassAudioChannel bassChannel)
                 return;
 
             if (Handle == 0 || bassChannel.Handle == 0)
+            {
+                // Channel will be added to the BASS mix when the mixer is created.
+                // See createMixer() which processes all channels in activeChannels.
+                if (!activeChannels.Contains(bassChannel))
+                    activeChannels.Add(bassChannel);
                 return;
+            }
 
             if (!bassChannel.MixerChannelPaused)
                 ChannelPlay(bassChannel);
@@ -91,7 +97,7 @@ namespace osu.Framework.Audio.Mixing.Bass
         {
             Debug.Assert(CanPerformInline);
 
-            if (!(channel is IBassAudioChannel bassChannel))
+            if (channel is not IBassAudioChannel bassChannel)
                 return;
 
             if (Handle == 0 || bassChannel.Handle == 0)
@@ -303,7 +309,8 @@ namespace osu.Framework.Audio.Mixing.Bass
             // Lower latency is valued more for the time since we are not using complex DSP effects. Disable buffering on the mixer channel in order for data to be produced immediately.
             ManagedBass.Bass.ChannelSetAttribute(Handle, ChannelAttribute.Buffer, 0);
 
-            // Register all channels that were previously played prior to the mixer being loaded.
+            // Register all channels that were previously added prior to the mixer being loaded.
+            // These channels were queued in activeChannels but not yet added to the BASS mix.
             var toAdd = activeChannels.ToArray();
             activeChannels.Clear();
             foreach (var channel in toAdd)

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -183,7 +183,7 @@ namespace osu.Framework.Audio.Sample
             if (relativeFrequencyHandler.IsFrequencyZero)
                 return true;
 
-            return bassMixer.ChannelPlay(this);
+            return bassMixer.AddToBassMixAndPlay(this);
         }
 
         private void stopInternal()

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -284,7 +284,7 @@ namespace osu.Framework.Audio.Track
 
             setLoopFlag(Looping);
 
-            return bassMixer.ChannelPlay(this);
+            return bassMixer.AddToBassMixAndPlay(this);
         }
 
         public override bool Looping


### PR DESCRIPTION
This is a reopening of #6715 with a correct branch from my fork.

### TODO
- [ ] Add a timeout mechanism.

---

### The Symptom

When you smash on the `AudioMixer` test scene button, it should play the sample immediately, but most of the time it doesn't play any sound:

https://github.com/user-attachments/assets/c1dfa56e-3bcf-417a-a8c7-8c9d5e9f993b

Since dragging the pink speaker onto mixers are working fine, I guess this is why we've been ignoring this.

### The Cause
There's a race condition during test scene initialization.

- `AudioPlayingDrawable.load()` schedules a `mixer.Add(channel)` in Update thread
- `DrawableAudioMixer.load()` schedules a `createMixer` in another background thread
- They both schedule things to run in the audio thread eventually, but queuing sequence may different
- Channel might be added to the mixer before mixer creation complete, which results in an early return in `BassAudioMixer.ChannelPlay` (now renamed to `AddToBassMixAndPlay`).

### The Fix
Fixing that symptom solely is just a one-liner:

```cs
// BassAudioMixer.AddInternal
if (Handle == 0 || bassChannel.Handle == 0)
{
    // Do not return early immediately
    if (!activeChannels.Contains(bassChannel))
        activeChannels.Add(bassChannel);
    return;
}
```
But I took a more rigorous approach: to track the channels adding before mixer creation complete as `pending`, and retry them in `UpdateState`.

This is what it should have been (after the fix):

https://github.com/user-attachments/assets/5aebdc2f-20d0-4711-902d-b54e228d646f