### PR TITLE
Add libgamemode support on Linux

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform.Linux.Native;
 
 namespace osu.Framework.Platform.Linux
 {
@@ -45,6 +46,18 @@ namespace osu.Framework.Platform.Linux
             }
 
             return handlers;
+        }
+
+        protected override void SetupForRun()
+        {
+            Gamemode.RequestStart();
+            base.SetupForRun();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            Gamemode.RequestEnd();
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Gamemode.cs
+++ b/osu.Framework/Platform/Linux/Native/Gamemode.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Platform.Linux.Native
             {
                 if (gamemode_request_start() < 0)
                 {
-                    Logger.Log($"gamemode_rewust_start: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                    Logger.Log($"gamemode_request_start: failed.", LoggingTarget.Runtime, LogLevel.Debug);
                 }
             }
             catch (DllNotFoundException)
@@ -46,7 +46,7 @@ namespace osu.Framework.Platform.Linux.Native
             {
                 if (gamemode_request_end() < 0)
                 {
-                    Logger.Log($"gamemode_rewust_end: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                    Logger.Log($"gamemode_request_end: failed.", LoggingTarget.Runtime, LogLevel.Debug);
                 }
             }
             catch (DllNotFoundException)

--- a/osu.Framework/Platform/Linux/Native/Gamemode.cs
+++ b/osu.Framework/Platform/Linux/Native/Gamemode.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Platform.Linux.Native
             {
                 if (gamemode_request_start() < 0)
                 {
-                    Logger.Log($"gamemode_request_start: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                    Logger.Log("gamemode_request_start: failed.", LoggingTarget.Runtime, LogLevel.Debug);
                 }
             }
             catch (DllNotFoundException)
@@ -46,7 +46,7 @@ namespace osu.Framework.Platform.Linux.Native
             {
                 if (gamemode_request_end() < 0)
                 {
-                    Logger.Log($"gamemode_request_end: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                    Logger.Log("gamemode_request_end: failed.", LoggingTarget.Runtime, LogLevel.Debug);
                 }
             }
             catch (DllNotFoundException)

--- a/osu.Framework/Platform/Linux/Native/Gamemode.cs
+++ b/osu.Framework/Platform/Linux/Native/Gamemode.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Platform.Linux.Native
+{
+    internal class Gamemode
+    {
+        [DllImport("libgamemode.so.0", EntryPoint = "real_gamemode_request_start", ExactSpelling = true)]
+        private static extern int gamemode_request_start();
+
+        [DllImport("libgamemode.so.0", EntryPoint = "real_gamemode_request_end", ExactSpelling = true)]
+        private static extern int gamemode_request_end();
+
+        /// <summary>
+        /// Requests gamemode activation. Silently does nothing if libgamemode is not installed.
+        /// </summary>
+        public static void RequestStart()
+        {
+            try
+            {
+                if (gamemode_request_start() < 0)
+                {
+                    Logger.Log($"gamemode_rewust_start: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                }
+            }
+            catch (DllNotFoundException)
+            {
+                // libgamemode is not installed; this is not an error.
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"gamemode_request_start threw an unexpected exception: {e}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+        }
+
+        /// <summary>
+        /// Requests gamemode deactivation. Silently does nothing if libgamemode is not installed.
+        /// </summary>
+        public static void RequestEnd()
+        {
+            try
+            {
+                if (gamemode_request_end() < 0)
+                {
+                    Logger.Log($"gamemode_rewust_end: failed.", LoggingTarget.Runtime, LogLevel.Debug);
+                }
+            }
+            catch (DllNotFoundException)
+            {
+                // libgamemode is not installed; this is not an error.
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"gamemode_request_end threw an unexpected exception: {e}", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Calls `gamemode_request_start()` on startup and `gamemode_request_end()` on shutdown via P/Invoke to `libgamemode.so.0`.

If libgamemode is not installed, the calls are silently ignored.

This allows osu-framework-based games (including osu!) to benefit from gamemode's CPU/GPU optimisations without requiring `gamemoderun` as a wrapper.