### PR TITLE
Improve Apple Silicon Veldrid efficiency

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -19,6 +19,8 @@ namespace osu.Framework
         public static int? StagingBufferType { get; }
         public static int? VertexBufferCount { get; }
         public static bool NoStructuredBuffers { get; }
+        public static bool LogVeldridFrameTimings { get; }
+        public static bool? ForceMacOSPreDrawTextureUploadFlush { get; }
         public static string? DeferredRendererEventsOutputPath { get; }
         public static bool UseSDL3 { get; }
 
@@ -47,6 +49,8 @@ namespace osu.Framework
                 StagingBufferType = stagingBufferImplementation;
 
             NoStructuredBuffers = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_NO_SSBO")) ?? false;
+            LogVeldridFrameTimings = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_LOG_VELDRID_FRAME_TIMINGS")) ?? false;
+            ForceMacOSPreDrawTextureUploadFlush = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_MACOS_PREDRAW_TEXTURE_UPLOAD_FLUSH"));
 
             DeferredRendererEventsOutputPath = Environment.GetEnvironmentVariable("DEFERRED_RENDERER_EVENTS_OUTPUT");
 

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredShaderStorageBufferObject.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredShaderStorageBufferObject.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering.Deferred.Allocation;
 using osu.Framework.Graphics.Rendering.Deferred.Events;
+using osu.Framework.Graphics.Veldrid;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using Veldrid;
 
@@ -21,6 +23,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
         private readonly DeviceBuffer buffer;
         private readonly DeferredRenderer renderer;
         private readonly int elementSize;
+        private readonly Dictionary<ResourceLayout, ResourceSet> resourceSets = new Dictionary<ResourceLayout, ResourceSet>();
 
         public DeferredShaderStorageBufferObject(DeferredRenderer renderer, int ssboSize)
         {
@@ -53,13 +56,24 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             => memory.WriteTo(renderer.Context, buffer, index * elementSize);
 
         public ResourceSet GetResourceSet(ResourceLayout layout)
-            => renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        {
+            if (resourceSets.TryGetValue(layout, out ResourceSet? existing))
+                return existing;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.ShaderStorage);
+            return resourceSets[layout] = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        }
 
         public void ResetCounters()
         {
         }
 
         public void Dispose()
-            => buffer.Dispose();
+        {
+            foreach ((_, ResourceSet resourceSet) in resourceSets)
+                resourceSet.Dispose();
+
+            buffer.Dispose();
+        }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering.Deferred.Allocation;
 using osu.Framework.Graphics.Rendering.Deferred.Events;
+using osu.Framework.Graphics.Veldrid;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Statistics;
 using Veldrid;
@@ -56,6 +57,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             if (bufferChunks.TryGetValue((currentChunk, layout), out ResourceSet? existing))
                 return existing;
 
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Uniform);
             return bufferChunks[(currentChunk, layout)] = renderer.Factory.CreateResourceSet(
                 new ResourceSetDescription(
                     layout,

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridShaderStorageBufferObject.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridShaderStorageBufferObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using osu.Framework.Development;
@@ -19,6 +20,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly DeviceBuffer buffer;
         private readonly VeldridRenderer renderer;
         private readonly uint elementSize;
+        private readonly Dictionary<ResourceLayout, ResourceSet> resourceSets = new Dictionary<ResourceLayout, ResourceSet>();
 
         public VeldridShaderStorageBufferObject(VeldridRenderer renderer, int uboSize, int ssboSize)
         {
@@ -89,7 +91,12 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public ResourceSet GetResourceSet(ResourceLayout layout)
         {
             flushChanges();
-            return renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+
+            if (resourceSets.TryGetValue(layout, out ResourceSet? existing))
+                return existing;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.ShaderStorage);
+            return resourceSets[layout] = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
         }
 
         public void ResetCounters()
@@ -98,6 +105,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public void Dispose()
         {
+            foreach ((_, ResourceSet resourceSet) in resourceSets)
+                resourceSet.Dispose();
+
             buffer.Dispose();
         }
     }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -37,7 +37,14 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             }
         }
 
-        public ResourceSet GetResourceSet(ResourceLayout layout) => set ??= renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        public ResourceSet GetResourceSet(ResourceLayout layout)
+        {
+            if (set != null)
+                return set;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Uniform);
+            return set = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        }
 
         public void Dispose()
         {

--- a/osu.Framework/Graphics/Veldrid/Pipelines/BasicPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/BasicPipeline.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Veldrid.Textures;
 using Veldrid;
@@ -57,10 +58,12 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private readonly Queue<Fence> fencePool = new Queue<Fence>();
 
         private readonly VeldridDevice device;
+        private readonly VeldridPipelineKind pipelineKind;
 
-        public BasicPipeline(VeldridDevice device)
+        public BasicPipeline(VeldridDevice device, VeldridPipelineKind pipelineKind)
         {
             this.device = device;
+            this.pipelineKind = pipelineKind;
             Commands = device.Factory.CreateCommandList();
         }
 
@@ -86,7 +89,16 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
             pendingExecutions.Add(new ExecutionCompletionFence(fence, executionIndex));
 
             Commands.End();
+
+            if (!VeldridInstrumentation.Enabled)
+            {
+                device.Device.SubmitCommands(Commands, fence);
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
             device.Device.SubmitCommands(Commands, fence);
+            VeldridInstrumentation.RecordSubmit(pipelineKind, Stopwatch.GetTimestamp() - start);
         }
 
         private void updatePendingExecutions()

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private VertexLayoutDescription currentVertexLayout;
 
         public GraphicsPipeline(VeldridDevice device)
-            : base(device)
+            : base(device, VeldridPipelineKind.Graphics)
         {
             pipelineDesc.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }
@@ -303,10 +303,19 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
 
         private Pipeline createPipeline()
         {
-            if (!pipelineCache.TryGetValue(pipelineDesc, out var instance))
+            if (pipelineCache.TryGetValue(pipelineDesc, out var instance))
+            {
+                VeldridInstrumentation.RecordPipelineCacheHit();
+                return instance;
+            }
+
+            VeldridInstrumentation.RecordPipelineCacheMiss();
+
+            if (!pipelineCache.TryGetValue(pipelineDesc, out instance))
             {
                 pipelineCache[pipelineDesc.Clone()] = instance = Factory.CreateGraphicsPipeline(ref pipelineDesc);
                 stat_graphics_pipeline_created.Value++;
+                VeldridInstrumentation.RecordPipelineCreated();
             }
 
             return instance;

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
@@ -47,7 +47,11 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             if (Sampler == null)
                 throw new InvalidOperationException("Attempting to create resource set without a sampler attached to the resources.");
 
-            return Set ??= factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
+            if (Set != null)
+                return Set;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Texture);
+            return Set = factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -88,7 +88,15 @@ namespace osu.Framework.Graphics.Veldrid
         public int MaxTextureSize { get; }
 
         private readonly IGraphicsSurface graphicsSurface;
+        private readonly bool logFrameTimings = FrameworkEnvironment.LogVeldridFrameTimings;
         private Vector2I currentWindowSize;
+        private bool loggedNonVSyncWaitBypass;
+
+        private long swapTimingTicks;
+        private long waitTimingTicks;
+        private int swapTimingSamples;
+        private int waitTimingSamples;
+        private int skippedWaits;
 
         /// <summary>
         /// Creates a new <see cref="VeldridDevice"/>
@@ -236,7 +244,17 @@ namespace osu.Framework.Graphics.Veldrid
         /// Swaps the back buffer with the front buffer to display the new frame.
         /// </summary>
         public void SwapBuffers()
-            => Device.SwapBuffers();
+        {
+            if (!logFrameTimings)
+            {
+                Device.SwapBuffers();
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            Device.SwapBuffers();
+            recordSwapTiming(Stopwatch.GetTimestamp() - start);
+        }
 
         /// <summary>
         /// Waits until all renderer commands have been fully executed GPU-side, as signaled by the graphics backend.
@@ -251,7 +269,31 @@ namespace osu.Framework.Graphics.Veldrid
         /// Waits until the GPU signals that the next frame is ready to be rendered.
         /// </summary>
         public void WaitUntilNextFrameReady()
-            => Device.WaitForNextFrameReady();
+        {
+            if (shouldBypassFrameReadyWait())
+            {
+                skippedWaits++;
+
+                if (!loggedNonVSyncWaitBypass)
+                {
+                    Logger.Log("Metal frame-ready wait bypassed while vertical sync is disabled.", level: LogLevel.Important);
+                    loggedNonVSyncWaitBypass = true;
+                }
+
+                maybeLogTimingSummary();
+                return;
+            }
+
+            if (!logFrameTimings)
+            {
+                Device.WaitForNextFrameReady();
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            Device.WaitForNextFrameReady();
+            recordWaitTiming(Stopwatch.GetTimestamp() - start);
+        }
 
         /// <summary>
         /// Invoked when the rendering thread is active and commands will be enqueued.
@@ -375,5 +417,51 @@ namespace osu.Framework.Graphics.Veldrid
 
             return Device.WaitForFence(fence, (ulong)(millisecondsTimeout * 1_000_000));
         }
+
+        private bool shouldBypassFrameReadyWait()
+            => RuntimeInfo.OS == RuntimeInfo.Platform.macOS
+               && graphicsSurface.Type == GraphicsSurfaceType.Metal
+               && !VerticalSync;
+
+        private void recordSwapTiming(long elapsedTicks)
+        {
+            swapTimingTicks += elapsedTicks;
+            swapTimingSamples++;
+            maybeLogTimingSummary();
+        }
+
+        private void recordWaitTiming(long elapsedTicks)
+        {
+            waitTimingTicks += elapsedTicks;
+            waitTimingSamples++;
+            maybeLogTimingSummary();
+        }
+
+        private void maybeLogTimingSummary()
+        {
+            if (!logFrameTimings)
+                return;
+
+            int sampleCount = Math.Max(swapTimingSamples, waitTimingSamples + skippedWaits);
+
+            if (sampleCount == 0 || sampleCount % 240 != 0)
+                return;
+
+            double swapAverageMs = swapTimingSamples == 0 ? 0 : ticksToMilliseconds(swapTimingTicks / (double)swapTimingSamples);
+            double waitAverageMs = waitTimingSamples == 0 ? 0 : ticksToMilliseconds(waitTimingTicks / (double)waitTimingSamples);
+
+            Logger.Log(
+                $"Veldrid frame timing summary ({SurfaceType}): avg_swap={swapAverageMs:0.###}ms, avg_wait={waitAverageMs:0.###}ms, wait_samples={waitTimingSamples}, wait_skipped={skippedWaits}",
+                level: LogLevel.Important);
+
+            swapTimingTicks = 0;
+            waitTimingTicks = 0;
+            swapTimingSamples = 0;
+            waitTimingSamples = 0;
+            skippedWaits = 0;
+        }
+
+        private static double ticksToMilliseconds(double ticks)
+            => ticks * 1000 / Stopwatch.Frequency;
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
@@ -1,0 +1,247 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    internal enum VeldridPipelineKind
+    {
+        Graphics,
+        BufferUpdate,
+        TextureUpload,
+    }
+
+    internal enum VeldridResourceSetKind
+    {
+        Texture,
+        Uniform,
+        ShaderStorage,
+    }
+
+    internal static class VeldridInstrumentation
+    {
+        public static bool Enabled => FrameworkEnvironment.LogVeldridFrameTimings;
+
+        private static readonly object sync = new object();
+
+        private static readonly GlobalStatistic<double> stat_graphics_submit_count = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Graphics submits/frame");
+        private static readonly GlobalStatistic<double> stat_graphics_submit_ms = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Graphics submit ms/frame");
+        private static readonly GlobalStatistic<double> stat_buffer_update_submit_count = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Buffer update submits/frame");
+        private static readonly GlobalStatistic<double> stat_buffer_update_submit_ms = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Buffer update submit ms/frame");
+        private static readonly GlobalStatistic<double> stat_texture_upload_submit_count = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Texture upload submits/frame");
+        private static readonly GlobalStatistic<double> stat_texture_upload_submit_ms = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Texture upload submit ms/frame");
+        private static readonly GlobalStatistic<double> stat_texture_upload_flush_count = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Texture upload flushes/frame");
+        private static readonly GlobalStatistic<double> stat_pipeline_cache_hits = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Pipeline cache hits/frame");
+        private static readonly GlobalStatistic<double> stat_pipeline_cache_misses = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Pipeline cache misses/frame");
+        private static readonly GlobalStatistic<double> stat_pipeline_creates = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Pipelines created/frame");
+        private static readonly GlobalStatistic<double> stat_texture_resource_set_creates = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Texture resource sets/frame");
+        private static readonly GlobalStatistic<double> stat_uniform_resource_set_creates = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Uniform resource sets/frame");
+        private static readonly GlobalStatistic<double> stat_shader_storage_resource_set_creates = GlobalStatistics.Get<double>(nameof(VeldridRenderer), "Shader storage resource sets/frame");
+
+        private static readonly GlobalStatistic<long> stat_total_graphics_submits = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total graphics submits");
+        private static readonly GlobalStatistic<long> stat_total_buffer_update_submits = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total buffer update submits");
+        private static readonly GlobalStatistic<long> stat_total_texture_upload_submits = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total texture upload submits");
+        private static readonly GlobalStatistic<long> stat_total_texture_upload_flushes = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total texture upload flushes");
+        private static readonly GlobalStatistic<long> stat_total_pipeline_cache_hits = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total pipeline cache hits");
+        private static readonly GlobalStatistic<long> stat_total_pipeline_cache_misses = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total pipeline cache misses");
+        private static readonly GlobalStatistic<long> stat_total_pipeline_creates = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total pipelines created (windowed)");
+        private static readonly GlobalStatistic<long> stat_total_texture_resource_sets = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total texture resource sets");
+        private static readonly GlobalStatistic<long> stat_total_uniform_resource_sets = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total uniform resource sets");
+        private static readonly GlobalStatistic<long> stat_total_shader_storage_resource_sets = GlobalStatistics.Get<long>(nameof(VeldridRenderer), "Total shader storage resource sets");
+
+        private static int framesInWindow;
+        private static long graphicsSubmitCountWindow;
+        private static long graphicsSubmitTicksWindow;
+        private static long bufferUpdateSubmitCountWindow;
+        private static long bufferUpdateSubmitTicksWindow;
+        private static long textureUploadSubmitCountWindow;
+        private static long textureUploadSubmitTicksWindow;
+        private static long textureUploadFlushCountWindow;
+        private static long pipelineCacheHitWindow;
+        private static long pipelineCacheMissWindow;
+        private static long pipelineCreateWindow;
+        private static long textureResourceSetCreateWindow;
+        private static long uniformResourceSetCreateWindow;
+        private static long shaderStorageResourceSetCreateWindow;
+
+        public static void RecordSubmit(VeldridPipelineKind kind, long elapsedTicks)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                switch (kind)
+                {
+                    case VeldridPipelineKind.Graphics:
+                        graphicsSubmitCountWindow++;
+                        graphicsSubmitTicksWindow += elapsedTicks;
+                        stat_total_graphics_submits.Value++;
+                        break;
+
+                    case VeldridPipelineKind.BufferUpdate:
+                        bufferUpdateSubmitCountWindow++;
+                        bufferUpdateSubmitTicksWindow += elapsedTicks;
+                        stat_total_buffer_update_submits.Value++;
+                        break;
+
+                    case VeldridPipelineKind.TextureUpload:
+                        textureUploadSubmitCountWindow++;
+                        textureUploadSubmitTicksWindow += elapsedTicks;
+                        stat_total_texture_upload_submits.Value++;
+                        break;
+                }
+            }
+        }
+
+        public static void RecordTextureUploadFlush()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                textureUploadFlushCountWindow++;
+                stat_total_texture_upload_flushes.Value++;
+            }
+        }
+
+        public static void RecordPipelineCacheHit()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                pipelineCacheHitWindow++;
+                stat_total_pipeline_cache_hits.Value++;
+            }
+        }
+
+        public static void RecordPipelineCacheMiss()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                pipelineCacheMissWindow++;
+                stat_total_pipeline_cache_misses.Value++;
+            }
+        }
+
+        public static void RecordPipelineCreated()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                pipelineCreateWindow++;
+                stat_total_pipeline_creates.Value++;
+            }
+        }
+
+        public static void RecordResourceSetCreated(VeldridResourceSetKind kind)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                switch (kind)
+                {
+                    case VeldridResourceSetKind.Texture:
+                        textureResourceSetCreateWindow++;
+                        stat_total_texture_resource_sets.Value++;
+                        break;
+
+                    case VeldridResourceSetKind.Uniform:
+                        uniformResourceSetCreateWindow++;
+                        stat_total_uniform_resource_sets.Value++;
+                        break;
+
+                    case VeldridResourceSetKind.ShaderStorage:
+                        shaderStorageResourceSetCreateWindow++;
+                        stat_total_shader_storage_resource_sets.Value++;
+                        break;
+                }
+            }
+        }
+
+        public static void EndFrame(GraphicsSurfaceType surfaceType)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                framesInWindow++;
+
+                if (framesInWindow % 240 != 0)
+                    return;
+
+                double graphicsSubmitsPerFrame = graphicsSubmitCountWindow / (double)framesInWindow;
+                double bufferUpdateSubmitsPerFrame = bufferUpdateSubmitCountWindow / (double)framesInWindow;
+                double textureUploadSubmitsPerFrame = textureUploadSubmitCountWindow / (double)framesInWindow;
+                double textureUploadFlushesPerFrame = textureUploadFlushCountWindow / (double)framesInWindow;
+                double pipelineHitsPerFrame = pipelineCacheHitWindow / (double)framesInWindow;
+                double pipelineMissesPerFrame = pipelineCacheMissWindow / (double)framesInWindow;
+                double pipelineCreatesPerFrame = pipelineCreateWindow / (double)framesInWindow;
+                double textureResourceSetsPerFrame = textureResourceSetCreateWindow / (double)framesInWindow;
+                double uniformResourceSetsPerFrame = uniformResourceSetCreateWindow / (double)framesInWindow;
+                double shaderStorageResourceSetsPerFrame = shaderStorageResourceSetCreateWindow / (double)framesInWindow;
+
+                double graphicsSubmitMs = ticksToMilliseconds(graphicsSubmitTicksWindow / (double)Math.Max(1, graphicsSubmitCountWindow));
+                double bufferUpdateSubmitMs = ticksToMilliseconds(bufferUpdateSubmitTicksWindow / (double)Math.Max(1, bufferUpdateSubmitCountWindow));
+                double textureUploadSubmitMs = ticksToMilliseconds(textureUploadSubmitTicksWindow / (double)Math.Max(1, textureUploadSubmitCountWindow));
+
+                stat_graphics_submit_count.Value = graphicsSubmitsPerFrame;
+                stat_graphics_submit_ms.Value = graphicsSubmitMs;
+                stat_buffer_update_submit_count.Value = bufferUpdateSubmitsPerFrame;
+                stat_buffer_update_submit_ms.Value = bufferUpdateSubmitMs;
+                stat_texture_upload_submit_count.Value = textureUploadSubmitsPerFrame;
+                stat_texture_upload_submit_ms.Value = textureUploadSubmitMs;
+                stat_texture_upload_flush_count.Value = textureUploadFlushesPerFrame;
+                stat_pipeline_cache_hits.Value = pipelineHitsPerFrame;
+                stat_pipeline_cache_misses.Value = pipelineMissesPerFrame;
+                stat_pipeline_creates.Value = pipelineCreatesPerFrame;
+                stat_texture_resource_set_creates.Value = textureResourceSetsPerFrame;
+                stat_uniform_resource_set_creates.Value = uniformResourceSetsPerFrame;
+                stat_shader_storage_resource_set_creates.Value = shaderStorageResourceSetsPerFrame;
+
+                Logger.Log(
+                    $"Veldrid workload summary ({surfaceType}): graphics_submit={graphicsSubmitsPerFrame:0.###}/f@{graphicsSubmitMs:0.###}ms, " +
+                    $"buffer_submit={bufferUpdateSubmitsPerFrame:0.###}/f@{bufferUpdateSubmitMs:0.###}ms, " +
+                    $"texture_submit={textureUploadSubmitsPerFrame:0.###}/f@{textureUploadSubmitMs:0.###}ms, " +
+                    $"texture_flush={textureUploadFlushesPerFrame:0.###}/f, " +
+                    $"pipeline_cache={pipelineHitsPerFrame:0.###}h/{pipelineMissesPerFrame:0.###}m/{pipelineCreatesPerFrame:0.###}c, " +
+                    $"resource_sets tex={textureResourceSetsPerFrame:0.###}/f uni={uniformResourceSetsPerFrame:0.###}/f ssbo={shaderStorageResourceSetsPerFrame:0.###}/f",
+                    level: LogLevel.Important);
+
+                framesInWindow = 0;
+                graphicsSubmitCountWindow = 0;
+                graphicsSubmitTicksWindow = 0;
+                bufferUpdateSubmitCountWindow = 0;
+                bufferUpdateSubmitTicksWindow = 0;
+                textureUploadSubmitCountWindow = 0;
+                textureUploadSubmitTicksWindow = 0;
+                textureUploadFlushCountWindow = 0;
+                pipelineCacheHitWindow = 0;
+                pipelineCacheMissWindow = 0;
+                pipelineCreateWindow = 0;
+                textureResourceSetCreateWindow = 0;
+                uniformResourceSetCreateWindow = 0;
+                shaderStorageResourceSetCreateWindow = 0;
+            }
+        }
+
+        private static double ticksToMilliseconds(double ticks)
+            => ticks * 1000 / Stopwatch.Frequency;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -17,6 +18,7 @@ using osu.Framework.Graphics.Veldrid.Pipelines;
 using osu.Framework.Graphics.Veldrid.Shaders;
 using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Graphics.Veldrid.Vertices;
+using osu.Framework.Logging;
 using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
@@ -77,11 +79,20 @@ namespace osu.Framework.Graphics.Veldrid
         {
             veldridDevice = new VeldridDevice(graphicsSurface);
             graphicsPipeline = new GraphicsPipeline(veldridDevice);
-            bufferUpdatePipeline = new BasicPipeline(veldridDevice);
-            textureUploadPipeline = new BasicPipeline(veldridDevice);
+            bufferUpdatePipeline = new BasicPipeline(veldridDevice, VeldridPipelineKind.BufferUpdate);
+            textureUploadPipeline = new BasicPipeline(veldridDevice, VeldridPipelineKind.TextureUpload);
             stagingTexturePool = new VeldridStagingTexturePool(graphicsPipeline);
 
             MaxTextureSize = veldridDevice.MaxTextureSize;
+
+            if (FrameworkEnvironment.LogVeldridFrameTimings && RuntimeInfo.OS == RuntimeInfo.Platform.macOS && SurfaceType == GraphicsSurfaceType.Metal)
+            {
+                Logger.Log(
+                    shouldFlushTextureUploadBeforeDraw()
+                        ? "Using conservative pre-draw texture upload flushes on macOS Metal."
+                        : "Using batched texture upload flushes on native Apple Silicon Metal.",
+                    level: LogLevel.Important);
+            }
         }
 
         protected internal override void BeginFrame(Vector2 windowSize)
@@ -105,6 +116,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             bufferUpdatePipeline.End();
             graphicsPipeline.End();
+            VeldridInstrumentation.EndFrame(SurfaceType);
         }
 
         protected internal override void SwapBuffers()
@@ -166,12 +178,12 @@ namespace osu.Framework.Graphics.Veldrid
 
         public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)
         {
-            // normally we would flush/submit all texture upload commands at the end of the frame, since no actual rendering by the GPU will happen until then,
-            // but turns out on macOS with non-apple GPU, this results in rendering corruption.
-            // flushing the texture upload commands here before a draw call fixes the corruption, and there's no explanation as to why that's the case,
-            // but there is nothing to be lost in flushing here except for a frame that contains many sprites with Texture.BypassTextureUploadQueue = true.
-            // until that appears to be problem, let's just flush here.
-            flushTextureUploadPipeline();
+            if (shouldFlushTextureUploadBeforeDraw())
+            {
+                // Keep the historical workaround on Intel/unknown macOS Metal devices where batched uploads have shown corruption.
+                // Native Apple Silicon Metal can batch uploads until the end of the frame.
+                flushTextureUploadPipeline();
+            }
 
             graphicsPipeline.DrawVertices(topology.ToPrimitiveTopology(), vertexStart, verticesCount);
         }
@@ -211,6 +223,17 @@ namespace osu.Framework.Graphics.Veldrid
 
             textureUploadPipeline.End();
             beganTextureUploadPipeline = false;
+            VeldridInstrumentation.RecordTextureUploadFlush();
+        }
+
+        private bool shouldFlushTextureUploadBeforeDraw()
+        {
+            if (FrameworkEnvironment.ForceMacOSPreDrawTextureUploadFlush.HasValue)
+                return FrameworkEnvironment.ForceMacOSPreDrawTextureUploadFlush.Value;
+
+            return RuntimeInfo.OS == RuntimeInfo.Platform.macOS
+                   && SurfaceType == GraphicsSurfaceType.Metal
+                   && RuntimeInformation.ProcessArchitecture != Architecture.Arm64;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add opt-in Veldrid workload instrumentation for submit timing, pipeline cache churn, texture upload flushes, and resource set creation
- cache shader-storage `ResourceSet`s instead of allocating them per bind
- keep the historical macOS pre-draw texture-upload flush workaround on Intel/unknown Macs, but batch uploads by default on native Apple Silicon Metal

## Why
Apple Silicon benchmarking showed that the earlier non-vsync Metal pacing fix restored throughput, but there was still backend-side churn worth removing in the shared Veldrid path. This change focuses on low-risk work first:
- preserve the current Metal throughput win
- reduce unnecessary hot-path allocation and flush behaviour
- improve observability so future Apple Silicon work can target the remaining bottlenecks with better evidence

## Benchmark notes
Quick local Apple Silicon benchmark scenario:
- native macOS arm64
- `Metal + Limit2x + MultiThreaded`
- short deterministic autoplay gameplay run

Observed results after this change:
- `Metal + Limit2x` kept the current throughput win: draw median stayed at `241`
- Metal gameplay working set improved slightly: `426.09 MiB -> 424.03 MiB`
- Metal menu-idle resource usage improved:
  - CPU median `4.259% -> 3.919%`
  - working set median `391.64 MiB -> 368.62 MiB`
- `Deferred_Metal` remains heavier than non-deferred Metal in the same scenario, which suggests further work is likely deeper than the shared submit/upload path

The new instrumentation also shows that on the benchmark path:
- graphics submits are about `1/frame`
- buffer-update submits are about `1/frame`
- texture-upload flushes dropped to roughly `0.03-0.19/frame`
- shader-storage resource-set creation is no longer on the hot path in this scenario

## Validation
- `dotnet test osu.Desktop.Tests/osu.Desktop.Tests.csproj -c Release --no-restore`
