### PR TITLE
Allow configuring audio latency with an env variable

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -379,13 +379,14 @@ namespace osu.Framework.Audio
         /// <param name="device">The device to initialise.</param>
         protected virtual bool InitBass(int device)
         {
-            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int devPeriod))
+            int devicePeriod = 0;
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux && int.TryParse(Environment.GetEnvironmentVariable("OSU_TEMP_TESTING_BASS_CONFIG_DEV_PERIOD"), out devicePeriod))
             {
-                Logger.Log("Environment variable for audio detected, in case of audio issues unset it.", level: LogLevel.Important);
+                Logger.Log("Experimental environment variable for setting audio latency detected, in case of issues unset it.", level: LogLevel.Important);
                 // Device period normally is in milliseconds, but it might be set to a negative
                 // value too for an exact sample size, e.g. -256 for 256 samples.
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
-                Bass.Configure(ManagedBass.Configuration.DevicePeriod, devPeriod);
+                Bass.Configure(ManagedBass.Configuration.DevicePeriod, devicePeriod);
                 // 1ms is definitely too low, but we're setting such low number on purpose,
                 // in order for BASS to automatically set it to twice the length of BASS_CONFIG_DEV_PERIOD,
                 // This behaviour is documented.
@@ -459,7 +460,7 @@ namespace osu.Framework.Audio
                           BASS MIX version:       {BassMix.Version}
                           Device:                 {deviceInfo.Name}
                           Driver:                 {deviceInfo.Driver}
-                          Device period length:   {devPeriod}
+                          Device period length:   {devicePeriod}
                           Device buffer length:   {Bass.DeviceBufferLength} ms
                           Update period:          {Bass.UpdatePeriod} ms
                           Playback buffer length: {Bass.PlaybackBufferLength} ms");

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -379,7 +379,8 @@ namespace osu.Framework.Audio
         /// <param name="device">The device to initialise.</param>
         protected virtual bool InitBass(int device)
         {
-            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int devPeriod)) {
+            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int devPeriod))
+            {
                 Logger.Log($"Environment variable for audio detected, in case of audio issues unset it.", level: LogLevel.Important);
                 // Device period normally is in milliseconds, but it might be set to a negative
                 // value too for an exact sample size, e.g. -256 for 256 samples.
@@ -390,10 +391,11 @@ namespace osu.Framework.Audio
                 // This behaviour is documented.
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
                 Bass.DeviceBufferLength = 1;
-            } else {
+            }
+            else
                 // reduce latency to a known sane minimum.
                 Bass.DeviceBufferLength = 10;
-            }
+
 
             // These two likely don't have any effect because we set StreamSystem.NoBuffer on audio streams.
             Bass.UpdatePeriod = 5;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -379,15 +379,21 @@ namespace osu.Framework.Audio
         /// <param name="device">The device to initialise.</param>
         protected virtual bool InitBass(int device)
         {
-            // Setting lower value here reduces audio latency, bit it might cause choppy playback, depending on hardware.
-            int devicePeriodSizeMs = int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int x1) ? x1 : 10;
-
-            // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
-            Bass.Configure((ManagedBass.Configuration)53, devicePeriodSizeMs);
-
-            // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
-            // This has to be a multiple of device period, at least 2x.
-            Bass.DeviceBufferLength = devicePeriodSizeMs * 2;
+            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int devPeriod)) {
+                Logger.Log($"Environment variable for audio detected, in case of audio issues unset it.", level: LogLevel.Important);
+                // Device period normally is in milliseconds, but it might be set to a negative
+                // value too for an exact sample size, e.g. -256 for 256 samples.
+                // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
+                Bass.Configure(ManagedBass.Configuration.DevicePeriod, devPeriod);
+                // 1ms is definitely too low, but we're setting such low number on purpose,
+                // in order for BASS to automatically set it to twice the length of OSU_BASS_CONFIG_DEV_PERIOD,
+                // This behaviour is documented.
+                // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
+                Bass.DeviceBufferLength = 1;
+            } else {
+                // reduce latency to a known sane minimum.
+                Bass.DeviceBufferLength = 10;
+            }
 
             // These two likely don't have any effect because we set StreamSystem.NoBuffer on audio streams.
             Bass.UpdatePeriod = 5;
@@ -450,7 +456,7 @@ namespace osu.Framework.Audio
                           BASS MIX version:       {BassMix.Version}
                           Device:                 {deviceInfo.Name}
                           Driver:                 {deviceInfo.Driver}
-                          Device period length:   {devicePeriodSizeMs} ms
+                          Device period length:   {devPeriod}
                           Device buffer length:   {Bass.DeviceBufferLength} ms
                           Update period:          {Bass.UpdatePeriod} ms
                           Playback buffer length: {Bass.PlaybackBufferLength} ms");

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -386,7 +386,7 @@ namespace osu.Framework.Audio
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
                 Bass.Configure(ManagedBass.Configuration.DevicePeriod, devPeriod);
                 // 1ms is definitely too low, but we're setting such low number on purpose,
-                // in order for BASS to automatically set it to twice the length of OSU_BASS_CONFIG_DEV_PERIOD,
+                // in order for BASS to automatically set it to twice the length of BASS_CONFIG_DEV_PERIOD,
                 // This behaviour is documented.
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
                 Bass.DeviceBufferLength = 1;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -379,11 +379,18 @@ namespace osu.Framework.Audio
         /// <param name="device">The device to initialise.</param>
         protected virtual bool InitBass(int device)
         {
-            // this likely doesn't help us but also doesn't seem to cause any issues or any cpu increase.
-            Bass.UpdatePeriod = 5;
+            // Setting lower value here reduces audio latency, bit it might cause choppy playback, depending on hardware.
+            int devicePeriodSizeMs = int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int x1) ? x1 : 10;
 
-            // reduce latency to a known sane minimum.
-            Bass.DeviceBufferLength = 10;
+            // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
+            Bass.Configure((ManagedBass.Configuration)53, devicePeriodSizeMs);
+
+            // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
+            // This has to be a multiple of device period, at least 2x.
+            Bass.DeviceBufferLength = devicePeriodSizeMs * 2;
+
+            // These two likely don't have any effect because we set StreamSystem.NoBuffer on audio streams.
+            Bass.UpdatePeriod = 5;
             Bass.PlaybackBufferLength = 100;
 
             // ensure there are no brief delays on audio operations (causing stream stalls etc.) after periods of silence.
@@ -443,8 +450,9 @@ namespace osu.Framework.Audio
                           BASS MIX version:       {BassMix.Version}
                           Device:                 {deviceInfo.Name}
                           Driver:                 {deviceInfo.Driver}
-                          Update period:          {Bass.UpdatePeriod} ms
+                          Device period length:   {devicePeriodSizeMs} ms
                           Device buffer length:   {Bass.DeviceBufferLength} ms
+                          Update period:          {Bass.UpdatePeriod} ms
                           Playback buffer length: {Bass.PlaybackBufferLength} ms");
 
                 return true;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -381,7 +381,7 @@ namespace osu.Framework.Audio
         {
             if (int.TryParse(Environment.GetEnvironmentVariable("OSU_BASS_CONFIG_DEV_PERIOD"), out int devPeriod))
             {
-                Logger.Log($"Environment variable for audio detected, in case of audio issues unset it.", level: LogLevel.Important);
+                Logger.Log("Environment variable for audio detected, in case of audio issues unset it.", level: LogLevel.Important);
                 // Device period normally is in milliseconds, but it might be set to a negative
                 // value too for an exact sample size, e.g. -256 for 256 samples.
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
@@ -393,9 +393,10 @@ namespace osu.Framework.Audio
                 Bass.DeviceBufferLength = 1;
             }
             else
+            {
                 // reduce latency to a known sane minimum.
                 Bass.DeviceBufferLength = 10;
-
+            }
 
             // These two likely don't have any effect because we set StreamSystem.NoBuffer on audio streams.
             Bass.UpdatePeriod = 5;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -379,10 +379,11 @@ namespace osu.Framework.Audio
         /// <param name="device">The device to initialise.</param>
         protected virtual bool InitBass(int device)
         {
-            int devicePeriod = 0;
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux && int.TryParse(Environment.GetEnvironmentVariable("OSU_TEMP_TESTING_BASS_CONFIG_DEV_PERIOD"), out devicePeriod))
+            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_TEMP_TESTING_BASS_CONFIG_DEV_PERIOD"), out int devicePeriod))
             {
-                Logger.Log($"Device period is set to \"{devicePeriod}\" via environment variable for testing purposes.\n\nThis is made available for testing so we can gather feedback on how to incorporate as a permanent game setting. Incorrect settings may lead to serious issues.", level: LogLevel.Important);
+                Logger.Log(
+                    $"Device period is set to \"{devicePeriod}\" via environment variable for testing purposes.\n\nThis is made available for testing so we can gather feedback on how to incorporate as a permanent game setting. Incorrect settings may lead to serious issues.",
+                    level: LogLevel.Important);
 
                 // Device period normally is in milliseconds, but it might be set to a negative
                 // value too for an exact sample size, e.g. -256 for 256 samples.

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -382,15 +382,17 @@ namespace osu.Framework.Audio
             int devicePeriod = 0;
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux && int.TryParse(Environment.GetEnvironmentVariable("OSU_TEMP_TESTING_BASS_CONFIG_DEV_PERIOD"), out devicePeriod))
             {
-                Logger.Log("Experimental environment variable for setting audio latency detected, in case of issues unset it.", level: LogLevel.Important);
+                Logger.Log($"Device period is set to \"{devicePeriod}\" via environment variable for testing purposes.\n\nThis is made available for testing so we can gather feedback on how to incorporate as a permanent game setting. Incorrect settings may lead to serious issues.", level: LogLevel.Important);
+
                 // Device period normally is in milliseconds, but it might be set to a negative
                 // value too for an exact sample size, e.g. -256 for 256 samples.
                 // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_PERIOD.html
                 Bass.Configure(ManagedBass.Configuration.DevicePeriod, devicePeriod);
+
                 // 1ms is definitely too low, but we're setting such low number on purpose,
-                // in order for BASS to automatically set it to twice the length of BASS_CONFIG_DEV_PERIOD,
-                // This behaviour is documented.
-                // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
+                // in order for BASS to automatically set it to twice the length of BASS_CONFIG_DEV_PERIOD.
+                //
+                // See https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
                 Bass.DeviceBufferLength = 1;
             }
             else


### PR DESCRIPTION
This allows setting latency below currently unchangeable 20 ms audio device buffer by setting an environment variable `OSU_TEMP_TESTING_BASS_CONFIG_DEV_PERIOD`.

Resolves #6647

Previously there was an attempt at a similar change in https://github.com/ppy/osu-framework/pull/4008, except it tried adding in-game settings. From my understanding it didn't work out because we don't want casual users to have access game-breaking settings. It makes sense.
Environment variable on the other hand is less visible, and usually noobs won't be able to just set it mindlessly and break their game lol.

Tested in osu on Linux + ALSA exclusive mode, per instructions [in this comment](https://github.com/ppy/osu/discussions/30527#discussioncomment-16215544). 
I have not tested on other platforms (sorry! please someone else do)

Before (raw ALSA device):
```
$ cat /proc/asound/card*/pcm*/sub*/hw_params
access: MMAP_INTERLEAVED
format: S32_LE
subformat: STD
channels: 2
rate: 44100 (44100/1)
period_size: 441
buffer_size: 882
```

After (raw ALSA device + `OSU_BASS_CONFIG_DEV_PERIOD=2`):

```
$ cat /proc/asound/card*/pcm*/sub*/hw_params
access: MMAP_INTERLEAVED
format: S32_LE
subformat: STD
channels: 2
rate: 44100 (44100/1)
period_size: 88
buffer_size: 176
```

Value of `10` (ms for period_size, 20ms for buffer_size) is the default currently for raw ALSA devices output for me on Linux running the latest tachyon release (2026.318.0-tachyon).
I can set as low as `2` on my machine but `1` does chop terribly.
I run RT kernel FWIW. This will vary for on different hardware of course.

Edit: with the lastest commit, by setting `OSU_BASS_CONFIG_DEV_PERIOD=-64` I can lower it even more to `period_size=64, buffer_size=128`.

Edit 2: real measurements here: https://github.com/ppy/osu-framework/issues/6647#issuecomment-4114578725