### PR TITLE
Fix audio component enqueued actions potentially executing out-of-order in single thread mode

### DIFF
--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -72,6 +73,56 @@ namespace osu.Framework.Tests.Audio
             });
 
             AddAssert("track has 0 volume", () => track.AggregateVolume.Value == 0);
+        }
+
+        // this test attempts to exercise that `DrawableTrack` is safe to initialise in BDL via a specific sequence of steps.
+        // while it may seem farfetched, there are reasonable game-side usages that may hit this same pattern
+        // (example: https://github.com/ppy/osu/blob/5b6d2155835d2682d2599b4dc5c7b3a2e61b73a8/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs).
+        //
+        // if this test is going to fail, it will fail in single thread mode.
+        [Test]
+        public void TestAsyncLoadComponentWithTrack()
+        {
+            var component = new ComponentWithTrack();
+
+            AddStep("create component with track", () =>
+            {
+                // async load our `ComponentWithTrack`.
+                // this is important because we want to provoke `TrackBass`'s ctor to be actually enqueued for execution on audio thread later
+                // and not accidentally inlined due to being on update or audio thread.
+                LoadComponentAsync(component, t => Child = t);
+
+                // with the async load started, attempt to start the track as soon as it's initialised in the component.
+                // notably we're on the update thread here.
+                // the expectation is that all track initialisation logic runs *before* the track start is attempted.
+                while (!component.StartTrack())
+                {
+                }
+            });
+            AddUntilStep("wait for running", () => component.IsRunning);
+        }
+
+        private partial class ComponentWithTrack : CompositeDrawable
+        {
+            [CanBeNull]
+            private DrawableTrack track;
+
+            public bool IsRunning => track?.IsRunning == true;
+
+            [BackgroundDependencyLoader]
+            private void load(ITrackStore trackStore)
+            {
+                AddInternal(track = new DrawableTrack(trackStore.Get("sample-track")));
+            }
+
+            public bool StartTrack()
+            {
+                if (track == null)
+                    return false;
+
+                track.Start();
+                return true;
+            }
         }
     }
 }

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Platform;
@@ -40,6 +41,7 @@ namespace osu.Framework.Audio
         {
             if (CanPerformInline)
             {
+                flushEnqueuedActions();
                 action();
                 return Task.CompletedTask;
             }
@@ -79,18 +81,40 @@ namespace osu.Framework.Audio
             FrameStatistics.Add(StatisticsCounterType.TasksRun, PendingActions.Count);
             FrameStatistics.Increment(StatisticsCounterType.Components);
 
-            while (!IsDisposed && PendingActions.TryDequeue(out Task task))
+            flushEnqueuedActions();
+
+            if (!IsDisposed)
+                UpdateState();
+
+            UpdateChildren();
+        }
+
+        private void flushEnqueuedActions()
+        {
+            // this early guard is important for avoiding allocs lower down
+            if (PendingActions.IsEmpty)
+                return;
+
+            // some enqueued actions will call other enqueued actions inside of them and expect them to be executed inline.
+            // this requires careful handling during the flush because there is a possibility of call reordering.
+            // example:
+            // - enqueued operation A => calls enqueued operation B
+            // - enqueued operation C
+            // expected call order is A => B => C, but the naive implementation will:
+            // - call A
+            // - inside A call it will trigger enqueue of B
+            // - but because B is expected to be inlined, the naive implementation would attempt to flush first, therefore inadvertently executing C before itself
+            // ending in an incorrect call order of A => C => B.
+            // to avoid this, completely consume / substitute the task queue such that B no longer sees C as enqueued.
+            var actions = Interlocked.Exchange(ref PendingActions, new ConcurrentQueue<Task>());
+
+            while (!IsDisposed && actions.TryDequeue(out Task task))
             {
                 task.RunSynchronously();
 
                 if (task.Exception != null)
                     ExceptionDispatchInfo.Throw(task.Exception);
             }
-
-            if (!IsDisposed)
-                UpdateState();
-
-            UpdateChildren();
         }
 
         /// <summary>


### PR DESCRIPTION
RFC

The issue this is trying to fix is the root cause of game-side test failures as seen in https://github.com/ppy/osu/actions/runs/23890777748#user-content-r1s1.

Has been discussed at length elsewhere and I'd rather not repeat myself as to why and where and how; the test added here explains some of that anyway.

This incurs extra memory allocations. As to how much to worry about it, I'm unsure. I did quick profiling with game via a set sequence of actions:

<details>

<summary>see description of sequence of actions</summary>

- launch game
- go into song select
- switch song like 3 times
- put DT on
- play [seal.mp4](https://dev.ppy.sh/beatmapsets/386151#osu/843308)
- go back to song select, play and pause track via music controller like 3 times
- quit

</details>

The allocs are not negligible but they're not "top 5 allocs by type" for `AudioComponent` so my feelings are very much mixed.

| all allocations by `AudioComponent`, master | all allocations by `AudioComponent`, this PR | allocs incurred by `flushEnqueuedActions()` specifically |
| :-: | :-: | :-: |
| <img width="1255" height="527" alt="Screenshot 2026-04-03 at 12 53 10" src="https://github.com/user-attachments/assets/740efdfe-93c2-4910-a32a-c9f10fc9bf5a" /> | <img width="1262" height="527" alt="Screenshot 2026-04-03 at 12 53 47" src="https://github.com/user-attachments/assets/5bb9cf41-2699-40fe-9d06-40d29f888a66" /> | <img width="1260" height="527" alt="Screenshot 2026-04-03 at 12 54 21" src="https://github.com/user-attachments/assets/d99e995f-42f5-44a4-88f6-c0ba27163c31" /> |