### PR TITLE
Revert "Fix audio component enqueued actions potentially executing out-of-order in single thread mode"

### DIFF
--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -73,56 +72,6 @@ namespace osu.Framework.Tests.Audio
             });
 
             AddAssert("track has 0 volume", () => track.AggregateVolume.Value == 0);
-        }
-
-        // this test attempts to exercise that `DrawableTrack` is safe to initialise in BDL via a specific sequence of steps.
-        // while it may seem farfetched, there are reasonable game-side usages that may hit this same pattern
-        // (example: https://github.com/ppy/osu/blob/5b6d2155835d2682d2599b4dc5c7b3a2e61b73a8/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/BackgroundMusicManager.cs).
-        //
-        // if this test is going to fail, it will fail in single thread mode.
-        [Test]
-        public void TestAsyncLoadComponentWithTrack()
-        {
-            var component = new ComponentWithTrack();
-
-            AddStep("create component with track", () =>
-            {
-                // async load our `ComponentWithTrack`.
-                // this is important because we want to provoke `TrackBass`'s ctor to be actually enqueued for execution on audio thread later
-                // and not accidentally inlined due to being on update or audio thread.
-                LoadComponentAsync(component, t => Child = t);
-
-                // with the async load started, attempt to start the track as soon as it's initialised in the component.
-                // notably we're on the update thread here.
-                // the expectation is that all track initialisation logic runs *before* the track start is attempted.
-                while (!component.StartTrack())
-                {
-                }
-            });
-            AddUntilStep("wait for running", () => component.IsRunning);
-        }
-
-        private partial class ComponentWithTrack : CompositeDrawable
-        {
-            [CanBeNull]
-            private DrawableTrack track;
-
-            public bool IsRunning => track?.IsRunning == true;
-
-            [BackgroundDependencyLoader]
-            private void load(ITrackStore trackStore)
-            {
-                AddInternal(track = new DrawableTrack(trackStore.Get("sample-track")));
-            }
-
-            public bool StartTrack()
-            {
-                if (track == null)
-                    return false;
-
-                track.Start();
-                return true;
-            }
         }
     }
 }

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
-using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Platform;
@@ -41,7 +40,6 @@ namespace osu.Framework.Audio
         {
             if (CanPerformInline)
             {
-                flushEnqueuedActions();
                 action();
                 return Task.CompletedTask;
             }
@@ -81,40 +79,18 @@ namespace osu.Framework.Audio
             FrameStatistics.Add(StatisticsCounterType.TasksRun, PendingActions.Count);
             FrameStatistics.Increment(StatisticsCounterType.Components);
 
-            flushEnqueuedActions();
-
-            if (!IsDisposed)
-                UpdateState();
-
-            UpdateChildren();
-        }
-
-        private void flushEnqueuedActions()
-        {
-            // this early guard is important for avoiding allocs lower down
-            if (PendingActions.IsEmpty)
-                return;
-
-            // some enqueued actions will call other enqueued actions inside of them and expect them to be executed inline.
-            // this requires careful handling during the flush because there is a possibility of call reordering.
-            // example:
-            // - enqueued operation A => calls enqueued operation B
-            // - enqueued operation C
-            // expected call order is A => B => C, but the naive implementation will:
-            // - call A
-            // - inside A call it will trigger enqueue of B
-            // - but because B is expected to be inlined, the naive implementation would attempt to flush first, therefore inadvertently executing C before itself
-            // ending in an incorrect call order of A => C => B.
-            // to avoid this, completely consume / substitute the task queue such that B no longer sees C as enqueued.
-            var actions = Interlocked.Exchange(ref PendingActions, new ConcurrentQueue<Task>());
-
-            while (!IsDisposed && actions.TryDequeue(out Task task))
+            while (!IsDisposed && PendingActions.TryDequeue(out Task task))
             {
                 task.RunSynchronously();
 
                 if (task.Exception != null)
                     ExceptionDispatchInfo.Throw(task.Exception);
             }
+
+            if (!IsDisposed)
+                UpdateState();
+
+            UpdateChildren();
         }
 
         /// <summary>


### PR DESCRIPTION
Reverts ppy/osu-framework#6727 because [game-side CI says it's broken](https://github.com/ppy/osu/actions/runs/24019928154/job/70046733058?pr=37217#step:5:119).