### PR TITLE
Fix unsafe threading in MIDI handler initialisation code

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Commons.Music.Midi;
 using osu.Framework.Extensions;
@@ -26,6 +27,7 @@ namespace osu.Framework.Input.Handlers.Midi
         public override string Description => "MIDI";
         public override bool IsActive => inGoodState;
 
+        private const int lock_acquire_timeout = 100;
         private const int milliseconds_between_device_refresh = 1000;
 
         private bool inGoodState = true;
@@ -33,6 +35,7 @@ namespace osu.Framework.Input.Handlers.Midi
         private ScheduledDelegate scheduledRefreshDevices;
 
         private readonly Dictionary<string, IMidiInput> openedDevices = new Dictionary<string, IMidiInput>();
+        private readonly SemaphoreSlim openedDevicesLock = new SemaphoreSlim(1);
 
         /// <summary>
         /// The last event for each midi device. This is required for Running Status (repeat messages sent without
@@ -51,16 +54,16 @@ namespace osu.Framework.Input.Handlers.Midi
             {
                 if (e.NewValue)
                 {
-                    lastInitTask = Task.Run(() =>
+                    lastInitTask = Task.Run(async () =>
                     {
                         inGoodState = true;
 
                         // First call to this can be expensive (macOS / coremidi) so let's run it on a separate thread.
-                        if (!refreshDevices())
+                        if (!await refreshDevices().ConfigureAwait(false))
                             return;
 
                         host.InputThread.Scheduler.Add(
-                            scheduledRefreshDevices = new ScheduledDelegate(() => refreshDevices(), milliseconds_between_device_refresh, milliseconds_between_device_refresh));
+                            scheduledRefreshDevices = new ScheduledDelegate(() => Task.Run(refreshDevices), milliseconds_between_device_refresh, milliseconds_between_device_refresh));
                     });
                 }
                 else
@@ -69,57 +72,69 @@ namespace osu.Framework.Input.Handlers.Midi
 
                     scheduledRefreshDevices?.Cancel();
 
-                    lock (openedDevices)
+                    if (openedDevicesLock.Wait(lock_acquire_timeout))
                     {
-                        foreach (var device in openedDevices.Values)
-                            closeDevice(device);
+                        try
+                        {
+                            foreach (var device in openedDevices.Values)
+                                closeDevice(device);
 
-                        openedDevices.Clear();
+                            openedDevices.Clear();
+                        }
+                        finally
+                        {
+                            openedDevicesLock.Release(1);
+                        }
                     }
+                    else
+                        Logger.Log($"Failed to acquire {nameof(openedDevicesLock)} on MIDI disable request", LoggingTarget.Input);
                 }
             }, true);
 
             return true;
         }
 
-        private bool refreshDevices()
+        private async Task<bool> refreshDevices()
         {
+            if (!await openedDevicesLock.WaitAsync(lock_acquire_timeout).ConfigureAwait(false))
+            {
+                Logger.Log($"Failed to acquire {nameof(openedDevicesLock)} on MIDI refresh");
+                return false;
+            }
+
             try
             {
-                lock (openedDevices)
+                int accountedDevices = 0;
+
+                foreach (var device in MidiAccessManager.Default.Inputs)
                 {
-                    int accountedDevices = 0;
+                    accountedDevices++;
 
-                    foreach (var device in MidiAccessManager.Default.Inputs)
+                    if (openedDevices.ContainsKey(device.Id))
+                        continue;
+
+                    var newInput = await MidiAccessManager.Default.OpenInputAsync(device.Id).ConfigureAwait(false);
+                    newInput.MessageReceived += onMidiMessageReceived;
+                    openedDevices[device.Id] = newInput;
+
+                    Log($"Connected MIDI device: {newInput.Details.Name}");
+                }
+
+                if (accountedDevices != openedDevices.Count)
+                {
+                    // A device must have gone missing.
+                    // This loop is a bit expensive so only run when we have to.
+                    var inputs = MidiAccessManager.Default.Inputs.ToArray();
+
+                    foreach (string key in openedDevices.Keys.ToArray())
                     {
-                        accountedDevices++;
+                        var device = openedDevices[key];
 
-                        if (openedDevices.ContainsKey(device.Id))
-                            continue;
-
-                        var newInput = MidiAccessManager.Default.OpenInputAsync(device.Id).GetResultSafely();
-                        newInput.MessageReceived += onMidiMessageReceived;
-                        openedDevices[device.Id] = newInput;
-
-                        Log($"Connected MIDI device: {newInput.Details.Name}");
-                    }
-
-                    if (accountedDevices != openedDevices.Count)
-                    {
-                        // A device must have gone missing.
-                        // This loop is a bit expensive so only run when we have to.
-                        var inputs = MidiAccessManager.Default.Inputs.ToArray();
-
-                        foreach (string key in openedDevices.Keys.ToArray())
+                        if (inputs.All(i => i.Id != key))
                         {
-                            var device = openedDevices[key];
-
-                            if (inputs.All(i => i.Id != key))
-                            {
-                                closeDevice(device);
-                                openedDevices.Remove(key);
-                                Log($"Disconnected MIDI device: {device.Details.Name}");
-                            }
+                            closeDevice(device);
+                            openedDevices.Remove(key);
+                            Log($"Disconnected MIDI device: {device.Details.Name}");
                         }
                     }
                 }
@@ -138,6 +153,10 @@ namespace osu.Framework.Input.Handlers.Midi
                 inGoodState = false;
                 scheduledRefreshDevices?.Cancel();
                 return false;
+            }
+            finally
+            {
+                openedDevicesLock.Release(1);
             }
         }
 

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -113,6 +113,8 @@ namespace osu.Framework.Input.Handlers.Midi
                     if (openedDevices.ContainsKey(device.Id))
                         continue;
 
+                    Log($"Attempting to connect MIDI device: {device.Name}");
+
                     var newInput = await MidiAccessManager.Default.OpenInputAsync(device.Id).ConfigureAwait(false);
                     newInput.MessageReceived += onMidiMessageReceived;
                     openedDevices[device.Id] = newInput;
@@ -147,7 +149,7 @@ namespace osu.Framework.Input.Handlers.Midi
                     ? "Is libasound2-dev installed?"
                     : "There may be another application already using MIDI.";
 
-                Log($"MIDI devices could not be enumerated. {message} ({e.Message})");
+                Log($"MIDI devices could not be enumerated. {message}\nException: {e}");
 
                 // stop attempting to refresh devices until next startup.
                 inGoodState = false;


### PR DESCRIPTION
Should close https://github.com/ppy/osu/issues/37154.

This is going to be a long one so I'll attempt to start with the most important.

Why this change?
---

https://github.com/ppy/osu-framework/commit/dc3adbc8dd495763b11ca42ab4515b13af88f7a1 changed MIDI initialisation code such that the first call to MIDI init is done on a TPL pool thread. The TPL pool thread calls `refreshDevices()`. While `refreshDevices()` was a sync method, it was also calling this inside:

https://github.com/ppy/osu-framework/blob/ab389cc4cab166f7836e132a9c2dca4a65e72212/osu.Framework/Input/Handlers/Midi/MidiHandler.cs#L100

*That `GetResultSafely()` is not safe to call in this context of initialisation.* We're on a TPL thread. It is absolutely not fine / deadlock-safe to just call `.Result` here.

In fact I'm rather astounded as to why this went unnoticed for so long. Part of it may be that just nobody uses the MIDI integration, part of it may be that on *macOS it doesn't throw*. My educated guess as to why it doesn't throw is that on macOS coremidi initialisation is synchronous, therefore the `OpenInputAsync()` call is essentially synchronous too, therefore the `.GetResultSafely()` call *doesn't matter* because it is a *no-op if the task has already completed*.

Why did it hard-crash Android?
---

The code doesn't look like anything should hard-crash here. Everything is try-caught, apparently. So why did it just kill Android?

Upstream managed-midi on Android spawns a `Task.Run()` to power `OpenInputAsync()`. This is because Android is, in typical Java fashion, callback class land; you don't have `async` and `await`, you have `IOnDeviceOpenedListener` that Android calls back into after it's done doing the OS setup stuff. So managed-midi wraps this back into TPL `Task`s via spawning a task and using `ManualResetEvent` to signal when the callback has completed.

This means that if `.GetResultSafely()` is going to throw, *it will throw immediately after the task is spawned*. But it's not going to *cancel any of the background work*. So once the `IOnDeviceOpenedListener` fails, and for instance throws an exception, we're now firmly in fire-and-forget land, there is nobody to pick the exception up anymore, and therefore this exception becomes *unobserved*.

Okay, so why does managed-midi die on MIDI init on some phones without MIDI devices even plugged in?
---

This is where my explanations run out and we enter cryptid territory. I have *maybe* a hint of an explanation, but I don't quite get it, and I don't wish to waste even more time following up on it than I already have.

While I was futzing about trying to find out if anything to do with MIDI even worked on my phone, I stumbled upon [this android docs page](https://source.android.com/docs/core/audio/midi_test) with a bunch of links to test apps for MIDI. Just to check against ground truth I grabbed "MidiScope" to verify that my MIDI controller that I own and tested with was  actually working with my Android test device.

Cue my shock and horror as I realised that *the presence of this app on my phone causes the exact same failure as the issue thread*. Like start-to-finish. Same thing, apparently.

I don't know what this app is doing, precisely, but my guess is that it's faking a MIDI input device but it's doing it in a not-quite-correct way. From logcat output, it looks like it's not giving the correct 'port' to open to listen to it, which then leads to some file descriptor open failure, which then leads to Android declaring failure to open this device and returning `null` to managed-midi's `IOnDeviceOpenedListener`, which then would kill the game.

As to what that app might be in the users' case? No idea. I'm not even sure I want to broach that subject at this point.

What's the fix?
---

The fix is to turn `refreshDevices()` fully async so it can actually safely await on the result of the task. Thus the exception returned from managed-midi is never dropped, therefore it will be caught and handled inside the input handler rather than spilling out as an unobserved exception.

A corollary of this is that `lock` sections are replaced with `SemaphoreSlim`, because you can't use `lock` sections in async code.

Final notes
---

- This also adds some extra logging in https://github.com/ppy/osu-framework/commit/13120f95c57ca59c2d2046023a4f96d52f640ece to be able to diagnose failures better.
- Even with this, I would not recommend anyone plug in MIDI devices to Android and try it in game. Currently it will die when you press any note. I have some fixes to PR to managed-midi to fix this (https://github.com/atsushieno/managed-midi/pull/92).