### PR TITLE
Fix audio track playing beyond expiry/disposal in edge cases

### DIFF
--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -30,6 +31,36 @@ namespace osu.Framework.Tests.Audio
         {
             Child = track = new DrawableTrack(trackStore.Get("sample-track"));
         });
+
+        [Test]
+        public void TestStopOnExpire()
+        {
+            SlowDisposer slowDispose = null;
+            AddStep("queue slow disposal", () => AsyncDisposalQueue.Enqueue(slowDispose = new SlowDisposer()));
+
+            AddStep("start playing", () => track.Start());
+            AddUntilStep("wait for runnning", () => track.IsRunning, () => Is.True);
+            AddStep("stop via expire", () => track.Expire());
+            AddUntilStep("wait for not runnning", () => track.IsRunning, () => Is.False);
+
+            AddAssert("track not disposed", () => track.IsDisposed, () => Is.False);
+            AddStep("unblock disposal", () => slowDispose.AllowDisposal());
+            AddUntilStep("track not disposed", () => track.IsDisposed, () => Is.True);
+        }
+
+        private partial class SlowDisposer : Drawable
+        {
+            private readonly ManualResetEventSlim allow = new ManualResetEventSlim();
+
+            public void AllowDisposal() => allow.Set();
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                allow.Wait(60000);
+            }
+        }
 
         [Test]
         public void TestVolumeResetWhenReset()

--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -39,13 +39,13 @@ namespace osu.Framework.Tests.Audio
             AddStep("queue slow disposal", () => AsyncDisposalQueue.Enqueue(slowDispose = new SlowDisposer()));
 
             AddStep("start playing", () => track.Start());
-            AddUntilStep("wait for runnning", () => track.IsRunning, () => Is.True);
+            AddUntilStep("track is running", () => track.IsRunning, () => Is.True);
             AddStep("stop via expire", () => track.Expire());
-            AddUntilStep("wait for not runnning", () => track.IsRunning, () => Is.False);
+            AddUntilStep("track is not running", () => track.IsRunning, () => Is.False);
 
             AddAssert("track not disposed", () => track.IsDisposed, () => Is.False);
-            AddStep("unblock disposal", () => slowDispose.AllowDisposal());
-            AddUntilStep("track not disposed", () => track.IsDisposed, () => Is.True);
+            AddStep("unblock slow disposal", () => slowDispose.AllowDisposal());
+            AddUntilStep("track disposed", () => track.IsDisposed, () => Is.True);
         }
 
         private partial class SlowDisposer : Drawable

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -144,6 +144,9 @@ namespace osu.Framework.Graphics.Audio
 
             if (!disposeUnderlyingComponentOnDispose)
                 component?.UnbindAdjustments(adjustments);
+
+            // Running this as early as we can seems beneficial for the case a mixer is present.
+            refreshLayoutFromParent();
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -104,7 +104,7 @@ namespace osu.Framework.Graphics.Audio
             IAggregateAudioAdjustment newAdjustments = null;
             IAudioMixer newMixer = null;
 
-            bool hadParent = Parent != null;
+            bool hasParent = Parent != null;
 
             while ((cursor = cursor.Parent) != null)
             {
@@ -133,7 +133,7 @@ namespace osu.Framework.Graphics.Audio
             if (parentMixer != newMixer)
                 OnMixerChanged(new ValueChangedEvent<IAudioMixer>(parentMixer, newMixer));
 
-            if (!hadParent)
+            if (!hasParent)
                 OnParentLost();
 
             parentMixer = newMixer;

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -104,6 +104,8 @@ namespace osu.Framework.Graphics.Audio
             IAggregateAudioAdjustment newAdjustments = null;
             IAudioMixer newMixer = null;
 
+            bool hadParent = Parent != null;
+
             while ((cursor = cursor.Parent) != null)
             {
                 if (newAdjustments == null && cursor is IAggregateAudioAdjustment candidateAdjustment)
@@ -131,10 +133,17 @@ namespace osu.Framework.Graphics.Audio
             if (parentMixer != newMixer)
                 OnMixerChanged(new ValueChangedEvent<IAudioMixer>(parentMixer, newMixer));
 
+            if (!hadParent)
+                OnParentLost();
+
             parentMixer = newMixer;
         }
 
         protected virtual void OnMixerChanged(ValueChangedEvent<IAudioMixer> mixer)
+        {
+        }
+
+        internal virtual void OnParentLost()
         {
         }
 

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -122,5 +122,13 @@ namespace osu.Framework.Graphics.Audio
             mixer.OldValue?.Remove(track);
             mixer.NewValue?.Add(track);
         }
+
+        internal override void UnbindAllBindables()
+        {
+            base.UnbindAllBindables();
+
+            // Relying on disposal for this can cause delays before audio stops playing.
+            StopAsync();
+        }
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -124,9 +124,9 @@ namespace osu.Framework.Graphics.Audio
             mixer.NewValue?.Add(track);
         }
 
-        internal override void UnbindAllBindables()
+        internal override void OnParentLost()
         {
-            base.UnbindAllBindables();
+            base.OnParentLost();
 
             // Relying on disposal for this can cause delays before audio stops playing.
             StopAsync().ContinueWith(t => Logger.Log($"Failed to stop audio track on losing parent: {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -7,6 +7,7 @@ using osu.Framework.Audio;
 using osu.Framework.Audio.Mixing;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Graphics.Audio
 {
@@ -128,7 +129,7 @@ namespace osu.Framework.Graphics.Audio
             base.UnbindAllBindables();
 
             // Relying on disposal for this can cause delays before audio stops playing.
-            StopAsync();
+            StopAsync().ContinueWith(t => Logger.Log($"Failed to stop audio track on losing parent: {t.Exception}"), TaskContinuationOptions.OnlyOnFaulted);
         }
     }
 }


### PR DESCRIPTION
This has haunted us many times now (previously, when [exiting gameplay](https://github.com/ppy/osu/pull/35966), required a local fix because we don't have `internal` access like we do here..)

Most recently, due to arbitrary changes in ordering/length of transitions at song select, there was a chance that a track would not get completely dimmed (to zero volume) before disposal. To emphasise, this was always an issue with the song select code, but it became audible to users in the [recent change](https://github.com/ppy/osu/pull/37022).

Should we use `UnbindAllBindables` for this purpose? It [wouldn't be the first time](https://github.com/ppy/osu-framework/blob/d682387998da77c4a27b0f3942c1b120de6f9666/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs#L145) so maybe?

Does `DrawableSample` need the same treatment? Possibly, but even the `Dispose` flow doesn't handle stopping samples so I'd treat that as its own issue and fix.

Closes https://github.com/ppy/osu/issues/37136.