### PR TITLE
Add `PluralisableString`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -499,6 +499,58 @@ namespace osu.Framework.Tests.Localisation
             Assert.That(config.Get<string>(FrameworkSetting.Locale), Is.EqualTo(default_locale));
         }
 
+        [Test]
+        public void TestPluralisableString()
+        {
+            const string key = FakeStorage.LOCALISABLE_PLURALISABLE_STRING_EN;
+
+            manager.AddLanguage("fr", new FakeStorage("fr"));
+
+            var textSingularVariant = manager.GetLocalisedBindableString(new PluralisableString(key, key, 1, 1));
+            Assert.AreEqual("1 circle", textSingularVariant.Value);
+
+            config.SetValue(FrameworkSetting.Locale, "fr");
+            Assert.AreEqual("1 cercle", textSingularVariant.Value);
+
+            var textPluralVariant = manager.GetLocalisedBindableString(new PluralisableString(key, key, 2, 2));
+            Assert.AreEqual("2 cercles", textPluralVariant.Value);
+
+            config.SetValue(FrameworkSetting.Locale, "en");
+            Assert.AreEqual("2 circles", textPluralVariant.Value);
+        }
+
+        [Test]
+        public void TestPluralisableStringNonEnglishPluralRules()
+        {
+            const string key = FakeStorage.LOCALISABLE_PLURALISABLE_STRING_EN;
+
+            manager.AddLanguage("pl", new FakeStorage("pl"));
+            config.SetValue(FrameworkSetting.Locale, "pl");
+
+            var textFirstVariant = manager.GetLocalisedBindableString(new PluralisableString(key, key, 1, 1));
+            Assert.AreEqual("1 krąg", textFirstVariant.Value);
+
+            var textSecondVariant = manager.GetLocalisedBindableString(new PluralisableString(key, key, 3, 3));
+            Assert.AreEqual("3 kręgi", textSecondVariant.Value);
+
+            var textThirdVariant = manager.GetLocalisedBindableString(new PluralisableString(key, key, 13, 13));
+            Assert.AreEqual("13 kręgów", textThirdVariant.Value);
+        }
+
+        [Test]
+        public void TestPluralisableStringPluralFormFallback()
+        {
+            const string key = FakeStorage.LOCALISABLE_PLURALISABLE_INCOMPLETE_EN;
+
+            manager.AddLanguage("fr", new FakeStorage("fr"));
+
+            var textString = manager.GetLocalisedBindableString(new PluralisableString(key, key, 2, 2));
+            Assert.AreEqual("2 circle", textString.Value);
+
+            config.SetValue(FrameworkSetting.Locale, "fr");
+            Assert.AreEqual("2 cercle", textString.Value);
+        }
+
         private class FakeFrameworkConfigManager : FrameworkConfigManager
         {
             protected override string Filename => null;
@@ -527,6 +579,11 @@ namespace osu.Framework.Tests.Localisation
             public const string LOCALISABLE_NUMBER_FORMAT_STRING_FR = "number {0} FR";
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_EN = "number {0} with {1} and {2} EN";
             public const string LOCALISABLE_COMPLEX_FORMAT_STRING_FR = "number {0} with {1} and {2} FR";
+            public const string LOCALISABLE_PLURALISABLE_STRING_EN = "{0} circle|{0} circles";
+            public const string LOCALISABLE_PLURALISABLE_STRING_FR = "{0} cercle|{0} cercles";
+            public const string LOCALISABLE_PLURALISABLE_STRING_PL = "{0} krąg|{0} kręgi|{0} kręgów";
+            public const string LOCALISABLE_PLURALISABLE_INCOMPLETE_EN = "{0} circle";
+            public const string LOCALISABLE_PLURALISABLE_INCOMPLETE_FR = "{0} cercle";
 
             public CultureInfo EffectiveCulture { get; }
 
@@ -590,6 +647,33 @@ namespace osu.Framework.Tests.Localisation
                             case "fr":
                                 return LOCALISABLE_COMPLEX_FORMAT_STRING_FR;
                         }
+
+                    case LOCALISABLE_PLURALISABLE_STRING_EN:
+                    {
+                        switch (locale)
+                        {
+                            default:
+                                return LOCALISABLE_PLURALISABLE_STRING_EN;
+
+                            case "fr":
+                                return LOCALISABLE_PLURALISABLE_STRING_FR;
+
+                            case "pl":
+                                return LOCALISABLE_PLURALISABLE_STRING_PL;
+                        }
+                    }
+
+                    case LOCALISABLE_PLURALISABLE_INCOMPLETE_EN:
+                    {
+                        switch (locale)
+                        {
+                            default:
+                                return LOCALISABLE_PLURALISABLE_INCOMPLETE_EN;
+
+                            case "fr":
+                                return LOCALISABLE_PLURALISABLE_INCOMPLETE_FR;
+                        }
+                    }
 
                     default:
                         return null;

--- a/osu.Framework/Localisation/PluralisableString.cs
+++ b/osu.Framework/Localisation/PluralisableString.cs
@@ -1,0 +1,400 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// A string which can be translated using a key lookup and display a plural variant according to the plural context.
+    /// </summary>
+    public class PluralisableString : LocalisableFormattableString
+    {
+        private const char variant_separator = '|';
+
+        public readonly string Key;
+
+        /// <summary>
+        /// The plural count to use when applying plural rules.
+        /// </summary>
+        public readonly int Count;
+
+        /// <summary>
+        /// Creates a <see cref="PluralisableString"/> using texts.
+        /// </summary>
+        /// <param name="key">The key for <see cref="LocalisationManager"/> to look up with.</param>
+        /// <param name="fallback">The fallback string to use when no translation can be found.</param>
+        /// <param name="count">The plural count to use when applying plural rules.</param>
+        /// <param name="args">Optional formattable arguments.</param>
+        public PluralisableString(string key, string fallback, int count, params object?[] args)
+            : base(fallback, args)
+        {
+            Key = key;
+            Count = count;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PluralisableString"/> using interpolated string.
+        /// Example usage:
+        /// <code>
+        /// new PluralisableString("played_count_self", count, $"You have played {count:N0} time!|You have played {count:N0} times!");
+        /// </code>
+        /// </summary>
+        /// <param name="key">The key for <see cref="LocalisationManager"/> to look up with.</param>
+        /// <param name="count">The plural count to use when applying plural rules.</param>
+        /// <param name="interpolation">The interpolated string containing fallback and formattable arguments.</param>
+        public PluralisableString(string key, int count, FormattableString interpolation)
+            : base(interpolation)
+        {
+            Key = key;
+            Count = count;
+        }
+
+        protected override string FormatString(string fallback, object?[] args, LocalisationParameters parameters)
+        {
+            string format = parameters.Store?.Get(Key) ?? fallback;
+
+            string[] variants = format.Split(variant_separator);
+
+            int pluralIndex = getPluralIndex(parameters);
+
+            return base.FormatString(variants[Math.Min(pluralIndex, variants.Length - 1)], args, parameters);
+        }
+
+        public bool Equals(PluralisableString? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return base.Equals(other) && Key == other.Key && Count == other.Count;
+        }
+
+        public override bool Equals(ILocalisableStringData? other) => other is PluralisableString pluralisable && Equals(pluralisable);
+        public override bool Equals(object? obj) => obj is PluralisableString pluralisable && Equals(pluralisable);
+
+        public override int GetHashCode() => HashCode.Combine(base.GetHashCode(), Key, Count);
+
+        #region Mapping of plural variant indices according to locale
+
+        private int getPluralIndex(LocalisationParameters parameters)
+        {
+            switch (parameters.Store?.EffectiveCulture?.Name ?? string.Empty)
+            {
+                case "az":
+                case "az_AZ":
+                case "bo":
+                case "bo_CN":
+                case "bo_IN":
+                case "dz":
+                case "dz_BT":
+                case "id":
+                case "id_ID":
+                case "ja":
+                case "ja_JP":
+                case "jv":
+                case "ka":
+                case "ka_GE":
+                case "km":
+                case "km_KH":
+                case "kn":
+                case "kn_IN":
+                case "ko":
+                case "ko_KR":
+                case "ms":
+                case "ms_MY":
+                case "th":
+                case "th_TH":
+                case "tr":
+                case "tr_CY":
+                case "tr_TR":
+                case "vi":
+                case "vi_VN":
+                case "zh":
+                case "zh_CN":
+                case "zh_HK":
+                case "zh_SG":
+                case "zh_TW":
+                    return 0;
+
+                case "af":
+                case "af_ZA":
+                case "bn":
+                case "bn_BD":
+                case "bn_IN":
+                case "bg":
+                case "bg_BG":
+                case "ca":
+                case "ca_AD":
+                case "ca_ES":
+                case "ca_FR":
+                case "ca_IT":
+                case "da":
+                case "da_DK":
+                case "de":
+                case "de_AT":
+                case "de_BE":
+                case "de_CH":
+                case "de_DE":
+                case "de_LI":
+                case "de_LU":
+                case "el":
+                case "el_CY":
+                case "el_GR":
+                case "en":
+                case "en_AG":
+                case "en_AU":
+                case "en_BW":
+                case "en_CA":
+                case "en_DK":
+                case "en_GB":
+                case "en_HK":
+                case "en_IE":
+                case "en_IN":
+                case "en_NG":
+                case "en_NZ":
+                case "en_PH":
+                case "en_SG":
+                case "en_US":
+                case "en_ZA":
+                case "en_ZM":
+                case "en_ZW":
+                case "eo":
+                case "eo_US":
+                case "es":
+                case "es_AR":
+                case "es_BO":
+                case "es_CL":
+                case "es_CO":
+                case "es_CR":
+                case "es_CU":
+                case "es_DO":
+                case "es_EC":
+                case "es_ES":
+                case "es_GT":
+                case "es_HN":
+                case "es_MX":
+                case "es_NI":
+                case "es_PA":
+                case "es_PE":
+                case "es_PR":
+                case "es_PY":
+                case "es_SV":
+                case "es_US":
+                case "es_UY":
+                case "es_VE":
+                case "et":
+                case "et_EE":
+                case "eu":
+                case "eu_ES":
+                case "eu_FR":
+                case "fa":
+                case "fa_IR":
+                case "fi":
+                case "fi_FI":
+                case "fo":
+                case "fo_FO":
+                case "fur":
+                case "fur_IT":
+                case "fy":
+                case "fy_DE":
+                case "fy_NL":
+                case "gl":
+                case "gl_ES":
+                case "gu":
+                case "gu_IN":
+                case "ha":
+                case "ha_NG":
+                case "he":
+                case "he_IL":
+                case "hu":
+                case "hu_HU":
+                case "is":
+                case "is_IS":
+                case "it":
+                case "it_CH":
+                case "it_IT":
+                case "ku":
+                case "ku_TR":
+                case "lb":
+                case "lb_LU":
+                case "ml":
+                case "ml_IN":
+                case "mn":
+                case "mn_MN":
+                case "mr":
+                case "mr_IN":
+                case "nah":
+                case "nb":
+                case "nb_NO":
+                case "ne":
+                case "ne_NP":
+                case "nl":
+                case "nl_AW":
+                case "nl_BE":
+                case "nl_NL":
+                case "nn":
+                case "nn_NO":
+                case "no":
+                case "om":
+                case "om_ET":
+                case "om_KE":
+                case "or":
+                case "or_IN":
+                case "pa":
+                case "pa_IN":
+                case "pa_PK":
+                case "pap":
+                case "pap_AN":
+                case "pap_AW":
+                case "pap_CW":
+                case "ps":
+                case "ps_AF":
+                case "pt":
+                case "pt_BR":
+                case "pt_PT":
+                case "so":
+                case "so_DJ":
+                case "so_ET":
+                case "so_KE":
+                case "so_SO":
+                case "sq":
+                case "sq_AL":
+                case "sq_MK":
+                case "sv":
+                case "sv_FI":
+                case "sv_SE":
+                case "sw":
+                case "sw_KE":
+                case "sw_TZ":
+                case "ta":
+                case "ta_IN":
+                case "ta_LK":
+                case "te":
+                case "te_IN":
+                case "tk":
+                case "tk_TM":
+                case "ur":
+                case "ur_IN":
+                case "ur_PK":
+                case "zu":
+                case "zu_ZA":
+                    return Count == 1 ? 0 : 1;
+
+                case "am":
+                case "am_ET":
+                case "bh":
+                case "fil":
+                case "fil_PH":
+                case "fr":
+                case "fr_BE":
+                case "fr_CA":
+                case "fr_CH":
+                case "fr_FR":
+                case "fr_LU":
+                case "gun":
+                case "hi":
+                case "hi_IN":
+                case "hy":
+                case "hy_AM":
+                case "ln":
+                case "ln_CD":
+                case "mg":
+                case "mg_MG":
+                case "nso":
+                case "nso_ZA":
+                case "ti":
+                case "ti_ER":
+                case "ti_ET":
+                case "wa":
+                case "wa_BE":
+                case "xbr":
+                    return Count == 0 || Count == 1 ? 0 : 1;
+
+                case "be":
+                case "be_BY":
+                case "bs":
+                case "bs_BA":
+                case "hr":
+                case "hr_HR":
+                case "ru":
+                case "ru_RU":
+                case "ru_UA":
+                case "sr":
+                case "sr_ME":
+                case "sr_RS":
+                case "uk":
+                case "uk_UA":
+                    return Count % 10 == 1 && Count % 100 != 11 ? 0 : Count % 10 >= 2 && Count % 10 <= 4 && (Count % 100 < 10 || Count % 100 >= 20) ? 1 : 2;
+
+                case "cs":
+                case "cs_CZ":
+                case "sk":
+                case "sk_SK":
+                    return Count == 1 ? 0 : Count >= 2 && Count <= 4 ? 1 : 2;
+
+                case "ga":
+                case "ga_IE":
+                    return Count == 1 ? 0 : Count == 2 ? 1 : 2;
+
+                case "lt":
+                case "lt_LT":
+                    return Count % 10 == 1 && Count % 100 != 11 ? 0 : Count % 10 >= 2 && (Count % 100 < 10 || Count % 100 >= 20) ? 1 : 2;
+
+                case "sl":
+                case "sl_SI":
+                    return Count % 100 == 1 ? 0 : Count % 100 == 2 ? 1 : Count % 100 == 3 || Count % 100 == 4 ? 2 : 3;
+
+                case "mk":
+                case "mk_MK":
+                    return Count % 10 == 1 ? 0 : 1;
+
+                case "mt":
+                case "mt_MT":
+                    return Count == 1 ? 0 : Count == 0 || (Count % 100 > 1 && Count % 100 < 11) ? 1 : Count % 100 > 10 && Count % 100 < 20 ? 2 : 3;
+
+                case "lv":
+                case "lv_LV":
+                    return Count == 0 ? 0 : Count % 10 == 1 && Count % 100 != 11 ? 1 : 2;
+
+                case "pl":
+                case "pl_PL":
+                    return Count == 1 ? 0 : Count % 10 >= 2 && Count % 10 <= 4 && (Count % 100 < 12 || Count % 100 > 14) ? 1 : 2;
+
+                case "cy":
+                case "cy_GB":
+                    return Count == 1 ? 0 : Count == 2 ? 1 : Count == 8 || Count == 11 ? 2 : 3;
+
+                case "ro":
+                case "ro_RO":
+                    return Count == 1 ? 0 : Count == 0 || (Count % 100 > 0 && Count % 100 < 20) ? 1 : 2;
+
+                case "ar":
+                case "ar_AE":
+                case "ar_BH":
+                case "ar_DZ":
+                case "ar_EG":
+                case "ar_IN":
+                case "ar_IQ":
+                case "ar_JO":
+                case "ar_KW":
+                case "ar_LB":
+                case "ar_LY":
+                case "ar_MA":
+                case "ar_OM":
+                case "ar_QA":
+                case "ar_SA":
+                case "ar_SD":
+                case "ar_SS":
+                case "ar_SY":
+                case "ar_TN":
+                case "ar_YE":
+                    return Count == 0 ? 0 : Count == 1 ? 1 : Count == 2 ? 2 : Count % 100 >= 3 && Count % 100 <= 10 ? 3 : Count % 100 >= 11 && Count % 100 <= 99 ? 4 : 5;
+
+                default:
+                    return 0;
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
- supersedes and closes https://github.com/ppy/osu-framework/pull/4918

in this PR i tried to resolve the problems of the past one: https://github.com/ppy/osu-framework/pull/4918#pullrequestreview-817232770

## implementation references
- [code-based plural rules](https://github.com/laravel/framework/blob/c4e9a37612eee94159efd08f37257181f42e7562/src/Illuminate/Translation/MessageSelector.php#L99)
- [unicode specification](https://www.unicode.org/cldr/charts/48/supplemental/language_plural_rules.html)