### PR TITLE
Turn on SDL 3 for windows

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -53,8 +53,8 @@ namespace osu.Framework
             if (DebugUtils.IsDebugBuild)
                 AllowInsecureRequests = parseBool(Environment.GetEnvironmentVariable("OSU_INSECURE_REQUESTS")) ?? false;
 
-            // Desktop has many issues, see https://github.com/ppy/osu-framework/issues/6540.
-            UseSDL3 = RuntimeInfo.IsMobile || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
+            // Some desktop platforms have remaining issues, see https://github.com/ppy/osu-framework/issues/6540.
+            UseSDL3 = RuntimeInfo.IsMobile || RuntimeInfo.OS == RuntimeInfo.Platform.Windows || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
         }
 
         private static bool? parseBool(string? value)


### PR DESCRIPTION
While we are still not sure about Linux / macOS (remaining issues do exist, documented elsewhere), windows should be in a good state hopefully. Last [major blocker](https://github.com/ppy/osu/issues/28223) has since been fixed.

Getting this back in the hands of users is seen as important as more users report performance issues when having discord running in the background. It turns out that discord hooks basically anything and everything on your PC, including input events at a global level.

Switching to SDL3 means we can avoid getting delayed by applications like discord, because it comes with the better input handling path which is not based on legacy global hooks.