### PR TITLE
Prevent held non-modifier keys from re-triggering bindings after modifier release

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -370,6 +370,38 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
+        public void TestHeldNonModifierKeyDoesNotRetriggerAfterModifierRelease()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                Child = new TestKeyBindingContainer(matchingMode: KeyCombinationMatchingMode.Modifiers)
+                {
+                    Child = new TestKeyBindingReceptor
+                    {
+                        Pressed = pressedActions.Add,
+                    }
+                };
+            });
+
+            AddStep("press ctrl+A", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.PressKey(Key.A);
+            });
+
+            AddStep("release ctrl", () => InputManager.ReleaseKey(Key.LControl));
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+
+            AddAssert("ActionA never triggered", () => pressedActions.Contains(TestAction.ActionA), () => Is.False);
+
+            AddStep("release A", () => InputManager.ReleaseKey(Key.A));
+            AddStep("release enter", () => InputManager.ReleaseKey(Key.Enter));
+        }
+
+        [Test]
         public void TestPrioritisedNonPositionalInput([Values] bool prioritised)
         {
             bool containerReceivedInput = false;
@@ -502,6 +534,7 @@ namespace osu.Framework.Tests.Visual.Input
             {
                 new KeyBinding(InputKey.A, TestAction.ActionA),
                 new KeyBinding(new KeyCombination(InputKey.A, InputKey.B), TestAction.ActionAb),
+                new KeyBinding(new KeyCombination(InputKey.Control, InputKey.A), TestAction.ActionControlA),
                 new KeyBinding(InputKey.Enter, TestAction.ActionEnter),
                 new KeyBinding(InputKey.Control, TestAction.ActionControl),
                 new KeyBinding(InputKey.ExtraMouseButton4, TestAction.ActionMouse4),
@@ -531,6 +564,7 @@ namespace osu.Framework.Tests.Visual.Input
         {
             ActionA,
             ActionAb,
+            ActionControlA,
             ActionEnter,
             ActionControl,
             ActionMouse4,

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -524,7 +524,7 @@ namespace osu.Framework.Tests.Visual.Input
             public Func<TestAction, bool>? Pressed;
 
             public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None,
-                                            KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
+                               KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
                 : base(mode, matchingMode)
             {
                 Prioritised = prioritised;

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -491,8 +491,9 @@ namespace osu.Framework.Tests.Visual.Input
 
             public Func<TestAction, bool>? Pressed;
 
-            public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None)
-                : base(mode)
+            public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None,
+                                            KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
+                : base(mode, matchingMode)
             {
                 Prioritised = prioritised;
             }

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -392,9 +392,12 @@ namespace osu.Framework.Tests.Visual.Input
                 InputManager.PressKey(Key.A);
             });
 
-            AddStep("release ctrl", () => InputManager.ReleaseKey(Key.LControl));
-            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+            AddAssert("ActionControlA triggered", () => pressedActions.Contains(TestAction.ActionControlA), () => Is.True);
 
+            AddStep("release ctrl", () => InputManager.ReleaseKey(Key.LControl));
+            AddAssert("ActionA never triggered", () => pressedActions.Contains(TestAction.ActionA), () => Is.False);
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
             AddAssert("ActionA never triggered", () => pressedActions.Contains(TestAction.ActionA), () => Is.False);
 
             AddStep("release A", () => InputManager.ReleaseKey(Key.A));
@@ -524,7 +527,7 @@ namespace osu.Framework.Tests.Visual.Input
             public Func<TestAction, bool>? Pressed;
 
             public TestKeyBindingContainer(bool prioritised = false, SimultaneousBindingMode mode = SimultaneousBindingMode.None,
-                               KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
+                                           KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
                 : base(mode, matchingMode)
             {
                 Prioritised = prioritised;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -359,6 +359,7 @@ namespace osu.Framework.Input.Bindings
         private void handleNewReleased(InputState state, InputKey releasedKey)
         {
             pressedInputKeys.Remove(releasedKey);
+            bindingInitiatingKeys.Remove(releasedKey);
 
             if (pressedBindings.Count == 0)
                 return;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -272,10 +272,13 @@ namespace osu.Framework.Input.Bindings
 
                 if (handledBy != null)
                 {
-                    foreach (var key in newBinding.KeyCombination.Keys)
+                    if (newBinding.KeyCombination.Keys.Any(KeyCombination.IsModifierKey))
                     {
-                        if (!KeyCombination.IsModifierKey(key))
-                            bindingInitiatingKeys.Add(key);
+                        foreach (var key in newBinding.KeyCombination.Keys)
+                        {
+                            if (!KeyCombination.IsModifierKey(key))
+                                bindingInitiatingKeys.Add(key);
+                        }
                     }
 
                     // only drawables up to the one that handled the press should handle the release, so remove all subsequent drawables from the queue (for future use).

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -226,6 +226,11 @@ namespace osu.Framework.Input.Bindings
                     if (pressedBindings.Contains(binding))
                         continue;
 
+                    // Don't allow a binding to fire if any of its non-modifier keys were
+                    // already consumed by a previous binding that hasn't been fully released yet.
+                    if (binding.KeyCombination.Keys.Any(key => !KeyCombination.IsModifierKey(key) && bindingInitiatingKeys.Contains(key)))
+                        continue;
+
                     if (binding.KeyCombination.IsPressed(pressedCombination, state, matchingMode))
                         newlyPressed.Add(binding);
                 }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -44,6 +44,8 @@ namespace osu.Framework.Input.Bindings
 
         private readonly List<T> pressedActions = new List<T>();
 
+        private readonly HashSet<InputKey> bindingInitiatingKeys = new HashSet<InputKey>();
+
         /// <summary>
         /// All actions in a currently pressed state.
         /// </summary>
@@ -265,6 +267,12 @@ namespace osu.Framework.Input.Bindings
 
                 if (handledBy != null)
                 {
+                    foreach (var key in newBinding.KeyCombination.Keys)
+                    {
+                        if (!KeyCombination.IsModifierKey(key))
+                            bindingInitiatingKeys.Add(key);
+                    }
+
                     // only drawables up to the one that handled the press should handle the release, so remove all subsequent drawables from the queue (for future use).
                     int count = inputQueue.IndexOf(handledBy) + 1;
                     inputQueue.RemoveRange(count, inputQueue.Count - count);


### PR DESCRIPTION
Fixes a bug where releasing a modifier key while a non-modifier key is still held causes the non-modifier to "ghost", remaining in pressedInputKeys without belonging to any active binding. Any subsequent key press could then accidentally satisfy a binding that includes the held non-modifier, even though the user never made a new intentional press of it.

Closes https://github.com/ppy/osu/issues/36779