### PR TITLE
Add sensitivity setting for SDL3 pens

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -15,6 +15,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Platform;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Input.Handlers.Pen;
 using osuTK;
 using osuTK.Graphics;
 
@@ -201,6 +202,8 @@ namespace osu.Framework.Tests.Visual.Input
         {
             AddSliderStep("Cursor sensitivity", 0.5, 5, 1, setCursorSensitivityConfig);
             setCursorSensitivityConfig(1);
+            AddSliderStep("Pen sensitivity", 0.5, 5, 1, setPenSensitivityConfig);
+            setPenSensitivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
             AddStep("Set confine to Never", () => setConfineMouseModeConfig(ConfineMouseMode.Never));
             AddStep("Set confine to Fullscreen", () => setConfineMouseModeConfig(ConfineMouseMode.Fullscreen));
@@ -218,6 +221,13 @@ namespace osu.Framework.Tests.Visual.Input
 
             foreach (var h in host.AvailableInputHandlers)
                 AddToggleStep($"{h.Description} enabled", v => h.Enabled.Value = v);
+        }
+
+        private void setPenSensitivityConfig(double sensitivity)
+        {
+            var penHandler = host.AvailableInputHandlers.OfType<PenHandler>().FirstOrDefault();
+            if (penHandler != null)
+                penHandler.Sensitivity.Value = sensitivity;
         }
 
         private void setCursorSensitivityConfig(double sensitivity)

--- a/osu.Framework/Input/Handlers/Pen/PenHandler.cs
+++ b/osu.Framework/Input/Handlers/Pen/PenHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Platform.SDL3;
@@ -16,15 +17,26 @@ namespace osu.Framework.Input.Handlers.Pen
     {
         private static readonly GlobalStatistic<ulong> statistic_total_events = GlobalStatistics.Get<ulong>(StatisticGroupFor<PenHandler>(), "Total events");
 
+        public BindableDouble Sensitivity { get; } = new BindableDouble(1)
+        {
+            MinValue = 0.1,
+            MaxValue = 10,
+            Precision = 0.01
+        };
+
         public override bool IsActive => true;
+
+        private SDL3Window window = null!;
 
         public override bool Initialize(GameHost host)
         {
             if (!base.Initialize(host))
                 return false;
 
-            if (host.Window is not SDL3Window window)
+            if (host.Window is not SDL3Window sdlWindow)
                 return false;
+
+            window = sdlWindow;
 
             Enabled.BindValueChanged(enabled =>
             {
@@ -45,12 +57,18 @@ namespace osu.Framework.Input.Handlers.Pen
             return true;
         }
 
+        public override void Reset()
+        {
+            Sensitivity.SetDefault();
+            base.Reset();
+        }
+
         private void handlePenMove(TabletPenDeviceType deviceType, Vector2 position, bool pressed)
         {
             if (pressed && deviceType == TabletPenDeviceType.Direct)
                 enqueueInput(new TouchInput(new Input.Touch(TouchSource.PenTouch, position), true));
             else
-                enqueueInput(new MousePositionAbsoluteInputFromPen { DeviceType = deviceType, Position = position });
+                enqueueInput(new MousePositionAbsoluteInputFromPen { DeviceType = deviceType, Position = applySensitivity(position) });
         }
 
         private void handlePenTouch(TabletPenDeviceType deviceType, bool pressed, Vector2 position)
@@ -71,6 +89,57 @@ namespace osu.Framework.Input.Handlers.Pen
             PendingInputs.Enqueue(input);
             FrameStatistics.Increment(StatisticsCounterType.TabletEvents);
             statistic_total_events.Value++;
+        }
+
+        private Vector2 windowPosition()
+        {
+            var position = window.Position;
+            return new Vector2(position.X, position.Y);
+        }
+
+        private Vector2 currentDisplayPosition()
+        {
+            var position = window.CurrentDisplayBindable.Value.Bounds.Location;
+            return new Vector2(position.X, position.Y);
+        }
+
+        private Vector2 currentDisplaySize()
+        {
+            var size = window.CurrentDisplayBindable.Value.Bounds.Size;
+            return new Vector2(size.Width, size.Height);
+        }
+
+        /// <summary>
+        /// Converts a position relative to the top-left corner of the window to a position relative to the top-left corner of the current display.
+        /// </summary>
+        /// <param name="positionInWindow">A position relative to the top-left corner of the window.</param>
+        /// <returns>The same position, but relative to the top-left corner of the current display.</returns>
+        private Vector2 windowToCurrentDisplay(Vector2 positionInWindow)
+        {
+            return windowPosition() - currentDisplayPosition() + positionInWindow;
+        }
+
+        /// <summary>
+        /// Gets the delta needed to apply sensitivity.
+        /// </summary>
+        /// <param name="positionInCurrentDisplay">A position relative to the top-left corner of the current display.</param>
+        /// <returns>A vector that can be added to a position to apply sensitivity.</returns>
+        private Vector2 getSensitivityDelta(Vector2 positionInCurrentDisplay)
+        {
+            var displayCentre = currentDisplaySize() * 0.5f;
+            var relativeToCentre = positionInCurrentDisplay - displayCentre;
+            return relativeToCentre * (float)(Sensitivity.Value - 1);
+        }
+
+        /// <summary>
+        /// Applies sensitivity to a pixel position relative to the top-left corner of the window.
+        /// </summary>
+        /// <param name="position">A pixel position relative to the top-left corner of the window.</param>
+        /// <returns>A pixel position relative to the top-left corner of the window with sensitivity applied.</returns>
+        private Vector2 applySensitivity(Vector2 position)
+        {
+            var delta = getSensitivityDelta(windowToCurrentDisplay(position / window.Scale)) * window.Scale;
+            return position + delta;
         }
     }
 }


### PR DESCRIPTION
This PR adds sensitivity setting for SDL3 pens to address concerns raised in https://github.com/ppy/osu/pull/37472#issuecomment-4301063583.

On Windows, this means Windows Ink and absolute mouse input (when high precision mouse is enabled). I have tested this with windows ink (via [vTablet](https://github.com/Teages/vTablet)), but not with OpenTabletDriver.

The sensitivity is applied from the centre of the current screen (not the game window) to match osu!(stable).