### PR TITLE
Update OpenTabletDriver to 0.6.7

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,9 +32,9 @@
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="OpenTabletDriver" Version="0.6.6.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="OpenTabletDriver" Version="0.6.7" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />


### PR DESCRIPTION
Updating `Newtonsoft.Json` and `JetBrains.Annotations` here since it gives nasty package downgrade errors otherwise. OTD ended up updating these dependencies above what osu-framework was using. No problems building lazer.

Brief changelog of tablet support changes that will affect osu-framework:

### Added Support
- Artisul D22S
- Bosto BT-12HD
- Gaomon 1060 Pro
- Gaomon M7
- Gaomon PD1320
- Genius G-Pen F509
- Huion GT-220 V2 (2048)
- Huion Kamvas Pro 16 V2
- Huion Kamvas Pro 24 (Gen 3)
- Huion note x10
- Huion RDS-220
- LetSketch WP9620C
- Parblo Intangbo SW
- UC-Logic TWMNA62
- UGEE M708 V3
- UGEE S640
- VEIKK VK1200
- Veikk vk2200pro
- Wacom Cintiq 18SX (PL-800)
- Wacom Cintiq 21UX (DTZ-2100)
- Wacom DTC-121
- XOPPOX D161
- XP-Pen Artist 22R Pro
- XP-Pen Artist Pro 22 (Gen2)
- XP-Pen Deco LW
- XP-Pen Deco mini7w V2
- XP-Pen Deco MW
- XP-Pen deco pro mw variant
- XP-Pen star 03 v2

### Improved support
- Artisul M0610 Pro
- Gaomon m10k
- Huion GT-191 V2
- Huion H641P
- Huion H951P
- Huion Kamvas 24
- Huion Kamvas Pro 19
- Huion New 1060 Plus 2048
- Huion Q620M
- Kamvas 13 3rd gen
- Kamvas 16 3rd gen
- Parblo A610 Pro
- Parblo Ninos M
- Parblo Ninos N4
- UC-Logic 1060N
- Veikk vk430 v2
- Wacom CTE-460
- Wacom PTH-450
- Wacom PTH-451
- Wacom PTH-651
- Wacom PTH-851
- Wacom PTH-460
- Wacom PTH-660
- Wacom PTH-860
- Wacom PTK-470
- Wacom PTK-670
- Wacom PTK-870
- XP-Pen Artist 13.3 Pro
- XP-Pen Artist 15.6 Pro V2
- XP-Pen Artist 22R Pro
- XP-Pen Artist 24 Pro
- XP-Pen CT1060
- XP-Pen Deco 01 V2
- XP-Pen Deco 03
- XP-Pen Deco pro Small

### Parser Changes
- IntuosReportParser: Added Out of Range detection
- UCLogicReportParser: Added Out of Range detection
- IntuosV1ToolReport: Fixed incorrect shift in RawToolID
