### PR TITLE
Reduce redundant Veldrid renderer hot-path work

### DIFF
--- a/osu.Framework.Tests/Graphics/Veldrid/GraphicsBindStateTest.cs
+++ b/osu.Framework.Tests/Graphics/Veldrid/GraphicsBindStateTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics.Veldrid.Pipelines;
+
+namespace osu.Framework.Tests.Graphics.Veldrid
+{
+    [TestFixture]
+    public class GraphicsBindStateTest
+    {
+        [Test]
+        public void TestFirstPipelineBindEmits()
+        {
+            var state = new GraphicsBindState();
+
+            Assert.That(state.ShouldBindPipeline(new object()), Is.True);
+        }
+
+        [Test]
+        public void TestRepeatedPipelineBindSkipped()
+        {
+            var state = new GraphicsBindState();
+            object pipeline = new object();
+
+            Assert.That(state.ShouldBindPipeline(pipeline), Is.True);
+            Assert.That(state.ShouldBindPipeline(pipeline), Is.False);
+        }
+
+        [Test]
+        public void TestChangedPipelineBindEmits()
+        {
+            var state = new GraphicsBindState();
+
+            Assert.That(state.ShouldBindPipeline(new object()), Is.True);
+            Assert.That(state.ShouldBindPipeline(new object()), Is.True);
+        }
+
+        [Test]
+        public void TestFirstResourceSetBindEmits()
+        {
+            var state = new GraphicsBindState();
+
+            Assert.That(state.ShouldBindResourceSet(0, new object()), Is.True);
+        }
+
+        [Test]
+        public void TestRepeatedResourceSetBindSkipped()
+        {
+            var state = new GraphicsBindState();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.False);
+        }
+
+        [Test]
+        public void TestDifferentResourceSetBindEmits()
+        {
+            var state = new GraphicsBindState();
+
+            Assert.That(state.ShouldBindResourceSet(0, new object()), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, new object()), Is.True);
+        }
+
+        [Test]
+        public void TestDifferentResourceSetSlotBindEmits()
+        {
+            var state = new GraphicsBindState();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+            Assert.That(state.ShouldBindResourceSet(1, resourceSet), Is.True);
+        }
+
+        [Test]
+        public void TestDifferentDynamicOffsetBindEmits()
+        {
+            var state = new GraphicsBindState();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet, 4), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet, 8), Is.True);
+        }
+
+        [Test]
+        public void TestRepeatedDynamicOffsetBindSkipped()
+        {
+            var state = new GraphicsBindState();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet, 4), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet, 4), Is.False);
+        }
+
+        [Test]
+        public void TestResetRequiresBindsToEmitAgain()
+        {
+            var state = new GraphicsBindState();
+            object pipeline = new object();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindPipeline(pipeline), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+
+            state.Reset();
+
+            Assert.That(state.ShouldBindPipeline(pipeline), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+        }
+
+        [Test]
+        public void TestPipelineChangeClearsResourceSetBindings()
+        {
+            var state = new GraphicsBindState();
+            object resourceSet = new object();
+
+            Assert.That(state.ShouldBindPipeline(new object()), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.False);
+
+            Assert.That(state.ShouldBindPipeline(new object()), Is.True);
+            Assert.That(state.ShouldBindResourceSet(0, resourceSet), Is.True);
+        }
+    }
+}

--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -19,6 +19,8 @@ namespace osu.Framework
         public static int? StagingBufferType { get; }
         public static int? VertexBufferCount { get; }
         public static bool NoStructuredBuffers { get; }
+        internal static bool LogVeldridFrameTimings { get; }
+        internal static bool? ForceMacOSPreDrawTextureUploadFlush { get; }
         public static string? DeferredRendererEventsOutputPath { get; }
         public static bool UseSDL3 { get; }
 
@@ -47,6 +49,8 @@ namespace osu.Framework
                 StagingBufferType = stagingBufferImplementation;
 
             NoStructuredBuffers = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_NO_SSBO")) ?? false;
+            LogVeldridFrameTimings = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_LOG_VELDRID_FRAME_TIMINGS")) ?? false;
+            ForceMacOSPreDrawTextureUploadFlush = parseBool(Environment.GetEnvironmentVariable("OSU_GRAPHICS_MACOS_PREDRAW_TEXTURE_UPLOAD_FLUSH"));
 
             DeferredRendererEventsOutputPath = Environment.GetEnvironmentVariable("DEFERRED_RENDERER_EVENTS_OUTPUT");
 

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredRenderer.cs
@@ -134,6 +134,9 @@ namespace osu.Framework.Graphics.Rendering.Deferred
         void IVeldridRenderer.EnqueueTextureUpload(VeldridTexture texture)
             => EnqueueTextureUpload(texture);
 
+        void IVeldridRenderer.InvalidateTextureBinding(VeldridTexture texture)
+            => InvalidateTextureBinding(texture);
+
         void IVeldridRenderer.GenerateMipmaps(VeldridTexture texture)
             => Graphics.Commands.GenerateMipmaps(texture.GetResourceList().Single().Texture);
 

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredShaderStorageBufferObject.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredShaderStorageBufferObject.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering.Deferred.Allocation;
 using osu.Framework.Graphics.Rendering.Deferred.Events;
+using osu.Framework.Graphics.Veldrid;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using Veldrid;
 
@@ -21,6 +23,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
         private readonly DeviceBuffer buffer;
         private readonly DeferredRenderer renderer;
         private readonly int elementSize;
+        private readonly Dictionary<ResourceLayout, ResourceSet> resourceSets = new Dictionary<ResourceLayout, ResourceSet>();
 
         public DeferredShaderStorageBufferObject(DeferredRenderer renderer, int ssboSize)
         {
@@ -53,13 +56,24 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             => memory.WriteTo(renderer.Context, buffer, index * elementSize);
 
         public ResourceSet GetResourceSet(ResourceLayout layout)
-            => renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        {
+            if (resourceSets.TryGetValue(layout, out ResourceSet? existing))
+                return existing;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.ShaderStorage);
+            return resourceSets[layout] = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        }
 
         public void ResetCounters()
         {
         }
 
         public void Dispose()
-            => buffer.Dispose();
+        {
+            foreach ((_, ResourceSet resourceSet) in resourceSets)
+                resourceSet.Dispose();
+
+            buffer.Dispose();
+        }
     }
 }

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredUniformBuffer.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using osu.Framework.Development;
 using osu.Framework.Graphics.Rendering.Deferred.Allocation;
 using osu.Framework.Graphics.Rendering.Deferred.Events;
+using osu.Framework.Graphics.Veldrid;
 using osu.Framework.Graphics.Veldrid.Buffers;
 using osu.Framework.Statistics;
 using Veldrid;
@@ -56,6 +57,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
             if (bufferChunks.TryGetValue((currentChunk, layout), out ResourceSet? existing))
                 return existing;
 
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Uniform);
             return bufferChunks[(currentChunk, layout)] = renderer.Factory.CreateResourceSet(
                 new ResourceSetDescription(
                     layout,

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -105,6 +105,8 @@ namespace osu.Framework.Graphics.Rendering
 
         private readonly ConcurrentQueue<ScheduledDelegate> expensiveOperationQueue = new ConcurrentQueue<ScheduledDelegate>();
         private readonly ConcurrentQueue<INativeTexture> textureUploadQueue = new ConcurrentQueue<INativeTexture>();
+        private readonly HashSet<INativeTexture> queuedTextureUploads = new HashSet<INativeTexture>();
+        private readonly object textureUploadQueueSync = new object();
         private readonly RendererDisposalQueue disposalQueue = new RendererDisposalQueue();
 
         private readonly Scheduler resetScheduler = new Scheduler(() => ThreadSafety.IsDrawThread, new StopwatchClock(true)); // force no thread set until we are actually on the draw thread.
@@ -270,18 +272,26 @@ namespace osu.Framework.Graphics.Rendering
             freeUnusedVertexBuffers();
             vboInUse.Value = vertexBuffersInUse.Count;
 
-            statTextureUploadsQueued.Value = textureUploadQueue.Count;
+            int textureUploadsQueued;
+
+            lock (textureUploadQueueSync)
+                textureUploadsQueued = queuedTextureUploads.Count;
+
+            statTextureUploadsQueued.Value = textureUploadsQueued;
             statTextureUploadsDequeued.Value = 0;
             statTextureUploadsPerformed.Value = 0;
 
             // increase the number of items processed with the queue length to ensure it doesn't get out of hand.
-            int targetUploads = Math.Clamp(textureUploadQueue.Count / 2, 1, MaxTexturesUploadedPerFrame);
+            int targetUploads = Math.Clamp(textureUploadsQueued / 2, 1, MaxTexturesUploadedPerFrame);
             int uploads = 0;
             int uploadedPixels = 0;
 
             // continue attempting to upload textures until enough uploads have been performed.
             while (textureUploadQueue.TryDequeue(out INativeTexture? texture))
             {
+                lock (textureUploadQueueSync)
+                    queuedTextureUploads.Remove(texture);
+
                 statTextureUploadsDequeued.Value++;
 
                 if (!texture.Upload())
@@ -845,6 +855,26 @@ namespace osu.Framework.Graphics.Rendering
             return true;
         }
 
+        protected void InvalidateTextureBinding(INativeTexture texture)
+        {
+            bool flushed = false;
+
+            for (int i = 0; i < lastBoundTexture.Length; i++)
+            {
+                if (lastBoundTexture[i] != texture)
+                    continue;
+
+                if (!flushed)
+                {
+                    FlushCurrentBatch(FlushBatchSource.BindTexture);
+                    flushed = true;
+                }
+
+                lastBoundTexture[i] = null;
+                lastBoundTextureIsAtlas[i] = false;
+            }
+        }
+
         private void setWrapMode(WrapMode wrapModeS, WrapMode wrapModeT)
         {
             if (wrapModeS != CurrentWrapModeS)
@@ -886,10 +916,16 @@ namespace osu.Framework.Graphics.Rendering
         /// <param name="texture">The texture to be uploaded.</param>
         internal void EnqueueTextureUpload(INativeTexture texture)
         {
-            if (!IsInitialised || textureUploadQueue.Contains(texture))
+            if (!IsInitialised)
                 return;
 
-            textureUploadQueue.Enqueue(texture);
+            lock (textureUploadQueueSync)
+            {
+                if (!queuedTextureUploads.Add(texture))
+                    return;
+
+                textureUploadQueue.Enqueue(texture);
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridShaderStorageBufferObject.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridShaderStorageBufferObject.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using osu.Framework.Development;
@@ -19,6 +20,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         private readonly DeviceBuffer buffer;
         private readonly VeldridRenderer renderer;
         private readonly uint elementSize;
+        private readonly Dictionary<ResourceLayout, ResourceSet> resourceSets = new Dictionary<ResourceLayout, ResourceSet>();
 
         public VeldridShaderStorageBufferObject(VeldridRenderer renderer, int uboSize, int ssboSize)
         {
@@ -89,7 +91,12 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         public ResourceSet GetResourceSet(ResourceLayout layout)
         {
             flushChanges();
-            return renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+
+            if (resourceSets.TryGetValue(layout, out ResourceSet? existing))
+                return existing;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.ShaderStorage);
+            return resourceSets[layout] = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
         }
 
         public void ResetCounters()
@@ -98,6 +105,9 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
         public void Dispose()
         {
+            foreach ((_, ResourceSet resourceSet) in resourceSets)
+                resourceSet.Dispose();
+
             buffer.Dispose();
         }
     }

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridUniformBufferStorage.cs
@@ -37,7 +37,14 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             }
         }
 
-        public ResourceSet GetResourceSet(ResourceLayout layout) => set ??= renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        public ResourceSet GetResourceSet(ResourceLayout layout)
+        {
+            if (set != null)
+                return set;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Uniform);
+            return set = renderer.Factory.CreateResourceSet(new ResourceSetDescription(layout, buffer));
+        }
 
         public void Dispose()
         {

--- a/osu.Framework/Graphics/Veldrid/IVeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/IVeldridRenderer.cs
@@ -93,6 +93,12 @@ namespace osu.Framework.Graphics.Veldrid
         void EnqueueTextureUpload(VeldridTexture texture);
 
         /// <summary>
+        /// Invalidates any cached binding for the given texture.
+        /// </summary>
+        /// <param name="texture">The texture.</param>
+        void InvalidateTextureBinding(VeldridTexture texture);
+
+        /// <summary>
         /// Generates mipmaps for the given texture.
         /// </summary>
         /// <param name="texture">The texture.</param>

--- a/osu.Framework/Graphics/Veldrid/Pipelines/BasicPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/BasicPipeline.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Veldrid.Textures;
 using Veldrid;
@@ -57,10 +58,12 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private readonly Queue<Fence> fencePool = new Queue<Fence>();
 
         private readonly VeldridDevice device;
+        private readonly VeldridPipelineKind pipelineKind;
 
-        public BasicPipeline(VeldridDevice device)
+        public BasicPipeline(VeldridDevice device, VeldridPipelineKind pipelineKind)
         {
             this.device = device;
+            this.pipelineKind = pipelineKind;
             Commands = device.Factory.CreateCommandList();
         }
 
@@ -86,7 +89,16 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
             pendingExecutions.Add(new ExecutionCompletionFence(fence, executionIndex));
 
             Commands.End();
+
+            if (!VeldridInstrumentation.Enabled)
+            {
+                device.Device.SubmitCommands(Commands, fence);
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
             device.Device.SubmitCommands(Commands, fence);
+            VeldridInstrumentation.RecordSubmit(pipelineKind, Stopwatch.GetTimestamp() - start);
         }
 
         private void updatePendingExecutions()

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsBindState.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsBindState.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Framework.Graphics.Veldrid.Pipelines
+{
+    internal sealed class GraphicsBindState
+    {
+        private object? pipeline;
+        private readonly Dictionary<uint, ResourceSetBinding> resourceSets = new Dictionary<uint, ResourceSetBinding>();
+
+        public void Reset()
+        {
+            pipeline = null;
+            resourceSets.Clear();
+        }
+
+        public bool ShouldBindPipeline(object nextPipeline)
+        {
+            if (ReferenceEquals(pipeline, nextPipeline))
+                return false;
+
+            pipeline = nextPipeline;
+            resourceSets.Clear();
+            return true;
+        }
+
+        public bool ShouldBindResourceSet(uint set, object resourceSet, uint? dynamicOffset = null)
+        {
+            if (resourceSets.TryGetValue(set, out var current) && current.Matches(resourceSet, dynamicOffset))
+                return false;
+
+            resourceSets[set] = new ResourceSetBinding(resourceSet, dynamicOffset);
+            return true;
+        }
+
+        private readonly struct ResourceSetBinding
+        {
+            private readonly object resourceSet;
+            private readonly uint? dynamicOffset;
+
+            public ResourceSetBinding(object resourceSet, uint? dynamicOffset)
+            {
+                this.resourceSet = resourceSet;
+                this.dynamicOffset = dynamicOffset;
+            }
+
+            public bool Matches(object otherResourceSet, uint? otherDynamicOffset)
+                => ReferenceEquals(resourceSet, otherResourceSet) && dynamicOffset == otherDynamicOffset;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private readonly Dictionary<int, VeldridTextureResources> attachedTextures = new Dictionary<int, VeldridTextureResources>();
         private readonly Dictionary<string, IVeldridUniformBuffer> attachedUniformBuffers = new Dictionary<string, IVeldridUniformBuffer>();
         private readonly Dictionary<IVeldridUniformBuffer, uint> uniformBufferOffsets = new Dictionary<IVeldridUniformBuffer, uint>();
+        private readonly GraphicsBindState bindState = new GraphicsBindState();
 
         private GraphicsPipelineDescription pipelineDesc = new GraphicsPipelineDescription
         {
@@ -55,6 +56,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
             currentShader = null;
             currentIndexBuffer = null;
             currentVertexBuffer = null;
+            bindState.Reset();
         }
 
         /// <summary>
@@ -163,6 +165,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
 
             Commands.SetFramebuffer(fb);
             pipelineDesc.Outputs = fb.OutputDescription;
+            bindState.Reset();
         }
 
         /// <summary>
@@ -273,7 +276,15 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
             }
 
             // Activate the pipeline.
-            Commands.SetPipeline(createPipeline());
+            var pipeline = createPipeline();
+
+            if (bindState.ShouldBindPipeline(pipeline))
+            {
+                Commands.SetPipeline(pipeline);
+                VeldridInstrumentation.RecordGraphicsPipelineBind(true);
+            }
+            else
+                VeldridInstrumentation.RecordGraphicsPipelineBind(false);
 
             // Activate texture resources.
             foreach (var (unit, texture) in attachedTextures)
@@ -282,7 +293,16 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
                 if (layout == null)
                     continue;
 
-                Commands.SetGraphicsResourceSet((uint)layout.Set, texture.GetResourceSet(Factory, layout.Layout));
+                uint set = (uint)layout.Set;
+                var resourceSet = texture.GetResourceSet(Factory, layout.Layout);
+
+                if (bindState.ShouldBindResourceSet(set, resourceSet))
+                {
+                    Commands.SetGraphicsResourceSet(set, resourceSet);
+                    VeldridInstrumentation.RecordGraphicsResourceSetBind(true);
+                }
+                else
+                    VeldridInstrumentation.RecordGraphicsResourceSetBind(false);
             }
 
             // Activate uniform buffer resources.
@@ -293,7 +313,16 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
                     continue;
 
                 uint bufferOffset = uniformBufferOffsets.GetValueOrDefault(buffer);
-                Commands.SetGraphicsResourceSet((uint)layout.Set, buffer.GetResourceSet(layout.Layout), 1, ref bufferOffset);
+                uint set = (uint)layout.Set;
+                var resourceSet = buffer.GetResourceSet(layout.Layout);
+
+                if (bindState.ShouldBindResourceSet(set, resourceSet, bufferOffset))
+                {
+                    Commands.SetGraphicsResourceSet(set, resourceSet, 1, ref bufferOffset);
+                    VeldridInstrumentation.RecordGraphicsResourceSetBind(true);
+                }
+                else
+                    VeldridInstrumentation.RecordGraphicsResourceSetBind(false);
             }
 
             int indexStart = currentIndexBuffer.TranslateToIndex(vertexStart);
@@ -303,11 +332,17 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
 
         private Pipeline createPipeline()
         {
-            if (!pipelineCache.TryGetValue(pipelineDesc, out var instance))
+            if (pipelineCache.TryGetValue(pipelineDesc, out var instance))
             {
-                pipelineCache[pipelineDesc.Clone()] = instance = Factory.CreateGraphicsPipeline(ref pipelineDesc);
-                stat_graphics_pipeline_created.Value++;
+                VeldridInstrumentation.RecordPipelineCacheHit();
+                return instance;
             }
+
+            VeldridInstrumentation.RecordPipelineCacheMiss();
+
+            pipelineCache[pipelineDesc.Clone()] = instance = Factory.CreateGraphicsPipeline(ref pipelineDesc);
+            stat_graphics_pipeline_created.Value++;
+            VeldridInstrumentation.RecordPipelineCreated();
 
             return instance;
         }

--- a/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
+++ b/osu.Framework/Graphics/Veldrid/Pipelines/GraphicsPipeline.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Veldrid.Pipelines
         private VertexLayoutDescription currentVertexLayout;
 
         public GraphicsPipeline(VeldridDevice device)
-            : base(device)
+            : base(device, VeldridPipelineKind.Graphics)
         {
             pipelineDesc.Outputs = Device.SwapchainFramebuffer.OutputDescription;
         }

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -451,12 +451,13 @@ namespace osu.Framework.Graphics.Veldrid.Textures
 
         protected virtual void DoUpload(ITextureUpload upload)
         {
-            Texture? texture = resources?.Texture;
-            Sampler? sampler = resources?.Sampler;
+            VeldridTextureResources? currentResources = resources;
+            Texture? texture = currentResources?.Texture;
 
             if (texture == null || texture.Width != Width || texture.Height != Height)
             {
-                texture?.Dispose();
+                Renderer.InvalidateTextureBinding(this);
+                currentResources?.Dispose();
 
                 var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, PixelFormat.R8G8B8A8UNorm, Usages);
                 texture = Renderer.Factory.CreateTexture(ref textureDescription);
@@ -466,6 +467,9 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 initialiseLevel(texture, 0, Width, Height);
 
                 maximumUploadedLod = 0;
+
+                resources = currentResources = new VeldridTextureResources(texture, null);
+                VeldridInstrumentation.RecordTextureResourcesRecreated();
             }
 
             int lastMaximumUploadedLod = maximumUploadedLod;
@@ -486,13 +490,11 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                     upload.Level, upload.Data);
             }
 
-            if (sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
+            if (currentResources!.Sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
             {
-                sampler?.Dispose();
-                sampler = createSampler();
+                Renderer.InvalidateTextureBinding(this);
+                currentResources.Sampler = createSampler();
             }
-
-            resources = new VeldridTextureResources(texture, sampler);
         }
 
         private unsafe void initialiseLevel(Texture texture, int level, int width, int height)

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
@@ -47,7 +47,11 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             if (Sampler == null)
                 throw new InvalidOperationException("Attempting to create resource set without a sampler attached to the resources.");
 
-            return Set ??= factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
+            if (Set != null)
+                return Set;
+
+            VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Texture);
+            return Set = factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureResources.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using Veldrid;
 
 namespace osu.Framework.Graphics.Veldrid.Textures
@@ -23,12 +24,11 @@ namespace osu.Framework.Graphics.Veldrid.Textures
                 sampler?.Dispose();
                 sampler = value;
 
-                Set?.Dispose();
-                Set = null;
+                disposeResourceSets();
             }
         }
 
-        public ResourceSet? Set { get; private set; }
+        private readonly Dictionary<ResourceLayout, ResourceSet> resourceSets = new Dictionary<ResourceLayout, ResourceSet>();
 
         public VeldridTextureResources(Texture texture, Sampler? sampler)
         {
@@ -47,18 +47,26 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             if (Sampler == null)
                 throw new InvalidOperationException("Attempting to create resource set without a sampler attached to the resources.");
 
-            if (Set != null)
-                return Set;
+            if (resourceSets.TryGetValue(layout, out ResourceSet? set))
+                return set;
 
             VeldridInstrumentation.RecordResourceSetCreated(VeldridResourceSetKind.Texture);
-            return Set = factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
+            return resourceSets[layout] = factory.CreateResourceSet(new ResourceSetDescription(layout, Texture, Sampler));
         }
 
         public void Dispose()
         {
             Texture.Dispose();
             Sampler?.Dispose();
-            Set?.Dispose();
+            disposeResourceSets();
+        }
+
+        private void disposeResourceSets()
+        {
+            foreach ((_, ResourceSet set) in resourceSets)
+                set.Dispose();
+
+            resourceSets.Clear();
         }
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridDevice.cs
@@ -89,6 +89,10 @@ namespace osu.Framework.Graphics.Veldrid
 
         private readonly IGraphicsSurface graphicsSurface;
         private Vector2I currentWindowSize;
+        private long swapTimingTicks;
+        private long waitTimingTicks;
+        private int swapTimingSamples;
+        private int waitTimingSamples;
 
         /// <summary>
         /// Creates a new <see cref="VeldridDevice"/>
@@ -236,7 +240,17 @@ namespace osu.Framework.Graphics.Veldrid
         /// Swaps the back buffer with the front buffer to display the new frame.
         /// </summary>
         public void SwapBuffers()
-            => Device.SwapBuffers();
+        {
+            if (!VeldridInstrumentation.Enabled)
+            {
+                Device.SwapBuffers();
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            Device.SwapBuffers();
+            recordSwapTiming(Stopwatch.GetTimestamp() - start);
+        }
 
         /// <summary>
         /// Waits until all renderer commands have been fully executed GPU-side, as signaled by the graphics backend.
@@ -251,7 +265,17 @@ namespace osu.Framework.Graphics.Veldrid
         /// Waits until the GPU signals that the next frame is ready to be rendered.
         /// </summary>
         public void WaitUntilNextFrameReady()
-            => Device.WaitForNextFrameReady();
+        {
+            if (!VeldridInstrumentation.Enabled)
+            {
+                Device.WaitForNextFrameReady();
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            Device.WaitForNextFrameReady();
+            recordWaitTiming(Stopwatch.GetTimestamp() - start);
+        }
 
         /// <summary>
         /// Invoked when the rendering thread is active and commands will be enqueued.
@@ -375,5 +399,39 @@ namespace osu.Framework.Graphics.Veldrid
 
             return Device.WaitForFence(fence, (ulong)(millisecondsTimeout * 1_000_000));
         }
+
+        private void recordSwapTiming(long elapsedTicks)
+        {
+            swapTimingTicks += elapsedTicks;
+            swapTimingSamples++;
+            maybeLogTimingSummary();
+        }
+
+        private void recordWaitTiming(long elapsedTicks)
+        {
+            waitTimingTicks += elapsedTicks;
+            waitTimingSamples++;
+        }
+
+        private void maybeLogTimingSummary()
+        {
+            if (swapTimingSamples == 0 || swapTimingSamples % 240 != 0)
+                return;
+
+            double swapAverageMs = ticksToMilliseconds(swapTimingTicks / (double)swapTimingSamples);
+            double waitAverageMs = waitTimingSamples == 0 ? 0 : ticksToMilliseconds(waitTimingTicks / (double)waitTimingSamples);
+
+            Logger.Log(
+                $"Veldrid frame timing summary ({SurfaceType}): avg_swap={swapAverageMs:0.###}ms, avg_wait={waitAverageMs:0.###}ms, wait_samples={waitTimingSamples}",
+                level: LogLevel.Important);
+
+            swapTimingTicks = 0;
+            waitTimingTicks = 0;
+            swapTimingSamples = 0;
+            waitTimingSamples = 0;
+        }
+
+        private static double ticksToMilliseconds(double ticks)
+            => ticks * 1000 / Stopwatch.Frequency;
     }
 }

--- a/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
@@ -1,0 +1,275 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    internal enum VeldridPipelineKind
+    {
+        Graphics,
+        BufferUpdate,
+        TextureUpload,
+    }
+
+    internal enum VeldridResourceSetKind
+    {
+        Texture,
+        Uniform,
+        ShaderStorage,
+    }
+
+    internal static class VeldridInstrumentation
+    {
+        public static bool Enabled => FrameworkEnvironment.LogVeldridFrameTimings;
+
+        private static readonly object sync = new object();
+
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_submit_count = createDoubleStatistic("Graphics submits/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_submit_ms = createDoubleStatistic("Graphics submit ms/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_buffer_update_submit_count = createDoubleStatistic("Buffer update submits/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_buffer_update_submit_ms = createDoubleStatistic("Buffer update submit ms/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_texture_upload_submit_count = createDoubleStatistic("Texture upload submits/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_texture_upload_submit_ms = createDoubleStatistic("Texture upload submit ms/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_texture_upload_flush_count = createDoubleStatistic("Texture upload flushes/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_pipeline_cache_hits = createDoubleStatistic("Pipeline cache hits/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_pipeline_cache_misses = createDoubleStatistic("Pipeline cache misses/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_pipeline_creates = createDoubleStatistic("Pipelines created/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_pipeline_binds = createDoubleStatistic("Graphics pipeline binds/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_pipeline_binds_skipped = createDoubleStatistic("Graphics pipeline binds skipped/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_resource_set_binds = createDoubleStatistic("Graphics resource set binds/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_graphics_resource_set_binds_skipped = createDoubleStatistic("Graphics resource set binds skipped/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_texture_resource_set_creates = createDoubleStatistic("Texture resource sets/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_uniform_resource_set_creates = createDoubleStatistic("Uniform resource sets/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_shader_storage_resource_set_creates = createDoubleStatistic("Shader storage resource sets/frame");
+
+        private static int framesInWindow;
+        private static long graphicsSubmitCountWindow;
+        private static long graphicsSubmitTicksWindow;
+        private static long bufferUpdateSubmitCountWindow;
+        private static long bufferUpdateSubmitTicksWindow;
+        private static long textureUploadSubmitCountWindow;
+        private static long textureUploadSubmitTicksWindow;
+        private static long textureUploadFlushCountWindow;
+        private static long pipelineCacheHitWindow;
+        private static long pipelineCacheMissWindow;
+        private static long pipelineCreateWindow;
+        private static long graphicsPipelineBindWindow;
+        private static long graphicsPipelineBindSkippedWindow;
+        private static long graphicsResourceSetBindWindow;
+        private static long graphicsResourceSetBindSkippedWindow;
+        private static long textureResourceSetCreateWindow;
+        private static long uniformResourceSetCreateWindow;
+        private static long shaderStorageResourceSetCreateWindow;
+
+        public static void RecordSubmit(VeldridPipelineKind kind, long elapsedTicks)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                switch (kind)
+                {
+                    case VeldridPipelineKind.Graphics:
+                        graphicsSubmitCountWindow++;
+                        graphicsSubmitTicksWindow += elapsedTicks;
+                        break;
+
+                    case VeldridPipelineKind.BufferUpdate:
+                        bufferUpdateSubmitCountWindow++;
+                        bufferUpdateSubmitTicksWindow += elapsedTicks;
+                        break;
+
+                    case VeldridPipelineKind.TextureUpload:
+                        textureUploadSubmitCountWindow++;
+                        textureUploadSubmitTicksWindow += elapsedTicks;
+                        break;
+                }
+            }
+        }
+
+        public static void RecordTextureUploadFlush()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+                textureUploadFlushCountWindow++;
+        }
+
+        public static void RecordPipelineCacheHit()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+                pipelineCacheHitWindow++;
+        }
+
+        public static void RecordPipelineCacheMiss()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+                pipelineCacheMissWindow++;
+        }
+
+        public static void RecordPipelineCreated()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+                pipelineCreateWindow++;
+        }
+
+        public static void RecordGraphicsPipelineBind(bool emitted)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                if (emitted)
+                    graphicsPipelineBindWindow++;
+                else
+                    graphicsPipelineBindSkippedWindow++;
+            }
+        }
+
+        public static void RecordGraphicsResourceSetBind(bool emitted)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                if (emitted)
+                    graphicsResourceSetBindWindow++;
+                else
+                    graphicsResourceSetBindSkippedWindow++;
+            }
+        }
+
+        public static void RecordResourceSetCreated(VeldridResourceSetKind kind)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                switch (kind)
+                {
+                    case VeldridResourceSetKind.Texture:
+                        textureResourceSetCreateWindow++;
+                        break;
+
+                    case VeldridResourceSetKind.Uniform:
+                        uniformResourceSetCreateWindow++;
+                        break;
+
+                    case VeldridResourceSetKind.ShaderStorage:
+                        shaderStorageResourceSetCreateWindow++;
+                        break;
+                }
+            }
+        }
+
+        public static void EndFrame(GraphicsSurfaceType surfaceType)
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+            {
+                framesInWindow++;
+
+                if (framesInWindow % 240 != 0)
+                    return;
+
+                double graphicsSubmitsPerFrame = graphicsSubmitCountWindow / (double)framesInWindow;
+                double bufferUpdateSubmitsPerFrame = bufferUpdateSubmitCountWindow / (double)framesInWindow;
+                double textureUploadSubmitsPerFrame = textureUploadSubmitCountWindow / (double)framesInWindow;
+                double textureUploadFlushesPerFrame = textureUploadFlushCountWindow / (double)framesInWindow;
+                double pipelineHitsPerFrame = pipelineCacheHitWindow / (double)framesInWindow;
+                double pipelineMissesPerFrame = pipelineCacheMissWindow / (double)framesInWindow;
+                double pipelineCreatesPerFrame = pipelineCreateWindow / (double)framesInWindow;
+                double graphicsPipelineBindsPerFrame = graphicsPipelineBindWindow / (double)framesInWindow;
+                double graphicsPipelineBindsSkippedPerFrame = graphicsPipelineBindSkippedWindow / (double)framesInWindow;
+                double graphicsResourceSetBindsPerFrame = graphicsResourceSetBindWindow / (double)framesInWindow;
+                double graphicsResourceSetBindsSkippedPerFrame = graphicsResourceSetBindSkippedWindow / (double)framesInWindow;
+                double textureResourceSetsPerFrame = textureResourceSetCreateWindow / (double)framesInWindow;
+                double uniformResourceSetsPerFrame = uniformResourceSetCreateWindow / (double)framesInWindow;
+                double shaderStorageResourceSetsPerFrame = shaderStorageResourceSetCreateWindow / (double)framesInWindow;
+
+                double graphicsSubmitMs = ticksToMilliseconds(graphicsSubmitTicksWindow / (double)Math.Max(1, graphicsSubmitCountWindow));
+                double bufferUpdateSubmitMs = ticksToMilliseconds(bufferUpdateSubmitTicksWindow / (double)Math.Max(1, bufferUpdateSubmitCountWindow));
+                double textureUploadSubmitMs = ticksToMilliseconds(textureUploadSubmitTicksWindow / (double)Math.Max(1, textureUploadSubmitCountWindow));
+
+                stat_graphics_submit_count.Value.Value = graphicsSubmitsPerFrame;
+                stat_graphics_submit_ms.Value.Value = graphicsSubmitMs;
+                stat_buffer_update_submit_count.Value.Value = bufferUpdateSubmitsPerFrame;
+                stat_buffer_update_submit_ms.Value.Value = bufferUpdateSubmitMs;
+                stat_texture_upload_submit_count.Value.Value = textureUploadSubmitsPerFrame;
+                stat_texture_upload_submit_ms.Value.Value = textureUploadSubmitMs;
+                stat_texture_upload_flush_count.Value.Value = textureUploadFlushesPerFrame;
+                stat_pipeline_cache_hits.Value.Value = pipelineHitsPerFrame;
+                stat_pipeline_cache_misses.Value.Value = pipelineMissesPerFrame;
+                stat_pipeline_creates.Value.Value = pipelineCreatesPerFrame;
+                stat_graphics_pipeline_binds.Value.Value = graphicsPipelineBindsPerFrame;
+                stat_graphics_pipeline_binds_skipped.Value.Value = graphicsPipelineBindsSkippedPerFrame;
+                stat_graphics_resource_set_binds.Value.Value = graphicsResourceSetBindsPerFrame;
+                stat_graphics_resource_set_binds_skipped.Value.Value = graphicsResourceSetBindsSkippedPerFrame;
+                stat_texture_resource_set_creates.Value.Value = textureResourceSetsPerFrame;
+                stat_uniform_resource_set_creates.Value.Value = uniformResourceSetsPerFrame;
+                stat_shader_storage_resource_set_creates.Value.Value = shaderStorageResourceSetsPerFrame;
+
+                Logger.Log(
+                    $"Veldrid workload summary ({surfaceType}): graphics_submit={graphicsSubmitsPerFrame:0.###}/f@{graphicsSubmitMs:0.###}ms, " +
+                    $"buffer_submit={bufferUpdateSubmitsPerFrame:0.###}/f@{bufferUpdateSubmitMs:0.###}ms, " +
+                    $"texture_submit={textureUploadSubmitsPerFrame:0.###}/f@{textureUploadSubmitMs:0.###}ms, " +
+                    $"texture_flush={textureUploadFlushesPerFrame:0.###}/f, " +
+                    $"pipeline_cache={pipelineHitsPerFrame:0.###}h/{pipelineMissesPerFrame:0.###}m/{pipelineCreatesPerFrame:0.###}c, " +
+                    $"binds pipeline={graphicsPipelineBindsPerFrame:0.###}/f({graphicsPipelineBindsSkippedPerFrame:0.###} skipped) resources={graphicsResourceSetBindsPerFrame:0.###}/f({graphicsResourceSetBindsSkippedPerFrame:0.###} skipped), " +
+                    $"resource_sets tex={textureResourceSetsPerFrame:0.###}/f uni={uniformResourceSetsPerFrame:0.###}/f ssbo={shaderStorageResourceSetsPerFrame:0.###}/f",
+                    level: LogLevel.Important);
+
+                resetWindow();
+            }
+        }
+
+        private static void resetWindow()
+        {
+            framesInWindow = 0;
+            graphicsSubmitCountWindow = 0;
+            graphicsSubmitTicksWindow = 0;
+            bufferUpdateSubmitCountWindow = 0;
+            bufferUpdateSubmitTicksWindow = 0;
+            textureUploadSubmitCountWindow = 0;
+            textureUploadSubmitTicksWindow = 0;
+            textureUploadFlushCountWindow = 0;
+            pipelineCacheHitWindow = 0;
+            pipelineCacheMissWindow = 0;
+            pipelineCreateWindow = 0;
+            graphicsPipelineBindWindow = 0;
+            graphicsPipelineBindSkippedWindow = 0;
+            graphicsResourceSetBindWindow = 0;
+            graphicsResourceSetBindSkippedWindow = 0;
+            textureResourceSetCreateWindow = 0;
+            uniformResourceSetCreateWindow = 0;
+            shaderStorageResourceSetCreateWindow = 0;
+        }
+
+        private static Lazy<GlobalStatistic<double>> createDoubleStatistic(string name)
+            => new Lazy<GlobalStatistic<double>>(() => GlobalStatistics.Get<double>(nameof(VeldridRenderer), name));
+
+        private static double ticksToMilliseconds(double ticks)
+            => ticks * 1000 / Stopwatch.Frequency;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridInstrumentation.cs
@@ -46,6 +46,7 @@ namespace osu.Framework.Graphics.Veldrid
         private static readonly Lazy<GlobalStatistic<double>> stat_texture_resource_set_creates = createDoubleStatistic("Texture resource sets/frame");
         private static readonly Lazy<GlobalStatistic<double>> stat_uniform_resource_set_creates = createDoubleStatistic("Uniform resource sets/frame");
         private static readonly Lazy<GlobalStatistic<double>> stat_shader_storage_resource_set_creates = createDoubleStatistic("Shader storage resource sets/frame");
+        private static readonly Lazy<GlobalStatistic<double>> stat_texture_resource_recreates = createDoubleStatistic("Texture resource recreates/frame");
 
         private static int framesInWindow;
         private static long graphicsSubmitCountWindow;
@@ -65,6 +66,7 @@ namespace osu.Framework.Graphics.Veldrid
         private static long textureResourceSetCreateWindow;
         private static long uniformResourceSetCreateWindow;
         private static long shaderStorageResourceSetCreateWindow;
+        private static long textureResourceRecreateWindow;
 
         public static void RecordSubmit(VeldridPipelineKind kind, long elapsedTicks)
         {
@@ -181,6 +183,15 @@ namespace osu.Framework.Graphics.Veldrid
             }
         }
 
+        public static void RecordTextureResourcesRecreated()
+        {
+            if (!Enabled)
+                return;
+
+            lock (sync)
+                textureResourceRecreateWindow++;
+        }
+
         public static void EndFrame(GraphicsSurfaceType surfaceType)
         {
             if (!Enabled)
@@ -207,6 +218,7 @@ namespace osu.Framework.Graphics.Veldrid
                 double textureResourceSetsPerFrame = textureResourceSetCreateWindow / (double)framesInWindow;
                 double uniformResourceSetsPerFrame = uniformResourceSetCreateWindow / (double)framesInWindow;
                 double shaderStorageResourceSetsPerFrame = shaderStorageResourceSetCreateWindow / (double)framesInWindow;
+                double textureResourceRecreatesPerFrame = textureResourceRecreateWindow / (double)framesInWindow;
 
                 double graphicsSubmitMs = ticksToMilliseconds(graphicsSubmitTicksWindow / (double)Math.Max(1, graphicsSubmitCountWindow));
                 double bufferUpdateSubmitMs = ticksToMilliseconds(bufferUpdateSubmitTicksWindow / (double)Math.Max(1, bufferUpdateSubmitCountWindow));
@@ -229,6 +241,7 @@ namespace osu.Framework.Graphics.Veldrid
                 stat_texture_resource_set_creates.Value.Value = textureResourceSetsPerFrame;
                 stat_uniform_resource_set_creates.Value.Value = uniformResourceSetsPerFrame;
                 stat_shader_storage_resource_set_creates.Value.Value = shaderStorageResourceSetsPerFrame;
+                stat_texture_resource_recreates.Value.Value = textureResourceRecreatesPerFrame;
 
                 Logger.Log(
                     $"Veldrid workload summary ({surfaceType}): graphics_submit={graphicsSubmitsPerFrame:0.###}/f@{graphicsSubmitMs:0.###}ms, " +
@@ -237,7 +250,8 @@ namespace osu.Framework.Graphics.Veldrid
                     $"texture_flush={textureUploadFlushesPerFrame:0.###}/f, " +
                     $"pipeline_cache={pipelineHitsPerFrame:0.###}h/{pipelineMissesPerFrame:0.###}m/{pipelineCreatesPerFrame:0.###}c, " +
                     $"binds pipeline={graphicsPipelineBindsPerFrame:0.###}/f({graphicsPipelineBindsSkippedPerFrame:0.###} skipped) resources={graphicsResourceSetBindsPerFrame:0.###}/f({graphicsResourceSetBindsSkippedPerFrame:0.###} skipped), " +
-                    $"resource_sets tex={textureResourceSetsPerFrame:0.###}/f uni={uniformResourceSetsPerFrame:0.###}/f ssbo={shaderStorageResourceSetsPerFrame:0.###}/f",
+                    $"resource_sets tex={textureResourceSetsPerFrame:0.###}/f uni={uniformResourceSetsPerFrame:0.###}/f ssbo={shaderStorageResourceSetsPerFrame:0.###}/f, " +
+                    $"texture_resources={textureResourceRecreatesPerFrame:0.###}/f",
                     level: LogLevel.Important);
 
                 resetWindow();
@@ -264,6 +278,7 @@ namespace osu.Framework.Graphics.Veldrid
             textureResourceSetCreateWindow = 0;
             uniformResourceSetCreateWindow = 0;
             shaderStorageResourceSetCreateWindow = 0;
+            textureResourceRecreateWindow = 0;
         }
 
         private static Lazy<GlobalStatistic<double>> createDoubleStatistic(string name)

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Rendering.Vertices;
@@ -17,6 +18,7 @@ using osu.Framework.Graphics.Veldrid.Pipelines;
 using osu.Framework.Graphics.Veldrid.Shaders;
 using osu.Framework.Graphics.Veldrid.Textures;
 using osu.Framework.Graphics.Veldrid.Vertices;
+using osu.Framework.Logging;
 using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
@@ -77,11 +79,20 @@ namespace osu.Framework.Graphics.Veldrid
         {
             veldridDevice = new VeldridDevice(graphicsSurface);
             graphicsPipeline = new GraphicsPipeline(veldridDevice);
-            bufferUpdatePipeline = new BasicPipeline(veldridDevice);
-            textureUploadPipeline = new BasicPipeline(veldridDevice);
+            bufferUpdatePipeline = new BasicPipeline(veldridDevice, VeldridPipelineKind.BufferUpdate);
+            textureUploadPipeline = new BasicPipeline(veldridDevice, VeldridPipelineKind.TextureUpload);
             stagingTexturePool = new VeldridStagingTexturePool(graphicsPipeline);
 
             MaxTextureSize = veldridDevice.MaxTextureSize;
+
+            if (VeldridInstrumentation.Enabled && RuntimeInfo.OS == RuntimeInfo.Platform.macOS && SurfaceType == GraphicsSurfaceType.Metal)
+            {
+                Logger.Log(
+                    shouldFlushTextureUploadBeforeDraw()
+                        ? "Using conservative pre-draw texture upload flushes on macOS Metal."
+                        : "Using batched texture upload flushes on native Apple Silicon Metal.",
+                    level: LogLevel.Important);
+            }
         }
 
         protected internal override void BeginFrame(Vector2 windowSize)
@@ -105,6 +116,7 @@ namespace osu.Framework.Graphics.Veldrid
 
             bufferUpdatePipeline.End();
             graphicsPipeline.End();
+            VeldridInstrumentation.EndFrame(SurfaceType);
         }
 
         protected internal override void SwapBuffers()
@@ -166,12 +178,11 @@ namespace osu.Framework.Graphics.Veldrid
 
         public override void DrawVerticesImplementation(PrimitiveTopology topology, int vertexStart, int verticesCount)
         {
-            // normally we would flush/submit all texture upload commands at the end of the frame, since no actual rendering by the GPU will happen until then,
-            // but turns out on macOS with non-apple GPU, this results in rendering corruption.
-            // flushing the texture upload commands here before a draw call fixes the corruption, and there's no explanation as to why that's the case,
-            // but there is nothing to be lost in flushing here except for a frame that contains many sprites with Texture.BypassTextureUploadQueue = true.
-            // until that appears to be problem, let's just flush here.
-            flushTextureUploadPipeline();
+            if (shouldFlushTextureUploadBeforeDraw())
+            {
+                // Keep the historical workaround on Intel/unknown macOS Metal devices where batched uploads have shown corruption.
+                flushTextureUploadPipeline();
+            }
 
             graphicsPipeline.DrawVertices(topology.ToPrimitiveTopology(), vertexStart, verticesCount);
         }
@@ -211,6 +222,17 @@ namespace osu.Framework.Graphics.Veldrid
 
             textureUploadPipeline.End();
             beganTextureUploadPipeline = false;
+            VeldridInstrumentation.RecordTextureUploadFlush();
+        }
+
+        private bool shouldFlushTextureUploadBeforeDraw()
+        {
+            if (FrameworkEnvironment.ForceMacOSPreDrawTextureUploadFlush.HasValue)
+                return FrameworkEnvironment.ForceMacOSPreDrawTextureUploadFlush.Value;
+
+            return RuntimeInfo.OS == RuntimeInfo.Platform.macOS
+                   && SurfaceType == GraphicsSurfaceType.Metal
+                   && RuntimeInformation.ProcessArchitecture != Architecture.Arm64;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -149,6 +149,9 @@ namespace osu.Framework.Graphics.Veldrid
             return true;
         }
 
+        public void InvalidateTextureBinding(VeldridTexture texture)
+            => InvalidateTextureBinding((INativeTexture)texture);
+
         protected override void SetShaderImplementation(IShader shader)
             => graphicsPipeline.SetShader((VeldridShader)shader);
 
@@ -250,7 +253,9 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected internal Image<Rgba32>? ExtractTexture(VeldridTexture texture)
         {
-            var resource = texture.GetResourceList().FirstOrDefault();
+            var resources = texture.GetResourceList();
+            var resource = resources.Count > 0 ? resources[0] : null;
+
             if (resource == null)
                 return null;
 


### PR DESCRIPTION
## Summary

This reduces redundant work in Veldrid-backed rendering paths:

- adds opt-in internal Veldrid workload counters behind `OSU_GRAPHICS_LOG_VELDRID_FRAME_TIMINGS`
- skips redundant `SetPipeline()` / `SetGraphicsResourceSet()` calls when the Veldrid bind state is unchanged
- keeps Veldrid texture resource wrappers stable across same-size uploads so cached resource sets can be reused
- avoids the historical pre-draw Metal texture-upload flush on native macOS arm64, using the existing end-of-frame flush instead

The runtime changes are internal to the Veldrid backend. No public framework API is added.

## Scope

This is not an Apple Silicon-only change.

The bind-state and texture resource-set changes are shared Veldrid hot-path changes. They can affect any graphics API used through the Veldrid backend because they sit below the API-specific backend selection:

| Change | Scope |
| --- | --- |
| Veldrid counters | All Veldrid-backed paths, inactive unless `OSU_GRAPHICS_LOG_VELDRID_FRAME_TIMINGS=1` |
| Pipeline bind skipping | Shared Veldrid graphics pipeline path |
| Resource-set bind skipping | Shared Veldrid graphics pipeline path |
| Same-size texture resource/resource-set reuse | Shared Veldrid texture path |
| Pre-draw texture-upload flush removal | Native macOS arm64 Metal only by default |

The framework's separate `GLRenderer` path is not changed by this PR. Veldrid-backed OpenGL/deferred paths are still Veldrid paths and should be considered in scope if selected explicitly.

## Historical context

The texture-upload path has prior correctness history, so this PR keeps the old conservative behaviour where it matters:

- https://github.com/ppy/osu-framework/issues/5923 reported Metal texture corruption under heavy upload load.
- https://github.com/ppy/osu-framework/pull/5924 added the pre-draw Metal upload flush as a conservative workaround, explicitly noting that the root cause was not fully understood.
- https://github.com/ppy/osu-framework/pull/5928 fixed another texture-upload corruption case where uploads could cross frame boundaries without being submitted.

For that reason, this PR does **not** remove the conservative pre-draw upload flush everywhere. It only changes the default on native macOS arm64 Metal, where local validation shows the batched path is active and the existing end-of-frame flush still submits uploads. Non-arm64 macOS Metal keeps the conservative pre-draw flush by default.

## Safety model

The shared Veldrid changes are intended to skip only redundant work:

- pipeline binds are skipped only when the cached pipeline object is the same instance
- resource-set binds are skipped only when the resource-set instance and dynamic offset are unchanged
- bind state is reset on command-list begin, framebuffer changes, and pipeline changes
- pipeline changes clear cached resource-set state
- texture resource sets are cached per `ResourceLayout`
- cached texture bindings are invalidated before texture resource or sampler replacement, so disposed resource sets are not reused

The Metal upload batching path keeps an explicit override:

- `OSU_GRAPHICS_MACOS_PREDRAW_TEXTURE_UPLOAD_FLUSH=1` forces the historical pre-draw flush
- `OSU_GRAPHICS_MACOS_PREDRAW_TEXTURE_UPLOAD_FLUSH=0` forces the batched path for validation

## Validation

Correctness and style:

- `dotnet test osu.Framework.Tests/osu.Framework.Tests.csproj -c Release --filter FullyQualifiedName~Veldrid`
- `dotnet test osu.Framework.Tests/osu.Framework.Tests.csproj -c Release --filter FullyQualifiedName~RendererTest`
- `dotnet test osu.Framework.Tests/osu.Framework.Tests.csproj -c Release --filter FullyQualifiedName~TextureStoreTest`
- `dotnet build osu.Framework/osu.Framework.csproj -c Debug -warnaserror -p:EnforceCodeStyleInBuild=true`

Added/covered behaviours:

- first bind emits
- repeated pipeline bind skips
- repeated resource-set bind skips
- changed pipeline/resource-set emits
- dynamic offset changes emit
- command-list begin resets bind cache
- framebuffer changes reset bind cache
- pipeline changes clear cached resource-set state

Targeted local validation environment:

- native macOS arm64
- Veldrid + Metal
- `FrameSync.Limit2x`
- multi-threaded
- repeated targeted harness runs after warmup

Observed mechanism-level results on that environment:

- upload batching path logged as active on native Apple Silicon Metal
- forced conservative pre-draw texture upload flushing remained available via `OSU_GRAPHICS_MACOS_PREDRAW_TEXTURE_UPLOAD_FLUSH=1`
- fixed Metal workload reduced texture upload flush frequency from `0.904/f` to `0.725/f`
- bind-state workload reported about `799` skipped pipeline binds/frame and about `799` skipped resource-set binds/frame
- upload-heavy workload reduced texture resource-set creation from about `37-39/f` to `0.417/f`

These are counter-level validation results. I am not claiming a power or FPS improvement from these numbers because local frame-time and system power samples were too noisy for a defensible end-user performance claim.

## Backend risk matrix

| Backend/path | Expected impact | Current validation status |
| --- | --- | --- |
| Native macOS arm64 Metal | Shared bind/resource-set changes plus default batched upload flush | Locally tested with counters and focused correctness tests |
| Non-arm64 macOS Metal | Shared bind/resource-set changes; conservative pre-draw upload flush remains default | Behaviour preserved for upload flushing; needs platform validation for shared bind/resource-set changes |
| Direct3D11 through Veldrid | Shared bind/resource-set and texture resource-set changes | Needs CI/platform validation; no local D3D11 claim made |
| Vulkan through Veldrid | Shared bind/resource-set and texture resource-set changes | Needs CI/platform validation; no local Vulkan claim made |
| Separate `GLRenderer` | Not changed | Out of scope |
| Explicit Veldrid OpenGL/deferred paths | Shared Veldrid changes may apply if selected | Needs validation if considered supported/important |

The main regression risks to watch for are stale resource-set bindings, missed dynamic-offset updates, missed bind-state reset boundaries, and texture-upload corruption. The tests cover deterministic bind-state boundaries; upload-heavy visual scenes are still the most relevant validation for texture corruption because historical failures were visual.

## Non-goals

- This PR does not make power or FPS improvement claims.
- This PR does not remove the historical macOS Metal conservative upload flush globally.
- This PR does not change the separate non-Veldrid `GLRenderer`.
- This PR does not include the later framebuffer resize or index-buffer growth experiments; those can be reviewed separately.
