### PR TITLE
Fix Korean IME input

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -169,7 +169,7 @@ namespace osu.Framework.Graphics.UserInterface
         public event OnCommitHandler OnCommit;
 
         /// <summary>
-        /// Scheduler used for scheduling text input events coming from <see cref="textInput"/>.
+        /// Scheduler used for scheduling text input events, IME composition and result events coming from <see cref="textInput"/>.
         /// </summary>
         /// <remarks>
         /// Used for scheduling text events so that the <see cref="Text"/> is updated on the update thread.
@@ -180,11 +180,6 @@ namespace osu.Framework.Graphics.UserInterface
         ///  - Later in the same update frame, in <see cref="Update"/>. In case there was no associated key event. This is mostly required for mobile platforms.
         /// </remarks>
         private readonly Scheduler textInputScheduler = new Scheduler(() => ThreadSafety.IsUpdateThread, null);
-
-        /// <summary>
-        /// Scheduler used for scheduling IME composition and result events coming from <see cref="textInput"/>.
-        /// </summary>
-        private readonly Scheduler imeCompositionScheduler = new Scheduler(() => ThreadSafety.IsUpdateThread, null);
 
         protected TextBox()
         {
@@ -599,17 +594,17 @@ namespace osu.Framework.Graphics.UserInterface
             // and then call `onImeResult()`.
             // the composition being inactive and having scheduled tasks shouldn't happen,
             // but the check is here to cover that improbable edge case.
-            if (!ImeCompositionActive && !imeCompositionScheduler.HasPendingTasks)
+            if (!ImeCompositionActive && !textInputScheduler.HasPendingTasks)
                 return;
 
-            imeCompositionScheduler.Add(() => onImeResult(userEvent, false));
+            textInputScheduler.Add(() => onImeResult(userEvent, false));
 
             if (textInputBound)
                 textInput.ResetIme();
 
             // importantly, we want to force-update all pending composition events,
             // so that when we return control to the caller, those events won't mutate text and/or caret position.
-            imeCompositionScheduler.Update();
+            textInputScheduler.Update();
         }
 
         /// <summary>
@@ -619,14 +614,14 @@ namespace osu.Framework.Graphics.UserInterface
         protected void CancelImeComposition()
         {
             // same rationale as above, in `FinalizeImeComposition()`
-            if (!ImeCompositionActive && !imeCompositionScheduler.HasPendingTasks)
+            if (!ImeCompositionActive && !textInputScheduler.HasPendingTasks)
                 return;
 
             if (textInputBound)
                 textInput.ResetIme();
 
-            imeCompositionScheduler.Add(() => onImeComposition(string.Empty, 0, 0, false));
-            imeCompositionScheduler.Update(); // same rationale as above, in `FinalizeImeComposition()`
+            textInputScheduler.Add(() => onImeComposition(string.Empty, 0, 0, false));
+            textInputScheduler.Update(); // same rationale as above, in `FinalizeImeComposition()`
         }
 
         protected override void Dispose(bool isDisposing)
@@ -690,7 +685,6 @@ namespace osu.Framework.Graphics.UserInterface
             // update the schedulers before updating children as it might mutate TextFlow.
             // we want the character drawables to be up-to date for further calculations in `updateCursorAndLayout()`.
             textInputScheduler.Update();
-            imeCompositionScheduler.Update();
         }
 
         protected override void UpdateAfterChildren()
@@ -1533,7 +1527,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             textInputBlocking = true;
 
-            InsertString(t);
+            insertString(t);
             OnUserTextAdded(t);
 
             // clear the flag in the next frame if no buttons are pressed/held.
@@ -1550,12 +1544,12 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void handleImeComposition(string composition, int selectionStart, int selectionLength)
         {
-            imeCompositionScheduler.Add(() => onImeComposition(composition, selectionStart, selectionLength, true));
+            textInputScheduler.Add(() => onImeComposition(composition, selectionStart, selectionLength, true));
         }
 
         private void handleImeResult(string result)
         {
-            imeCompositionScheduler.Add(() =>
+            textInputScheduler.Add(() =>
             {
                 onImeComposition(result, result.Length, 0, false);
                 onImeResult(true, true);


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/37601

The old SDL2 implementation avoids the issue by implementing Windows IME natively and taking the result before composition (I also tried reverting https://github.com/ppy/osu-framework/pull/6419, but it eats up some input unlike SDL2 for some reason), while the current SDL3 implementation simply uses SDL TextInput events.

However, osu!framework TextBox wants to differentiate default input and IME input, so the problem emerges here:

1. Type ㅈ ,ㅣ and ㅂ consecutively
2. SDL sends a TextEditing event that contains '집'<br />('집' is now in the textbox, but the composition has not ended at this point because a consonant can still be added to this character)
3. Type ㅇ<br />(the composition of '집' has ended and now committed, so a new composition should start with 'ㅇ')
4. SDL sends an empty TextEditing event to clear composition, and since this is an empty string, `TextInputSource.ImeActive` is set to false
5. SDL sends a TextInput event that contains '집', but `ImeActive` is false, and SDL provides no distinction between default and IME input, so `Textbox.handleTextInput` instead of `handleImeResult` is called and IME is reset <br /> (`handleImeResult` has probably never been used in our SDL3 implementation)
6. SDL sends a TextEditing event that contains 'ㅇ', but due to race condition in TextBox, the user now sees 'ㅇ집' (expected '집ㅇ')
7. Type ㅔ<br />(the composition is going on, '집에' should be displayed)
8. osu!framework reset IME while a character is being composited, so ㅇ and ㅔ are disconnected and 'ㅇ집ㅔ' gets displayed

You can install Korean IME on Windows (use 101/type1 layout), press right Alt to activate IME, and type wlqdp on osu! to reproduce.

This PR fixes the issue by making TextBox not finalize IME composition on text input, and synchronize text input events with IME events. I made SDL2 available again for Windows to compare changes, but I can remove the commit if anyone wants.