### PR TITLE
Add a passing and a failing test for Korean IME

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
@@ -385,6 +385,122 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("input deactivated", () => textInput.DeactivationQueue.Dequeue() && textInput.DeactivationQueue.Count == 0);
         }
 
+        // Microsoft Korean IME
+        // When pressing letter keys, the IME is perpetually in composition mode. The IME leaves composition mode when you type a non-letter character.
+        // Let's assume the following mappings
+        // - "lt" -> "<"
+        // - "lte" -> "≤"
+        // - single letters map to themselves
+
+        [Test]
+        public void TestKoreanImeFinalizeByNonLetter()
+        {
+            AddStep("type l", () => textInput.TriggerImeComposition("l", 0, 1));
+            AddAssert(@"ime composition event for ""l"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "l",
+                AddedTextLength = 1,
+                RemovedTextLength = 0,
+                SelectionMoved = true
+            }));
+
+            AddStep("type t", () => textInput.TriggerImeComposition("<", 0, 1));
+            AddAssert(@"ime composition event for ""<"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "<",
+                AddedTextLength = 1,
+                RemovedTextLength = 1,
+                SelectionMoved = false
+            }));
+
+            AddStep("type e", () => textInput.TriggerImeComposition("≤", 0, 1));
+            AddAssert(@"ime composition event for ""≤"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "≤",
+                AddedTextLength = 1,
+                RemovedTextLength = 1,
+                SelectionMoved = false
+            }));
+
+            AddStep("type .", () =>
+            {
+                // SDL3 reports IME finalize by first signalling an empty composition and then a text event
+                textInput.TriggerImeComposition("", 0, 0);
+                textInput.Text("≤");
+                // after that, we get the actual key press
+                InputManager.PressKey(Key.Period);
+                textInput.Text(".");
+                InputManager.ReleaseKey(Key.Period);
+            });
+            AddAssert("empty ime composition event raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "",
+                AddedTextLength = 0,
+                RemovedTextLength = 1,
+                SelectionMoved = true
+            }));
+            AddAssert(@"text event for ""≤"" raised", () => textBox.UserConsumedTextQueue.Dequeue(), () => Is.EqualTo("≤"));
+            AddAssert(@"text event for ""."" raised", () => textBox.UserConsumedTextQueue.Dequeue(), () => Is.EqualTo("."));
+            AddAssert(@"added text is ""≤.""", () => textBox.Text, () => Is.EqualTo(default_text + "≤."));
+        }
+
+        [Test]
+        public void TestKoreanImeFinalizeByNewComposition()
+        {
+            AddStep("type l", () => textInput.TriggerImeComposition("l", 0, 1));
+            AddAssert(@"ime composition event for ""l"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "l",
+                AddedTextLength = 1,
+                RemovedTextLength = 0,
+                SelectionMoved = true
+            }));
+
+            AddStep("type t", () => textInput.TriggerImeComposition("<", 0, 1));
+            AddAssert(@"ime composition event for ""<"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "<",
+                AddedTextLength = 1,
+                RemovedTextLength = 1,
+                SelectionMoved = false
+            }));
+
+            AddStep("type e", () => textInput.TriggerImeComposition("≤", 0, 1));
+            AddAssert(@"ime composition event for ""≤"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "≤",
+                AddedTextLength = 1,
+                RemovedTextLength = 1,
+                SelectionMoved = false
+            }));
+
+            AddStep("type l", () =>
+            {
+                // SDL3 reports IME finalize by first signalling an empty composition and then a text event
+                textInput.TriggerImeComposition("", 0, 0);
+                textInput.Text("≤");
+                // after that, we get the new composition
+                textInput.TriggerImeComposition("l", 0, 1);
+            });
+            AddAssert("empty ime composition event raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "",
+                AddedTextLength = 0,
+                RemovedTextLength = 1,
+                SelectionMoved = true
+            }));
+            AddAssert(@"text event for ""≤"" raised", () => textBox.UserConsumedTextQueue.Dequeue(), () => Is.EqualTo("≤"));
+            AddAssert(@"ime composition event for ""l"" raised", () => textBox.ImeCompositionQueue.Dequeue().Equals(new ImeCompositionEvent
+            {
+                NewComposition = "l",
+                AddedTextLength = 1,
+                RemovedTextLength = 0,
+                SelectionMoved = true
+            }));
+            AddAssert(@"added text is ""≤l""", () => textBox.Text, () => Is.EqualTo(default_text + "≤l"));
+            AddAssert("ime is active", () => textInput.ImeActive, () => Is.True);
+        }
+
         [Test]
         public void TestLengthLimitTruncatesComposition()
         {


### PR DESCRIPTION
Tests the problem as reported in https://github.com/ppy/osu/issues/37601. The tests are based on actual events reported by SDL3 when using Microsoft Korean IME on Windows, but modified to use characters supported by o!f fonts instead of Hangul.

TestKoreanImeFinalizeByNonLetter passes on master, while TestKoreanImeFinalizeByNewComposition fails the last two asserts.

Applying https://github.com/ppy/osu-framework/pull/6742 makes the second test pass, as you would expect.

I would suggest merging this either directly before or directly after #6742.