### PR TITLE
Use SDL3 for linux by default

### DIFF
--- a/osu.Framework/FrameworkEnvironment.cs
+++ b/osu.Framework/FrameworkEnvironment.cs
@@ -53,8 +53,11 @@ namespace osu.Framework
             if (DebugUtils.IsDebugBuild)
                 AllowInsecureRequests = parseBool(Environment.GetEnvironmentVariable("OSU_INSECURE_REQUESTS")) ?? false;
 
-            // Some desktop platforms have remaining issues, see https://github.com/ppy/osu-framework/issues/6540.
-            UseSDL3 = RuntimeInfo.IsMobile || RuntimeInfo.OS == RuntimeInfo.Platform.Windows || (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) ?? false);
+            if (parseBool(Environment.GetEnvironmentVariable("OSU_SDL3")) is bool userSDL3Override)
+                UseSDL3 = userSDL3Override;
+            else
+                // Some desktop platforms have remaining issues, see https://github.com/ppy/osu-framework/issues/6540.
+                UseSDL3 = RuntimeInfo.OS != RuntimeInfo.Platform.macOS;
         }
 
         private static bool? parseBool(string? value)


### PR DESCRIPTION
Most issue are now fixed. Let's give this another try.

Closes https://github.com/ppy/osu/issues/21939 and probably others.

This also resolves the inability to forcefully disable SDL3 by setting the envvar to `false`. Because we're probably going to recommend this to users which are experiencing issues going forward, rather than reverting this change yet again.