### PR TITLE
Attempt to fix file type detection logic on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Android
 
         public FileInfo CreateTemporaryFileFromContentUri(Uri contentUri)
         {
-            // while content URIs are not real paths, in practice they appear to at least contain filenames at the end.
+            // while content URIs are not real paths, in practice they *appear* to at least *sometimes* contain real filenames at the end.
             // try using that first, since it's the least likely thing to fail later.
             // the reason why this is important is that downstream consumers may depend on the *extension* of the file in particular,
             // and there's no guarantee that we can recover it safely from anywhere else.
@@ -136,8 +136,15 @@ namespace osu.Framework.Android
 
             // if the content URI fails generate something else.
             if (string.IsNullOrEmpty(filename))
-            {
                 filename = Path.GetRandomFileName();
+
+            // check if we have an extension to use.
+            // there are two cases where we might not:
+            // - the content-providing app gave something resembling a filename but not an extension (known to happen in the wild)
+            // - there was no actual filename to use at any point, and we just generated our own above
+            // in both cases, attempt to synthesise an extension ourselves since there's nothing left to use anyway.
+            if (string.IsNullOrEmpty(Path.GetExtension(filename)))
+            {
                 string? mimeType = ContentResolver?.GetType(contentUri);
                 string? extension = MimeTypeMap.Singleton?.GetExtensionFromMimeType(mimeType);
 


### PR DESCRIPTION
Intends to close https://github.com/ppy/osu/issues/37704

On Android, you can choose what file picker you like best. Some OEMs leverage this to implement their own (sometimes ad-ridden, *you know who you are*) file pickers.

It appears that while some file pickers return content URIs that end with the actual underlying file's name, some file pickers return their specific gibberish, without a file extension in sight. And they are entitled to do so by the Android Decree of "you shall only ever interact with files via our magic APIs".

But then game-side TagLib rolls up, sees a filename without an extension, goes "wots all dis den" and just rejects the file. So to keep the lie up, attempt a little harder to synthesise an actual usable file extension as if this was still a desktop computer with actual files.