### PR TITLE
Fix: Fixed caret staying at composition status.

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -1768,7 +1768,11 @@ namespace osu.Framework.Graphics.UserInterface
             // this selection is only a hint to the user, and is not used in the compositing logic.
             selectionStart = imeCompositionStart + newSelectionStart;
             selectionEnd = selectionStart + newSelectionLength;
-
+            
+            // push caret to end if composition is working
+            if (imeCompositionLength > 0)
+                selectionStart = selectionEnd = imeCompositionStart + imeCompositionLength;
+                
             if (userEvent) OnImeComposition(newComposition, removeCount, addCount, oldStart != selectionStart || oldEnd != selectionEnd);
 
             endTextChange(beganChange);


### PR DESCRIPTION
en:
Push caret to the end during IME composition for better visibility

**(While the underlying IME logic remains to be fixed, this PR provides a workaround for the frozen cursor during composition.)**

ko:
카렛(커서)를 조합 중인 상태(Composition)에서도 강제로 밀어 사용자 UI/UX를 개선하였습니다

**(이 PR은 근본적인 IME로직은 해결하지 않지만, UI개선 임시방편을 제공합니다)**