### PR TITLE
Work around infrequent crash when pen enters proximity on Windows

### DIFF
--- a/osu.Framework/Platform/SDL3/SDL3Window.Input.cs
+++ b/osu.Framework/Platform/SDL3/SDL3Window.Input.cs
@@ -571,7 +571,13 @@ namespace osu.Framework.Platform.SDL3
                 if (!penProximityWorkaround && penDeviceTypes.ContainsKey(evtPenProximity.which))
                     Logger.Log($"Unexpected SDL_EVENT_PEN_PROXIMITY_IN for pen id={evtPenProximity.which}. Pen already in proximity.", level: LogLevel.Important);
 
-                penDeviceTypes[evtPenProximity.which] = SDL_GetPenDeviceType(evtPenProximity.which).ThrowIfFailed().ToTabletPenDeviceType();
+                // On windows, the call to SDL_GetPenDeviceType() can infrequently error out with "Invalid pen instance ID".
+                // This doesn't make sense, as we got the pen ID from an event, so it should be valid.
+                // Hard-code to `Unknown` pen type to avoid the crash. Currently, on windows, all pens are already reported as Unknown.
+                // See https://github.com/ppy/osu-framework/issues/6747 for more information.
+                penDeviceTypes[evtPenProximity.which] = RuntimeInfo.OS == RuntimeInfo.Platform.Windows
+                    ? TabletPenDeviceType.Unknown
+                    : SDL_GetPenDeviceType(evtPenProximity.which).ThrowIfFailed().ToTabletPenDeviceType();
             }
             else
             {


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu-framework/issues/6747

This hard-codes the pen type on Windows to `TabletPenDeviceType.Unknown`. There is no change in functionality as SDL already reports all pens on Windows as `SDL_PEN_DEVICE_TYPE_UNKNOWN`.

The crash is fixed by not calling `SDL_GetPenDeviceType()`, which may sometimes error out with "Invalid pen instance ID".

---

I also considered storing the last pen type and using that in the error case, but I found it too hacky, it doesn't fix the underlying issue and increases complexity.