### PR TITLE
Skip elapsed iterations for looping transforms when time jumps forward

### DIFF
--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -175,6 +175,24 @@ namespace osu.Framework.Graphics.Transforms
 
                         if (t.IsLooping)
                         {
+                            int loopAdvanceCount = 1;
+
+                            if (!tCanRewind && t.LoopDelay > 0)
+                            {
+                                int additionalLoopsToSkip = (int)Math.Floor((time - t.EndTime) / t.LoopDelay);
+
+                                if (additionalLoopsToSkip > 0)
+                                {
+                                    if (t.LoopCount > 0)
+                                    {
+                                        additionalLoopsToSkip = Math.Min(additionalLoopsToSkip, t.LoopCount);
+                                        t.LoopCount -= additionalLoopsToSkip;
+                                    }
+
+                                    loopAdvanceCount += additionalLoopsToSkip;
+                                }
+                            }
+
                             int oldLoopCount = t.LoopCount;
 
                             if (tCanRewind)
@@ -190,13 +208,19 @@ namespace osu.Framework.Graphics.Transforms
                             if (tCanRewind)
                                 t.LoopCount = oldLoopCount;
 
-                            t.StartTime += t.LoopDelay;
-                            t.EndTime += t.LoopDelay;
+                            t.StartTime += t.LoopDelay * loopAdvanceCount;
+                            t.EndTime += t.LoopDelay * loopAdvanceCount;
 
-                            // this could be added back at a lower index than where we are currently iterating, but
-                            // running the same transform twice isn't a huge deal.
-                            transforms.Add(t);
-                            flushAppliedCache = true;
+                            // When the story version uses a large amount of looping animation in a short period, it can experience a serious performance drop.
+                            // For example: https://osu.ppy.sh/beatmapsets/974689#mania/2220863
+                            // By resolving the cycle and releasing it early, problems can be effectively improved
+                            if (t.IsLooping)
+                            {
+                                transforms.Add(t);
+                                flushAppliedCache = true;
+                            }
+                            else if (t.CompletionTargetSequence != null)
+                                removalActions.Enqueue((t.CompletionTargetSequence, s => s.TransformCompleted()));
                         }
                         else if (t.CompletionTargetSequence != null)
                             removalActions.Enqueue((t.CompletionTargetSequence, s => s.TransformCompleted()));


### PR DESCRIPTION
## 
The purpose of this PR
In https://osu.ppy.sh/beatmapsets/974689#mania/2220863 BeatmapSet (including beatmaps similar to the storyboard), When a large number of loop animations appear on the screen, loop stacking occurs, leading to severe performance drops and memory growth.

Two main changes have been made:
- Batch skipping outdated loop rounds (Skip outdated loop iterations in a single update, rather than once per frame.)
- Don't re-add transforms to the list after loop count is exhausted.

This issue should have existed for a long time because no solution has been found, so I submitted this PR to provide a temporary improvement.
I lack experience submitting PRs, so my writing may not be comprehensive enough. I'll try to include screenshots before and after the changes and a memory performance comparison table (due to time difference, it's too late).

Simple build tests can show significant improvements in-game (at least from being completely playable to barely playable). This is not an urgent need, but it must be addressed. I'm even more looking forward to the official team coming up with better solutions—I'm looking forward to it.

This PR is relevant to Topic [osu/#37952](https://github.com/ppy/osu/issues/37952)