### PR TITLE
Increase `Path` SDF precision by encoding it as 3 color components

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_Path.fs
+++ b/osu.Framework/Resources/Shaders/sh_Path.fs
@@ -25,7 +25,15 @@ layout(location = 0) out vec4 o_Colour;
 void main(void) 
 {
     lowp vec4 frameBuffer = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9);
-    lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(frameBuffer.r, 0.0) * TexRect1.zw, -0.9);
+    
+    // in sh_PathPrepass.fs we were encoding [0, 1] 24-bit float as 3 8-bit floats. Decoding to get original value
+    highp float r = frameBuffer.r * 255.0;
+    highp float g = frameBuffer.g * 255.0;
+    highp float b = frameBuffer.b * 255.0;
+    highp float v = r * 65536.0 + g * 256.0 + b;
+    highp float decodedDst = v / 16777215.0;
+
+    lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(decodedDst, 0.0) * TexRect1.zw, -0.9);
     o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * frameBuffer.a), v_TexCoord);
 }
 

--- a/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
+++ b/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
@@ -13,7 +13,16 @@ layout(location = 0) out vec4 o_Colour;
 void main(void) 
 {    
     highp float dst = clamp(dstToLine(v_StartPos, v_EndPos, v_Position), 0.0, v_Radius);
-    o_Colour = vec4(vec3(1.0 - dst / v_Radius), float(dst < v_Radius));
+    highp float result = 1.0 - dst / v_Radius; // [0, 1] 24 bit
+
+    // encode 24-bit float as 3 8-bit floats
+    highp float v = result * 16777215.0;
+
+    highp float r = floor(v / 65536.0) / 255.0;
+    highp float g = floor(mod(v, 65536.0) / 256.0) / 255.0;
+    highp float b = mod(v, 256.0) / 255.0;
+
+    o_Colour = vec4(r, g, b, float(dst < v_Radius));
 }
 
 #endif


### PR DESCRIPTION
After trying various potential solutions I noticed color banding which is core of the problem: 256 distance values in path sdf isn't enough. 
We can use a 24 float distance value by encoding it within 3 lowp values. By using that sampling from the texture strip is more accurate.

|master|pr|
|---|---|
|<img width="821" height="390" alt="pr-pre-framework" src="https://github.com/user-attachments/assets/348a1057-ead2-4bd1-b979-0009fe151603" />|<img width="821" height="390" alt="pr-post-framework" src="https://github.com/user-attachments/assets/08c4b322-115a-40a7-abce-70eb332b0dbe" />|
|<img width="1420" height="700" alt="pre" src="https://github.com/user-attachments/assets/0b22c05f-3dfe-4e9c-9ad0-e97a1d8e680e" />|<img width="1420" height="700" alt="post" src="https://github.com/user-attachments/assets/a1f2b9da-04be-468b-85b2-5e3ee28bd91c" />|