### PR TITLE
Improve `Path` sdf encoding

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new TexturedPath
+                Child = new OverlapTestPath
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -94,8 +94,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         new Vector2(150, 150),
                         new Vector2(150, 100),
                         new Vector2(20, 100),
-                    },
-                    Texture = gradientTexture,
+                    }
                 };
             });
         }
@@ -214,6 +213,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             AddAssert("size = (100, 100)", () => Precision.AlmostEquals(new Vector2(100), path.DrawSize));
+        }
+
+        private partial class OverlapTestPath : SmoothPath
+        {
+            protected override Color4 ColourAt(float position)
+            {
+                return Interpolation.ValueAt(position, Color4.Red, Color4.Blue, 0f, 1f);
+            }
         }
     }
 }

--- a/osu.Framework/Resources/Shaders/sh_Path.fs
+++ b/osu.Framework/Resources/Shaders/sh_Path.fs
@@ -23,18 +23,11 @@ layout(std140, set = 2, binding = 0) uniform m_PathTextureParameters
 layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
-{
-    lowp vec4 frameBuffer = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9);
-    
-    // in sh_PathPrepass.fs we were encoding [0, 1] 24-bit float as 3 8-bit floats. Decoding to get original value
-    highp float r = frameBuffer.r * 255.0;
-    highp float g = frameBuffer.g * 255.0;
-    highp float b = frameBuffer.b * 255.0;
-    highp float v = r * 65536.0 + g * 256.0 + b;
-    highp float decodedDst = v / 16777215.0;
-
-    lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(decodedDst, 0.0) * TexRect1.zw, -0.9);
-    o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * frameBuffer.a), v_TexCoord);
+{ 
+    // in sh_PathPrepass.fs we were encoding [0, 1) 24-bit float as 4 8-bit floats. Decoding to get original value
+    highp float dstFromEdge = decodeFloat(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9));
+    lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(dstFromEdge, 0.0) * TexRect1.zw, -0.9);
+    o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * float(dstFromEdge > 0.000001)), v_TexCoord);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_Path.fs
+++ b/osu.Framework/Resources/Shaders/sh_Path.fs
@@ -23,11 +23,12 @@ layout(std140, set = 2, binding = 0) uniform m_PathTextureParameters
 layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
-{ 
+{
+    lowp vec4 framebuffer = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9);
     // in sh_PathPrepass.fs we were encoding [0, 1) 24-bit float as 4 8-bit floats. Decoding to get original value
-    highp float dstFromEdge = decodeFloat(texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9));
+    highp float dstFromEdge = framebuffer == vec4(1.0) ? 1.0 : decodeFloat(framebuffer);
     lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(dstFromEdge, 0.0) * TexRect1.zw, -0.9);
-    o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * float(dstFromEdge > 0.000001)), v_TexCoord);
+    o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * float(dstFromEdge > 0.0)), v_TexCoord);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
+++ b/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
@@ -2,6 +2,7 @@
 #define PATH_PREPASS_FS
 
 #include "sh_CircularProgressUtils.h"
+#include "sh_Utils.h"
 
 layout(location = 0) in highp vec2 v_Position;
 layout(location = 1) in highp vec2 v_StartPos;
@@ -12,17 +13,9 @@ layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
 {    
-    highp float dst = clamp(dstToLine(v_StartPos, v_EndPos, v_Position), 0.0, v_Radius);
-    highp float result = 1.0 - dst / v_Radius; // [0, 1] 24 bit
-
-    // encode 24-bit float as 3 8-bit floats
-    highp float v = result * 16777215.0;
-
-    highp float r = floor(v / 65536.0) / 255.0;
-    highp float g = floor(mod(v, 65536.0) / 256.0) / 255.0;
-    highp float b = mod(v, 256.0) / 255.0;
-
-    o_Colour = vec4(r, g, b, float(dst < v_Radius));
+    highp float dst = clamp(dstToLine(v_StartPos, v_EndPos, v_Position) / v_Radius, 0.0, 1.0);
+    highp float dstFromEdge = clamp(1.0 - dst, 0.0, 0.9999999);
+    o_Colour = encodeFloat(dstFromEdge);
 }
 
 #endif

--- a/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
+++ b/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
@@ -13,8 +13,15 @@ layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
 {    
-    highp float dst = clamp(dstToLine(v_StartPos, v_EndPos, v_Position) / v_Radius, 0.0, 1.0);
-    highp float dstFromEdge = clamp(1.0 - dst, 0.0, 0.9999999);
+    highp float dstFromEdge = clamp(1.0 - dstToLine(v_StartPos, v_EndPos, v_Position) / v_Radius, 0.0, 1.0);
+
+    // special handling for 1.0 since it can't be encoded properly
+    if (dstFromEdge == 1.0)
+    {
+        o_Colour = vec4(1.0);
+        return;
+    }
+
     o_Colour = encodeFloat(dstFromEdge);
 }
 

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -28,4 +28,19 @@ vec4 hsv2rgb(vec4 c)
     return vec4(c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y), c.w);
 }
 
+// decodes 24-bit float from 4 8-bit floats (https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/)
+highp float decodeFloat(highp vec4 frameBuffer)
+{
+    return dot(frameBuffer, vec4(1.0, 1/255.0, 1/65025.0, 1/16581375.0));
+}
+
+// encodes 24-bit [0, 1) float to 4 8-bit floats (https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/)
+lowp vec4 encodeFloat(highp float value)
+{
+    highp vec4 enc = value * vec4(1.0, 255.0, 65025.0, 16581375.0);
+    enc = fract(enc);
+    enc -= enc.yzww / 255.0;
+    return enc;
+}
+
 #endif

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -39,7 +39,7 @@ lowp vec4 encodeFloat(highp float value)
 {
     highp vec4 enc = value * vec4(1.0, 255.0, 65025.0, 16581375.0);
     enc = fract(enc);
-    enc -= enc.yzww / 255.0;
+    enc -= enc.yzww * vec4(1.0/255.0, 1.0/255.0, 1.0/255.0, 0.0);
     return enc;
 }
 


### PR DESCRIPTION
Iteration upon https://github.com/ppy/osu-framework/pull/6767 with applied proposal from https://github.com/ppy/osu-framework/pull/6767#discussion_r3401933836. Visuals are almost identical.
Added visual test for path intersection and moved encoder/decoder to `sh_Utils.h` for practicality.