### PR TITLE
Make TextFlowContainer wrap on individual characters as a last resort

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -24,7 +24,9 @@ namespace osu.Framework.Tests.Visual.Containers
         private TextFlowContainer textContainer = null!;
 
         [SetUp]
-        public void Setup() => Schedule(() =>
+        public void Setup() => Schedule(() => createContainer(default_text));
+
+        private void createContainer(string text = default_text)
         {
             Child = topLevelContainer = new Container
             {
@@ -43,11 +45,11 @@ namespace osu.Framework.Tests.Visual.Containers
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Text = default_text
+                        Text = text
                     }
                 }
             };
-        });
+        }
 
         [TestCase(Anchor.TopLeft)]
         [TestCase(Anchor.TopCentre)]
@@ -121,6 +123,54 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("set latin text", () => textContainer.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer mattis eu turpis vitae posuere. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam mauris nibh, faucibus maximus ornare eu, ultrices ut ipsum. Proin rhoncus, nunc et faucibus pretium, nisl nunc dapibus massa, et scelerisque nibh ligula id odio. Praesent dapibus ex sed nunc egestas, in placerat risus mattis. Nulla sed ligula velit. Vestibulum auctor porta eros et condimentum. Etiam laoreet nunc nec lacinia pulvinar. Mauris hendrerit, mi at aliquet condimentum, ex ex cursus dolor, non porta erat eros id justo. Cras malesuada tincidunt nunc, at tincidunt risus eleifend id. Maecenas hendrerit venenatis mi et lobortis. Etiam sem tortor, elementum eget lacus non, porta tristique quam. Morbi sed lacinia odio. Phasellus ut pretium nunc. Fusce vitae mollis magna, vel scelerisque dui. ");
             AddStep("set url", () => textContainer.Text = "https://osu.ppy.sh/home/news/2024-03-27-osutaiko-world-cup-2024-round-of-32-recap");
             AddStep("set cjk text", () => textContainer.Text = "日本の桜は世界中から観光客を引きつけています。寿司は美味しい伝統的な日本食です。東京タワーは景色が美しいです。速い新幹線は、便利な交通手段です。富士山は、その美しさと完全な形状で知られています。日本文化は、優雅さと繊細さを象徴しています。抹茶は特別な日本の茶です。着物は、伝統的な日本の衣装で、特別な場面でよく着用されます。");
+        }
+
+        [Test]
+        public void TestOverflowCharacterSplitting()
+        {
+            string overflowText = "LoremipsumdolorsitametconsecteturadipiscingelitIntegermattiseuturpisvitaeposuereOrcivariusnatoquepenatibusetmagnisdisparturientmontesnasceturridiculusmusEtiammaurisnibhfaucibusmaximusornareeuultricesutipsumProinrhoncusnuncetfaucibuspretiumnislnuncdapibusmassaetscelerisquenibhligulaidodioPraesentdapibusexsednuncegestasinplaceratrisusmattisNullasedligulavelitVestibulumauctorportaerosetcondimentumEtiamlaoreetnuncneclaciniapulvinarMaurishendreritmiataliquetcondimentumexexcursusdolornonportaeraterosidjustoCrasmalesuadatinciduntnuncattinciduntrisuseleifendidMaecenashendreritvenenatismietlobortisEtiamsemtortorelementumegetlacusnonportatristiquequamMorbisedlaciniaodioPhasellusutpretiumnuncFuscevitaemollismagnavelscelerisquedui";
+
+            AddStep("set text to overflow on creation", () =>
+            {
+                createContainer(overflowText);
+            });
+            assertSpriteTextCount(overflowText.Length);
+
+            AddStep("set overflow text post-creation", () => textContainer.Text = overflowText);
+            assertSpriteTextCount(overflowText.Length);
+
+            AddStep("set overflow text mid-sentence", () =>
+            {
+                textContainer.Text = "start/" + overflowText + "/end";
+            });
+            assertSpriteTextCount(overflowText.Length + 3);
+
+
+            AddStep("set relative width", () =>
+            {
+                topLevelContainer.AutoSizeAxes = textContainer.AutoSizeAxes = Axes.Y;
+                topLevelContainer.RelativeSizeAxes = textContainer.RelativeSizeAxes = Axes.X;
+                topLevelContainer.Width = textContainer.Width = 0.5f;
+                textContainer.Text = overflowText;
+            });
+            assertSpriteTextCount(overflowText.Length);
+
+            AddStep("set absolute width", () =>
+            {
+                topLevelContainer.AutoSizeAxes = textContainer.AutoSizeAxes = Axes.Y;
+                topLevelContainer.RelativeSizeAxes = textContainer.RelativeSizeAxes = Axes.None;
+                topLevelContainer.Width = textContainer.Width = 200f;
+                textContainer.Text = overflowText;
+            });
+            assertSpriteTextCount(overflowText.Length);
+
+            AddStep("set autosize width", () =>
+            {
+                topLevelContainer.RelativeSizeAxes = textContainer.RelativeSizeAxes = Axes.None;
+                topLevelContainer.AutoSizeAxes = textContainer.AutoSizeAxes = Axes.Both;
+                textContainer.Text = overflowText;
+            });
+            assertSpriteTextCount(1);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -145,7 +145,6 @@ namespace osu.Framework.Tests.Visual.Containers
             });
             assertSpriteTextCount(overflowText.Length + 3);
 
-
             AddStep("set relative width", () =>
             {
                 topLevelContainer.AutoSizeAxes = textContainer.AutoSizeAxes = Axes.Y;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
@@ -73,6 +73,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             textFlowContainer.AddText(" (and so are inline styles!)", t => t.Colour = Color4.Yellow);
             textFlowContainer.AddParagraph("There's 2 line breaks\n\ninside this paragraph!", t => t.Colour = Color4.GreenYellow);
             textFlowContainer.AddParagraph("Make\nTextFlowContainer\ngreat\nagain!", t => t.Colour = Color4.Red);
+            textFlowContainer.AddText("\ntext overflowwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww", t => t.Colour = Color4.Blue);
 
             paragraphContainer.Add(new TextFlowContainer
             {
@@ -104,6 +105,28 @@ osu! is written in C# on the .NET Framework. On August 28, 2016, osu!'s source c
                     })
                 },
                 Text = "Test icons [RedBox] interleaved\n[GreenBox] with other [0] text, also [[0]] escaping stuff is possible."
+            });
+
+            paragraphContainer.Add(new CustomText
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Placeholders = new Drawable[]
+                {
+                    new LineBaseBox
+                    {
+                        Colour = Color4.Purple,
+                        LineBaseHeight = 25f,
+                        Size = new Vector2(25, 25)
+                    }.WithEffect(new OutlineEffect
+                    {
+                        Strength = 20f,
+                        PadExtent = true,
+                        BlurSigma = new Vector2(5f),
+                        Colour = Color4.White
+                    })
+                },
+                Text = "Test icons interleaved with wrapping overflowwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww[0]wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww"
             });
 
             paragraphContainer.Add(new Container

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -73,12 +73,31 @@ namespace osu.Framework.Graphics.Containers
 
                     var textSprite = CreateSpriteText(textFlowContainer);
                     textSprite.Text = word;
-                    sprites.Add(textSprite);
+
+                    // Avoid splitting if we don't know what the container's size will be (this check will short circut if so)
+                    if (textFlowContainer.Parent != null && !textFlowContainer.TextFitsInFlow(textSprite))
+                    {
+                        addCharacters(word);
+                    }
+                    else
+                    {
+                        sprites.Add(textSprite);
+                    }
                 }
 
                 first = false;
             }
 
+            void addCharacters(string text)
+            {
+                foreach (char character in text)
+                {
+                    var characterSprite = CreateSpriteText(textFlowContainer);
+                    characterSprite.Text = character.ToString();
+
+                    sprites.Add(characterSprite);
+                }
+            }
             return sprites;
         }
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -194,7 +194,6 @@ namespace osu.Framework.Graphics.Containers
             base.LoadAsyncComplete();
 
             localisationParameters.Value = Localisation.CurrentParameters.Value;
-            RecreateAllParts();
         }
 
         protected override void LoadComplete()
@@ -203,6 +202,7 @@ namespace osu.Framework.Graphics.Containers
 
             localisationParameters.BindValueChanged(_ => partsCache.Invalidate());
             ((IBindable<LocalisationParameters>)localisationParameters).BindTo(Localisation.CurrentParameters);
+            RecreateAllParts();
         }
 
         protected override void Update()
@@ -287,6 +287,26 @@ namespace osu.Framework.Graphics.Containers
 
         protected internal virtual SpriteText CreateSpriteText() => new SpriteText();
 
+        /// <summary>
+        /// Checks whether the width of a <see cref="SpriteText"/> would fit within the bounds of this TextFlowContainer when drawn.
+        /// </summary>
+        /// <param name="spriteText">The <see cref="SpriteText"/> to check.</param>
+        /// <returns>Whether the text fits within the bounds of this TextFlowContainer.</returns>
+        /// <exception cref="InvalidOperationException">If this container's <see cref="RelativeSizeAxes"/> == <see cref="Axes.X"/> and/or it hasn't loaded (Parent == null)</exception>
+        /// <remarks>The <paramref name="spriteText"/> provided will be pre-loaded by being passed into <see cref="CompositeDrawable.LoadComponent{TLoadable}(TLoadable)"/> to get its width.</remarks>
+        public bool TextFitsInFlow(SpriteText spriteText)
+        {
+            if (AutoSizeAxes.HasFlagFast(Axes.X))
+                return true;
+            if (Parent == null)
+                throw new InvalidOperationException($"Cannot invoke {nameof(TextFitsInFlow)} before this {nameof(TextFlowContainer)} has a parent. Consider calling after this container has loaded.");
+            if (Flow.LoadState < LoadState.Ready)
+                throw new InvalidOperationException($"Cannot invoke {nameof(TextFitsInFlow)} before this container's {nameof(InnerFlow)} is ready. Consider calling after this container has loaded.");
+
+            Flow.LoadSpriteTextComponent(spriteText);
+            return spriteText.Width <= Flow.ChildSize.X;
+        }
+
         internal void ApplyDefaultCreationParameters(SpriteText spriteText) => defaultCreationParameters?.Invoke(spriteText);
 
         public void Clear(bool disposeChildren = true)
@@ -347,6 +367,11 @@ namespace osu.Framework.Graphics.Containers
 
         protected partial class InnerFlow : FillFlowContainer
         {
+            protected internal void LoadSpriteTextComponent(SpriteText item)
+            {
+                LoadComponent(item);
+            }
+
             private float firstLineIndent;
 
             /// <summary>


### PR DESCRIPTION
- Closes #5007 

There are a few aspects of this implementation that are worth a second opinion, like how part recreation must be done in `LoadComplete()` rather than `LoadCompleteAsync()` due to the container's size being unknown at that point. Open to heavy feedback on where/how to improve this and any other aspect of the PR.

Note: the "`ChangeLocalisationAfterAsyncLoad`" test case in `TestSceneTextFlowContainerLocalisation.cs` fails due to attempting to acquire parts before the container has called `LoadComplete()`.

Video preview:

https://github.com/user-attachments/assets/98c67c0c-7ef6-4d5a-9016-75a681f64cbf

https://github.com/user-attachments/assets/cf6c1d28-6b1d-4543-9d4d-3e513eb84de6



No AI was used at any point for this contribution.