### PR TITLE
Fix remaining `Path` aliasing issues by adding support for R32F framebuffer format

### DIFF
--- a/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
+++ b/osu.Framework.Tests/Visual/Graphics/TestSceneStencil.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Tests.Visual.Graphics
                         RelativeSizeAxes = Axes.Both
                     }
                 },
-                new BufferedContainer(new[] { RenderBufferFormat.D32S8 })
+                new BufferedContainer(formats: new[] { RenderBufferFormat.D32S8 })
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.TopRight,

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
@@ -25,6 +26,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private const int texture_width = 20;
 
         private Texture gradientTexture;
+        private InteractiveContainer content;
 
         [BackgroundDependencyLoader]
         private void load(IRenderer renderer)
@@ -39,6 +41,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             gradientTexture = renderer.CreateTexture(texture_width, 1, true);
             gradientTexture.SetData(new TextureUpload(image));
+
+            Child = content = new InteractiveContainer();
         }
 
         [Test]
@@ -46,7 +50,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new TexturedPath
+                content.Child = new TexturedPath
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -61,7 +65,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new TexturedPath
+                content.Child = new TexturedPath
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -83,10 +87,32 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new OverlapTestPath
+                content.Child = new OverlapTestPath
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
+                    Vertices = new List<Vector2>
+                    {
+                        new Vector2(50, 50),
+                        new Vector2(50, 150),
+                        new Vector2(150, 150),
+                        new Vector2(150, 100),
+                        new Vector2(20, 100),
+                    }
+                };
+            });
+        }
+
+        [Test]
+        public void TestThinStripesPath()
+        {
+            AddStep("create path", () =>
+            {
+                content.Child = new ThinStripesPath
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    PathRadius = 20,
                     Vertices = new List<Vector2>
                     {
                         new Vector2(50, 50),
@@ -104,7 +130,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new SmoothPath
+                content.Child = new SmoothPath
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -123,7 +149,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Child = new Path
+                content.Child = new Path
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -142,7 +168,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             AddStep("create path", () =>
             {
-                Children = new Drawable[]
+                content.Children = new Drawable[]
                 {
                     new Box
                     {
@@ -176,7 +202,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("create autosize path", () =>
             {
-                Child = new Container
+                content.Child = new Container
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
@@ -220,6 +246,77 @@ namespace osu.Framework.Tests.Visual.UserInterface
             protected override Color4 ColourAt(float position)
             {
                 return Interpolation.ValueAt(position, Color4.Red, Color4.Blue, 0f, 1f);
+            }
+        }
+
+        private partial class ThinStripesPath : SmoothPath
+        {
+            protected override Color4 ColourAt(float position)
+            {
+                return position % 0.1f < 0.05f ? Color4.Red : Color4.Blue;
+            }
+        }
+
+        private partial class InteractiveContainer : Container
+        {
+            protected override Container<Drawable> Content => ScalableContent;
+
+            protected readonly Container ScalableContent;
+            private readonly bool smooth;
+
+            public InteractiveContainer(bool smooth = true)
+            {
+                this.smooth = smooth;
+
+                RelativeSizeAxes = Axes.Both;
+                AddInternal(ScalableContent = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                Reset();
+            }
+
+            private float zoom = 1f;
+
+            public void Reset()
+            {
+                ResetPosition();
+            }
+
+            public void ResetPosition()
+            {
+                ScalableContent.Anchor = Anchor.Centre;
+                ScalableContent.Origin = Anchor.Centre;
+                ScalableContent.Position = Vector2.Zero;
+            }
+
+            protected override bool OnDragStart(DragStartEvent e) => true;
+
+            protected override void OnDrag(DragEvent e)
+            {
+                base.OnDrag(e);
+                ScalableContent.Position += e.Delta;
+            }
+
+            protected override bool OnScroll(ScrollEvent e)
+            {
+                base.OnScroll(e);
+
+                ScalableContent.OriginPosition = ToSpaceOfOtherDrawable(e.MousePosition, ScalableContent);
+                ScalableContent.Anchor = Anchor.TopLeft;
+                ScalableContent.Position = e.MousePosition;
+
+                zoom += (e.ScrollDelta.Y > 0 ? 1 : -1) * zoom * 0.1f;
+                ScalableContent.ScaleTo(zoom, smooth ? 150 : 0, Easing.OutQuint);
+
+                return true;
             }
         }
     }

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -44,6 +44,7 @@ namespace osu.Framework.Graphics
 
         private readonly RenderBufferFormat[] mainBufferFormats;
         private readonly TextureFilteringMode filterMode;
+        private readonly TexturePixelFormat textureFormat;
 
         private IRenderer renderer;
         private IFrameBuffer mainBuffer;
@@ -51,8 +52,8 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Creates a new <see cref="BufferedDrawNodeSharedData"/> with no effect buffers.
         /// </summary>
-        public BufferedDrawNodeSharedData(RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
-            : this(0, formats, pixelSnapping, clipToRootNode)
+        public BufferedDrawNodeSharedData(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+            : this(0, textureFormat, formats, pixelSnapping, clipToRootNode)
         {
         }
 
@@ -60,15 +61,17 @@ namespace osu.Framework.Graphics
         /// Creates a new <see cref="BufferedDrawNodeSharedData"/> with a specific amount of effect buffers.
         /// </summary>
         /// <param name="effectBufferCount">The number of effect buffers.</param>
+        /// <param name="textureFormat">The main render buffer format.</param>
         /// <param name="mainBufferFormats">The render buffer formats to attach to the main frame buffer.</param>
         /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".</param>
         /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node..</param>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="effectBufferCount"/> is less than 0.</exception>
-        public BufferedDrawNodeSharedData(int effectBufferCount, RenderBufferFormat[] mainBufferFormats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+        public BufferedDrawNodeSharedData(int effectBufferCount, TexturePixelFormat textureFormat, RenderBufferFormat[] mainBufferFormats = null, bool pixelSnapping = false, bool clipToRootNode = false)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(effectBufferCount);
 
+            this.textureFormat = textureFormat;
             this.mainBufferFormats = mainBufferFormats;
             PixelSnapping = pixelSnapping;
             ClipToRootNode = clipToRootNode;
@@ -80,7 +83,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The <see cref="IFrameBuffer"/> which contains the original version of the rendered <see cref="Drawable"/>.
         /// </summary>
-        public IFrameBuffer MainBuffer => mainBuffer ??= renderer.CreateFrameBuffer(mainBufferFormats, filterMode);
+        public IFrameBuffer MainBuffer => mainBuffer ??= renderer.CreateFrameBuffer(textureFormat, mainBufferFormats, filterMode);
 
         public void Initialise(IRenderer renderer)
         {

--- a/osu.Framework/Graphics/Containers/BufferedContainer.DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.DrawNode.cs
@@ -186,8 +186,8 @@ namespace osu.Framework.Graphics.Containers
 
         private class BufferedContainerDrawNodeSharedData : BufferedDrawNodeSharedData
         {
-            public BufferedContainerDrawNodeSharedData(RenderBufferFormat[] mainBufferFormats, bool pixelSnapping, bool clipToRootNode)
-                : base(2, mainBufferFormats, pixelSnapping, clipToRootNode)
+            public BufferedContainerDrawNodeSharedData(TexturePixelFormat mainBufferTextureFormat, RenderBufferFormat[] mainBufferFormats, bool pixelSnapping, bool clipToRootNode)
+                : base(2, mainBufferTextureFormat, mainBufferFormats, pixelSnapping, clipToRootNode)
             {
             }
         }

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -28,8 +28,8 @@ namespace osu.Framework.Graphics.Containers
     public partial class BufferedContainer : BufferedContainer<Drawable>
     {
         /// <inheritdoc />
-        public BufferedContainer(RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
-            : base(formats, pixelSnapping, cachedFrameBuffer)
+        public BufferedContainer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
+            : base(textureFormat, formats, pixelSnapping, cachedFrameBuffer)
         {
         }
     }
@@ -259,6 +259,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Constructs an empty buffered container.
         /// </summary>
+        /// <param name="textureFormat">The main render buffer format.</param>
         /// <param name="formats">The render buffer formats attached to the frame buffer of this <see cref="BufferedContainer"/>.</param>
         /// <param name="pixelSnapping">
         /// Whether the frame buffer position should be snapped to the nearest pixel when blitting.
@@ -269,11 +270,11 @@ namespace osu.Framework.Graphics.Containers
         /// or the size of the container (i.e. frame buffer) changes.
         /// When disabled, drawing will be clipped to the game window bounds. Enabling can allow drawing larger than (or outside) the game window bounds.
         /// </param>
-        public BufferedContainer(RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
+        public BufferedContainer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
         {
             UsingCachedFrameBuffer = cachedFrameBuffer;
 
-            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !cachedFrameBuffer);
+            sharedData = new BufferedContainerDrawNodeSharedData(textureFormat, formats, pixelSnapping, !cachedFrameBuffer);
 
             AddLayout(screenSpaceSizeBacking);
         }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -315,7 +315,7 @@ namespace osu.Framework.Graphics.Lines
             return result;
         }
 
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(clipToRootNode: true);
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(TexturePixelFormat.R32Float, clipToRootNode: true);
 
         protected override DrawNode CreateDrawNode() => new PathBufferedDrawNode(this, new PathDrawNode(this), sharedData);
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/GLFrameBuffer.cs
@@ -24,12 +24,12 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private readonly bool externalTexture;
 
-        public GLFrameBuffer(GLRenderer renderer, RenderbufferInternalFormat[]? renderBufferFormats = null, All filteringMode = All.Linear)
+        public GLFrameBuffer(GLRenderer renderer, TextureComponentCount textureFormat, RenderbufferInternalFormat[]? renderBufferFormats = null, All filteringMode = All.Linear)
         {
             this.renderer = renderer;
             FrameBuffer = GL.GenFramebuffer();
 
-            Texture = renderer.CreateTexture(glTexture = new FrameBufferTexture(renderer, filteringMode));
+            Texture = renderer.CreateTexture(glTexture = new FrameBufferTexture(renderer, textureFormat, filteringMode));
 
             renderer.BindFrameBuffer(this);
 
@@ -147,8 +147,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private class FrameBufferTexture : GLTexture
         {
-            public FrameBufferTexture(GLRenderer renderer, All filteringMode = All.Linear)
-                : base(renderer, 1, 1, true, filteringMode)
+            public FrameBufferTexture(GLRenderer renderer, TextureComponentCount textureFormat, All filteringMode = All.Linear)
+                : base(renderer, 1, 1, textureFormat, true, filteringMode)
             {
                 BypassTextureUploadQueueing = true;
 

--- a/osu.Framework/Graphics/OpenGL/GLRenderer.cs
+++ b/osu.Framework/Graphics/OpenGL/GLRenderer.cs
@@ -415,9 +415,10 @@ namespace osu.Framework.Graphics.OpenGL
         protected override IShader CreateShader(string name, IShaderPart[] parts, ShaderCompilationStore compilationStore)
             => new GLShader(this, name, parts.Cast<GLShaderPart>().ToArray(), compilationStore);
 
-        public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
+        public override IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
         {
             All glFilteringMode;
+            TextureComponentCount glTextureFormat;
             RenderbufferInternalFormat[]? glFormats = null;
 
             switch (filteringMode)
@@ -432,6 +433,20 @@ namespace osu.Framework.Graphics.OpenGL
 
                 default:
                     throw new ArgumentException($"Unsupported filtering mode: {filteringMode}", nameof(filteringMode));
+            }
+
+            switch (textureFormat)
+            {
+                case TexturePixelFormat.R8G8B8A8Float:
+                    glTextureFormat = TextureComponentCount.Rgba8;
+                    break;
+
+                case TexturePixelFormat.R32Float:
+                    glTextureFormat = TextureComponentCount.R32f;
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unsupported render buffer format: {textureFormat}", nameof(textureFormat));
             }
 
             if (renderBufferFormats != null)
@@ -464,7 +479,7 @@ namespace osu.Framework.Graphics.OpenGL
                 }
             }
 
-            return new GLFrameBuffer(this, glFormats, glFilteringMode);
+            return new GLFrameBuffer(this, glTextureFormat, glFormats, glFilteringMode);
         }
 
         protected override IUniformBuffer<TData> CreateUniformBuffer<TData>()
@@ -492,7 +507,7 @@ namespace osu.Framework.Graphics.OpenGL
                     throw new ArgumentException($"Unsupported filtering mode: {filteringMode}", nameof(filteringMode));
             }
 
-            return new GLTexture(this, width, height, manualMipmaps, glFilteringMode, initialisationColour);
+            return new GLTexture(this, width, height, TextureComponentCount.Rgba8, manualMipmaps, glFilteringMode, initialisationColour);
         }
 
         protected override INativeTexture CreateNativeVideoTexture(int width, int height) => new GLVideoTexture(this, width, height);

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -79,6 +79,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <param name="renderer"></param>
         /// <param name="width">The width of the texture.</param>
         /// <param name="height">The height of the texture.</param>
+        /// <param name="textureFormat">The pixel format of the texture.</param>
         /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
         /// <param name="filteringMode">The filtering mode.</param>
         /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads). If null, no initialisation is provided out-of-the-box.</param>

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -70,6 +70,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         private readonly List<RectangleI> uploadedRegions = new List<RectangleI>();
 
         private readonly All filteringMode;
+        private readonly TextureComponentCount textureFormat;
         private readonly Color4? initialisationColour;
 
         /// <summary>
@@ -81,13 +82,14 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
         /// <param name="filteringMode">The filtering mode.</param>
         /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads). If null, no initialisation is provided out-of-the-box.</param>
-        public GLTexture(GLRenderer renderer, int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear, Color4? initialisationColour = null)
+        public GLTexture(GLRenderer renderer, int width, int height, TextureComponentCount textureFormat = TextureComponentCount.Rgba8, bool manualMipmaps = false, All filteringMode = All.Linear, Color4? initialisationColour = null)
         {
             Renderer = renderer;
             Width = width;
             Height = height;
 
             this.manualMipmaps = manualMipmaps;
+            this.textureFormat = textureFormat;
             this.filteringMode = filteringMode;
             this.initialisationColour = initialisationColour;
         }
@@ -433,7 +435,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 if ((Width == upload.Bounds.Width && Height == upload.Bounds.Height) || dataPointer == IntPtr.Zero)
                 {
                     updateMemoryUsage(upload.Level, (long)Width * Height * 4);
-                    GL.TexImage2D(TextureTarget2d.Texture2D, upload.Level, TextureComponentCount.Rgba8, Width, Height, 0, upload.Format, PixelType.UnsignedByte, dataPointer);
+                    GL.TexImage2D(TextureTarget2d.Texture2D, upload.Level, textureFormat, Width, Height, 0, upload.Format, PixelType.UnsignedByte, dataPointer);
                 }
                 else
                 {
@@ -486,7 +488,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             using (var pixels = image.CreateReadOnlyPixelSpan())
             {
                 updateMemoryUsage(level, (long)width * height * 4);
-                GL.TexImage2D(TextureTarget2d.Texture2D, level, TextureComponentCount.Rgba8, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte,
+                GL.TexImage2D(TextureTarget2d.Texture2D, level, textureFormat, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte,
                     ref MemoryMarshal.GetReference(pixels.Span));
             }
         }

--- a/osu.Framework/Graphics/OpenGL/Textures/GLVideoTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLVideoTexture.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public int[]? TextureIds { get; private set; }
 
         public GLVideoTexture(GLRenderer renderer, int width, int height)
-            : base(renderer, width, height, true)
+            : base(renderer, width, height, manualMipmaps: true)
         {
         }
 

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredFrameBuffer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredFrameBuffer.cs
@@ -21,14 +21,16 @@ namespace osu.Framework.Graphics.Rendering.Deferred
         private readonly DeferredFrameBufferTexture nativeTexture;
         private readonly DeferredRenderer renderer;
         private readonly PixelFormat[]? formats;
+        private readonly PixelFormat textureFormat;
         private readonly SamplerFilter filteringMode;
 
         private Vector2I size = Vector2I.One;
 
-        public DeferredFrameBuffer(DeferredRenderer renderer, PixelFormat[]? formats, SamplerFilter filteringMode)
+        public DeferredFrameBuffer(DeferredRenderer renderer, PixelFormat textureFormat, PixelFormat[]? formats, SamplerFilter filteringMode)
         {
             this.renderer = renderer;
             this.formats = formats;
+            this.textureFormat = textureFormat;
             this.filteringMode = filteringMode;
 
             nativeTexture = new DeferredFrameBufferTexture(this);
@@ -145,7 +147,7 @@ namespace osu.Framework.Graphics.Rendering.Deferred
                             (uint)resourceSize.Y,
                             1,
                             1,
-                            PixelFormat.R8G8B8A8UNorm,
+                            deferredFrameBuffer.textureFormat,
                             TextureUsage.Sampled | TextureUsage.RenderTarget)),
                     deferredFrameBuffer.renderer.Factory.CreateSampler(
                         new SamplerDescription(

--- a/osu.Framework/Graphics/Rendering/Deferred/DeferredRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Deferred/DeferredRenderer.cs
@@ -206,12 +206,12 @@ namespace osu.Framework.Graphics.Rendering.Deferred
         protected override IShader CreateShader(string name, IShaderPart[] parts, ShaderCompilationStore compilationStore)
             => new DeferredShader(this, new VeldridShader(this, name, parts.Cast<VeldridShaderPart>().ToArray(), compilationStore));
 
-        public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
-            => new DeferredFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
+        public override IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
+            => new DeferredFrameBuffer(this, textureFormat.ToPixelFormat(), renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
 
         protected override INativeTexture CreateNativeTexture(int width, int height, bool manualMipmaps = false, TextureFilteringMode filteringMode = TextureFilteringMode.Linear,
                                                               Color4? initialisationColour = null)
-            => new VeldridTexture(this, width, height, manualMipmaps, filteringMode.ToSamplerFilter(), initialisationColour);
+            => new VeldridTexture(this, width, height, PixelFormat.R8G8B8A8UNorm, manualMipmaps, filteringMode.ToSamplerFilter(), initialisationColour);
 
         protected override INativeTexture CreateNativeVideoTexture(int width, int height)
             => new VeldridVideoTexture(this, width, height);

--- a/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/Dummy/DummyRenderer.cs
@@ -136,7 +136,7 @@ namespace osu.Framework.Graphics.Rendering.Dummy
         {
         }
 
-        public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
+        public override IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
             => new DummyFrameBuffer(this);
     }
 }

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -376,10 +376,11 @@ namespace osu.Framework.Graphics.Rendering
         /// <summary>
         /// Creates a new <see cref="IFrameBuffer"/>.
         /// </summary>
+        /// <param name="textureFormat">The texture pixel format.</param>
         /// <param name="renderBufferFormats">Any render buffer formats.</param>
         /// <param name="filteringMode">The texture filtering mode.</param>
         /// <returns>The <see cref="IFrameBuffer"/>.</returns>
-        IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear);
+        IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear);
 
         /// <summary>
         /// Creates a new <see cref="Texture"/>.

--- a/osu.Framework/Graphics/Rendering/Renderer.cs
+++ b/osu.Framework/Graphics/Rendering/Renderer.cs
@@ -1105,7 +1105,7 @@ namespace osu.Framework.Graphics.Rendering
 
         #region Factory
 
-        public abstract IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear);
+        public abstract IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear);
 
         /// <inheritdoc cref="IRenderer.CreateShaderPart"/>
         protected abstract IShaderPart CreateShaderPart(IShaderStore store, string name, byte[]? rawData, ShaderPartType partType);

--- a/osu.Framework/Graphics/Rendering/TexturePixelFormat.cs
+++ b/osu.Framework/Graphics/Rendering/TexturePixelFormat.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Rendering
+{
+    public enum TexturePixelFormat
+    {
+        R8G8B8A8Float,
+        R32Float
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
+++ b/osu.Framework/Graphics/Veldrid/Buffers/VeldridFrameBuffer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
             }
         }
 
-        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
+        public VeldridFrameBuffer(VeldridRenderer renderer, PixelFormat textureFormat = PixelFormat.R8G8B8A8UNorm, PixelFormat[]? formats = null, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
         {
             // todo: we probably want the arguments separated to "PixelFormat[] colorFormats, PixelFormat depthFormat".
             if (formats?.Length > 1)
@@ -57,7 +57,7 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
 
             depthFormat = formats?[0];
 
-            colourTarget = new FrameBufferTexture(renderer, filteringMode);
+            colourTarget = new FrameBufferTexture(renderer, textureFormat, filteringMode);
             Texture = renderer.CreateTexture(colourTarget);
 
             recreateResources();
@@ -147,8 +147,8 @@ namespace osu.Framework.Graphics.Veldrid.Buffers
         {
             protected override TextureUsage Usages => base.Usages | TextureUsage.RenderTarget;
 
-            public FrameBufferTexture(VeldridRenderer renderer, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
-                : base(renderer, 1, 1, true, filteringMode)
+            public FrameBufferTexture(VeldridRenderer renderer, PixelFormat textureFormat, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear)
+                : base(renderer, 1, 1, textureFormat, true, filteringMode)
             {
                 BypassTextureUploadQueueing = true;
 

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -55,6 +55,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         private readonly List<RectangleI> uploadedRegions = new List<RectangleI>();
 
         private readonly SamplerFilter filteringMode;
+        private readonly PixelFormat textureFormat;
         private readonly Color4? initialisationColour;
 
         public ulong BindCount { get; protected set; }
@@ -82,15 +83,17 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         /// <param name="renderer">The renderer.</param>
         /// <param name="width">The width of the texture.</param>
         /// <param name="height">The height of the texture.</param>
+        /// <param name="textureFormat">The pixel format of the texture.</param>
         /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
         /// <param name="filteringMode">The filtering mode.</param>
         /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads). If null, no initialisation is provided out-of-the-box.</param>
-        public VeldridTexture(IVeldridRenderer renderer, int width, int height, bool manualMipmaps = false, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear,
+        public VeldridTexture(IVeldridRenderer renderer, int width, int height, PixelFormat textureFormat = PixelFormat.R8G8B8A8UNorm, bool manualMipmaps = false, SamplerFilter filteringMode = SamplerFilter.MinLinearMagLinearMipLinear,
                               Color4? initialisationColour = null)
         {
             this.manualMipmaps = manualMipmaps;
             this.filteringMode = filteringMode;
             this.initialisationColour = initialisationColour;
+            this.textureFormat = textureFormat;
 
             Renderer = renderer;
             Width = width;
@@ -458,7 +461,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
             {
                 texture?.Dispose();
 
-                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, PixelFormat.R8G8B8A8UNorm, Usages);
+                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)CalculateMipmapLevels(Width, Height), 1, textureFormat, Usages);
                 texture = Renderer.Factory.CreateTexture(ref textureDescription);
 
                 // todo: we may want to look into not having to allocate chunks of zero byte region for initialising textures

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridVideoTexture.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.Veldrid.Textures
         private VeldridTextureResources[]? resourceList;
 
         public VeldridVideoTexture(IVeldridRenderer renderer, int width, int height)
-            : base(renderer, width, height, true)
+            : base(renderer, width, height, manualMipmaps: true)
         {
         }
 

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -114,6 +114,21 @@ namespace osu.Framework.Graphics.Veldrid
             return writeMask;
         }
 
+        public static PixelFormat ToPixelFormat(this TexturePixelFormat texturePixelFormat)
+        {
+            switch (texturePixelFormat)
+            {
+                case TexturePixelFormat.R8G8B8A8Float:
+                    return PixelFormat.R8G8B8A8UNorm;
+
+                case TexturePixelFormat.R32Float:
+                    return PixelFormat.R32Float;
+
+                default:
+                    throw new ArgumentException($"Unsupported render buffer format: {texturePixelFormat}", nameof(texturePixelFormat));
+            }
+        }
+
         public static PixelFormat[] ToPixelFormats(this RenderBufferFormat[] renderBufferFormats)
         {
             var pixelFormats = new PixelFormat[renderBufferFormats.Length];

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -298,8 +298,8 @@ namespace osu.Framework.Graphics.Veldrid
         protected override IShader CreateShader(string name, IShaderPart[] parts, ShaderCompilationStore compilationStore)
             => new VeldridShader(this, name, parts.Cast<VeldridShaderPart>().ToArray(), compilationStore);
 
-        public override IFrameBuffer CreateFrameBuffer(RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
-            => new VeldridFrameBuffer(this, renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
+        public override IFrameBuffer CreateFrameBuffer(TexturePixelFormat textureFormat = TexturePixelFormat.R8G8B8A8Float, RenderBufferFormat[]? renderBufferFormats = null, TextureFilteringMode filteringMode = TextureFilteringMode.Linear)
+            => new VeldridFrameBuffer(this, textureFormat.ToPixelFormat(), renderBufferFormats?.ToPixelFormats(), filteringMode.ToSamplerFilter());
 
         protected override IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveTopology primitiveType)
             // maxBuffers is ignored because batches are not allowed to wrap around in Veldrid.
@@ -317,7 +317,7 @@ namespace osu.Framework.Graphics.Veldrid
 
         protected override INativeTexture CreateNativeTexture(int width, int height, bool manualMipmaps = false, TextureFilteringMode filteringMode = TextureFilteringMode.Linear,
                                                               Color4? initialisationColour = null)
-            => new VeldridTexture(this, width, height, manualMipmaps, filteringMode.ToSamplerFilter(), initialisationColour);
+            => new VeldridTexture(this, width, height, PixelFormat.R8G8B8A8UNorm, manualMipmaps, filteringMode.ToSamplerFilter(), initialisationColour);
 
         protected override INativeTexture CreateNativeVideoTexture(int width, int height)
             => new VeldridVideoTexture(this, width, height);

--- a/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableScreenshotter.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         public override DrawInfo DrawInfo => Target.DrawInfo;
 
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderBufferFormat.D16 }, pixelSnapping: true, clipToRootNode: true);
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(formats: new[] { RenderBufferFormat.D16 }, pixelSnapping: true, clipToRootNode: true);
 
         [Resolved]
         private GameHost host { get; set; } = null!;

--- a/osu.Framework/Resources/Shaders/sh_Path.fs
+++ b/osu.Framework/Resources/Shaders/sh_Path.fs
@@ -24,9 +24,7 @@ layout(location = 0) out vec4 o_Colour;
 
 void main(void) 
 {
-    lowp vec4 framebuffer = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord, -0.9);
-    // in sh_PathPrepass.fs we were encoding [0, 1) 24-bit float as 4 8-bit floats. Decoding to get original value
-    highp float dstFromEdge = framebuffer == vec4(1.0) ? 1.0 : decodeFloat(framebuffer);
+    highp float dstFromEdge = texture(sampler2D(m_Texture, m_Sampler), v_TexCoord).r;
     lowp vec4 pathCol = texture(sampler2D(m_Texture1, m_Sampler1), TexRect1.xy + vec2(dstFromEdge, 0.0) * TexRect1.zw, -0.9);
     o_Colour = getRoundedColor(vec4(pathCol.rgb, pathCol.a * float(dstFromEdge > 0.0)), v_TexCoord);
 }

--- a/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
+++ b/osu.Framework/Resources/Shaders/sh_PathPrepass.fs
@@ -9,20 +9,11 @@ layout(location = 1) in highp vec2 v_StartPos;
 layout(location = 2) in highp vec2 v_EndPos;
 layout(location = 3) in highp float v_Radius;
 
-layout(location = 0) out vec4 o_Colour;
+layout(location = 0) out highp float o_Colour;
 
 void main(void) 
-{    
-    highp float dstFromEdge = clamp(1.0 - dstToLine(v_StartPos, v_EndPos, v_Position) / v_Radius, 0.0, 1.0);
-
-    // special handling for 1.0 since it can't be encoded properly
-    if (dstFromEdge == 1.0)
-    {
-        o_Colour = vec4(1.0);
-        return;
-    }
-
-    o_Colour = encodeFloat(dstFromEdge);
+{
+    o_Colour = clamp(1.0 - dstToLine(v_StartPos, v_EndPos, v_Position) / v_Radius, 0.0, 1.0);
 }
 
 #endif


### PR DESCRIPTION
### Issue

While https://github.com/ppy/osu-framework/pull/6767 is good enough for most cases, there are still cases where it fails. There underlying issue - `Max` blending used for solving path intersections isn't working correctly with our encoded sdf value. It selects max value per component while with our encoded value we would need it to select the color with the **first** max component.
Example:
pixel 1 - `0.5, 0.5, 0.5, 0.5`
pixel2 - `0.5, 0.6, 0.1, 0.1`
Current resulted color - `0.5, 0.6, 0.5, 0.5` (max per component, blends colors)
Desired color - `0.5, 0.6, 0.1, 0.1` (green value is bigger - full pixel2 color should be the result)

### Solution
By adding support for R32F (32-bit single-channel) texture format `Max` will work as expected since there's only a single value to compare. We also can store 32-bit float SDF directly in the texture without encoding/decoding step with the same memory usage per texture.

|master|pr|
|---|---|
|<img width="881" height="783" alt="master-path" src="https://github.com/user-attachments/assets/cf176669-7e68-4e9c-86e1-f2442937d532" />|<img width="672" height="656" alt="pr-path" src="https://github.com/user-attachments/assets/a57b6345-4940-439f-838d-d525e6c4d2f2" />|
|<img width="460" height="204" alt="master-aliasing" src="https://github.com/user-attachments/assets/c3474478-8ea3-4a5e-8cd3-9a23f725258b" />|<img width="460" height="204" alt="pr-aliasing" src="https://github.com/user-attachments/assets/5e7003c1-6087-4c6a-8a60-d1e905f6c849" />|

Performance:
Tested with the most complex aspire slider I could find (tens of thousands of vertices) and it's basically the same

|master|pr|
|---|---|
|<img width="2560" height="1440" alt="master-perf" src="https://github.com/user-attachments/assets/ad96b40e-fefd-46e5-bc36-a464933b27fb" />|<img width="2560" height="1440" alt="pr-perf" src="https://github.com/user-attachments/assets/5165992c-2aa2-402c-a9a1-96929f10fc9c" />|

Tested on windows with all 3 renderers, mobile/mac probably needs testing as well.