### PR TITLE
Fix fullscreen compatibility note not being shown when using OpenGL on Windows

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -921,7 +921,7 @@ namespace osu.Framework.Platform
                         case RendererType.OpenGL:
                             // Use the legacy GL renderer. This is basically guaranteed to support all platforms
                             // and performs better than the Veldrid-GL renderer due to reduction in allocs.
-                            SetupRendererAndWindow(new GLRenderer(), GraphicsSurfaceType.OpenGL);
+                            SetupRendererAndWindow(CreateGLRenderer(), GraphicsSurfaceType.OpenGL);
                             break;
 
                         case RendererType.Deferred_Metal:


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/commit/d0b2db760e409f2ef753ae2b71cf40f9fa126524.

Talking about this:

<img width="556" height="156" alt="osu!_zHYqPZPIVR" src="https://github.com/user-attachments/assets/5d445b54-ee86-4b2d-90f9-00cf151290ad" />
