### PR TITLE
Fix paths not rendering on mobile

### DIFF
--- a/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneTextureUploadPerformance.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osuTK.Graphics;
-using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.Performance
@@ -102,8 +101,6 @@ namespace osu.Framework.Tests.Visual.Performance
                 get => upload.Bounds;
                 set => upload.Bounds = value;
             }
-
-            public PixelFormat Format => upload.Format;
 
             public ReusableTextureUpload(ITextureUpload upload)
             {

--- a/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLTexture.cs
@@ -63,6 +63,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         public bool BypassTextureUploadQueueing { get; set; }
 
+        protected TextureComponentCount InternalFormat { get; private set; }
+        protected PixelFormat PixelFormat { get; private set; }
+        protected PixelType PixelType { get; private set; }
+
         private int internalWidth;
         private int internalHeight;
         private bool manualMipmaps;
@@ -70,7 +74,6 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         private readonly List<RectangleI> uploadedRegions = new List<RectangleI>();
 
         private readonly All filteringMode;
-        private readonly TextureComponentCount textureFormat;
         private readonly Color4? initialisationColour;
 
         /// <summary>
@@ -89,10 +92,39 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             Width = width;
             Height = height;
 
+            setFormat(textureFormat);
+
             this.manualMipmaps = manualMipmaps;
-            this.textureFormat = textureFormat;
             this.filteringMode = filteringMode;
             this.initialisationColour = initialisationColour;
+        }
+
+        private void setFormat(TextureComponentCount internalFormat)
+        {
+            InternalFormat = internalFormat;
+
+            // reference: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml
+            // add more formats as desired
+            switch (internalFormat)
+            {
+                case TextureComponentCount.Rgba8:
+                    PixelFormat = PixelFormat.Rgba;
+                    PixelType = PixelType.UnsignedByte;
+                    break;
+
+                case TextureComponentCount.R8:
+                    PixelFormat = PixelFormat.Red;
+                    PixelType = PixelType.UnsignedByte;
+                    break;
+
+                case TextureComponentCount.R32f:
+                    PixelFormat = PixelFormat.Red;
+                    PixelType = PixelType.Float;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(internalFormat), internalFormat, null);
+            }
         }
 
         #region Disposal
@@ -436,14 +468,14 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 if ((Width == upload.Bounds.Width && Height == upload.Bounds.Height) || dataPointer == IntPtr.Zero)
                 {
                     updateMemoryUsage(upload.Level, (long)Width * Height * 4);
-                    GL.TexImage2D(TextureTarget2d.Texture2D, upload.Level, textureFormat, Width, Height, 0, upload.Format, PixelType.UnsignedByte, dataPointer);
+                    GL.TexImage2D(TextureTarget2d.Texture2D, upload.Level, InternalFormat, Width, Height, 0, PixelFormat, PixelType, dataPointer);
                 }
                 else
                 {
                     initializeLevel(upload.Level, Width, Height);
 
-                    GL.TexSubImage2D(TextureTarget2d.Texture2D, upload.Level, upload.Bounds.X, upload.Bounds.Y, upload.Bounds.Width, upload.Bounds.Height, upload.Format,
-                        PixelType.UnsignedByte, dataPointer);
+                    GL.TexSubImage2D(TextureTarget2d.Texture2D, upload.Level, upload.Bounds.X, upload.Bounds.Y, upload.Bounds.Width, upload.Bounds.Height, PixelFormat,
+                        PixelType, dataPointer);
                 }
             }
             // Just update content of the current texture
@@ -470,7 +502,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 int div = (int)Math.Pow(2, upload.Level);
 
                 GL.TexSubImage2D(TextureTarget2d.Texture2D, upload.Level, upload.Bounds.X / div, upload.Bounds.Y / div, upload.Bounds.Width / div, upload.Bounds.Height / div,
-                    upload.Format, PixelType.UnsignedByte, dataPointer);
+                    PixelFormat, PixelType, dataPointer);
             }
         }
 
@@ -489,7 +521,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             using (var pixels = image.CreateReadOnlyPixelSpan())
             {
                 updateMemoryUsage(level, (long)width * height * 4);
-                GL.TexImage2D(TextureTarget2d.Texture2D, level, textureFormat, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte,
+                GL.TexImage2D(TextureTarget2d.Texture2D, level, InternalFormat, width, height, 0, PixelFormat, PixelType,
                     ref MemoryMarshal.GetReference(pixels.Span));
             }
         }

--- a/osu.Framework/Graphics/OpenGL/Textures/GLVideoTexture.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/GLVideoTexture.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public int[]? TextureIds { get; private set; }
 
         public GLVideoTexture(GLRenderer renderer, int width, int height)
-            : base(renderer, width, height, manualMipmaps: true)
+            : base(renderer, width, height, textureFormat: TextureComponentCount.R8, manualMipmaps: true)
         {
         }
 
@@ -52,8 +52,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
                     GL.ActiveTexture(TextureUnit.Texture0 + (int)i);
 
-                    GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height,
-                        0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+                    GL.TexImage2D(TextureTarget2d.Texture2D, 0, InternalFormat, width, height,
+                        0, PixelFormat, PixelType, IntPtr.Zero);
 
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)All.Linear);
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 GL.PixelStore(PixelStoreParameter.UnpackRowLength, videoUpload.Frame->linesize[i]);
 
                 GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, videoUpload.GetPlaneWidth(i), videoUpload.GetPlaneHeight(i),
-                    PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[i]);
+                    PixelFormat, PixelType, (IntPtr)videoUpload.Frame->data[i]);
 
                 GL.PixelStore(PixelStoreParameter.UnpackRowLength, 0);
             }

--- a/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Buffers;
 using osu.Framework.Graphics.Primitives;
-using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
@@ -39,8 +38,6 @@ namespace osu.Framework.Graphics.Textures
         public ReadOnlySpan<Rgba32> Data => data;
 
         public int Level { get; set; }
-
-        public virtual PixelFormat Format => PixelFormat.Rgba;
 
         public RectangleI Bounds { get; set; }
     }

--- a/osu.Framework/Graphics/Textures/ITextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ITextureUpload.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics.Primitives;
-using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
@@ -24,10 +23,5 @@ namespace osu.Framework.Graphics.Textures
         /// The target bounds for this upload. If not specified, will assume to be (0, 0, width, height).
         /// </summary>
         RectangleI Bounds { get; set; }
-
-        /// <summary>
-        /// The texture format for this upload.
-        /// </summary>
-        PixelFormat Format { get; }
     }
 }

--- a/osu.Framework/Graphics/Textures/MemoryAllocatorTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/MemoryAllocatorTextureUpload.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Buffers;
 using osu.Framework.Graphics.Primitives;
-using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -21,8 +20,6 @@ namespace osu.Framework.Graphics.Textures
         private readonly IMemoryOwner<Rgba32> memoryOwner;
 
         public int Level { get; set; }
-
-        public virtual PixelFormat Format => PixelFormat.Rgba;
 
         public RectangleI Bounds { get; set; }
 

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -10,7 +10,6 @@ using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
-using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using StbiSharp;
@@ -27,11 +26,6 @@ namespace osu.Framework.Graphics.Textures
         /// The target mipmap level to upload into.
         /// </summary>
         public int Level { get; set; }
-
-        /// <summary>
-        /// The texture format for this upload.
-        /// </summary>
-        public PixelFormat Format => PixelFormat.Rgba;
 
         /// <summary>
         /// The target bounds for this upload. If not specified, will assume to be (0, 0, width, height).

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Graphics.Textures;
-using osuTK.Graphics.ES30;
 using FFmpeg.AutoGen;
 using osu.Framework.Graphics.Primitives;
 using SixLabors.ImageSharp.PixelFormats;
@@ -29,8 +28,6 @@ namespace osu.Framework.Graphics.Video
         public int Level => 0;
 
         public RectangleI Bounds { get; set; }
-
-        public PixelFormat Format => PixelFormat.Red;
 
         private readonly FFmpegFrame ffmpegFrame;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38411.

Other than the paths not being visible, the direct symptom of the breakage here was that when inspecting `glGetError()` return value before and after a `glTexImage2D()` call that was specifying the `R32f` internal texture format introduced in https://github.com/ppy/osu-framework/pull/6776, the value changed from no error to `GL_INVALID_OPERATION`.

As per https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexImage2D.xhtml, the `internalformat`, `format`, and `type` parameters to `glTexImage2D()` must match one another for the call to succeed. In this particular instance, the game was trying to create a `R32f` internal format texture with `Rgba` pixel format and `UnsignedByte` pixel type, which is clearly nonsensical.

Changing the values to `Red` pixel format and `Float` pixel type in an ad-hoc type fixed the issue, but also exposed a large level of haphazardness in `GLTexture` and co. If the pixel format and type are ultimately dependent on the texture internal format, then it makes very little sense for the pixel format to be specified in `TextureUpload` of all places, and pixel type to be hardcoded.

There were even classes working around this in very OOP-brained ways. See `GLVideoTexture : GLTexture`, which was actually not specifying the texture format and thus using the base ctor default of `Rgba8`, but then *completely overriding the entirety* of `DoUpload()`, which meant that the value passed to the base was essentially dead, and the `DoUpload()` implementation hardcoded the appropriate values of the pixel format and type for the `R8` internal type.

To this end, `ITextureUpload.Format` is completely removed. The pixel format and type are now decided completely internally to `GLTexture`, and both in conjunction with `InternalFormat` are now exposed as protected so that `GLTexture` and subclasses can pass them directly in calls to `glTexImage2D()` and `glTexSubImage2D()`.

Questions as to why design `glTexImage2D()` in such a way that you need to coordinate three separate parameters to match a table present in documentation are best directed to the Khronos Group.

---

Tested on:
- macOS (M4 Max) - was not broken, continues to work
- Windows 11 (NVIDIA GeForce RTX 3060M) - was not broken, continues to work
- Android (OnePlus 8T, Qualcomm Adreno 650) - was broken, now works

Tests were performed by checking visual test browser overall appearance (covers off normal textures), video test scenes (covers off video textures), and `TestSceneDrawablePath` (covers off path rendering).

Not tested on Linux. I technically have the possibility to test Linux if so desired but I do not have development tools installed on that machine and would rather not do that, so I'd appreciate a cross-check from someone else.

cc @smoogipoo @EVAST9919