### PR TITLE
Update SDL3-CS

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
     <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
-    <PackageReference Include="ppy.SDL3-CS" Version="2026.629.0" />
+    <PackageReference Include="ppy.SDL3-CS" Version="2026.722.0" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2025.1121.1" />
 
     <!-- DO NOT use ProjectReference for native packaging project.


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu/issues/38545

Was gonna look upstream, but realized there's a recent nuget build that fixes the above. Have done basic testing (navigating menus, gameplay, and notch setting) and found no regressions on Pixel 6a (Android 17 Beta) and Moto G Play (2021) (Android 11).