### PR TITLE
Get the size before calling Bitmap.Recycle()

### DIFF
--- a/osu.Framework.Android/Graphics/Textures/AndroidTextureLoaderStore.cs
+++ b/osu.Framework.Android/Graphics/Textures/AndroidTextureLoaderStore.cs
@@ -23,8 +23,11 @@ namespace osu.Framework.Android.Graphics.Textures
             {
                 if (bitmap == null) throw new ArgumentException($"{nameof(Image)} could not be created from {nameof(stream)}.");
 
-                int[] pixels = new int[bitmap.Width * bitmap.Height];
-                bitmap.GetPixels(pixels, 0, bitmap.Width, 0, 0, bitmap.Width, bitmap.Height);
+                int width = bitmap.Width;
+                int height = bitmap.Height;
+
+                int[] pixels = new int[width * height];
+                bitmap.GetPixels(pixels, 0, width, 0, 0, width, height);
                 byte[] result = new byte[pixels.Length * sizeof(int)];
                 Buffer.BlockCopy(pixels, 0, result, 0, result.Length);
 
@@ -34,7 +37,7 @@ namespace osu.Framework.Android.Graphics.Textures
                 }
 
                 bitmap.Recycle();
-                return Image.LoadPixelData<TPixel>(result, bitmap.Width, bitmap.Height);
+                return Image.LoadPixelData<TPixel>(result, width, height);
             }
         }
     }


### PR DESCRIPTION
A warning was appearing in logcat because the code was referencing Width and Height after the image data had already been discarded.

Before:

https://github.com/user-attachments/assets/a78a3187-5d40-4b36-b0fd-4f3e2e8166be

After:

https://github.com/user-attachments/assets/da40008a-ed79-4aaf-82fb-b0f5aa8aff7b

