### PR TITLE
Update packages

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkButtonStates.cs
+++ b/osu.Framework.Benchmarks/BenchmarkButtonStates.cs
@@ -13,10 +13,6 @@ namespace osu.Framework.Benchmarks
         [Benchmark(Baseline = true)]
         public ButtonStates<MouseButton> CreateNew() => new ButtonStates<MouseButton>();
 
-        [Arguments(1)]
-        [Arguments(5)]
-        [Arguments(10)]
-        [Arguments(50)]
         [Benchmark]
         public bool SetPressed()
         {

--- a/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
+++ b/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <!-- The following two are unused, but resolves warning MSB3277. -->
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.CodeDom" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
+++ b/osu.Framework.SourceGeneration.Tests/osu.Framework.SourceGeneration.Tests.csproj
@@ -6,13 +6,13 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework.SourceGeneration\osu.Framework.SourceGeneration.csproj" />

--- a/osu.Framework.SourceGeneration/osu.Framework.SourceGeneration.csproj
+++ b/osu.Framework.SourceGeneration/osu.Framework.SourceGeneration.csproj
@@ -8,6 +8,7 @@
     <!-- Do not include the generator as a lib dependency. -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Label="Nuget">
@@ -17,9 +18,9 @@
     <PackageTags>osu game framework source generator</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/TemplateGame.Game.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\TemplateGame.Game\TemplateGame.Game.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/FlappyDon.Game.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\FlappyDon.Game\FlappyDon.Game.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -10,8 +10,8 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
   </ItemGroup>
 </Project>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
     <PackageReference Include="ppy.managed-midi" Version="1.10.2" />
     <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />
     <PackageReference Include="ppy.ManagedBass.Fx" Version="2022.1216.0" />
@@ -29,14 +29,13 @@
     <PackageReference Include="ppy.Veldrid" Version="4.9.69-ga405fe8484" />
     <PackageReference Include="ppy.Veldrid.SPIRV" Version="1.0.15-g5911265ec3" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
-    <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTabletDriver" Version="0.6.7" />
-    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.211" />
-    <PackageReference Include="StbiSharp" Version="1.1.0" />
+    <PackageReference Include="StbiSharp" Version="1.2.2" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.741-alpha" />
     <PackageReference Include="ppy.SDL3-CS" Version="2026.722.0" />
     <PackageReference Include="ppy.osu.Framework.SourceGeneration" Version="2025.1121.1" />
@@ -52,6 +51,6 @@
     <!-- Any version ahead of this will cause runtime issues on iOS
          See https://github.com/xoofx/markdig/issues/564 -->
     <PackageReference Include="Markdig" Version="0.23.0" />
-    <PackageReference Include="System.Numerics.Tensors" Version="8.0.0" />
+    <PackageReference Include="System.Numerics.Tensors" Version="10.0.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The primary reason for this is to pull in security fixes from `stbi` / StbiSharp.

New StbiSharp lightly tested on Windows. It does work... after I disabled Windows Defender's "Smart App Control", because it did not like the `stbi` binary. Things still continue to work because of the fallback to ImageSharp:

https://github.com/ppy/osu-framework/blob/4446acceacfd59286a0b5aa69010fe3f6bc2219b/osu.Framework/Graphics/Textures/TextureUpload.cs#L93

So it's probably better for StbiSharp to not work than have security issues? And maybe eventually "Smart App Control" becomes smart enough to not block it?

I'm hoping this will not be an issue on actual game release builds because [Microsoft says](https://support.microsoft.com/en-us/windows/security/threat-malware-protection/smart-app-control-frequently-asked-questions#im-an-app-developer-how-can-i-get-smart-app-control-to-not-block-my-app) that signed binaries will not trip "Smart App Control", and on an actual previous lazer release `stbi.dll` is signed, so I'm hoping things just work.

Linux is not tested. I expect a *non-zero* degree of breakage because the image is now built on Ubuntu 22.04, so some very old Linuxen will probably break due to glibc incompatibilities, but hopefully this is again silent breakage due to the fallback to ImageSharp.

macOS doesn't use StbiSharp directly since https://github.com/ppy/osu-framework/pull/6475 (though I have tested it by locally disabling the macOS-specific path and it still does work).

Updated
---

| package                                                | old version(s) |                                               new version                                                | downloads | released on |                               changelogs                               |
| :----------------------------------------------------- | :------------: | :------------------------------------------------------------------------------------------------------: | --------: | :---------: | :--------------------------------------------------------------------: |
| BenchmarkDotNet                                        |     0.13.5     |                     [0.15.8](https://www.nuget.org/packages/BenchmarkDotNet/0.15.8)                      |     >8.4M | 2025-11-30  | [link](https://github.com/dotnet/BenchmarkDotNet/releases/tag/v0.15.8) |
| JetBrains.Annotations                                  |    2025.2.4    |                [2026.2.0](https://www.nuget.org/packages/JetBrains.Annotations/2026.2.0)                 |     >1.9M | 2026-06-16  |                                  n/a                                   |
| Microsoft.CodeAnalysis.Analyzers[^5]                   |     3.3.3      |              [3.3.4](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Analyzers/3.3.4)              |     >264M | 2023-01-18  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| Microsoft.CodeAnalysis.BannedApiAnalyzers[^5]          |     3.3.3      |         [3.3.4](https://www.nuget.org/packages/Microsoft.CodeAnalysis.BannedApiAnalyzers/3.3.4)          |    >20.9M | 2023-01-18  |                                                                        |
| Microsoft.CodeAnalysis.Common                          |   4.8.0[^3]    |                  [5.6.0](https://www.nuget.org/packages/Microsoft.CodeAnalysis.Common)                   |     >1.9M | 2026-07-02  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing |     1.1.2      | [1.1.3](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/1.1.3)[^4] |     >344k | 2026-01-13  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| Microsoft.Extensions.ObjectPool                        |     5.0.11     |            [10.0.11](https://www.nuget.org/packages/Microsoft.Extensions.ObjectPool/10.0.11)             |     >9.2k | 2026-08-11  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| Microsoft.NET.Test.Sdk                                 |    multiple    |                  [18.8.1](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/18.8.1)                  |     >7.1M | 2026-07-14  |    [link](https://github.com/microsoft/vstest/releases/tag/v18.8.1)    |
| NUnit3TestAdapter                                      |     4.4.2      |                     [6.2.0](https://www.nuget.org/packages/NUnit3TestAdapter/6.2.0)                      |    >14.7M | 2026-03-21  | [link](https://github.com/nunit/nunit3-vs-adapter/releases/tag/v6.2.0) |
| StbiSharp                                              |     1.1.0      |                         [1.2.2](https://www.nuget.org/packages/StbiSharp/1.2.2)                          |         0 | 2026-08-12  |                                  n/a                                   |
| System.CodeDom[^1]                                     |     7.0.0      |                     [10.0.11](https://www.nuget.org/packages/System.CodeDom/10.0.11)                     |     >5.2k | 2026-08-11  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| System.Numerics.Tensors                                |     8.0.0      |                [10.0.11](https://www.nuget.org/packages/System.Numerics.Tensors/10.0.11)                 |     >1.9k | 2026-08-11  |  [link](https://github.com/dotnet/dotnet/releases/tag/v10.0.400)[^2]   |
| xunit.runner.visualstudio                              |     2.8.2      |                 [3.1.5](https://www.nuget.org/packages/xunit.runner.visualstudio/3.1.5)                  |    >79.2M | 2025-09-27  | [link](https://github.com/xunit/visualstudio.xunit/releases/tag/3.1.5) |

[^1]: Required to bump BenchmarkDotNet.
[^2]: Microsoft doesn't really do specific changelogs for these packages. Counterpoint: if one of these is pwned, it's just all over.
[^3]: Other dependencies transitively pull in different versions of this.
[^4]: The newest version is [1.1.4](https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing/1.1.4), but I can't install it due to what looks like an upstream issue: https://github.com/dotnet/roslyn-sdk/issues/1259
[^5]: All versions >=5.0.0 produce build warnings about mismatching compiler versions. Probably needs to wait for .NET 10.

Replaced
---
- [xunit](https://www.nuget.org/packages/xunit) is deprecated and has been replaced with latest [xunit.v3](https://www.nuget.org/packages/xunit.v3/).

Held back
---
- FFmpeg.AutoGen: https://github.com/ppy/osu-framework/issues/5051
- Markdig: https://github.com/ppy/osu-framework/pull/4911. Probably needs re-checking that this is still an issue, but will need to do .NET 10 first to actually be able to build iOS.
- Microsoft.CodeAnalysis.CSharp, Microsoft.CodeAnalysis.CSharp.Workspaces: All I've done here is unify versions because the test project and the actual analyzers project used different ones. Anything further than that depends on Microsoft.CodeAnalysis.Analyzers bump to >=5.0.0 and thus probably on .NET 10.
- Microsoft.Diagnostics.Runtime: See inline commentary in csproj ("AOT issues with iOS").
- NUnit: Will require migration similar to https://github.com/ppy/osu/pull/36996, and I don't want to right now.
- SixLabors.ImageSharp: I'd rather not bump this *and* StbiSharp in one release.