### PR TITLE
Use SocketsHttpHandler on Android as well

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -138,19 +138,12 @@ namespace osu.Framework.IO.Network
         private bool completed;
 
         private static readonly HttpClient client = new HttpClient(
-            // SocketsHttpHandler causes crash in Android Debug, and seems to have compatibility issue on SSL
-            // Use platform HTTP handler which is invoked by HttpClientHandler for better compatibility and app size
-            RuntimeInfo.OS == RuntimeInfo.Platform.Android
-                ? new HttpClientHandler
-                {
-                    AutomaticDecompression = DecompressionMethods.All
-                }
-                : new SocketsHttpHandler
-                {
-                    AutomaticDecompression = DecompressionMethods.All,
-                    DefaultProxyCredentials = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? CredentialCache.DefaultCredentials : null,
-                    ConnectCallback = onConnect,
-                }
+            new SocketsHttpHandler
+            {
+                AutomaticDecompression = DecompressionMethods.All,
+                DefaultProxyCredentials = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? CredentialCache.DefaultCredentials : null,
+                ConnectCallback = onConnect,
+            }
         )
         {
             // Timeout is controlled manually through cancellation tokens because

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -143,14 +143,12 @@ namespace osu.Framework.IO.Network
             RuntimeInfo.OS == RuntimeInfo.Platform.Android
                 ? new HttpClientHandler
                 {
-                    Credentials = CredentialCache.DefaultCredentials,
                     AutomaticDecompression = DecompressionMethods.All
                 }
                 : new SocketsHttpHandler
                 {
                     AutomaticDecompression = DecompressionMethods.All,
-                    // Can be replaced by a static HttpClient.DefaultCredentials after net60 everywhere.
-                    Credentials = CredentialCache.DefaultCredentials,
+                    DefaultProxyCredentials = RuntimeInfo.OS == RuntimeInfo.Platform.Windows ? CredentialCache.DefaultCredentials : null,
                     ConnectCallback = onConnect,
                 }
         )


### PR DESCRIPTION
AndroidMessageHandler triggers an explicit Java VM GC after use.
This GC occurs even during gameplay—such as during the online notifications sent at one-minute intervals—causing a freeze of approximately two frames.
In contrast, SocketsHttpHandler is an implementation written entirely in C# that is independent of Java, so it does not trigger Java VM GC.

Game log and logcat
<details><summary>Before</summary>

The following lines are from the Java VM GC log.
`08-22 20:13:38.311 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 352KB AllocSpace bytes, 11(252KB) LOS objects, 75% free, 20MB/82MB, paused 61us,255us total 58.655ms`

```
 $ logcat --uid=10430 &                                                        
[1] 14241
 $ clear--------- beginning of main                                            
08-22 20:13:38.311 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 352KB AllocSpace bytes, 11(252KB) LOS objects, 75% free, 20MB/82MB, paused 61us,255us total 58.655ms
 $ tail -F 1787396725.network.log 1787396725.runtime.log                       
==> 1787396725.network.log <==
2026-08-22 11:12:46 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapSetRequest
2026-08-22 11:12:47 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmapsets/1470072 successfully completed!
2026-08-22 11:12:47 [verbose]: GetBeatmapSetRequest finished with response size of 30,197 bytes
2026-08-22 11:12:47 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:12:47 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:12:47 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:12:47 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:13:35 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:13:35 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:13:35 [verbose]: ChatAckRequest finished with response size of 15 bytes

==> 1787396725.runtime.log <==
2026-08-22 11:12:46 [verbose]: Carousel[op 1106477162] 291 ms: Items ready for display
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (100)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (200)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (300)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (400)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (500)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (600)
2026-08-22 11:13:09 [verbose]: Texture 138's upload queue is large (700)
2026-08-22 11:13:28 [verbose]: Received beatmap updates 1 updates with last id 10671960
2026-08-22 11:13:48 [verbose]: Received beatmap updates 1 updates with last id 10671961
2026-08-22 11:14:02 [verbose]: Invalidating working beatmap cache for Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 11:14:02 [verbose]: Game-wide working beatmap updated to Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 11:14:02 [verbose]: Invalidating working beatmap cache for Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 11:14:02 [verbose]: 📺 OsuScreenStack#-18(depth:4) suspended SoloSongSelect#-11 (waiting on SoloSongSelect+PlayerLoader#754)
2026-08-22 11:14:02 [verbose]: 📺 OsuScreenStack#-18(depth:5) loading SoloSongSelect+PlayerLoader#754
2026-08-22 11:14:02 [verbose]: 📺 OsuScreenStack#-18(depth:5) entered SoloSongSelect+PlayerLoader#754

==> 1787396725.network.log <==
2026-08-22 11:14:03 [verbose]: Performing request osu.Game.Online.Solo.CreateSoloScoreRequest
2026-08-22 11:14:05 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmaps/3018109/solo/scores successfully completed!
2026-08-22 11:14:05 [verbose]: CreateSoloScoreRequest finished with response size of 117 bytes

==> 1787396725.runtime.log <==
2026-08-22 11:14:05 [verbose]: Score submission token retrieved (1691416257)
08-22 20:14:05.722 10311 12390 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 608KB AllocSpace bytes, 7(140KB) LOS objects, 75% free, 20MB/82MB, paused 125us,372us total 77.846ms

==> 1787396725.network.log <==
2026-08-22 11:14:05 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:14:05 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:14:05 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:14:05 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:14:05 [verbose]: Online asset https://a.ppy.sh/29580667?1750257632.png retrieved from OnlineAssetCachingStore.

==> 1787396725.runtime.log <==
2026-08-22 11:14:05 [verbose]: 📺 OsuScreenStack#-18(depth:5) suspended SoloSongSelect+PlayerLoader#754 (waiting on SoloPlayer#133)
2026-08-22 11:14:05 [verbose]: 📺 OsuScreenStack#-18(depth:6) entered SoloPlayer#133
2026-08-22 11:14:05 [verbose]: GameplayClockContainer seeking to 0
2026-08-22 11:14:05 [verbose]: GameplayClockContainer started via call to StartGameplayClock
2026-08-22 11:14:07 [verbose]: GameplayClockContainer seeking to 13839
2026-08-22 11:14:08 [verbose]: Received beatmap updates 1 updates with last id 10671962
2026-08-22 11:14:08 [verbose]: SDL error: That operation is not supported
2026-08-22 11:14:08 [verbose]: at SDL_SetWindowMouseRect(SDLWindowHandle, null)
2026-08-22 11:14:13 [verbose]: Received beatmap updates 1 updates with last id 10671963
2026-08-22 11:14:28 [verbose]: Received beatmap updates 1 updates with last id 10671964

==> 1787396725.network.log <==
2026-08-22 11:14:35 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:14:36 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:14:36 [verbose]: ChatAckRequest finished with response size of 15 bytes
08-22 20:14:36.744 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 4028KB AllocSpace bytes, 15(332KB) LOS objects, 75% free, 20MB/82MB, paused 118us,298us total 71.355ms

==> 1787396725.runtime.log <==
2026-08-22 11:14:58 [verbose]: Received beatmap updates 1 updates with last id 10671965
08-22 20:15:04.947 10311 10547 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 3844KB AllocSpace bytes, 7(140KB) LOS objects, 75% free, 20MB/82MB, paused 96us,369us total 67.102ms
2026-08-22 11:15:08 [verbose]: Received beatmap updates 2 updates with last id 10671967
2026-08-22 11:15:33 [verbose]: Received beatmap updates 1 updates with last id 10671968

==> 1787396725.network.log <==
2026-08-22 11:15:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
08-22 20:15:36.572 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 4320KB AllocSpace bytes, 15(300KB) LOS objects, 75% free, 20MB/82MB, paused 150us,428us total 85.816ms
2026-08-22 11:15:36 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:15:36 [verbose]: ChatAckRequest finished with response size of 15 bytes
08-22 20:15:38.182 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 412KB AllocSpace bytes, 2(72KB) LOS objects, 75% free, 20MB/82MB, paused 92us,298us total 67.308ms

==> 1787396725.runtime.log <==
2026-08-22 11:16:13 [verbose]: Received beatmap updates 1 updates with last id 10671969
2026-08-22 11:16:18 [verbose]: Received beatmap updates 1 updates with last id 10671970
08-22 20:16:37.393 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 8000KB AllocSpace bytes, 25(532KB) LOS objects, 75% free, 20MB/82MB, paused 85us,349us total 68.789ms

==> 1787396725.network.log <==
2026-08-22 11:16:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:16:37 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:16:37 [verbose]: ChatAckRequest finished with response size of 15 bytes

==> 1787396725.runtime.log <==
2026-08-22 11:17:13 [verbose]: Received beatmap updates 1 updates with last id 10671971

==> 1787396725.network.log <==
2026-08-22 11:17:37 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:17:37 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:17:37 [verbose]: ChatAckRequest finished with response size of 15 bytes
08-22 20:17:37.840 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 8160KB AllocSpace bytes, 18(392KB) LOS objects, 75% free, 20MB/82MB, paused 70us,320us total 66.562ms

==> 1787396725.runtime.log <==
2026-08-22 11:18:08 [verbose]: Received beatmap updates 1 updates with last id 10671972
2026-08-22 11:18:33 [verbose]: Received beatmap updates 1 updates with last id 10671973

==> 1787396725.network.log <==
2026-08-22 11:18:37 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:18:37 [verbose]: Request to https://osu.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:18:37 [verbose]: ChatAckRequest finished with response size of 15 bytes
08-22 20:18:37.819 10311 10546 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 8096KB AllocSpace bytes, 24(512KB) LOS objects, 75% free, 20MB/82MB, paused 83us,274us total 67.174ms

==> 1787396725.runtime.log <==
2026-08-22 11:18:48 [verbose]: Received beatmap updates 1 updates with last id 10671974
2026-08-22 11:19:03 [verbose]: Received beatmap updates 1 updates with last id 10671975
2026-08-22 11:19:10 [verbose]: SDL error: That operation is not supported
2026-08-22 11:19:10 [verbose]: at SDL_SetWindowMouseRect(SDLWindowHandle, null)

==> 1787396725.network.log <==
2026-08-22 11:19:11 [verbose]: Performing request osu.Game.Online.Solo.SubmitSoloScoreRequest

==> 1787396725.runtime.log <==
2026-08-22 11:19:11 [verbose]: Beginning score submission (token:1691416257)...
08-22 20:19:12.882 10311 10499 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 4596KB AllocSpace bytes, 11(268KB) LOS objects, 75% free, 20MB/82MB, paused 93us,309us total 75.894ms
08-22 20:19:13.596 10311 10499 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 156KB AllocSpace bytes, 1(20KB) LOS objects, 75% free, 20MB/82MB, paused 87us,293us total 66.211ms

==> 1787396725.network.log <==
2026-08-22 11:19:12 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmaps/3018109/solo/scores/1691416257 successfully completed!
2026-08-22 11:19:12 [verbose]: SubmitSoloScoreRequest finished with response size of 942 bytes
2026-08-22 11:19:13 [verbose]: Performing request osu.Game.Online.API.Requests.GetUserRequest

==> 1787396725.runtime.log <==
2026-08-22 11:19:12 [verbose]: Score submission completed! (token:1691416257 id:7322848524)
08-22 20:19:14.131 10311 12390 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 560KB AllocSpace bytes, 2(136KB) LOS objects, 75% free, 20MB/82MB, paused 74us,286us total 69.038ms
08-22 20:19:14.325 10311 17076 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 404KB AllocSpace bytes, 1(68KB) LOS objects, 75% free, 20MB/82MB, paused 101us,254us total 70.648ms

==> 1787396725.network.log <==
2026-08-22 11:19:13 [verbose]: Request to https://osu.ppy.sh/api/v2/users/29580667/osu?key=id successfully completed!
2026-08-22 11:19:13 [verbose]: GetUserRequest finished with response size of 15,047 bytes
2026-08-22 11:19:13 [verbose]: Performing request osu.Game.Online.API.Requests.GetUserRequest
2026-08-22 11:19:14 [verbose]: Request to https://osu.ppy.sh/api/v2/users/29580667/?key=id successfully completed!
2026-08-22 11:19:14 [verbose]: GetUserRequest finished with response size of 15,047 bytes

==> 1787396725.runtime.log <==
2026-08-22 11:19:14 [verbose]: 📺 OsuScreenStack#-18(depth:6) suspended SoloPlayer#133 (waiting on SoloResultsScreen#153)
2026-08-22 11:19:14 [verbose]: 📺 OsuScreenStack#-18(depth:7) loading SoloResultsScreen#153
2026-08-22 11:19:14 [verbose]: 📺 OsuScreenStack#-18(depth:7) entered SoloResultsScreen#153
08-22 20:19:14.701 10311 10391 W Bitmap  : Called getWidth() on a recycle()'d bitmap! This is undefined behavior!
08-22 20:19:14.701 10311 10391 W Bitmap  : Called getHeight() on a recycle()'d bitmap! This is undefined behavior!
08-22 20:19:15.284 10311 12400 I sh.ppy.osulazer: Explicit concurrent mark compact GC freed 220KB AllocSpace bytes, 4(6112KB) LOS objects, 75% free, 20MB/82MB, paused 105us,390us total 75.410ms

==> 1787396725.network.log <==
2026-08-22 11:19:14 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapSetRequest
2026-08-22 11:19:14 [verbose]: Online asset https://assets.ppy.sh/user-cover-presets/14/af62823c1990a074e038e2ff6aad34aac54b61e48139874f1c8ff46c9d3904a2.png retrieved from OnlineAssetCachingStore.
2026-08-22 11:19:14 [verbose]: Online asset https://a.ppy.sh/29580667?1750257632.png retrieved from OnlineAssetCachingStore.
2026-08-22 11:19:15 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:19:15 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:19:15 [verbose]: Online asset https://a.ppy.sh/29580667 retrieved from OnlineAssetCachingStore.
2026-08-22 11:19:15 [verbose]: Request to https://osu.ppy.sh/api/v2/beatmapsets/1470072 successfully completed!
2026-08-22 11:19:15 [verbose]: GetBeatmapSetRequest finished with response size of 30,194 bytes

==> 1787396725.runtime.log <==
2026-08-22 11:19:18 [verbose]: Received beatmap updates 2 updates with last id 10671977
```

</details> 

<details><summary>After</summary>

```
 $ logcat --uid=10436 &                                                        
[1] 3595
 $ tail -F 1787395578.network.log 1787395578.runtime.log                       
==> 1787395578.network.log <==
2026-08-22 10:53:35 [verbose]: SubmitSoloScoreRequest finished with response size of 885 bytes
2026-08-22 10:53:35 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapSetRequest
2026-08-22 10:53:35 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmapsets/1470072 successfully completed!
2026-08-22 10:53:35 [verbose]: GetBeatmapSetRequest finished with response size of 10,638 bytes
2026-08-22 10:54:35 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:54:35 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:54:35 [verbose]: ChatAckRequest finished with response size of 15 bytes
2026-08-22 10:55:35 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:55:36 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:55:36 [verbose]: ChatAckRequest finished with response size of 15 bytes

==> 1787395578.runtime.log <==
2026-08-22 10:53:34 [verbose]: Carousel[op 1657872526] 105 ms: Updating Y positions
2026-08-22 10:53:34 [verbose]: Carousel[op 1657872526] 106 ms: Items ready for display
2026-08-22 10:53:35 [verbose]: Score submission completed! (token:190403364 id:34766)
2026-08-22 10:53:50 [verbose]: Texture 347's upload queue is large (100)
2026-08-22 10:53:50 [verbose]: Texture 347's upload queue is large (200)
2026-08-22 10:53:50 [verbose]: Texture 347's upload queue is large (300)
2026-08-22 10:53:50 [verbose]: Texture 347's upload queue is large (400)
2026-08-22 10:53:51 [verbose]: Texture 347's upload queue is large (500)
2026-08-22 10:53:51 [verbose]: Texture 347's upload queue is large (600)
2026-08-22 10:53:51 [verbose]: Texture 347's upload queue is large (700)
2026-08-22 10:56:29 [verbose]: Texture 347's upload queue is large (100)
2026-08-22 10:56:29 [verbose]: Invalidating working beatmap cache for Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 10:56:29 [verbose]: Game-wide working beatmap updated to Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 10:56:29 [verbose]: Invalidating working beatmap cache for Mage - The Words I Never Said (Strategas) [Regret]
2026-08-22 10:56:29 [verbose]: 📺 OsuScreenStack#-93(depth:4) suspended SoloSongSelect#-30 (waiting on SoloSongSelect+PlayerLoader#-91)
2026-08-22 10:56:29 [verbose]: 📺 OsuScreenStack#-93(depth:5) loading SoloSongSelect+PlayerLoader#-91
2026-08-22 10:56:29 [verbose]: 🌅 Global background change queued
2026-08-22 10:56:29 [verbose]: 📺 OsuScreenStack#-93(depth:5) entered SoloSongSelect+PlayerLoader#-91
--------- beginning of main
08-22 19:56:30.472 26575 26610 I .osulazer.debug: Explicit concurrent mark compact GC freed 2222KB AllocSpace bytes, 58(17MB) LOS objects, 89% free, 2964KB/26MB, paused 110us,589us total 8.072ms
08-22 19:56:30.853 26575 26610 I .osulazer.debug: Explicit concurrent mark compact GC freed 136KB AllocSpace bytes, 2(88KB) LOS objects, 89% free, 2956KB/26MB, paused 70us,381us total 4.424ms

==> 1787395578.network.log <==
2026-08-22 10:56:30 [verbose]: Performing request osu.Game.Online.Solo.CreateSoloScoreRequest

==> 1787395578.runtime.log <==
2026-08-22 10:56:30 [verbose]: 🌅 Global background loading

==> 1787395578.network.log <==
2026-08-22 10:56:31 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/3018109/solo/scores successfully completed!
2026-08-22 10:56:31 [verbose]: CreateSoloScoreRequest finished with response size of 112 bytes

==> 1787395578.runtime.log <==
2026-08-22 10:56:31 [verbose]: Score submission token retrieved (190403365)
2026-08-22 10:56:32 [verbose]: 📺 OsuScreenStack#-93(depth:5) suspended SoloSongSelect+PlayerLoader#-91 (waiting on SoloPlayer#464)
2026-08-22 10:56:32 [verbose]: 📺 OsuScreenStack#-93(depth:6) entered SoloPlayer#464
2026-08-22 10:56:32 [verbose]: GameplayClockContainer seeking to 0
2026-08-22 10:56:32 [verbose]: GameplayClockContainer started via call to StartGameplayClock
2026-08-22 10:56:33 [verbose]: GameplayClockContainer seeking to 13839
2026-08-22 10:56:34 [verbose]: SDL error: That operation is not supported
2026-08-22 10:56:34 [verbose]: at SDL_SetWindowMouseRect(SDLWindowHandle, null)

==> 1787395578.network.log <==
2026-08-22 10:56:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:56:36 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:56:36 [verbose]: ChatAckRequest finished with response size of 15 bytes
08-22 19:57:36.342 26575   517 I .osulazer.debug: Explicit concurrent mark compact GC freed 9344KB AllocSpace bytes, 23(460KB) LOS objects, 89% free, 2989KB/26MB, paused 152us,655us total 7.937ms
2026-08-22 10:57:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:57:36 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:57:36 [verbose]: ChatAckRequest finished with response size of 15 bytes
2026-08-22 10:58:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:58:36 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:58:36 [verbose]: ChatAckRequest finished with response size of 15 bytes
2026-08-22 10:59:36 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 10:59:37 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 10:59:37 [verbose]: ChatAckRequest finished with response size of 15 bytes
2026-08-22 11:00:37 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:00:37 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:00:37 [verbose]: ChatAckRequest finished with response size of 15 bytes

==> 1787395578.runtime.log <==
2026-08-22 11:01:36 [verbose]: SDL error: That operation is not supported
2026-08-22 11:01:36 [verbose]: at SDL_SetWindowMouseRect(SDLWindowHandle, null)

==> 1787395578.network.log <==
2026-08-22 11:01:37 [verbose]: Performing request osu.Game.Online.API.Requests.ChatAckRequest
2026-08-22 11:01:37 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/ack successfully completed!
2026-08-22 11:01:37 [verbose]: ChatAckRequest finished with response size of 15 bytes
2026-08-22 11:01:37 [verbose]: Performing request osu.Game.Online.Solo.SubmitSoloScoreRequest
2026-08-22 11:01:37 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/3018109/solo/scores/190403365 successfully completed!
2026-08-22 11:01:37 [verbose]: SubmitSoloScoreRequest finished with response size of 934 bytes

==> 1787395578.runtime.log <==
2026-08-22 11:01:37 [verbose]: Beginning score submission (token:190403365)...
2026-08-22 11:01:37 [verbose]: Score submission completed! (token:190403365 id:34767)
08-22 20:01:38.366 26575   713 I .osulazer.debug: Explicit concurrent mark compact GC freed 10MB AllocSpace bytes, 24(480KB) LOS objects, 89% free, 2957KB/26MB, paused 97us,659us total 8.650ms

==> 1787395578.network.log <==
2026-08-22 11:01:38 [verbose]: Performing request osu.Game.Online.API.Requests.GetUserRequest
2026-08-22 11:01:38 [verbose]: Request to https://dev.ppy.sh/api/v2/users/1134/osu?key=id successfully completed!
2026-08-22 11:01:38 [verbose]: GetUserRequest finished with response size of 3,293 bytes
2026-08-22 11:01:38 [verbose]: Performing request osu.Game.Online.API.Requests.GetUserRequest
2026-08-22 11:01:38 [verbose]: Request to https://dev.ppy.sh/api/v2/users/1134/?key=id successfully completed!
2026-08-22 11:01:38 [verbose]: GetUserRequest finished with response size of 3,293 bytes

==> 1787395578.runtime.log <==
2026-08-22 11:01:38 [verbose]: 📺 OsuScreenStack#-93(depth:6) suspended SoloPlayer#464 (waiting on SoloResultsScreen#973)
2026-08-22 11:01:38 [verbose]: 📺 OsuScreenStack#-93(depth:7) loading SoloResultsScreen#973
2026-08-22 11:01:38 [verbose]: 📺 OsuScreenStack#-93(depth:7) entered SoloResultsScreen#973

==> 1787395578.network.log <==
2026-08-22 11:01:39 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapSetRequest
2026-08-22 11:01:39 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmapsets/1470072 successfully completed!
2026-08-22 11:01:39 [verbose]: GetBeatmapSetRequest finished with response size of 10,638 bytes
```

</details>

However, I have been unable to reproduce the debug build crashes or SSL compatibility issues on my device.
There is no telling what might happen on older devices or devices from manufacturers like the tyrant Samsung.

But, the game freezing repeatedly during gameplay is extremely frustrating.
I’ve lost count of how many times I’ve missed a Full Combo because of it.