### PR TITLE
Reduce Android display latency by setting the desired frame timestamp

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.Android
     {
         private readonly AndroidGameActivity activity;
 
+        private ChoreographerVsyncWaiter vsyncWaiter = new ChoreographerVsyncWaiter();
+
         public AndroidGameHost(AndroidGameActivity activity)
             : base(string.Empty)
         {
@@ -59,6 +61,9 @@ namespace osu.Framework.Android
                 androidGraphics.SetPresentationTime(nowNanoTime);
 
                 base.Swap();
+
+                if (Renderer.VerticalSync)
+                    vsyncWaiter.WaitForNextVsync();
             }
             else
             {
@@ -190,6 +195,15 @@ namespace osu.Framework.Android
         public override bool SuspendToBackground()
         {
             return activity.MoveTaskToBack(true);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                vsyncWaiter.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Android
                 base.Swap();
 
                 if (Renderer.VerticalSync)
-                    vsyncWaiter.WaitForNextVsync();
+                    vsyncWaiter.WaitForVsync();
             }
             else
             {

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -17,6 +17,7 @@ using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Framework.Platform.SDL3;
 using Stream = System.IO.Stream;
 using Uri = Android.Net.Uri;
 
@@ -46,6 +47,23 @@ namespace osu.Framework.Android
         {
             if (AndroidGameActivity.Surface.IsSurfaceReady)
                 base.DrawFrame();
+        }
+
+        protected override void Swap()
+        {
+            if (Window.GraphicsSurface.Type == GraphicsSurfaceType.OpenGL
+                && Window.GraphicsSurface is IAndroidGraphicsSurface androidGraphics)
+            {
+                long nowNanoTime = TimeProvider.System.GetTimestamp();
+
+                androidGraphics.SetPresentationTime(nowNanoTime);
+
+                base.Swap();
+            }
+            else
+            {
+                base.Swap();
+            }
         }
 
         public override bool CanExit => false;

--- a/osu.Framework.Android/ChoreographerVsyncWaiter.cs
+++ b/osu.Framework.Android/ChoreographerVsyncWaiter.cs
@@ -18,6 +18,7 @@ namespace osu.Framework.Android
         private readonly VsyncWaiterFrameCallback callback;
         private readonly PostFrameCallbackRunnable runnable;
 
+        private bool hasVsyncCallback;
         private bool disposed;
 
         public ChoreographerVsyncWaiter()
@@ -42,15 +43,23 @@ namespace osu.Framework.Android
             runnable = new PostFrameCallbackRunnable(choreographer, callback);
         }
 
-        public void WaitForNextVsync()
+        /// <remarks>
+        /// Wait for the VSync callback posted during the previous frame.
+        /// This allows waiting for VSync to overlap with frame processing.
+        /// </remarks>
+        public void WaitForVsync()
         {
             ObjectDisposedException.ThrowIf(disposed, this);
+
+            // On the first run, the callback has not yet been set, so waiting is not possible.
+            if (hasVsyncCallback)
+                vsyncEvent.Wait(30000);
 
             vsyncEvent.Reset();
 
             handler.Post(runnable);
 
-            vsyncEvent.Wait(30000);
+            hasVsyncCallback = true;
         }
 
         public void Dispose()

--- a/osu.Framework.Android/ChoreographerVsyncWaiter.cs
+++ b/osu.Framework.Android/ChoreographerVsyncWaiter.cs
@@ -8,13 +8,14 @@ using System.Threading;
 
 namespace osu.Framework.Android
 {
-    public sealed class ChoreographerVsyncWaiter : Java.Lang.Object, Choreographer.IFrameCallback
+    public sealed class ChoreographerVsyncWaiter : IDisposable
     {
         private readonly HandlerThread thread;
         private readonly Handler handler;
         private readonly ManualResetEventSlim vsyncEvent = new ManualResetEventSlim(false);
 
         private Choreographer choreographer = null!;
+        private readonly VsyncWaiterFrameCallback callback;
         private bool disposed;
 
         public ChoreographerVsyncWaiter()
@@ -34,6 +35,8 @@ namespace osu.Framework.Android
 
             ready.Wait(30000);
             ready.Dispose();
+
+            callback = new VsyncWaiterFrameCallback(vsyncEvent);
         }
 
         public void WaitForNextVsync()
@@ -44,15 +47,13 @@ namespace osu.Framework.Android
 
             handler.Post(() =>
             {
-                choreographer.PostFrameCallback(this);
+                choreographer.PostFrameCallback(callback);
             });
 
             vsyncEvent.Wait(30000);
         }
 
-        public void DoFrame(long _) => vsyncEvent.Set();
-
-        public new void Dispose()
+        public void Dispose()
         {
             if (disposed)
                 return;
@@ -62,9 +63,20 @@ namespace osu.Framework.Android
             thread.QuitSafely();
             thread.Join();
 
+            callback.Dispose();
             vsyncEvent.Dispose();
+        }
 
-            base.Dispose();
+        private sealed class VsyncWaiterFrameCallback : Java.Lang.Object, Choreographer.IFrameCallback
+        {
+            private readonly ManualResetEventSlim vsyncEvent;
+
+            public VsyncWaiterFrameCallback(ManualResetEventSlim vsyncEvent)
+            {
+                this.vsyncEvent = vsyncEvent;
+            }
+
+            public void DoFrame(long _) => vsyncEvent.Set();
         }
     }
 }

--- a/osu.Framework.Android/ChoreographerVsyncWaiter.cs
+++ b/osu.Framework.Android/ChoreographerVsyncWaiter.cs
@@ -1,0 +1,70 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.OS;
+using Android.Views;
+using System;
+using System.Threading;
+
+namespace osu.Framework.Android
+{
+    public sealed class ChoreographerVsyncWaiter : Java.Lang.Object, Choreographer.IFrameCallback
+    {
+        private readonly HandlerThread thread;
+        private readonly Handler handler;
+        private readonly ManualResetEventSlim vsyncEvent = new ManualResetEventSlim(false);
+
+        private Choreographer choreographer = null!;
+        private bool disposed;
+
+        public ChoreographerVsyncWaiter()
+        {
+            thread = new HandlerThread("ChoreographerVsync");
+            thread.Start();
+
+            handler = new Handler(thread.Looper!);
+
+            using var ready = new ManualResetEventSlim(false);
+
+            handler.Post(() =>
+            {
+                choreographer = Choreographer.Instance!;
+                ready.Set();
+            });
+
+            ready.Wait(30000);
+            ready.Dispose();
+        }
+
+        public void WaitForNextVsync()
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            vsyncEvent.Reset();
+
+            handler.Post(() =>
+            {
+                choreographer.PostFrameCallback(this);
+            });
+
+            vsyncEvent.Wait(30000);
+        }
+
+        public void DoFrame(long _) => vsyncEvent.Set();
+
+        public new void Dispose()
+        {
+            if (disposed)
+                return;
+
+            disposed = true;
+
+            thread.QuitSafely();
+            thread.Join();
+
+            vsyncEvent.Dispose();
+
+            base.Dispose();
+        }
+    }
+}

--- a/osu.Framework.Android/ChoreographerVsyncWaiter.cs
+++ b/osu.Framework.Android/ChoreographerVsyncWaiter.cs
@@ -16,6 +16,8 @@ namespace osu.Framework.Android
 
         private Choreographer choreographer = null!;
         private readonly VsyncWaiterFrameCallback callback;
+        private readonly PostFrameCallbackRunnable runnable;
+
         private bool disposed;
 
         public ChoreographerVsyncWaiter()
@@ -37,6 +39,7 @@ namespace osu.Framework.Android
             ready.Dispose();
 
             callback = new VsyncWaiterFrameCallback(vsyncEvent);
+            runnable = new PostFrameCallbackRunnable(choreographer, callback);
         }
 
         public void WaitForNextVsync()
@@ -45,10 +48,7 @@ namespace osu.Framework.Android
 
             vsyncEvent.Reset();
 
-            handler.Post(() =>
-            {
-                choreographer.PostFrameCallback(callback);
-            });
+            handler.Post(runnable);
 
             vsyncEvent.Wait(30000);
         }
@@ -64,6 +64,7 @@ namespace osu.Framework.Android
             thread.Join();
 
             callback.Dispose();
+            runnable.Dispose();
             vsyncEvent.Dispose();
         }
 
@@ -77,6 +78,20 @@ namespace osu.Framework.Android
             }
 
             public void DoFrame(long _) => vsyncEvent.Set();
+        }
+
+        private sealed class PostFrameCallbackRunnable : Java.Lang.Object, Java.Lang.IRunnable
+        {
+            private readonly Choreographer choreographer;
+            private readonly Choreographer.IFrameCallback callback;
+
+            public PostFrameCallbackRunnable(Choreographer choreographer, Choreographer.IFrameCallback callback)
+            {
+                this.choreographer = choreographer;
+                this.callback = callback;
+            }
+
+            public void Run() => choreographer.PostFrameCallback(callback);
         }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -579,7 +579,7 @@ namespace osu.Framework.Platform
         {
             Renderer.SwapBuffers();
 
-            if (Window.GraphicsSurface.Type == GraphicsSurfaceType.OpenGL && Renderer.VerticalSync)
+            if (Window.GraphicsSurface.Type == GraphicsSurfaceType.OpenGL && Renderer.VerticalSync && RuntimeInfo.OS != RuntimeInfo.Platform.Android)
                 // without waiting (i.e. glFinish), vsync is basically unplayable due to the extra latency introduced.
                 // we will likely want to give the user control over this in the future as an advanced setting.
                 Renderer.WaitUntilIdle();

--- a/osu.Framework/Platform/IAndroidGraphicsSurface.cs
+++ b/osu.Framework/Platform/IAndroidGraphicsSurface.cs
@@ -17,5 +17,11 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <remarks>https://developer.android.com/reference/android/view/Surface.html</remarks>
         IntPtr SurfaceHandle { get; }
+
+        /// <summary>
+        /// Set the desired display time for GLES rendering.
+        /// </summary>
+        /// <remarks>https://developer.android.com/reference/android/opengl/EGLExt</remarks>
+        void SetPresentationTime(long presentationTimeNanos);
     }
 }

--- a/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
@@ -206,6 +206,54 @@ namespace osu.Framework.Platform.SDL3
         [SupportedOSPlatform("android")]
         IntPtr IAndroidGraphicsSurface.SurfaceHandle => window.SurfaceHandle;
 
+        [SupportedOSPlatform("android")]
+        void IAndroidGraphicsSurface.SetPresentationTime(long presentationTimeNanos)
+        {
+            IntPtr sdlEglDisplay = SDL_EGL_GetCurrentDisplay();
+            IntPtr sdlEglSurface = getCurrentDrawSurface();
+
+            if (sdlEglDisplay == IntPtr.Zero || sdlEglSurface == IntPtr.Zero) return;
+
+            setPresentationTime(sdlEglDisplay, sdlEglSurface, presentationTimeNanos);
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate IntPtr eglGetCurrentSurfaceDelegate(int readdraw);
+        private static eglGetCurrentSurfaceDelegate? eglGetCurrentSurface;
+
+        private static IntPtr getCurrentDrawSurface()
+        {
+            const int egl_draw = 0x3059;
+            if (eglGetCurrentSurface == null)
+            {
+                IntPtr proc = SDL_EGL_GetProcAddress("eglGetCurrentSurface");
+                if (proc != IntPtr.Zero)
+                {
+                    eglGetCurrentSurface = Marshal.GetDelegateForFunctionPointer<eglGetCurrentSurfaceDelegate>(proc);
+                }
+            }
+
+            return eglGetCurrentSurface?.Invoke(egl_draw) ?? IntPtr.Zero;
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate bool eglPresentationTimeANDROIDDelegate(IntPtr dpy, IntPtr surface, long time);
+        private static eglPresentationTimeANDROIDDelegate? eglPresentationTimeANDROID;
+
+        private static bool setPresentationTime(IntPtr eglDisplay, IntPtr eglSurface, long presentationTimeNanos)
+        {
+            if (eglPresentationTimeANDROID == null)
+            {
+                IntPtr proc = SDL_EGL_GetProcAddress("eglPresentationTimeANDROID");
+                if (proc != IntPtr.Zero)
+                {
+                    eglPresentationTimeANDROID = Marshal.GetDelegateForFunctionPointer<eglPresentationTimeANDROIDDelegate>(proc);
+                }
+            }
+
+            return eglPresentationTimeANDROID?.Invoke(eglDisplay, eglSurface, presentationTimeNanos) ?? false;
+        }
+
         #endregion
     }
 }

--- a/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
+++ b/osu.Framework/Platform/SDL3/SDL3GraphicsSurface.cs
@@ -218,18 +218,21 @@ namespace osu.Framework.Platform.SDL3
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate IntPtr eglGetCurrentSurfaceDelegate(int readdraw);
-        private static eglGetCurrentSurfaceDelegate? eglGetCurrentSurface;
+        private delegate IntPtr EglGetCurrentSurfaceDelegate(int readdraw);
+
+        private static EglGetCurrentSurfaceDelegate? eglGetCurrentSurface;
 
         private static IntPtr getCurrentDrawSurface()
         {
             const int egl_draw = 0x3059;
+
             if (eglGetCurrentSurface == null)
             {
                 IntPtr proc = SDL_EGL_GetProcAddress("eglGetCurrentSurface");
+
                 if (proc != IntPtr.Zero)
                 {
-                    eglGetCurrentSurface = Marshal.GetDelegateForFunctionPointer<eglGetCurrentSurfaceDelegate>(proc);
+                    eglGetCurrentSurface = Marshal.GetDelegateForFunctionPointer<EglGetCurrentSurfaceDelegate>(proc);
                 }
             }
 
@@ -237,21 +240,23 @@ namespace osu.Framework.Platform.SDL3
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool eglPresentationTimeANDROIDDelegate(IntPtr dpy, IntPtr surface, long time);
-        private static eglPresentationTimeANDROIDDelegate? eglPresentationTimeANDROID;
+        private delegate bool EglPresentationTimeAndroidDelegate(IntPtr dpy, IntPtr surface, long time);
+
+        private static EglPresentationTimeAndroidDelegate? eglPresentationTimeAndroid;
 
         private static bool setPresentationTime(IntPtr eglDisplay, IntPtr eglSurface, long presentationTimeNanos)
         {
-            if (eglPresentationTimeANDROID == null)
+            if (eglPresentationTimeAndroid == null)
             {
                 IntPtr proc = SDL_EGL_GetProcAddress("eglPresentationTimeANDROID");
+
                 if (proc != IntPtr.Zero)
                 {
-                    eglPresentationTimeANDROID = Marshal.GetDelegateForFunctionPointer<eglPresentationTimeANDROIDDelegate>(proc);
+                    eglPresentationTimeAndroid = Marshal.GetDelegateForFunctionPointer<EglPresentationTimeAndroidDelegate>(proc);
                 }
             }
 
-            return eglPresentationTimeANDROID?.Invoke(eglDisplay, eglSurface, presentationTimeNanos) ?? false;
+            return eglPresentationTimeAndroid?.Invoke(eglDisplay, eglSurface, presentationTimeNanos) ?? false;
         }
 
         #endregion


### PR DESCRIPTION
Display latency is reduced by two frames.

https://github.com/user-attachments/assets/6f21546c-4b25-4fd0-891d-5521cad7ac72

---

I also checked using [Perfetto](https://ui.perfetto.dev/), the official Android profiling tool.
(Trace coinfig: [config.txtpb.txt](https://github.com/user-attachments/files/31524777/config.txtpb.txt))

### Before
<img width="2281" height="506" alt="スクリーンショット 2026-08-28 014536" src="https://github.com/user-attachments/assets/76cce30e-8dab-4129-9bf7-544f67d577b9" />

### After
<img width="2279" height="585" alt="スクリーンショット 2026-08-28 014831" src="https://github.com/user-attachments/assets/6c3ce79a-8e70-4a4e-9fb5-c41934217624" />

The meanings of each location are as follows:
①: The application has started rendering 
②: The application has finished rendering
③: The frame to be composited has been selected
④: The frame has been displayed on the screen

I haven't addressed the time taken for the ①→② step this time; please disregard it, as it varies significantly depending on the situation.
The improvement made this time concerns the time taken for the ②→③ step.

---

### Description of changes for ec1a4f56ef9f94737de822a127655096d0df0526
After calling `eglPresentationTimeANDROID`, VSync no longer worked as expected even with SwapInterval set to 1.
Therefore, I implemented Choreographer as an alternative to VSync.

<details><summary>Details</summary>

By the way, Choreographer is **extremely strict** .
If the load increases even slightly, the frame rate immediately drops from 120fps to 60fps—far more drastically than with `SwapInterval(1)`.
As it stands, I believe there are only a handful of devices capable of consistently maintaining 120fps with VSync.

Furthermore, unfortunately, 120 fps without V-Sync results in lower latency than 60 Hz V-Sync.
</details> 