### PR TITLE
Fix incorrect xmldoc for Spin() transform extension

### DIFF
--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -267,7 +267,7 @@ namespace osu.Framework.Graphics
             transformable.Delay(0).Loop(pause);
 
         /// <summary>
-        /// Rotate over one full rotation with provided parameters.
+        /// Rotate indefinitely with provided parameters.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
         public static TransformSequence<T> Spin<T>(this T drawable, double revolutionDuration, RotationDirection direction, float startRotation = 0)


### PR DESCRIPTION
[Just noticed](https://discord.com/channels/188630481301012481/188630652340404224/1543875944161214484) that the xmldoc claims that it only rotates once, but the function it calls constructs the transform as a loop.

https://github.com/ppy/osu-framework/blob/27a5d1895bbe542a824abdbd2f21e12d54de6552/osu.Framework/Graphics/TransformSequenceExtensions.cs#L37-L39

also verified in the test browser that it really does spin indefinitely

https://github.com/user-attachments/assets/8fa86a14-3bc5-4a00-9a63-b09feae2ad36
