### PR TITLE
Add fill performance test scene

### DIFF
--- a/osu.Framework.Tests/Visual/Performance/PerformanceTestScene.cs
+++ b/osu.Framework.Tests/Visual/Performance/PerformanceTestScene.cs
@@ -29,7 +29,29 @@ namespace osu.Framework.Tests.Visual.Performance
 
         private Bindable<bool> bypassFrontToBack = null!;
 
-        private BufferedContainer buffer = null!;
+        private Container<Drawable> buffer = null!;
+
+        private void recreateBuffer(float renderScale)
+        {
+            buffer.Clear(false);
+            if (renderScale < 1f)
+            {
+                base.Content.Child = buffer = new BufferedContainer
+                {
+                    Child = content,
+                    RelativeSizeAxes = Axes.Both,
+                    FrameBufferScale = new Vector2(renderScale),
+                };
+            }
+            else
+            {
+                base.Content.Child = buffer = new Container
+                {
+                    Child = content,
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+        }
 
         protected override void LoadComplete()
         {
@@ -37,7 +59,12 @@ namespace osu.Framework.Tests.Visual.Performance
 
             bypassFrontToBack = debugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
 
-            base.Content.Child = buffer = new BufferedContainer(pixelSnapping: true)
+            AddLabel("General");
+
+            AddToggleStep("hide content", v => Content.Alpha = v ? 0 : 1);
+            AddToggleStep("enable front to back", v => bypassFrontToBack.Value = !v);
+
+            base.Content.Child = buffer = new Container
             {
                 RelativeSizeAxes = Axes.Both,
                 Child = content = new Container
@@ -48,11 +75,7 @@ namespace osu.Framework.Tests.Visual.Performance
                 },
             };
 
-            AddLabel("General");
-
-            AddToggleStep("hide content", v => Content.Alpha = v ? 0 : 1);
-            AddToggleStep("enable front to back", v => bypassFrontToBack.Value = !v);
-            AddSliderStep("render scale", 0.01f, 1f, 1f, v => buffer.FrameBufferScale = new Vector2(v));
+            AddSliderStep("render scale", 0.01f, 1f, 1f, recreateBuffer);
             AddToggleStep("rotate everything", v => rotation = v);
             AddToggleStep("cycle colour", v => cycleColour = v);
         }

--- a/osu.Framework.Tests/Visual/Performance/PerformanceTestScene.cs
+++ b/osu.Framework.Tests/Visual/Performance/PerformanceTestScene.cs
@@ -34,6 +34,7 @@ namespace osu.Framework.Tests.Visual.Performance
         private void recreateBuffer(float renderScale)
         {
             buffer.Clear(false);
+
             if (renderScale < 1f)
             {
                 base.Content.Child = buffer = new BufferedContainer

--- a/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
@@ -1,0 +1,122 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Performance
+{
+    public partial class TestSceneFillPerformance : PerformanceTestScene
+    {
+        private readonly BindableFloat alpha = new BindableFloat();
+        private readonly Bindable<BlendingParameters> blendingParameters = new Bindable<BlendingParameters>();
+
+        protected Drawable CreateDrawable() => new TestBlendingBox
+        {
+            BlendingParameters = { BindTarget = blendingParameters },
+            AlphaBindable = { BindTarget = alpha },
+        };
+
+        private partial class TestBlendingBox : Box
+        {
+            public readonly IBindable<BlendingParameters> BlendingParameters = new Bindable<BlendingParameters>();
+            public readonly IBindable<float> AlphaBindable = new Bindable<float>();
+
+            public TestBlendingBox()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                AlphaBindable.BindValueChanged(v => Alpha = v.NewValue, true);
+                BlendingParameters.BindValueChanged(v => Blending = v.NewValue, true);
+            }
+        }
+
+        protected readonly BindableFloat DrawableSize = new BindableFloat();
+        protected readonly BindableInt DrawableCount = new BindableInt();
+        protected readonly BindableBool GradientColour = new BindableBool();
+        protected readonly BindableBool RandomiseColour = new BindableBool();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            AddLabel("Drawables");
+
+            AddSliderStep("size", 1f, 128f, 20f, v => DrawableSize.Value = v);
+            AddSliderStep("count", 1, 100, 100, v => DrawableCount.Value = v);
+
+            AddToggleStep("gradient colour", v => GradientColour.Value = v);
+            AddToggleStep("randomise colour", v => RandomiseColour.Value = v);
+
+            DrawableCount.BindValueChanged(_ => adjustDrawableCount(), true);
+
+            DrawableSize.BindValueChanged(_ => updateMetrics());
+            GradientColour.BindValueChanged(_ => updateMetrics());
+            RandomiseColour.BindValueChanged(_ => updateMetrics());
+
+            AddLabel("Blending");
+            AddSliderStep("alpha", 0f, 1f, 0.01f, v => alpha.Value = v);
+            AddStep("disable blending", () => blendingParameters.Value = BlendingParameters.None);
+            AddStep("set additive blending", () => blendingParameters.Value = BlendingParameters.Additive);
+            AddStep("set mixture blending", () => blendingParameters.Value = BlendingParameters.Mixture);
+        }
+
+        protected void Recreate()
+        {
+            Content.Clear();
+            adjustDrawableCount();
+        }
+
+        private void adjustDrawableCount()
+        {
+            while (Content.Count > DrawableCount.Value)
+                Content.Remove(Content.Children.Last(), true);
+
+            while (Content.Count < DrawableCount.Value)
+            {
+                var drawable = CreateDrawable();
+                updateMetrics(drawable);
+                Content.Add(drawable);
+            }
+        }
+
+        private void updateMetrics()
+        {
+            foreach (var b in Content)
+                updateMetrics(b);
+        }
+
+        private void updateMetrics(Drawable drawable)
+        {
+            drawable.Size = new Vector2(DrawableSize.Value);
+
+            if (GradientColour.Value)
+            {
+                drawable.Colour = new ColourInfo
+                {
+                    TopLeft = RandomiseColour.Value ? getRandomColour() : Color4.Red,
+                    TopRight = RandomiseColour.Value ? getRandomColour() : Color4.Blue,
+                    BottomLeft = RandomiseColour.Value ? getRandomColour() : Color4.Green,
+                    BottomRight = RandomiseColour.Value ? getRandomColour() : Color4.Yellow
+                };
+            }
+            else
+                drawable.Colour = RandomiseColour.Value ? getRandomColour() : Color4.White;
+        }
+
+        private Colour4 getRandomColour() => new Colour4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1f);
+    }
+}

--- a/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Tests.Visual.Performance
 
             AddLabel("Drawables");
 
-            AddSliderStep("count", 1, 100, 100, v => DrawableCount.Value = v);
+            AddSliderStep("count", 1, 100, 1000, v => DrawableCount.Value = v);
             AddToggleStep("gradient colour", v => GradientColour.Value = v);
             AddToggleStep("randomise colour", v => RandomiseColour.Value = v);
 

--- a/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
+++ b/osu.Framework.Tests/Visual/Performance/TestSceneFillPerformance.cs
@@ -44,7 +44,6 @@ namespace osu.Framework.Tests.Visual.Performance
             }
         }
 
-        protected readonly BindableFloat DrawableSize = new BindableFloat();
         protected readonly BindableInt DrawableCount = new BindableInt();
         protected readonly BindableBool GradientColour = new BindableBool();
         protected readonly BindableBool RandomiseColour = new BindableBool();
@@ -55,15 +54,11 @@ namespace osu.Framework.Tests.Visual.Performance
 
             AddLabel("Drawables");
 
-            AddSliderStep("size", 1f, 128f, 20f, v => DrawableSize.Value = v);
             AddSliderStep("count", 1, 100, 100, v => DrawableCount.Value = v);
-
             AddToggleStep("gradient colour", v => GradientColour.Value = v);
             AddToggleStep("randomise colour", v => RandomiseColour.Value = v);
 
             DrawableCount.BindValueChanged(_ => adjustDrawableCount(), true);
-
-            DrawableSize.BindValueChanged(_ => updateMetrics());
             GradientColour.BindValueChanged(_ => updateMetrics());
             RandomiseColour.BindValueChanged(_ => updateMetrics());
 
@@ -101,8 +96,6 @@ namespace osu.Framework.Tests.Visual.Performance
 
         private void updateMetrics(Drawable drawable)
         {
-            drawable.Size = new Vector2(DrawableSize.Value);
-
             if (GradientColour.Value)
             {
                 drawable.Colour = new ColourInfo


### PR DESCRIPTION
Adds `TestSceneFillPerformance` that measures how performance varies under high fill rate load. With various blend modes, various render scales (achieved via buffered container), with/without gradient colours, and with/without front to back optimizations.

Motivated by https://github.com/ppy/osu/issues/38770#issuecomment-5629607228